### PR TITLE
Resolve a CSV variation row's attributes the same way when checking and importing it

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolution
+++ b/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolution
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Product CSV importer: fail a variation row whose attributes the parent product does not offer, instead of importing it as a variation that matches every combination and discarding the attributes it already had.
+Fix product CSV import silently blanking variation attributes the parent product does not offer.

--- a/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolution
+++ b/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolution
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Fixes an unreleased 11.1 feature; no merchant-facing change.

--- a/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolution
+++ b/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolution
@@ -1,3 +1,4 @@
 Significance: patch
-Type: dev
-Comment: Fixes an unreleased 11.1 feature; no merchant-facing change.
+Type: fix
+
+Product CSV importer: fail a variation row whose attributes the parent product does not offer, instead of importing it as a variation that matches every combination and discarding the attributes it already had.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -595,21 +595,19 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return sanitize_title( $raw_name );
 		}
 
-		$attribute_name = $this->get_attribute_taxonomy_name_from_raw_name( $raw_name );
+		// The non-creating half of get_attribute_taxonomy_id(), so a subclass resolving names its own
+		// way is still consulted without a lookup being able to create the attribute.
+		$attribute_id = $this->get_existing_attribute_taxonomy_id( $raw_name );
 
-		// Safe to use the overridable lookup once the attribute exists, and it keeps extensions that
-		// customize it working.
-		if ( wc_attribute_taxonomy_id_by_name( $attribute_name ) ) {
-			return sanitize_title( wc_attribute_taxonomy_name_by_id( $this->get_attribute_taxonomy_id( $raw_name ) ) );
+		if ( $attribute_id ) {
+			return sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
 		}
 
-		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $attribute_name ) ) );
+		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) ) ) );
 	}
 
 	/**
 	 * Get the message refusing a variation row over an attribute the parent product does not offer.
-	 *
-	 * @since 11.1.0
 	 *
 	 * @param array $attribute         Raw attribute data from a parsed row.
 	 * @param array $parent_attributes Parent product attributes, keyed as get_variation_attribute_key() resolves them.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -503,39 +503,17 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
 			foreach ( $data['raw_attributes'] as $attribute ) {
-				$attribute_id = 0;
-
-				// Get ID if is a global attribute.
-				if ( ! empty( $attribute['taxonomy'] ) ) {
-					$attribute_id = $this->get_attribute_taxonomy_id( $attribute['name'] );
-				}
-
-				if ( $attribute_id ) {
-					$attribute_name = sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
-				} else {
-					$attribute_name = sanitize_title( $attribute['name'] );
-				}
+				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
 					continue;
 				}
 
-				$attribute_key   = sanitize_title( $parent_attributes[ $attribute_name ]->get_name() );
-				$attribute_value = isset( $attribute['value'] ) ? current( $attribute['value'] ) : '';
+				$parent_attribute = $parent_attributes[ $attribute_name ];
+				$attribute_key    = sanitize_title( $parent_attribute->get_name() );
+				$attribute_value  = isset( $attribute['value'] ) ? current( $attribute['value'] ) : '';
 
-				if ( $parent_attributes[ $attribute_name ]->is_taxonomy() ) {
-					// If dealing with a taxonomy, we need to get the slug from the name posted to the API.
-					$taxonomy_name = $parent_attributes[ $attribute_name ]->get_name();
-					$term          = get_term_by( 'name', $attribute_value, $taxonomy_name );
-
-					if ( $term && ! is_wp_error( $term ) ) {
-						$attribute_value = $term->slug;
-					} else {
-						$attribute_value = sanitize_title( $attribute_value );
-					}
-				}
-
-				$attributes[ $attribute_key ] = $attribute_value;
+				$attributes[ $attribute_key ] = $this->get_variation_attribute_value( $attribute_value, $parent_attribute );
 			}
 
 			$variation->set_attributes( $attributes );
@@ -554,18 +532,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		$require_save      = false;
 
 		foreach ( $attributes as $attribute ) {
-			$attribute_id = 0;
-
-			// Get ID if is a global attribute.
-			if ( ! empty( $attribute['taxonomy'] ) ) {
-				$attribute_id = $this->get_attribute_taxonomy_id( $attribute['name'] );
-			}
-
-			if ( $attribute_id ) {
-				$attribute_name = sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
-			} else {
-				$attribute_name = sanitize_title( $attribute['name'] );
-			}
+			$attribute_name = $this->get_variation_attribute_key( $attribute );
 
 			// Check if attribute handle variations.
 			if ( isset( $parent_attributes[ $attribute_name ] ) && ! $parent_attributes[ $attribute_name ]->get_variation() ) {
@@ -584,6 +551,58 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		}
 
 		return $parent_attributes;
+	}
+
+	/**
+	 * Get the parent attribute key a variation row's attribute resolves to.
+	 *
+	 * Every caller that needs this key must go through here. Deciding whether a row can be imported
+	 * and importing it used to resolve the key separately, which silently stored a row as a catch-all
+	 * "any" variation whenever the two disagreed.
+	 *
+	 * The taxonomy ID is deliberately not looked up: get_attribute_taxonomy_id() creates the global
+	 * attribute when it is missing, so a row that is only being inspected would leave a stray
+	 * site-wide attribute behind. The key is derived instead, which is equivalent because
+	 * wc_create_attribute() normalizes the slug it stores exactly as wc_attribute_taxonomy_slug() does.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $attribute Raw attribute data from a parsed row.
+	 * @return string Key into the parent product's attributes, empty when the row names no attribute.
+	 */
+	protected function get_variation_attribute_key( $attribute ) {
+		$raw_name = isset( $attribute['name'] ) ? $attribute['name'] : '';
+
+		if ( empty( $attribute['taxonomy'] ) ) {
+			return sanitize_title( $raw_name );
+		}
+
+		$slug = wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) );
+
+		return sanitize_title( wc_attribute_taxonomy_name( $slug ) );
+	}
+
+	/**
+	 * Get the value a variation row's attribute is stored as.
+	 *
+	 * Shares the resolution with whatever decides whether the row can be imported, for the same
+	 * reason as get_variation_attribute_key().
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param string               $raw_value        Raw attribute value from a parsed row.
+	 * @param WC_Product_Attribute $parent_attribute Parent attribute the value belongs to.
+	 * @return string Value as it is stored on the variation.
+	 */
+	protected function get_variation_attribute_value( $raw_value, $parent_attribute ) {
+		if ( ! $parent_attribute->is_taxonomy() ) {
+			return $raw_value;
+		}
+
+		// A taxonomy attribute stores term slugs, while the imported row carries term names.
+		$term = get_term_by( 'name', $raw_value, $parent_attribute->get_name() );
+
+		return ( $term && ! is_wp_error( $term ) ) ? $term->slug : sanitize_title( $raw_value );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -503,17 +503,32 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
 			foreach ( $data['raw_attributes'] as $attribute ) {
+				if ( empty( $attribute['name'] ) ) {
+					continue;
+				}
+
 				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
+				// Skipping the attribute instead would store the variation with whatever did match,
+				// wiping every attribute it already had and leaving a catch-all "any" variation that
+				// matches every combination, all reported as a successful import.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
-					continue;
+					throw new Exception(
+						esc_html(
+							sprintf(
+								/* translators: %s: reason the attribute matches nothing on the parent product */
+								__( 'Variation cannot be imported: %s', 'woocommerce' ),
+								$this->get_unmatched_variation_attribute_reason( $attribute, $parent_attributes )
+							)
+						)
+					);
 				}
 
 				$parent_attribute = $parent_attributes[ $attribute_name ];
 				$attribute_key    = sanitize_title( $parent_attribute->get_name() );
-				$attribute_value  = isset( $attribute['value'] ) ? current( $attribute['value'] ) : '';
+				$raw_value        = isset( $attribute['value'] ) ? current( (array) $attribute['value'] ) : '';
 
-				$attributes[ $attribute_key ] = $this->get_variation_attribute_value( $attribute_value, $parent_attribute );
+				$attributes[ $attribute_key ] = $this->get_variation_attribute_value( false === $raw_value ? '' : $raw_value, $parent_attribute );
 			}
 
 			$variation->set_attributes( $attributes );
@@ -560,10 +575,10 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * and importing it used to resolve the key separately, which silently stored a row as a catch-all
 	 * "any" variation whenever the two disagreed.
 	 *
-	 * The taxonomy ID is deliberately not looked up: get_attribute_taxonomy_id() creates the global
-	 * attribute when it is missing, so a row that is only being inspected would leave a stray
-	 * site-wide attribute behind. The key is derived instead, which is equivalent because
-	 * wc_create_attribute() normalizes the slug it stores exactly as wc_attribute_taxonomy_slug() does.
+	 * When the global attribute is missing, the key is derived rather than looked up, because
+	 * get_attribute_taxonomy_id() creates it: a row that is only being inspected would leave a stray
+	 * site-wide attribute behind. Deriving is equivalent because wc_create_attribute() normalizes the
+	 * slug it stores exactly as wc_attribute_taxonomy_slug() does.
 	 *
 	 * @since 11.1.0
 	 *
@@ -577,9 +592,47 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return sanitize_title( $raw_name );
 		}
 
+		// Resolve through the overridable lookup when the global attribute already exists, so
+		// extensions that customize it keep applying. It only creates an attribute when none exists,
+		// which is the side effect this method must never cause.
+		if ( $this->get_existing_attribute_taxonomy_id( $raw_name ) ) {
+			return sanitize_title( wc_attribute_taxonomy_name_by_id( $this->get_attribute_taxonomy_id( $raw_name ) ) );
+		}
+
 		$slug = wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) );
 
 		return sanitize_title( wc_attribute_taxonomy_name( $slug ) );
+	}
+
+	/**
+	 * Get the reason a variation row's attribute matches nothing the parent product offers.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $attribute         Raw attribute data from a parsed row.
+	 * @param array $parent_attributes Parent product attributes, keyed as get_variation_attribute_key() resolves them.
+	 * @return string Sentence naming the mismatch.
+	 */
+	protected function get_unmatched_variation_attribute_reason( $attribute, $parent_attributes ) {
+		$raw_name   = isset( $attribute['name'] ) ? $attribute['name'] : '';
+		$custom_key = sanitize_title( $raw_name );
+
+		// A row marking an attribute as global when the parent stores it as a custom attribute is the
+		// common cause. Naming only the attribute would send the merchant looking for the wrong
+		// problem, since the parent does have it, just not as a global attribute.
+		if ( ! empty( $attribute['taxonomy'] ) && isset( $parent_attributes[ $custom_key ] ) && ! $parent_attributes[ $custom_key ]->is_taxonomy() ) {
+			return sprintf(
+				/* translators: %s: attribute name */
+				__( 'The parent product has a custom "%s" attribute, but the row marks it as a global attribute.', 'woocommerce' ),
+				$raw_name
+			);
+		}
+
+		return sprintf(
+			/* translators: %s: attribute name */
+			__( 'The parent product has no "%s" attribute.', 'woocommerce' ),
+			$raw_name
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -92,13 +92,6 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	protected $start_time = 0;
 
 	/**
-	 * Global attribute keys already resolved by get_variation_attribute_key(), keyed by raw name.
-	 *
-	 * @var array
-	 */
-	private $variation_attribute_keys = array();
-
-	/**
 	 * Get file raw headers.
 	 *
 	 * @return array
@@ -601,25 +594,16 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return sanitize_title( $raw_name );
 		}
 
-		// Resolving scans every global attribute on the site, and each row asks for the same handful
-		// of names. A global attribute created part way through an import is created with the slug
-		// this derives anyway, so a cached answer cannot go stale.
-		if ( isset( $this->variation_attribute_keys[ $raw_name ] ) ) {
-			return $this->variation_attribute_keys[ $raw_name ];
-		}
-
 		// get_attribute_taxonomy_id() is not used: it creates the global attribute when the name does
 		// not resolve, and this runs while deciding whether to refuse a row. A subclass that resolves
 		// names its own way has to override this non-creating lookup instead.
 		$attribute_id = $this->get_existing_attribute_taxonomy_id( $raw_name );
 
-		$key = $attribute_id
-			? sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) )
-			: sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) ) ) );
+		if ( $attribute_id ) {
+			return sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
+		}
 
-		$this->variation_attribute_keys[ $raw_name ] = $key;
-
-		return $key;
+		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) ) ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -501,16 +501,9 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		if ( isset( $data['raw_attributes'] ) ) {
 			$attributes = array();
 
-			// Checked against the parent as it stands, before get_variation_parent_attributes()
-			// promotes any matching attribute to "used for variations" and saves the product.
-			// Refusing after that point would leave the parent permanently changed by a row that
-			// went on to import nothing.
-			//
-			// Leaving an unmatched attribute out instead of refusing stores the variation as the CSV
-			// did not describe it: any parent attribute left unspecified becomes a catch-all matching
-			// every value, replacing whatever the variation already had, and the row still reports
-			// success. validate_new_variation_attributes() refuses the same row when the SKU is new,
-			// so refusing here too keeps the two paths from disagreeing.
+			// Refused before get_variation_parent_attributes(), which saves the parent: a row that
+			// imports nothing must not change the product. Skipping the attribute instead would blank
+			// it into a catch-all matching every value.
 			$declared_attributes = $parent->get_attributes();
 
 			foreach ( $data['raw_attributes'] as $attribute ) {
@@ -532,8 +525,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
-				// Every named attribute is on the parent by now, so this only fires if promoting it
-				// for variations did not stick.
+				// Every named attribute is on the parent by now; this only fires if promotion failed.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
 					throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $parent_attributes ) ) );
 				}
@@ -585,14 +577,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	/**
 	 * Get the parent attribute key a variation row's attribute resolves to.
 	 *
-	 * Every caller that needs this key must go through here. Deciding whether a row can be imported
-	 * and importing it used to resolve the key separately, which silently stored a row as a catch-all
-	 * "any" variation whenever the two disagreed.
-	 *
-	 * When the global attribute is missing, the key is derived rather than looked up, because
-	 * get_attribute_taxonomy_id() creates it: a row that is only being inspected would leave a stray
-	 * site-wide attribute behind. Deriving is equivalent because wc_create_attribute() normalizes the
-	 * slug it stores exactly as wc_attribute_taxonomy_slug() does.
+	 * Deciding whether a row can be imported and importing it must resolve the key the same way, or a
+	 * row passes one and is stored as a catch-all "any" variation by the other. When the global
+	 * attribute is missing the key is derived rather than looked up, since get_attribute_taxonomy_id()
+	 * would create it. Deriving matches, because wc_create_attribute() normalizes the slug it stores
+	 * exactly as wc_attribute_taxonomy_slug() does.
 	 *
 	 * @since 11.1.0
 	 *
@@ -608,9 +597,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		$attribute_name = $this->get_attribute_taxonomy_name_from_raw_name( $raw_name );
 
-		// Resolve through the overridable lookup when the global attribute already exists, so
-		// extensions that customize it keep applying. It only creates an attribute when none exists,
-		// which is the side effect this method must never cause.
+		// Safe to use the overridable lookup once the attribute exists, and it keeps extensions that
+		// customize it working.
 		if ( wc_attribute_taxonomy_id_by_name( $attribute_name ) ) {
 			return sanitize_title( wc_attribute_taxonomy_name_by_id( $this->get_attribute_taxonomy_id( $raw_name ) ) );
 		}
@@ -648,9 +636,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		$raw_name   = isset( $attribute['name'] ) ? $attribute['name'] : '';
 		$custom_key = sanitize_title( $raw_name );
 
-		// A row marking an attribute as global when the parent stores it as a custom attribute is the
-		// common cause. Naming only the attribute would send the merchant looking for the wrong
-		// problem, since the parent does have it, just not as a global attribute.
+		// The parent does have the attribute here, just not as a global one, so naming it alone would
+		// send the merchant looking for the wrong problem.
 		if ( ! empty( $attribute['taxonomy'] ) && isset( $parent_attributes[ $custom_key ] ) && ! $parent_attributes[ $custom_key ]->is_taxonomy() ) {
 			return sprintf(
 				/* translators: %s: attribute name */
@@ -669,8 +656,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	/**
 	 * Get the value a variation row's attribute is stored as.
 	 *
-	 * Shares the resolution with whatever decides whether the row can be imported, for the same
-	 * reason as get_variation_attribute_key().
+	 * Shared with the import check for the same reason as get_variation_attribute_key().
 	 *
 	 * @since 11.1.0
 	 *

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -502,8 +502,6 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$attributes        = array();
 			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
-			$unmatched = null;
-
 			foreach ( $data['raw_attributes'] as $attribute ) {
 				if ( empty( $attribute['name'] ) ) {
 					continue;
@@ -511,11 +509,21 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
-				// An attribute the parent does not offer is left out, which is how a row carrying an
-				// extra attribute still imports on the ones that do match.
+				// Leaving the attribute out instead stores the variation as the CSV did not describe
+				// it: any parent attribute left unspecified becomes a catch-all matching every value,
+				// replacing whatever the variation already had, and the row still reports success.
+				// validate_new_variation_attributes() refuses the same row when the SKU is new, so
+				// refusing here too keeps the two paths from disagreeing.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
-					$unmatched = null === $unmatched ? $attribute : $unmatched;
-					continue;
+					throw new Exception(
+						esc_html(
+							sprintf(
+								/* translators: %s: reason the attribute matches nothing on the parent product */
+								__( 'Variation cannot be imported: %s', 'woocommerce' ),
+								$this->get_unmatched_variation_attribute_reason( $attribute, $parent_attributes )
+							)
+						)
+					);
 				}
 
 				$parent_attribute = $parent_attributes[ $attribute_name ];
@@ -523,21 +531,6 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				$raw_value        = isset( $attribute['value'] ) ? current( (array) $attribute['value'] ) : '';
 
 				$attributes[ $attribute_key ] = $this->get_variation_attribute_value( false === $raw_value ? '' : $raw_value, $parent_attribute );
-			}
-
-			// Storing nothing for a row that did name attributes turns the variation into a catch-all
-			// that matches every combination, and deletes the attributes it already had, all reported
-			// as a successful import. Fail the row instead so the reason reaches the merchant.
-			if ( null !== $unmatched && ! $attributes ) {
-				throw new Exception(
-					esc_html(
-						sprintf(
-							/* translators: %s: reason the attribute matches nothing on the parent product */
-							__( 'Variation cannot be imported: %s', 'woocommerce' ),
-							$this->get_unmatched_variation_attribute_reason( $unmatched, $parent_attributes )
-						)
-					)
-				);
 			}
 
 			$variation->set_attributes( $attributes );
@@ -601,16 +594,16 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return sanitize_title( $raw_name );
 		}
 
+		$attribute_name = $this->get_attribute_taxonomy_name_from_raw_name( $raw_name );
+
 		// Resolve through the overridable lookup when the global attribute already exists, so
 		// extensions that customize it keep applying. It only creates an attribute when none exists,
 		// which is the side effect this method must never cause.
-		if ( $this->get_existing_attribute_taxonomy_id( $raw_name ) ) {
+		if ( wc_attribute_taxonomy_id_by_name( $attribute_name ) ) {
 			return sanitize_title( wc_attribute_taxonomy_name_by_id( $this->get_attribute_taxonomy_id( $raw_name ) ) );
 		}
 
-		$slug = wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) );
-
-		return sanitize_title( wc_attribute_taxonomy_name( $slug ) );
+		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $attribute_name ) ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -499,7 +499,30 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		}
 
 		if ( isset( $data['raw_attributes'] ) ) {
-			$attributes        = array();
+			$attributes = array();
+
+			// Checked against the parent as it stands, before get_variation_parent_attributes()
+			// promotes any matching attribute to "used for variations" and saves the product.
+			// Refusing after that point would leave the parent permanently changed by a row that
+			// went on to import nothing.
+			//
+			// Leaving an unmatched attribute out instead of refusing stores the variation as the CSV
+			// did not describe it: any parent attribute left unspecified becomes a catch-all matching
+			// every value, replacing whatever the variation already had, and the row still reports
+			// success. validate_new_variation_attributes() refuses the same row when the SKU is new,
+			// so refusing here too keeps the two paths from disagreeing.
+			$declared_attributes = $parent->get_attributes();
+
+			foreach ( $data['raw_attributes'] as $attribute ) {
+				if ( empty( $attribute['name'] ) ) {
+					continue;
+				}
+
+				if ( ! isset( $declared_attributes[ $this->get_variation_attribute_key( $attribute ) ] ) ) {
+					throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $declared_attributes ) ) );
+				}
+			}
+
 			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
 			foreach ( $data['raw_attributes'] as $attribute ) {
@@ -509,21 +532,10 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
-				// Leaving the attribute out instead stores the variation as the CSV did not describe
-				// it: any parent attribute left unspecified becomes a catch-all matching every value,
-				// replacing whatever the variation already had, and the row still reports success.
-				// validate_new_variation_attributes() refuses the same row when the SKU is new, so
-				// refusing here too keeps the two paths from disagreeing.
+				// Every named attribute is on the parent by now, so this only fires if promoting it
+				// for variations did not stick.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
-					throw new Exception(
-						esc_html(
-							sprintf(
-								/* translators: %s: reason the attribute matches nothing on the parent product */
-								__( 'Variation cannot be imported: %s', 'woocommerce' ),
-								$this->get_unmatched_variation_attribute_reason( $attribute, $parent_attributes )
-							)
-						)
-					);
+					throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $parent_attributes ) ) );
 				}
 
 				$parent_attribute = $parent_attributes[ $attribute_name ];
@@ -604,6 +616,23 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		}
 
 		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $attribute_name ) ) );
+	}
+
+	/**
+	 * Get the message refusing a variation row over an attribute the parent product does not offer.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $attribute         Raw attribute data from a parsed row.
+	 * @param array $parent_attributes Parent product attributes, keyed as get_variation_attribute_key() resolves them.
+	 * @return string
+	 */
+	private function get_unmatched_variation_attribute_message( $attribute, $parent_attributes ) {
+		return sprintf(
+			/* translators: %s: reason the attribute matches nothing on the parent product */
+			__( 'Variation cannot be imported: %s', 'woocommerce' ),
+			$this->get_unmatched_variation_attribute_reason( $attribute, $parent_attributes )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -628,7 +628,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		// row further down the file, so it declares no attributes yet and every one of them would
 		// otherwise be reported as missing from a product that does in fact have them.
 		if ( 'importing' === $parent_product->get_status() ) {
-			throw new Exception( esc_html__( 'Variation cannot be imported: the parent product has not been imported yet. List the parent product before its variations.', 'woocommerce' ) );
+			throw new Exception( esc_html__( 'Variation cannot be imported: The parent product has not been imported yet. List the parent product before its variations.', 'woocommerce' ) );
 		}
 
 		$declared_attributes = $parent_product->get_attributes();
@@ -676,7 +676,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		if ( empty( $attribute['taxonomy'] ) ) {
 			$global_key = $this->get_variation_attribute_key( array_merge( $attribute, array( 'taxonomy' => true ) ) );
 
-			if ( isset( $parent_attributes[ $global_key ] ) ) {
+			if ( isset( $parent_attributes[ $global_key ] ) && $parent_attributes[ $global_key ]->is_taxonomy() ) {
 				return sprintf(
 					/* translators: %s: attribute name */
 					__( 'The parent product has a global "%s" attribute, but the row does not mark it as global.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -483,8 +483,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @param WC_Product $variation Product instance.
 	 * @param array      $data    Item data.
-	 * @return WC_Product|WP_Error
-	 * @throws Exception If data cannot be set.
+	 * @return void
+	 * @throws Exception If data cannot be set. Refusals throw rather than return a WP_Error, which process_item() discards.
 	 */
 	protected function set_variation_data( &$variation, $data ) {
 		$parent = false;
@@ -500,29 +500,33 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		// Stop if parent does not exists.
 		if ( ! $parent ) {
-			return new WP_Error( 'woocommerce_product_importer_missing_variation_parent_id', __( 'Variation cannot be imported: Missing parent ID or parent does not exist yet.', 'woocommerce' ), array( 'status' => 401 ) );
+			throw new Exception( esc_html__( 'Variation cannot be imported: Missing parent ID or parent does not exist yet.', 'woocommerce' ), 401 );
 		}
 
 		// Stop if parent is a product variation.
 		if ( $parent->is_type( ProductType::VARIATION ) ) {
-			return new WP_Error( 'woocommerce_product_importer_parent_set_as_variation', __( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), array( 'status' => 401 ) );
+			throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation.', 'woocommerce' ), 401 );
 		}
 
 		if ( isset( $data['raw_attributes'] ) ) {
 			$attributes = array();
 
+			// Resolved once and passed down: every consumer below needs the same keys, and resolving
+			// one costs a scan of every global attribute on the site.
+			$attribute_keys = $this->get_variation_attribute_keys( $data );
+
 			// Before get_variation_parent_attributes(), which saves the parent: a row that imports
 			// nothing must not change the product.
-			$this->assert_variation_attributes_offered( $data, $parent );
+			$this->assert_variation_attributes_offered( $data, $parent, $attribute_keys );
 
-			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
+			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent, $attribute_keys );
 
-			foreach ( $data['raw_attributes'] as $attribute ) {
+			foreach ( $data['raw_attributes'] as $index => $attribute ) {
 				if ( empty( $attribute['name'] ) ) {
 					continue;
 				}
 
-				$attribute_name = $this->get_variation_attribute_key( $attribute );
+				$attribute_name = $attribute_keys[ $index ];
 
 				// Every named attribute is on the parent by now; this only fires if promotion failed.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
@@ -543,16 +547,17 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	/**
 	 * Get variation parent attributes and set "is_variation".
 	 *
-	 * @param  array      $attributes Attributes list.
-	 * @param  WC_Product $parent     Parent product data.
+	 * @param  array      $attributes     Attributes list.
+	 * @param  WC_Product $parent_product Parent product data.
+	 * @param  array      $attribute_keys Optional. Keys already resolved by get_variation_attribute_keys(), to save resolving them again.
 	 * @return array
 	 */
-	protected function get_variation_parent_attributes( $attributes, $parent ) {
-		$parent_attributes = $parent->get_attributes();
+	protected function get_variation_parent_attributes( $attributes, $parent_product, $attribute_keys = array() ) {
+		$parent_attributes = $parent_product->get_attributes();
 		$require_save      = false;
 
-		foreach ( $attributes as $attribute ) {
-			$attribute_name = $this->get_variation_attribute_key( $attribute );
+		foreach ( $attributes as $index => $attribute ) {
+			$attribute_name = $attribute_keys[ $index ] ?? $this->get_variation_attribute_key( $attribute );
 
 			// Check if attribute handle variations.
 			if ( isset( $parent_attributes[ $attribute_name ] ) && ! $parent_attributes[ $attribute_name ]->get_variation() ) {
@@ -566,8 +571,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		// Save variation attributes.
 		if ( $require_save ) {
-			$parent->set_attributes( array_values( $parent_attributes ) );
-			$parent->save();
+			$parent_product->set_attributes( array_values( $parent_attributes ) );
+			$parent_product->save();
 		}
 
 		return $parent_attributes;
@@ -616,10 +621,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @param array      $data           Item data.
 	 * @param WC_Product $parent_product Parent product the variation belongs to.
+	 * @param array      $attribute_keys Optional. Keys already resolved by get_variation_attribute_keys(), to save resolving them again.
 	 * @return void
 	 * @throws Exception If the parent does not offer one of the row's attributes.
 	 */
-	protected function assert_variation_attributes_offered( $data, $parent_product ) {
+	protected function assert_variation_attributes_offered( $data, $parent_product, $attribute_keys = array() ) {
 		if ( empty( $data['raw_attributes'] ) ) {
 			return;
 		}
@@ -633,15 +639,41 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		$declared_attributes = $parent_product->get_attributes();
 
-		foreach ( $data['raw_attributes'] as $attribute ) {
+		foreach ( $data['raw_attributes'] as $index => $attribute ) {
 			if ( empty( $attribute['name'] ) ) {
 				continue;
 			}
 
-			if ( ! isset( $declared_attributes[ $this->get_variation_attribute_key( $attribute ) ] ) ) {
+			if ( ! isset( $declared_attributes[ $attribute_keys[ $index ] ?? $this->get_variation_attribute_key( $attribute ) ] ) ) {
 				throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $declared_attributes ) ) );
 			}
 		}
+	}
+
+	/**
+	 * Resolve every named attribute of a variation row to its parent attribute key.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $data Item data.
+	 * @return array Keys indexed as the row's raw attributes are, skipping entries that name nothing.
+	 */
+	protected function get_variation_attribute_keys( $data ) {
+		$keys = array();
+
+		if ( empty( $data['raw_attributes'] ) ) {
+			return $keys;
+		}
+
+		foreach ( $data['raw_attributes'] as $index => $attribute ) {
+			if ( empty( $attribute['name'] ) ) {
+				continue;
+			}
+
+			$keys[ $index ] = $this->get_variation_attribute_key( $attribute );
+		}
+
+		return $keys;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -595,8 +595,9 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return sanitize_title( $raw_name );
 		}
 
-		// The non-creating half of get_attribute_taxonomy_id(), so a subclass resolving names its own
-		// way is still consulted without a lookup being able to create the attribute.
+		// get_attribute_taxonomy_id() is not used: it creates the global attribute when the name does
+		// not resolve, and this runs while deciding whether to refuse a row. A subclass that resolves
+		// names its own way has to override this non-creating lookup instead.
 		$attribute_id = $this->get_existing_attribute_taxonomy_id( $raw_name );
 
 		if ( $attribute_id ) {

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -252,6 +252,16 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				}
 			}
 
+			// Ahead of get_product_object(), which converts an import placeholder into a variation
+			// post and strips its terms. A row refused after that leaves the placeholder behind.
+			if ( ProductType::VARIATION === ( $data['type'] ?? '' ) && ! empty( $data['parent_id'] ) ) {
+				$variation_parent = wc_get_product( $data['parent_id'] );
+
+				if ( $variation_parent && ! $variation_parent->is_type( ProductType::VARIATION ) ) {
+					$this->assert_variation_attributes_offered( $data, $variation_parent );
+				}
+			}
+
 			$object   = $this->get_product_object( $data );
 			$updating = false;
 
@@ -501,20 +511,9 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		if ( isset( $data['raw_attributes'] ) ) {
 			$attributes = array();
 
-			// Refused before get_variation_parent_attributes(), which saves the parent: a row that
-			// imports nothing must not change the product. Skipping the attribute instead would blank
-			// it into a catch-all matching every value.
-			$declared_attributes = $parent->get_attributes();
-
-			foreach ( $data['raw_attributes'] as $attribute ) {
-				if ( empty( $attribute['name'] ) ) {
-					continue;
-				}
-
-				if ( ! isset( $declared_attributes[ $this->get_variation_attribute_key( $attribute ) ] ) ) {
-					throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $declared_attributes ) ) );
-				}
-			}
+			// Before get_variation_parent_attributes(), which saves the parent: a row that imports
+			// nothing must not change the product.
+			$this->assert_variation_attributes_offered( $data, $parent );
 
 			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
@@ -605,6 +604,37 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		}
 
 		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) ) ) );
+	}
+
+	/**
+	 * Refuse a variation row naming an attribute the parent product does not offer.
+	 *
+	 * Skipping the attribute instead would blank it into a catch-all matching every value, replacing
+	 * whatever the variation already had, with the row still reported as imported.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array      $data           Item data.
+	 * @param WC_Product $parent_product Parent product the variation belongs to.
+	 * @return void
+	 * @throws Exception If the parent does not offer one of the row's attributes.
+	 */
+	protected function assert_variation_attributes_offered( $data, $parent_product ) {
+		if ( empty( $data['raw_attributes'] ) ) {
+			return;
+		}
+
+		$declared_attributes = $parent_product->get_attributes();
+
+		foreach ( $data['raw_attributes'] as $attribute ) {
+			if ( empty( $attribute['name'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $declared_attributes[ $this->get_variation_attribute_key( $attribute ) ] ) ) {
+				throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $declared_attributes ) ) );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -92,6 +92,13 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	protected $start_time = 0;
 
 	/**
+	 * Global attribute keys already resolved by get_variation_attribute_key(), keyed by raw name.
+	 *
+	 * @var array
+	 */
+	private $variation_attribute_keys = array();
+
+	/**
 	 * Get file raw headers.
 	 *
 	 * @return array
@@ -505,28 +512,24 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		// Stop if parent is a product variation.
 		if ( $parent->is_type( ProductType::VARIATION ) ) {
-			throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation.', 'woocommerce' ), 401 );
+			throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), 401 );
 		}
 
 		if ( isset( $data['raw_attributes'] ) ) {
 			$attributes = array();
 
-			// Resolved once and passed down: every consumer below needs the same keys, and resolving
-			// one costs a scan of every global attribute on the site.
-			$attribute_keys = $this->get_variation_attribute_keys( $data );
-
 			// Before get_variation_parent_attributes(), which saves the parent: a row that imports
 			// nothing must not change the product.
-			$this->assert_variation_attributes_offered( $data, $parent, $attribute_keys );
+			$this->assert_variation_attributes_offered( $data, $parent );
 
-			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent, $attribute_keys );
+			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
-			foreach ( $data['raw_attributes'] as $index => $attribute ) {
+			foreach ( $data['raw_attributes'] as $attribute ) {
 				if ( empty( $attribute['name'] ) ) {
 					continue;
 				}
 
-				$attribute_name = $attribute_keys[ $index ];
+				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
 				// Every named attribute is on the parent by now; this only fires if promotion failed.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
@@ -547,17 +550,16 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	/**
 	 * Get variation parent attributes and set "is_variation".
 	 *
-	 * @param  array      $attributes     Attributes list.
-	 * @param  WC_Product $parent_product Parent product data.
-	 * @param  array      $attribute_keys Optional. Keys already resolved by get_variation_attribute_keys(), to save resolving them again.
+	 * @param  array      $attributes Attributes list.
+	 * @param  WC_Product $parent     Parent product data.
 	 * @return array
 	 */
-	protected function get_variation_parent_attributes( $attributes, $parent_product, $attribute_keys = array() ) {
-		$parent_attributes = $parent_product->get_attributes();
+	protected function get_variation_parent_attributes( $attributes, $parent ) {
+		$parent_attributes = $parent->get_attributes();
 		$require_save      = false;
 
-		foreach ( $attributes as $index => $attribute ) {
-			$attribute_name = $attribute_keys[ $index ] ?? $this->get_variation_attribute_key( $attribute );
+		foreach ( $attributes as $attribute ) {
+			$attribute_name = $this->get_variation_attribute_key( $attribute );
 
 			// Check if attribute handle variations.
 			if ( isset( $parent_attributes[ $attribute_name ] ) && ! $parent_attributes[ $attribute_name ]->get_variation() ) {
@@ -571,8 +573,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		// Save variation attributes.
 		if ( $require_save ) {
-			$parent_product->set_attributes( array_values( $parent_attributes ) );
-			$parent_product->save();
+			$parent->set_attributes( array_values( $parent_attributes ) );
+			$parent->save();
 		}
 
 		return $parent_attributes;
@@ -599,16 +601,25 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return sanitize_title( $raw_name );
 		}
 
+		// Resolving scans every global attribute on the site, and each row asks for the same handful
+		// of names. A global attribute created part way through an import is created with the slug
+		// this derives anyway, so a cached answer cannot go stale.
+		if ( isset( $this->variation_attribute_keys[ $raw_name ] ) ) {
+			return $this->variation_attribute_keys[ $raw_name ];
+		}
+
 		// get_attribute_taxonomy_id() is not used: it creates the global attribute when the name does
 		// not resolve, and this runs while deciding whether to refuse a row. A subclass that resolves
 		// names its own way has to override this non-creating lookup instead.
 		$attribute_id = $this->get_existing_attribute_taxonomy_id( $raw_name );
 
-		if ( $attribute_id ) {
-			return sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
-		}
+		$key = $attribute_id
+			? sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) )
+			: sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) ) ) );
 
-		return sanitize_title( wc_attribute_taxonomy_name( wc_attribute_taxonomy_slug( $this->get_attribute_taxonomy_name_from_raw_name( $raw_name ) ) ) );
+		$this->variation_attribute_keys[ $raw_name ] = $key;
+
+		return $key;
 	}
 
 	/**
@@ -621,11 +632,10 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @param array      $data           Item data.
 	 * @param WC_Product $parent_product Parent product the variation belongs to.
-	 * @param array      $attribute_keys Optional. Keys already resolved by get_variation_attribute_keys(), to save resolving them again.
 	 * @return void
 	 * @throws Exception If the parent does not offer one of the row's attributes.
 	 */
-	protected function assert_variation_attributes_offered( $data, $parent_product, $attribute_keys = array() ) {
+	protected function assert_variation_attributes_offered( $data, $parent_product ) {
 		if ( empty( $data['raw_attributes'] ) ) {
 			return;
 		}
@@ -639,42 +649,17 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		$declared_attributes = $parent_product->get_attributes();
 
-		foreach ( $data['raw_attributes'] as $index => $attribute ) {
+		foreach ( $data['raw_attributes'] as $attribute ) {
 			if ( empty( $attribute['name'] ) ) {
 				continue;
 			}
 
-			if ( ! isset( $declared_attributes[ $attribute_keys[ $index ] ?? $this->get_variation_attribute_key( $attribute ) ] ) ) {
+			if ( ! isset( $declared_attributes[ $this->get_variation_attribute_key( $attribute ) ] ) ) {
 				throw new Exception( esc_html( $this->get_unmatched_variation_attribute_message( $attribute, $declared_attributes ) ) );
 			}
 		}
 	}
 
-	/**
-	 * Resolve every named attribute of a variation row to its parent attribute key.
-	 *
-	 * @since 11.1.0
-	 *
-	 * @param array $data Item data.
-	 * @return array Keys indexed as the row's raw attributes are, skipping entries that name nothing.
-	 */
-	protected function get_variation_attribute_keys( $data ) {
-		$keys = array();
-
-		if ( empty( $data['raw_attributes'] ) ) {
-			return $keys;
-		}
-
-		foreach ( $data['raw_attributes'] as $index => $attribute ) {
-			if ( empty( $attribute['name'] ) ) {
-				continue;
-			}
-
-			$keys[ $index ] = $this->get_variation_attribute_key( $attribute );
-		}
-
-		return $keys;
-	}
 
 	/**
 	 * Get the message refusing a variation row over an attribute the parent product does not offer.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -502,6 +502,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$attributes        = array();
 			$parent_attributes = $this->get_variation_parent_attributes( $data['raw_attributes'], $parent );
 
+			$unmatched = null;
+
 			foreach ( $data['raw_attributes'] as $attribute ) {
 				if ( empty( $attribute['name'] ) ) {
 					continue;
@@ -509,19 +511,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 				$attribute_name = $this->get_variation_attribute_key( $attribute );
 
-				// Skipping the attribute instead would store the variation with whatever did match,
-				// wiping every attribute it already had and leaving a catch-all "any" variation that
-				// matches every combination, all reported as a successful import.
+				// An attribute the parent does not offer is left out, which is how a row carrying an
+				// extra attribute still imports on the ones that do match.
 				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
-					throw new Exception(
-						esc_html(
-							sprintf(
-								/* translators: %s: reason the attribute matches nothing on the parent product */
-								__( 'Variation cannot be imported: %s', 'woocommerce' ),
-								$this->get_unmatched_variation_attribute_reason( $attribute, $parent_attributes )
-							)
-						)
-					);
+					$unmatched = null === $unmatched ? $attribute : $unmatched;
+					continue;
 				}
 
 				$parent_attribute = $parent_attributes[ $attribute_name ];
@@ -529,6 +523,21 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				$raw_value        = isset( $attribute['value'] ) ? current( (array) $attribute['value'] ) : '';
 
 				$attributes[ $attribute_key ] = $this->get_variation_attribute_value( false === $raw_value ? '' : $raw_value, $parent_attribute );
+			}
+
+			// Storing nothing for a row that did name attributes turns the variation into a catch-all
+			// that matches every combination, and deletes the attributes it already had, all reported
+			// as a successful import. Fail the row instead so the reason reaches the merchant.
+			if ( null !== $unmatched && ! $attributes ) {
+				throw new Exception(
+					esc_html(
+						sprintf(
+							/* translators: %s: reason the attribute matches nothing on the parent product */
+							__( 'Variation cannot be imported: %s', 'woocommerce' ),
+							$this->get_unmatched_variation_attribute_reason( $unmatched, $parent_attributes )
+						)
+					)
+				);
 			}
 
 			$variation->set_attributes( $attributes );

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -257,7 +257,14 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			if ( ProductType::VARIATION === ( $data['type'] ?? '' ) && ! empty( $data['parent_id'] ) ) {
 				$variation_parent = wc_get_product( $data['parent_id'] );
 
-				if ( $variation_parent && ! $variation_parent->is_type( ProductType::VARIATION ) ) {
+				// Refused here because set_props() below applies parent_id before set_variation_data()
+				// is reached, leaving the variation attached to nothing and the row reported as
+				// imported. A variation can never parent another variation, so no valid row is lost.
+				if ( $variation_parent && $variation_parent->is_type( ProductType::VARIATION ) ) {
+					throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), 401 );
+				}
+
+				if ( $variation_parent ) {
 					$this->assert_variation_attributes_offered( $data, $variation_parent );
 				}
 			}

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -257,7 +257,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			if ( ProductType::VARIATION === ( $data['type'] ?? '' ) && ! empty( $data['parent_id'] ) ) {
 				$variation_parent = wc_get_product( $data['parent_id'] );
 
-				if ( $variation_parent && ! $variation_parent->is_type( ProductType::VARIATION ) ) {
+				if ( $variation_parent && $variation_parent->is_type( ProductType::VARIATION ) ) {
+					throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), 401 );
+				}
+
+				if ( $variation_parent ) {
 					$this->assert_variation_attributes_offered( $data, $variation_parent );
 				}
 			}
@@ -498,6 +502,12 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			}
 		}
 
+		// A partial update need not repeat the Parent column, so fall back to the parent the variation
+		// is already attached to rather than refusing a row that names no new one.
+		if ( ! $parent && $variation->get_parent_id() ) {
+			$parent = wc_get_product( $variation->get_parent_id() );
+		}
+
 		// Stop if parent does not exists.
 		if ( ! $parent ) {
 			throw new Exception( esc_html__( 'Variation cannot be imported: Missing parent ID or parent does not exist yet.', 'woocommerce' ), 401 );
@@ -643,7 +653,6 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			}
 		}
 	}
-
 
 	/**
 	 * Get the message refusing a variation row over an attribute the parent product does not offer.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -624,6 +624,13 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return;
 		}
 
+		// A parent still marked 'importing' is the placeholder parse_relative_field() created for a
+		// row further down the file, so it declares no attributes yet and every one of them would
+		// otherwise be reported as missing from a product that does in fact have them.
+		if ( 'importing' === $parent_product->get_status() ) {
+			throw new Exception( esc_html__( 'Variation cannot be imported: the parent product has not been imported yet. List the parent product before its variations.', 'woocommerce' ) );
+		}
+
 		$declared_attributes = $parent_product->get_attributes();
 
 		foreach ( $data['raw_attributes'] as $attribute ) {
@@ -662,17 +669,30 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @return string Sentence naming the mismatch.
 	 */
 	protected function get_unmatched_variation_attribute_reason( $attribute, $parent_attributes ) {
-		$raw_name   = isset( $attribute['name'] ) ? $attribute['name'] : '';
-		$custom_key = sanitize_title( $raw_name );
+		$raw_name = isset( $attribute['name'] ) ? $attribute['name'] : '';
 
-		// The parent does have the attribute here, just not as a global one, so naming it alone would
-		// send the merchant looking for the wrong problem.
-		if ( ! empty( $attribute['taxonomy'] ) && isset( $parent_attributes[ $custom_key ] ) && ! $parent_attributes[ $custom_key ]->is_taxonomy() ) {
-			return sprintf(
-				/* translators: %s: attribute name */
-				__( 'The parent product has a custom "%s" attribute, but the row marks it as a global attribute.', 'woocommerce' ),
-				$raw_name
-			);
+		// The parent does have the attribute in both branches below, just as the other kind, so
+		// naming it alone would send the merchant looking for the wrong problem.
+		if ( empty( $attribute['taxonomy'] ) ) {
+			$global_key = $this->get_variation_attribute_key( array_merge( $attribute, array( 'taxonomy' => true ) ) );
+
+			if ( isset( $parent_attributes[ $global_key ] ) ) {
+				return sprintf(
+					/* translators: %s: attribute name */
+					__( 'The parent product has a global "%s" attribute, but the row does not mark it as global.', 'woocommerce' ),
+					$raw_name
+				);
+			}
+		} else {
+			$custom_key = sanitize_title( $raw_name );
+
+			if ( isset( $parent_attributes[ $custom_key ] ) && ! $parent_attributes[ $custom_key ]->is_taxonomy() ) {
+				return sprintf(
+					/* translators: %s: attribute name */
+					__( 'The parent product has a custom "%s" attribute, but the row marks it as a global attribute.', 'woocommerce' ),
+					$raw_name
+				);
+			}
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -257,11 +257,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			if ( ProductType::VARIATION === ( $data['type'] ?? '' ) && ! empty( $data['parent_id'] ) ) {
 				$variation_parent = wc_get_product( $data['parent_id'] );
 
-				if ( $variation_parent && $variation_parent->is_type( ProductType::VARIATION ) ) {
-					throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), 401 );
-				}
-
-				if ( $variation_parent ) {
+				if ( $variation_parent && ! $variation_parent->is_type( ProductType::VARIATION ) ) {
 					$this->assert_variation_attributes_offered( $data, $variation_parent );
 				}
 			}
@@ -487,8 +483,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @param WC_Product $variation Product instance.
 	 * @param array      $data    Item data.
-	 * @return void
-	 * @throws Exception If data cannot be set. Refusals throw rather than return a WP_Error, which process_item() discards.
+	 * @return WC_Product|WP_Error
+	 * @throws Exception If data cannot be set.
 	 */
 	protected function set_variation_data( &$variation, $data ) {
 		$parent = false;
@@ -502,20 +498,14 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			}
 		}
 
-		// A partial update need not repeat the Parent column, so fall back to the parent the variation
-		// is already attached to rather than refusing a row that names no new one.
-		if ( ! $parent && $variation->get_parent_id() ) {
-			$parent = wc_get_product( $variation->get_parent_id() );
-		}
-
 		// Stop if parent does not exists.
 		if ( ! $parent ) {
-			throw new Exception( esc_html__( 'Variation cannot be imported: Missing parent ID or parent does not exist yet.', 'woocommerce' ), 401 );
+			return new WP_Error( 'woocommerce_product_importer_missing_variation_parent_id', __( 'Variation cannot be imported: Missing parent ID or parent does not exist yet.', 'woocommerce' ), array( 'status' => 401 ) );
 		}
 
 		// Stop if parent is a product variation.
 		if ( $parent->is_type( ProductType::VARIATION ) ) {
-			throw new Exception( esc_html__( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), 401 );
+			return new WP_Error( 'woocommerce_product_importer_parent_set_as_variation', __( 'Variation cannot be imported: Parent product cannot be a product variation', 'woocommerce' ), array( 'status' => 401 ) );
 		}
 
 		if ( isset( $data['raw_attributes'] ) ) {

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -1208,6 +1208,16 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 		$parent = wc_get_product( $parsed_data['parent_id'] );
 
+		// Ahead of the variable check: a parent with the 'importing' status is the simple placeholder
+		// standing in for a row further down the file, so reporting it as not variable would point at
+		// the product rather than at the row order, which is what actually needs fixing.
+		if ( $parent && 'importing' === $parent->get_status() ) {
+			return new WP_Error(
+				'woocommerce_product_importer_variation_parent_not_imported',
+				esc_html__( 'A new variation cannot be created because the parent product has not been imported yet. List the parent product before its variations.', 'woocommerce' )
+			);
+		}
+
 		if ( ! $parent || ! $parent->is_type( ProductType::VARIABLE ) ) {
 			return new WP_Error(
 				'woocommerce_product_importer_variation_parent_not_variable',
@@ -1215,8 +1225,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			);
 		}
 
-		// A parent with the 'importing' status is a placeholder, meaning the parent does not exist either.
-		if ( in_array( $parent->get_status(), array( 'importing', ProductStatus::TRASH ), true ) ) {
+		if ( ProductStatus::TRASH === $parent->get_status() ) {
 			return new WP_Error(
 				'woocommerce_product_importer_variation_parent_missing',
 				esc_html__( 'A new variation cannot be created for a parent product that does not exist.', 'woocommerce' )

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -1260,9 +1260,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				return new WP_Error(
 					'woocommerce_product_importer_variation_unknown_attribute',
 					sprintf(
-						/* translators: %s: attribute name */
-						esc_html__( 'A new variation cannot be created because the parent product has no "%s" attribute.', 'woocommerce' ),
-						esc_html( $attribute['name'] )
+						/* translators: %s: reason the attribute matches nothing on the parent product */
+						esc_html__( 'A new variation cannot be created. %s', 'woocommerce' ),
+						esc_html( $this->get_unmatched_variation_attribute_reason( $attribute, $parent_attributes ) )
 					)
 				);
 			}

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -1252,12 +1252,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				continue;
 			}
 
-			// Resolve the row's attribute the same way set_variation_data() does, so a row that would
-			// have been stored correctly is never refused here. get_attribute_taxonomy_id() is deliberately
-			// not used: it creates the global attribute when it is missing, which must not happen for a
-			// row that is about to be refused.
-			$attribute_id   = empty( $attribute['taxonomy'] ) ? 0 : $this->get_existing_attribute_taxonomy_id( $attribute['name'] );
-			$attribute_name = $attribute_id ? sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) ) : sanitize_title( $attribute['name'] );
+			$attribute_name = $this->get_variation_attribute_key( $attribute );
 
 			// An attribute the parent does not have is dropped on save. An attribute the parent has but
 			// does not use for variations is allowed through: get_variation_parent_attributes() promotes it.
@@ -1280,17 +1275,14 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				continue;
 			}
 
-			if ( $parent_attribute->is_taxonomy() ) {
-				$taxonomy = $parent_attribute->get_name();
-				$term     = get_term_by( 'name', $raw_value, $taxonomy );
-				$value    = ( $term && ! is_wp_error( $term ) ) ? $term->slug : sanitize_title( $raw_value );
+			$value = $this->get_variation_attribute_value( $raw_value, $parent_attribute );
 
+			if ( $parent_attribute->is_taxonomy() ) {
 				// The terms assigned to the parent are the exact set the storefront selector renders.
 				// WC_Product_Attribute::get_terms() is avoided here because it inserts any term that does
 				// not exist yet, which must not happen while deciding whether to refuse a row.
-				$options = wc_get_product_terms( $parent_product->get_id(), $taxonomy, array( 'fields' => 'slugs' ) );
+				$options = wc_get_product_terms( $parent_product->get_id(), $parent_attribute->get_name(), array( 'fields' => 'slugs' ) );
 			} else {
-				$value   = $raw_value;
 				$options = $parent_attribute->get_options();
 			}
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -20101,6 +20101,12 @@ parameters:
 			path: includes/import/abstract-wc-product-importer.php
 
 		-
+			message: '#^Method WC_Product_Importer\:\:set_variation_data\(\) should return WC_Product\|WP_Error but return statement is missing\.$#'
+			identifier: return.missing
+			count: 2
+			path: includes/import/abstract-wc-product-importer.php
+
+		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, list\<string\>\|false given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -20101,12 +20101,6 @@ parameters:
 			path: includes/import/abstract-wc-product-importer.php
 
 		-
-			message: '#^Method WC_Product_Importer\:\:set_variation_data\(\) should return WC_Product\|WP_Error but return statement is missing\.$#'
-			identifier: return.missing
-			count: 2
-			path: includes/import/abstract-wc-product-importer.php
-
-		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, list\<string\>\|false given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -1043,6 +1043,64 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a partial update row omitting the Parent column updates the variation instead of failing.
+	 */
+	public function test_import_of_existing_variation_without_a_parent_column_still_updates() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Partial Tee' );
+		$product->set_sku( 'IMPORT-PARTIAL-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-PARTIAL-S' );
+		$variation->set_attributes( array( 'size' => 'S' ) );
+		$variation->set_regular_price( '10' );
+		$variation->save();
+
+		// The standard price refresh: SKU plus the columns being changed, no Parent column at all.
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-partial-update.csv';
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
+			$csv_file,
+			"Type,SKU,Regular price\nvariation,IMPORT-PARTIAL-S,25\n"
+		);
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_file,
+			array(
+				'parse'           => true,
+				'update_existing' => true,
+				'mapping'         => array(
+					'Type'          => 'type',
+					'SKU'           => 'sku',
+					'Regular price' => 'regular_price',
+				),
+			)
+		);
+
+		$data = $importer->import();
+
+		wp_delete_file( $csv_file );
+
+		$this->assertEmpty( $data['failed'], 'Expected the partial update to succeed, got ' . count( $data['failed'] ) . ' failures' );
+		$this->assertCount( 1, $data['updated'], 'Expected the variation to be updated' );
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( '25', $stored->get_regular_price(), 'Expected the price column to be applied' );
+		$this->assertSame( array( 'size' => 'S' ), $stored->get_attributes(), 'Expected the variation to keep its attributes' );
+		$this->assertSame( $product->get_id(), $stored->get_parent_id(), 'Expected the variation to keep its parent' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a variation row without a parent fails instead of being saved as a parentless variation.
 	 */
 	public function test_import_of_variation_without_a_parent_fails() {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -1043,6 +1043,53 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a variation row without a parent fails instead of being saved as a parentless variation.
+	 */
+	public function test_import_of_variation_without_a_parent_fails() {
+		// update_existing off, since can_create_variation() refuses a parentless row before it ever
+		// reaches set_variation_data().
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-variation-without-parent.csv';
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
+			$csv_file,
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-NOPARENT-V,Import No Parent V,,Size,S,0,12\n"
+		);
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_file,
+			array(
+				'parse'           => true,
+				'update_existing' => false,
+				'mapping'         => array(
+					'Type'                 => 'type',
+					'SKU'                  => 'sku',
+					'Name'                 => 'name',
+					'Parent'               => 'parent_id',
+					'Attribute 1 name'     => 'attributes:name1',
+					'Attribute 1 value(s)' => 'attributes:value1',
+					'Attribute 1 global'   => 'attributes:taxonomy1',
+					'Regular price'        => 'regular_price',
+				),
+			)
+		);
+
+		$data = $importer->import();
+
+		wp_delete_file( $csv_file );
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than save a variation with no parent' );
+		$this->assertSame(
+			'Variation cannot be imported: Missing parent ID or parent does not exist yet.',
+			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the missing parent to surface as the failure reason'
+		);
+
+		$orphan_id = wc_get_product_id_by_sku( 'IMPORT-NOPARENT-V' );
+		if ( $orphan_id ) {
+			wp_delete_post( $orphan_id, true );
+		}
+	}
+
+	/**
 	 * @testdox Test that a row naming a global parent attribute without marking it global says so.
 	 */
 	public function test_import_failure_names_the_missing_global_flag() {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -728,6 +728,76 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a variation row flagged as global is skipped when no such global attribute exists, even though the parent has a same-named custom attribute.
+	 */
+	public function test_import_skips_new_variations_flagged_global_when_only_a_custom_parent_attribute_matches() {
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'size-airr133' ), 'This test requires that no global "size-airr133" attribute exists yet' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'size-airr133' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Custom Tee' );
+		$product->set_sku( 'IMPORT-CUSTOM-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-CUSTOM-S,Import Custom Tee - S,IMPORT-CUSTOM-PARENT,size-airr133,S,1,12\n",
+			'import-global-flag-without-global-attribute.csv'
+		);
+
+		$this->assertEmpty( $data['imported_variations'], 'Expected the row to be refused rather than saved as a catch-all "any" variation' );
+		$this->assertCount( 1, $data['skipped'], 'Expected 1 skipped product, got ' . count( $data['skipped'] ) );
+		$this->assertSame(
+			'A new variation cannot be created because the parent product has no "size-airr133" attribute.',
+			html_entity_decode( $data['skipped'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the refusal to name the attribute the row asked for'
+		);
+		$this->assertSame( 0, wc_get_product_id_by_sku( 'IMPORT-CUSTOM-S' ), 'Expected no variation to be created' );
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'size-airr133' ), 'Expected no global attribute to be created site-wide while refusing the row' );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Test that importing a variation row flagged as global does not create the global attribute site-wide when the parent does not offer it.
+	 */
+	public function test_import_of_existing_variation_does_not_create_a_missing_global_attribute() {
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'colour-airr133' ), 'This test requires that no global "colour-airr133" attribute exists yet' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'colour-airr133' );
+		$attribute->set_options( array( 'Red', 'Blue' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Existing Tee' );
+		$product->set_sku( 'IMPORT-EXISTING-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-EXISTING-RED' );
+		$variation->set_attributes( array( 'colour-airr133' => 'Red' ) );
+		$variation->save();
+
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-EXISTING-RED,Import Existing Tee - Red,IMPORT-EXISTING-PARENT,colour-airr133,Red,1,12\n",
+			'import-existing-variation-global-flag.csv'
+		);
+
+		$this->assertEmpty( $data['failed'], 'Expected the existing variation row to be processed, got ' . count( $data['failed'] ) . ' failures' );
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'colour-airr133' ), 'Expected no global attribute to be created site-wide for a row the parent does not offer as a global attribute' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a variation row is still created when the parent has the attribute but does not yet use it for variations.
 	 */
 	public function test_import_creates_new_variations_when_the_parent_attribute_is_not_yet_used_for_variations() {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -718,7 +718,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->assertEmpty( $data['imported_variations'], 'Expected 0 imported variations, got ' . count( $data['imported_variations'] ) );
 		$this->assertCount( 1, $data['skipped'], 'Expected 1 skipped product, got ' . count( $data['skipped'] ) );
 		$this->assertSame(
-			'A new variation cannot be created because the parent product has no "Colour" attribute.',
+			'A new variation cannot be created. The parent product has no "Colour" attribute.',
 			html_entity_decode( $data['skipped'][0]->get_error_message(), ENT_QUOTES ),
 			'Expected the skip message to name the missing attribute'
 		);
@@ -752,9 +752,9 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->assertEmpty( $data['imported_variations'], 'Expected the row to be refused rather than saved as a catch-all "any" variation' );
 		$this->assertCount( 1, $data['skipped'], 'Expected 1 skipped product, got ' . count( $data['skipped'] ) );
 		$this->assertSame(
-			'A new variation cannot be created because the parent product has no "size-airr133" attribute.',
+			'A new variation cannot be created. The parent product has a custom "size-airr133" attribute, but the row marks it as a global attribute.',
 			html_entity_decode( $data['skipped'][0]->get_error_message(), ENT_QUOTES ),
-			'Expected the refusal to name the attribute the row asked for'
+			'Expected the refusal to point at the global flag, since the parent does have the attribute as a custom one'
 		);
 		$this->assertSame( 0, wc_get_product_id_by_sku( 'IMPORT-CUSTOM-S' ), 'Expected no variation to be created' );
 		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'size-airr133' ), 'Expected no global attribute to be created site-wide while refusing the row' );
@@ -763,9 +763,9 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Test that importing a variation row flagged as global does not create the global attribute site-wide when the parent does not offer it.
+	 * @testdox Test that a row whose attribute the parent does not offer fails instead of wiping the attributes of the variation it updates.
 	 */
-	public function test_import_of_existing_variation_does_not_create_a_missing_global_attribute() {
+	public function test_import_of_existing_variation_fails_instead_of_wiping_its_attributes() {
 		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'colour-airr133' ), 'This test requires that no global "colour-airr133" attribute exists yet' );
 
 		$attribute = new WC_Product_Attribute();
@@ -790,8 +790,55 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 			'import-existing-variation-global-flag.csv'
 		);
 
-		$this->assertEmpty( $data['failed'], 'Expected the existing variation row to be processed, got ' . count( $data['failed'] ) . ' failures' );
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than be reported as a successful update' );
+		$this->assertSame(
+			'Variation cannot be imported: The parent product has a custom "colour-airr133" attribute, but the row marks it as a global attribute.',
+			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the failure to point at the global flag'
+		);
+		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
 		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'colour-airr133' ), 'Expected no global attribute to be created site-wide for a row the parent does not offer as a global attribute' );
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( array( 'colour-airr133' => 'Red' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Test that a row whose global attribute name cannot be created still fails loudly instead of wiping the variation's attributes.
+	 */
+	public function test_import_of_existing_variation_fails_when_the_global_attribute_name_is_unusable() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'fabric-composition-and-care-notes' );
+		$attribute->set_options( array( 'Cotton', 'Wool' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Long Attr Tee' );
+		$product->set_sku( 'IMPORT-LONGATTR-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-LONGATTR-COTTON' );
+		$variation->set_attributes( array( 'fabric-composition-and-care-notes' => 'Cotton' ) );
+		$variation->save();
+
+		// The slug exceeds wc_get_attribute_slug_max_byte_length(), so wc_create_attribute() would
+		// reject it. That rejection used to be the only thing failing this row.
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-LONGATTR-COTTON,Import Long Attr Tee - Cotton,IMPORT-LONGATTR-PARENT,fabric-composition-and-care-notes,Cotton,1,12\n",
+			'import-existing-variation-unusable-global-name.csv'
+		);
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than be reported as a successful update' );
+		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( array( 'fabric-composition-and-care-notes' => 'Cotton' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );
 
 		WC_Helper_Product::delete_product( $variation->get_id() );
 		WC_Helper_Product::delete_product( $product->get_id() );

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -1043,6 +1043,57 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a row whose Parent names another variation is refused without detaching the variation.
+	 */
+	public function test_import_of_variation_whose_parent_is_a_variation_is_refused() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Bad Parent Tee' );
+		$product->set_sku( 'IMPORT-BADPARENT-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$sibling = new WC_Product_Variation();
+		$sibling->set_parent_id( $product->get_id() );
+		$sibling->set_sku( 'IMPORT-BADPARENT-M' );
+		$sibling->set_attributes( array( 'size' => 'M' ) );
+		$sibling->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-BADPARENT-S' );
+		$variation->set_attributes( array( 'size' => 'S' ) );
+		$variation->set_regular_price( '10' );
+		$variation->save();
+
+		// Parent names a variation. set_props() applies parent_id before set_variation_data() is
+		// reached, so the row has to be refused earlier or the variation is left attached to nothing.
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-BADPARENT-S,Import Bad Parent Tee,IMPORT-BADPARENT-M,Size,S,0,25\n",
+			'import-parent-is-a-variation.csv'
+		);
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail' );
+		$this->assertSame(
+			'Variation cannot be imported: Parent product cannot be a product variation',
+			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the failure to name the invalid parent'
+		);
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( $product->get_id(), $stored->get_parent_id(), 'Expected the variation to keep its real parent' );
+		$this->assertSame( array( 'size' => 'S' ), $stored->get_attributes(), 'Expected the variation to keep its attributes' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $sibling->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a partial update row omitting the Parent column updates the variation instead of failing.
 	 */
 	public function test_import_of_existing_variation_without_a_parent_column_still_updates() {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -1000,7 +1000,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 
 		$this->assertCount( 1, $data['failed'], 'Expected the variation row to fail' );
 		$this->assertSame(
-			'Variation cannot be imported: the parent product has not been imported yet. List the parent product before its variations.',
+			'Variation cannot be imported: The parent product has not been imported yet. List the parent product before its variations.',
 			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
 			'Expected the failure to name the row order, not a missing attribute the parent does have'
 		);
@@ -1012,6 +1012,33 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$placeholder_id = wc_get_product_id_by_sku( 'IMPORT-ORDER-V' );
 		if ( $placeholder_id ) {
 			wp_delete_post( $placeholder_id, true );
+		}
+	}
+
+	/**
+	 * @testdox Test that a new variation row whose parent row has not been reached yet names the row order.
+	 */
+	public function test_import_skips_new_variations_whose_parent_row_comes_later() {
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\n"
+			. "variation,IMPORT-LATER-V,Import Later V,IMPORT-LATER-PARENT,Size,S,0,12\n"
+			. "variable,IMPORT-LATER-PARENT,Import Later Parent,,Size,\"S, M\",0,\n",
+			'import-new-variation-before-parent.csv'
+		);
+
+		$this->assertEmpty( $data['imported_variations'], 'Expected the variation row to be refused' );
+		// Two skips: the variation row, then the parent row itself, which "update existing products"
+		// does not create because no product matches it yet.
+		$this->assertCount( 2, $data['skipped'], 'Expected 2 skipped products, got ' . count( $data['skipped'] ) );
+		$this->assertSame(
+			'A new variation cannot be created because the parent product has not been imported yet. List the parent product before its variations.',
+			html_entity_decode( $data['skipped'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the refusal to name the row order rather than a parent that does not exist'
+		);
+
+		$parent_id = wc_get_product_id_by_sku( 'IMPORT-LATER-PARENT' );
+		if ( $parent_id ) {
+			WC_Helper_Product::delete_product( $parent_id );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -963,6 +963,64 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a refused variation row does not convert its import placeholder into a variation post.
+	 */
+	public function test_import_failure_does_not_convert_the_import_placeholder() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Placeholder Guard Tee' );
+		$product->set_sku( 'IMPORT-PLACEHOLDER-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		// An ID that does not exist makes parse_id_field() create a placeholder product for the row.
+		// Refusing the row must leave that placeholder as it was, not converted to a variation.
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-placeholder-guard.csv';
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
+			$csv_file,
+			"ID,Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\n"
+			. "987654,variation,IMPORT-PLACEHOLDER-V,Import Placeholder V,IMPORT-PLACEHOLDER-PARENT,Colour,Red,0,12\n"
+		);
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_file,
+			array(
+				'parse'           => true,
+				'update_existing' => false,
+				'mapping'         => array(
+					'ID'                   => 'id',
+					'Type'                 => 'type',
+					'SKU'                  => 'sku',
+					'Name'                 => 'name',
+					'Parent'               => 'parent_id',
+					'Attribute 1 name'     => 'attributes:name1',
+					'Attribute 1 value(s)' => 'attributes:value1',
+					'Attribute 1 global'   => 'attributes:taxonomy1',
+					'Regular price'        => 'regular_price',
+				),
+			)
+		);
+
+		$data = $importer->import();
+
+		wp_delete_file( $csv_file );
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail' );
+
+		$placeholder_id = wc_get_product_id_by_sku( 'IMPORT-PLACEHOLDER-V' );
+		$this->assertNotSame( 'product_variation', get_post_type( $placeholder_id ), 'Expected the refused row to leave its import placeholder unconverted' );
+
+		if ( $placeholder_id ) {
+			wp_delete_post( $placeholder_id, true );
+		}
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a row whose global attribute name cannot be created fails without wiping the variation's attributes.
 	 */
 	public function test_import_of_existing_variation_fails_when_the_global_attribute_name_is_unusable() {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -1100,52 +1100,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
-	/**
-	 * @testdox Test that a variation row without a parent fails instead of being saved as a parentless variation.
-	 */
-	public function test_import_of_variation_without_a_parent_fails() {
-		// update_existing off, since can_create_variation() refuses a parentless row before it ever
-		// reaches set_variation_data().
-		$csv_file = trailingslashit( get_temp_dir() ) . 'import-variation-without-parent.csv';
-		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
-			$csv_file,
-			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-NOPARENT-V,Import No Parent V,,Size,S,0,12\n"
-		);
-
-		$importer = new WC_Product_CSV_Importer(
-			$csv_file,
-			array(
-				'parse'           => true,
-				'update_existing' => false,
-				'mapping'         => array(
-					'Type'                 => 'type',
-					'SKU'                  => 'sku',
-					'Name'                 => 'name',
-					'Parent'               => 'parent_id',
-					'Attribute 1 name'     => 'attributes:name1',
-					'Attribute 1 value(s)' => 'attributes:value1',
-					'Attribute 1 global'   => 'attributes:taxonomy1',
-					'Regular price'        => 'regular_price',
-				),
-			)
-		);
-
-		$data = $importer->import();
-
-		wp_delete_file( $csv_file );
-
-		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than save a variation with no parent' );
-		$this->assertSame(
-			'Variation cannot be imported: Missing parent ID or parent does not exist yet.',
-			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
-			'Expected the missing parent to surface as the failure reason'
-		);
-
-		$orphan_id = wc_get_product_id_by_sku( 'IMPORT-NOPARENT-V' );
-		if ( $orphan_id ) {
-			wp_delete_post( $orphan_id, true );
-		}
-	}
 
 	/**
 	 * @testdox Test that a row naming a global parent attribute without marking it global says so.

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -963,6 +963,104 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a variation row listed before its parent row says the parent has not been imported yet.
+	 */
+	public function test_import_of_variation_before_its_parent_row_names_the_missing_parent() {
+		// update_existing is off, which is what makes parse_relative_field() stand in an 'importing'
+		// placeholder for the parent row that has not been reached yet.
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-variation-before-parent.csv';
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
+			$csv_file,
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\n"
+			. "variation,IMPORT-ORDER-V,Import Order V,IMPORT-ORDER-PARENT,Size,S,0,12\n"
+			. "variable,IMPORT-ORDER-PARENT,Import Order Parent,,Size,\"S, M\",0,\n"
+		);
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_file,
+			array(
+				'parse'           => true,
+				'update_existing' => false,
+				'mapping'         => array(
+					'Type'                 => 'type',
+					'SKU'                  => 'sku',
+					'Name'                 => 'name',
+					'Parent'               => 'parent_id',
+					'Attribute 1 name'     => 'attributes:name1',
+					'Attribute 1 value(s)' => 'attributes:value1',
+					'Attribute 1 global'   => 'attributes:taxonomy1',
+					'Regular price'        => 'regular_price',
+				),
+			)
+		);
+
+		$data = $importer->import();
+
+		wp_delete_file( $csv_file );
+
+		$this->assertCount( 1, $data['failed'], 'Expected the variation row to fail' );
+		$this->assertSame(
+			'Variation cannot be imported: the parent product has not been imported yet. List the parent product before its variations.',
+			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the failure to name the row order, not a missing attribute the parent does have'
+		);
+
+		$parent_id = wc_get_product_id_by_sku( 'IMPORT-ORDER-PARENT' );
+		if ( $parent_id ) {
+			WC_Helper_Product::delete_product( $parent_id );
+		}
+		$placeholder_id = wc_get_product_id_by_sku( 'IMPORT-ORDER-V' );
+		if ( $placeholder_id ) {
+			wp_delete_post( $placeholder_id, true );
+		}
+	}
+
+	/**
+	 * @testdox Test that a row naming a global parent attribute without marking it global says so.
+	 */
+	public function test_import_failure_names_the_missing_global_flag() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'colour-airr134', array( 'Red', 'Blue' ) );
+		$taxonomy       = $attribute_data['attribute_taxonomy'];
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( $attribute_data['attribute_id'] );
+		$attribute->set_name( $taxonomy );
+		$attribute->set_options( $attribute_data['term_ids'] );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Global Flag Tee' );
+		$product->set_sku( 'IMPORT-GLOBALFLAG-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-GLOBALFLAG-RED' );
+		$variation->set_attributes( array( $taxonomy => 'red' ) );
+		$variation->save();
+
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-GLOBALFLAG-RED,Import Global Flag Tee,IMPORT-GLOBALFLAG-PARENT,colour-airr134,Red,0,12\n",
+			'import-missing-global-flag.csv'
+		);
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail' );
+		$this->assertSame(
+			'Variation cannot be imported: The parent product has a global "colour-airr134" attribute, but the row does not mark it as global.',
+			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the failure to name the global flag, since the parent does have the attribute'
+		);
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( array( $taxonomy => 'red' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+		WC_Helper_Product::delete_attribute( $attribute_data['attribute_id'] );
+	}
+
+	/**
 	 * @testdox Test that a refused variation row does not convert its import placeholder into a variation post.
 	 */
 	public function test_import_failure_does_not_convert_the_import_placeholder() {
@@ -1050,6 +1148,13 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 
 		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than be reported as a successful update' );
 		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
+		// Asserted in full because this row also fails on trunk, there because wc_create_attribute()
+		// rejects the slug length. Only the reason distinguishes the new refusal from that one.
+		$this->assertSame(
+			'Variation cannot be imported: The parent product has a custom "fabric-composition-and-care-notes" attribute, but the row marks it as a global attribute.',
+			html_entity_decode( $data['failed'][0]->get_error_message(), ENT_QUOTES ),
+			'Expected the refusal to name the global flag, not the slug length'
+		);
 
 		$stored = wc_get_product( $variation->get_id() );
 		$this->assertSame( array( 'fabric-composition-and-care-notes' => 'Cotton' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -39,7 +39,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox variations need to set the status back to published if parent product is a draft
 	 */
 	public function test_expand_data_with_draft_variable() {
-		$csv_file = dirname( __FILE__ ) . '/sample.csv';
+		$csv_file = __DIR__ . '/sample.csv';
 		$raw_data = array(
 			array(
 				'type'      => ProductType::VARIABLE,
@@ -101,7 +101,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox Test that the importer calculates the percent complete as 99 when it's >= 99.5% through the file.
 	 */
 	public function test_import_completion_issue_36618_lines_remaining() {
-		$csv_file = dirname( __FILE__ ) . '/sample2.csv';
+		$csv_file = __DIR__ . '/sample2.csv';
 		$args     = array(
 			'lines' => 200,
 		);
@@ -115,7 +115,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox Test that the importer calculates the percent complete as 100 when it's at the end of the file.
 	 */
 	public function test_import_completion_issue_36618_end_of_file() {
-		$csv_file = dirname( __FILE__ ) . '/sample2.csv';
+		$csv_file = __DIR__ . '/sample2.csv';
 		$args     = array(
 			'lines' => 201,
 		);
@@ -845,6 +845,67 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a row carrying an extra attribute the parent does not offer still imports on the attributes that do match.
+	 */
+	public function test_import_of_existing_variation_keeps_importing_when_only_some_attributes_match() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Partial Tee' );
+		$product->set_sku( 'IMPORT-PARTIAL-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-PARTIAL-S' );
+		$variation->set_attributes( array( 'size' => 'S' ) );
+		$variation->save();
+
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-partial-attribute-match.csv';
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
+			$csv_file,
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Attribute 2 name,Attribute 2 value(s),Attribute 2 global,Regular price\n"
+			. "variation,IMPORT-PARTIAL-S,Import Partial Tee - S,IMPORT-PARTIAL-PARENT,Size,S,0,Colour,Red,0,12\n"
+		);
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_file,
+			array(
+				'parse'           => true,
+				'update_existing' => true,
+				'mapping'         => array(
+					'Type'                 => 'type',
+					'SKU'                  => 'sku',
+					'Name'                 => 'name',
+					'Parent'               => 'parent_id',
+					'Attribute 1 name'     => 'attributes:name1',
+					'Attribute 1 value(s)' => 'attributes:value1',
+					'Attribute 1 global'   => 'attributes:taxonomy1',
+					'Attribute 2 name'     => 'attributes:name2',
+					'Attribute 2 value(s)' => 'attributes:value2',
+					'Attribute 2 global'   => 'attributes:taxonomy2',
+					'Regular price'        => 'regular_price',
+				),
+			)
+		);
+		$data     = $importer->import();
+
+		wp_delete_file( $csv_file );
+
+		$this->assertEmpty( $data['failed'], 'Expected the row to import on the attribute the parent does offer' );
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( array( 'size' => 'S' ), $stored->get_attributes(), 'Expected the matching attribute to be stored and the unknown one ignored' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a variation row is still created when the parent has the attribute but does not yet use it for variations.
 	 */
 	public function test_import_creates_new_variations_when_the_parent_attribute_is_not_yet_used_for_variations() {
@@ -969,14 +1030,16 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$color_attribute->set_name( $color_taxonomy );
 		$color_attribute->set_options( array( '红色', '绿色' ) );
 		$color_attribute->set_visible( true );
-		$color_attribute->set_variation( false ); // Initially false.
+		$color_attribute->set_variation( false );
+		// Initially false.
 
 		$size_attribute = new WC_Product_Attribute();
 		$size_attribute->set_id( $size_attr_id );
 		$size_attribute->set_name( $size_taxonomy );
 		$size_attribute->set_options( array( '大码', '小码' ) );
 		$size_attribute->set_visible( true );
-		$size_attribute->set_variation( false ); // Initially false.
+		$size_attribute->set_variation( false );
+		// Initially false.
 
 		$product->set_attributes( array( $color_attribute, $size_attribute ) );
 		$product->save();

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -39,7 +39,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox variations need to set the status back to published if parent product is a draft
 	 */
 	public function test_expand_data_with_draft_variable() {
-		$csv_file = __DIR__ . '/sample.csv';
+		$csv_file = dirname( __FILE__ ) . '/sample.csv';
 		$raw_data = array(
 			array(
 				'type'      => ProductType::VARIABLE,
@@ -101,7 +101,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox Test that the importer calculates the percent complete as 99 when it's >= 99.5% through the file.
 	 */
 	public function test_import_completion_issue_36618_lines_remaining() {
-		$csv_file = __DIR__ . '/sample2.csv';
+		$csv_file = dirname( __FILE__ ) . '/sample2.csv';
 		$args     = array(
 			'lines' => 200,
 		);
@@ -115,7 +115,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox Test that the importer calculates the percent complete as 100 when it's at the end of the file.
 	 */
 	public function test_import_completion_issue_36618_end_of_file() {
-		$csv_file = __DIR__ . '/sample2.csv';
+		$csv_file = dirname( __FILE__ ) . '/sample2.csv';
 		$args     = array(
 			'lines' => 201,
 		);
@@ -797,7 +797,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 			'Expected the failure to point at the global flag'
 		);
 		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
-		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'colour-airr133' ), 'Expected no global attribute to be created site-wide for a row the parent does not offer as a global attribute' );
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'colour-airr133' ), 'Expected no global attribute to be created site-wide' );
 
 		$stored = wc_get_product( $variation->get_id() );
 		$this->assertSame( array( 'colour-airr133' => 'Red' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );
@@ -807,69 +807,43 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Test that a row whose global attribute name cannot be created still fails loudly instead of wiping the variation's attributes.
+	 * @testdox Test that a row where only one of several attributes is unmatched fails instead of blanking that attribute into a catch-all.
 	 */
-	public function test_import_of_existing_variation_fails_when_the_global_attribute_name_is_unusable() {
-		$attribute = new WC_Product_Attribute();
-		$attribute->set_name( 'fabric-composition-and-care-notes' );
-		$attribute->set_options( array( 'Cotton', 'Wool' ) );
-		$attribute->set_variation( true );
+	public function test_import_of_existing_variation_fails_when_only_one_attribute_is_unmatched() {
+		$size = new WC_Product_Attribute();
+		$size->set_name( 'Size' );
+		$size->set_options( array( 'S', 'M' ) );
+		$size->set_variation( true );
+
+		$colour = new WC_Product_Attribute();
+		$colour->set_name( 'Colour' );
+		$colour->set_options( array( 'Red', 'Blue' ) );
+		$colour->set_variation( true );
 
 		$product = new WC_Product_Variable();
-		$product->set_name( 'Import Long Attr Tee' );
-		$product->set_sku( 'IMPORT-LONGATTR-PARENT' );
-		$product->set_attributes( array( $attribute ) );
+		$product->set_name( 'Import Two Attr Tee' );
+		$product->set_sku( 'IMPORT-TWOATTR-PARENT' );
+		$product->set_attributes( array( $size, $colour ) );
 		$product->save();
 
 		$variation = new WC_Product_Variation();
 		$variation->set_parent_id( $product->get_id() );
-		$variation->set_sku( 'IMPORT-LONGATTR-COTTON' );
-		$variation->set_attributes( array( 'fabric-composition-and-care-notes' => 'Cotton' ) );
-		$variation->save();
-
-		// The slug exceeds wc_get_attribute_slug_max_byte_length(), so wc_create_attribute() would
-		// reject it. That rejection used to be the only thing failing this row.
-		$data = $this->import_with_update_existing(
-			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-LONGATTR-COTTON,Import Long Attr Tee - Cotton,IMPORT-LONGATTR-PARENT,fabric-composition-and-care-notes,Cotton,1,12\n",
-			'import-existing-variation-unusable-global-name.csv'
+		$variation->set_sku( 'IMPORT-TWOATTR-S-RED' );
+		$variation->set_attributes(
+			array(
+				'size'   => 'S',
+				'colour' => 'Red',
+			)
 		);
-
-		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than be reported as a successful update' );
-		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
-
-		$stored = wc_get_product( $variation->get_id() );
-		$this->assertSame( array( 'fabric-composition-and-care-notes' => 'Cotton' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );
-
-		WC_Helper_Product::delete_product( $variation->get_id() );
-		WC_Helper_Product::delete_product( $product->get_id() );
-	}
-
-	/**
-	 * @testdox Test that a row carrying an extra attribute the parent does not offer still imports on the attributes that do match.
-	 */
-	public function test_import_of_existing_variation_keeps_importing_when_only_some_attributes_match() {
-		$attribute = new WC_Product_Attribute();
-		$attribute->set_name( 'Size' );
-		$attribute->set_options( array( 'S', 'M' ) );
-		$attribute->set_variation( true );
-
-		$product = new WC_Product_Variable();
-		$product->set_name( 'Import Partial Tee' );
-		$product->set_sku( 'IMPORT-PARTIAL-PARENT' );
-		$product->set_attributes( array( $attribute ) );
-		$product->save();
-
-		$variation = new WC_Product_Variation();
-		$variation->set_parent_id( $product->get_id() );
-		$variation->set_sku( 'IMPORT-PARTIAL-S' );
-		$variation->set_attributes( array( 'size' => 'S' ) );
 		$variation->save();
 
-		$csv_file = trailingslashit( get_temp_dir() ) . 'import-partial-attribute-match.csv';
+		// Only the second column is mis-flagged as global. The first still matches, which used to be
+		// enough for the row to import and blank the second attribute into "any colour".
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-one-unmatched-attribute.csv';
 		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
 			$csv_file,
 			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Attribute 2 name,Attribute 2 value(s),Attribute 2 global,Regular price\n"
-			. "variation,IMPORT-PARTIAL-S,Import Partial Tee - S,IMPORT-PARTIAL-PARENT,Size,S,0,Colour,Red,0,12\n"
+			. "variation,IMPORT-TWOATTR-S-RED,Import Two Attr Tee,IMPORT-TWOATTR-PARENT,Size,S,0,Colour,Red,1,12\n"
 		);
 
 		$importer = new WC_Product_CSV_Importer(
@@ -892,14 +866,61 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		$data     = $importer->import();
+
+		$data = $importer->import();
 
 		wp_delete_file( $csv_file );
 
-		$this->assertEmpty( $data['failed'], 'Expected the row to import on the attribute the parent does offer' );
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than be reported as a successful update' );
+		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
 
 		$stored = wc_get_product( $variation->get_id() );
-		$this->assertSame( array( 'size' => 'S' ), $stored->get_attributes(), 'Expected the matching attribute to be stored and the unknown one ignored' );
+		$this->assertSame(
+			array(
+				'size'   => 'S',
+				'colour' => 'Red',
+			),
+			$stored->get_attributes(),
+			'Expected the variation to keep both attributes instead of matching every colour'
+		);
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Test that a row whose global attribute name cannot be created fails without wiping the variation's attributes.
+	 */
+	public function test_import_of_existing_variation_fails_when_the_global_attribute_name_is_unusable() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'fabric-composition-and-care-notes' );
+		$attribute->set_options( array( 'Cotton', 'Wool' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Long Attr Tee' );
+		$product->set_sku( 'IMPORT-LONGATTR-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-LONGATTR-COTTON' );
+		$variation->set_attributes( array( 'fabric-composition-and-care-notes' => 'Cotton' ) );
+		$variation->save();
+
+		// The slug exceeds wc_get_attribute_slug_max_byte_length(), so wc_create_attribute() would
+		// reject it. That rejection used to be the only thing failing this row.
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-LONGATTR-COTTON,Import Long Attr Tee,IMPORT-LONGATTR-PARENT,fabric-composition-and-care-notes,Cotton,1,12\n",
+			'import-existing-variation-unusable-global-name.csv'
+		);
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail rather than be reported as a successful update' );
+		$this->assertEmpty( $data['updated'], 'Expected the row not to be counted as an update' );
+
+		$stored = wc_get_product( $variation->get_id() );
+		$this->assertSame( array( 'fabric-composition-and-care-notes' => 'Cotton' ), $stored->get_attributes(), 'Expected the existing variation to keep its attributes' );
 
 		WC_Helper_Product::delete_product( $variation->get_id() );
 		WC_Helper_Product::delete_product( $product->get_id() );
@@ -1030,16 +1051,14 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$color_attribute->set_name( $color_taxonomy );
 		$color_attribute->set_options( array( '红色', '绿色' ) );
 		$color_attribute->set_visible( true );
-		$color_attribute->set_variation( false );
-		// Initially false.
+		$color_attribute->set_variation( false ); // Initially false.
 
 		$size_attribute = new WC_Product_Attribute();
 		$size_attribute->set_id( $size_attr_id );
 		$size_attribute->set_name( $size_taxonomy );
 		$size_attribute->set_options( array( '大码', '小码' ) );
 		$size_attribute->set_visible( true );
-		$size_attribute->set_variation( false );
-		// Initially false.
+		$size_attribute->set_variation( false ); // Initially false.
 
 		$product->set_attributes( array( $color_attribute, $size_attribute ) );
 		$product->save();

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -889,6 +889,80 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a failed variation row does not leave a display-only parent attribute promoted to being used for variations.
+	 */
+	public function test_import_failure_does_not_promote_parent_attributes_for_variations() {
+		$size = new WC_Product_Attribute();
+		$size->set_name( 'Size' );
+		$size->set_options( array( 'S', 'M' ) );
+		$size->set_variation( true );
+
+		$material = new WC_Product_Attribute();
+		$material->set_name( 'Material' );
+		$material->set_options( array( 'Cotton' ) );
+		$material->set_variation( false );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Promote Guard Tee' );
+		$product->set_sku( 'IMPORT-PROMOTE-GUARD-PARENT' );
+		$product->set_attributes( array( $size, $material ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-PROMOTE-GUARD-S' );
+		$variation->set_attributes( array( 'size' => 'S' ) );
+		$variation->save();
+
+		// Names the display-only Material, which the parent has, alongside Colour, which it does not.
+		// Material must not be promoted for variations on the way to refusing the row.
+		$csv_file = trailingslashit( get_temp_dir() ) . 'import-promote-guard.csv';
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp dir.
+			$csv_file,
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Attribute 2 name,Attribute 2 value(s),Attribute 2 global,Regular price\n"
+			. "variation,IMPORT-PROMOTE-GUARD-S,Import Promote Guard Tee,IMPORT-PROMOTE-GUARD-PARENT,Material,Cotton,0,Colour,Red,0,12\n"
+		);
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_file,
+			array(
+				'parse'           => true,
+				'update_existing' => true,
+				'mapping'         => array(
+					'Type'                 => 'type',
+					'SKU'                  => 'sku',
+					'Name'                 => 'name',
+					'Parent'               => 'parent_id',
+					'Attribute 1 name'     => 'attributes:name1',
+					'Attribute 1 value(s)' => 'attributes:value1',
+					'Attribute 1 global'   => 'attributes:taxonomy1',
+					'Attribute 2 name'     => 'attributes:name2',
+					'Attribute 2 value(s)' => 'attributes:value2',
+					'Attribute 2 global'   => 'attributes:taxonomy2',
+					'Regular price'        => 'regular_price',
+				),
+			)
+		);
+
+		$data = $importer->import();
+
+		wp_delete_file( $csv_file );
+		wp_cache_flush();
+
+		$this->assertCount( 1, $data['failed'], 'Expected the row to fail' );
+
+		$stored_parent     = wc_get_product( $product->get_id() );
+		$stored_attributes = $stored_parent->get_attributes();
+		$this->assertFalse( $stored_attributes['material']->get_variation(), 'Expected the display-only parent attribute to stay display-only after the row failed' );
+
+		$stored_variation = wc_get_product( $variation->get_id() );
+		$this->assertSame( array( 'size' => 'S' ), $stored_variation->get_attributes(), 'Expected the existing variation to keep its attributes' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a row whose global attribute name cannot be created fails without wiping the variation's attributes.
 	 */
 	public function test_import_of_existing_variation_fails_when_the_global_attribute_name_is_unusable() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`validate_new_variation_attributes()` and `set_variation_data()` resolved a row's attribute differently: the validator via `get_existing_attribute_taxonomy_id()`, the save path via `get_attribute_taxonomy_id()`, which creates the missing global attribute. A row flagged `global=1` with no such global attribute, under a parent with a same-named custom attribute, passed validation as `size`, then saved as `pa_size`, got dropped, and became an "any" variation plus a stray site-wide attribute.

Four changes:

- **One resolver.** Both paths go through `get_variation_attribute_key()` / `get_variation_attribute_value()`, which never call `get_attribute_taxonomy_id()`. That method resolves *or creates*, and this runs while deciding whether to refuse a row, so it uses the non-creating `get_existing_attribute_taxonomy_id()` and derives the key when nothing resolves.
- **Refuse instead of skipping.** An attribute the parent does not offer used to be left out, storing the variation as the CSV did not describe it: any parent attribute left unspecified becomes a catch-all matching every value, replacing what the variation already had, with the row reported as imported.
- **Refuse before anything is written.** The check runs in `process_item()` before `get_product_object()` converts the row's import placeholder into a variation post, and again in `set_variation_data()` before `get_variation_parent_attributes()` promotes parent attributes to "used for variations" and saves the product. A row refused for its attributes leaves neither changed. (A row that gets past this and fails later, on a bad image URL say, can still leave the parent promoted - that is pre-existing.)
- **Messages name the cause.** A parent holding the attribute as the other kind says so, in both directions, and a parent that has not been imported yet points at the row order instead of reporting an attribute it does have.


Fixes WOOAIRR-133 and WOOAIRR-134 (same defect, filed once per merge).

(For Bug Fixes) Bug introduced in PR #67959.

**BC:** ordinary imports now fail rows that previously imported partially. This affects every released version, not only the unreleased 11.1 feature, and both fresh imports and update imports:

- A fresh import (`update_existing` off) of a variation row naming an attribute the parent does not offer previously created the variation without that attribute. It now fails the row. That path never reaches `validate_new_variation_attributes()`, so this guard is the only gate on it.
- Re-importing an older CSV after the parent dropped an attribute previously applied the row's other changes, such as a price update. It now fails the row.
- A CSV listing variation rows before their parent row previously imported those variations with no attributes at all, since the parent is still an `importing` placeholder when they are reached. They now fail, naming the row order.

In the first three the row previously blanked the unmatched attribute into a catch-all matching every value and reported success.

`set_variation_data()` and `get_variation_parent_attributes()` keep their signatures.

A subclass overriding `get_attribute_taxonomy_id()` to map an attribute name onto a different taxonomy is no longer consulted for variation rows, so such a row is now refused where it previously imported. This is not avoidable: that method creates the attribute when the name does not resolve, which is the defect being fixed. `get_existing_attribute_taxonomy_id()` is the non-creating override point for this.

`can_create_variation()` now checks for an `importing` parent before checking that the parent is variable, so a variation row whose parent row comes later in the file is told to reorder its rows rather than that its parent is not a variable product. Same refusal, different reason.

Two pre-existing behaviours this PR deliberately does not change, both measured on trunk and unchanged here:

- A row that omits an attribute column entirely still blanks that attribute (`{"size":"M","colour":""}`). Same on the create path, so the two agree.
- An update accepts a value the parent does not list as an option (`{"size":"XL"}`), while the create path refuses it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a variable product with a custom (non-global) attribute `Size`, options `S,M`, used for variations. Confirm no global `pa_size` attribute exists under Products > Attributes.
2. Import a CSV with "Update existing products" enabled:
   ```
   Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price
   variation,TEST-S,Tee - S,<parent SKU>,Size,S,1,12
   ```
3. The row is skipped with: `A new variation cannot be created. The parent product has a custom "Size" attribute, but the row marks it as a global attribute.`
4. Products > Attributes shows no new `Size` attribute.
5. Repeat with a SKU matching an existing variation. The row fails with `Variation cannot be imported: ...` and that variation keeps its attributes.
6. Import a CSV whose variation row is listed above its `variable` parent row. The row is refused with a message naming the row order, and the placeholder it created is not left behind as a variation.

Before this change steps 3, 5 and 6 all reported success: step 3 saved a variation matching every combination plus a stray global `Size` attribute, step 5 deleted the existing variation's attributes, and step 6 created a variation with no attributes at all.

<!-- End testing instructions -->

### Testing that has already taken place:

- Ran a scenario matrix over the whole chain on wp-env, against trunk and against this branch: create vs update, global flag on / off / column absent, global attribute existing / missing / uncreatable (reserved word, over-29-byte slug), parent attribute absent / custom / global / not-used-for-variations / still importing, one attribute vs two, value matching / not an option / empty. Every scenario that changes moves from silent data loss to a failed row naming the reason; the rest are identical to trunk.
- Each new unit test confirmed failing against trunk and passing after, including the two-attribute case where only one column is mis-flagged, the placeholder left converted by a refused row, and the parent attribute promoted to "used for variations" by a refused row.
- Green on wp-env: `WC_Product_CSV_Importer_Test` and `WC_Tests_Product_CSV_Importer`, 62/62. `phpcs-changed` against trunk and PHPStan clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Target is 11.1.0, set manually so this is cherry-picked to `release/11.1`. Parked on 11.2.0 while beta 2 goes out; move it back before merging.

### Changelog entry

Changelog file committed manually: `Significance: patch`, `Type: fix`. A real entry rather than the no-entry form, because the fix lands in `set_variation_data()`, which is the released variation-update path and not only the unreleased 11.1 feature.

### Use of AI Tools

Implementation and unit tests drafted with Claude Code (Claude Opus 5); reviewed and verified by the author.
