### PR TITLE
Resolve a CSV variation row's global-flagged attributes without creating the missing global attribute

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolver
+++ b/plugins/woocommerce/changelog/fix-wooairr-133-variation-attribute-resolver
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CSV variation import saving a catch-all variation and a stray global attribute when a global-flagged row matches a custom parent attribute.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -505,9 +505,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			foreach ( $data['raw_attributes'] as $attribute ) {
 				$attribute_id = 0;
 
-				// Get ID if is a global attribute.
+				// Get ID if is a global attribute. Resolved without creating the attribute, the same way
+				// validate_new_variation_attributes() does: creating it yields a taxonomy key the parent
+				// cannot have, so the row's attribute is dropped and the variation matches every value.
 				if ( ! empty( $attribute['taxonomy'] ) ) {
-					$attribute_id = $this->get_attribute_taxonomy_id( $attribute['name'] );
+					$attribute_id = $this->get_existing_attribute_taxonomy_id( $attribute['name'] );
 				}
 
 				if ( $attribute_id ) {
@@ -556,9 +558,9 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		foreach ( $attributes as $attribute ) {
 			$attribute_id = 0;
 
-			// Get ID if is a global attribute.
+			// Get ID if is a global attribute. Resolved without creating it, as in set_variation_data().
 			if ( ! empty( $attribute['taxonomy'] ) ) {
-				$attribute_id = $this->get_attribute_taxonomy_id( $attribute['name'] );
+				$attribute_id = $this->get_existing_attribute_taxonomy_id( $attribute['name'] );
 			}
 
 			if ( $attribute_id ) {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -755,6 +755,105 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that a global-flagged variation row whose global attribute does not exist resolves to the parent's same-named custom attribute, instead of being saved as an "any" variation alongside a stray global attribute.
+	 */
+	public function test_import_creates_new_variations_when_a_global_flagged_row_matches_a_custom_parent_attribute() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Tee' );
+		$product->set_sku( 'IMPORT-GLBFLAG-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-GLBFLAG-S,Import Tee - S,IMPORT-GLBFLAG-PARENT,Size,S,1,12\n",
+			'import-global-flagged-custom-attribute.csv'
+		);
+
+		$this->assertCount( 1, $data['imported_variations'], 'Expected the row to be created against the parent\'s custom attribute' );
+		$this->assertEmpty( $data['skipped'], 'Expected 0 skipped products, got ' . count( $data['skipped'] ) );
+
+		$variation = wc_get_product( $data['imported_variations'][0] );
+		$this->assertSame( array( 'size' => 'S' ), $variation->get_attributes(), 'Expected the variation to store the custom attribute value instead of matching any value' );
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'size' ), 'Expected no global "size" attribute to be created by the import' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Test that a global-flagged variation row whose global attribute does not exist still promotes the parent's same-named custom attribute for variations.
+	 */
+	public function test_import_promotes_a_custom_parent_attribute_matched_by_a_global_flagged_row() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( false );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Tee' );
+		$product->set_sku( 'IMPORT-GLBPROMOTE-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-GLBPROMOTE-S,Import Tee - S,IMPORT-GLBPROMOTE-PARENT,Size,S,1,12\n",
+			'import-global-flagged-promoted-attribute.csv'
+		);
+
+		$this->assertCount( 1, $data['imported_variations'], 'Expected the row to be created once the parent attribute is promoted for variations' );
+		$this->assertEmpty( $data['skipped'], 'Expected 0 skipped products, got ' . count( $data['skipped'] ) );
+
+		$variation         = wc_get_product( $data['imported_variations'][0] );
+		$parent_attributes = wc_get_product( $product->get_id() )->get_attributes();
+		$this->assertSame( array( 'size' => 'S' ), $variation->get_attributes(), 'Expected the variation to store the custom attribute value instead of matching any value' );
+		$this->assertTrue( $parent_attributes['size']->get_variation(), 'Expected the parent\'s custom attribute to be promoted for variations' );
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'size' ), 'Expected no global "size" attribute to be created by the import' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Test that re-importing an existing variation with a global-flagged row whose global attribute does not exist keeps the stored custom attribute, instead of wiping it into an "any" variation.
+	 */
+	public function test_import_updates_an_existing_variation_from_a_global_flagged_row_without_wiping_its_attribute() {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Size' );
+		$attribute->set_options( array( 'S', 'M' ) );
+		$attribute->set_variation( true );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Import Tee' );
+		$product->set_sku( 'IMPORT-GLBUPDATE-PARENT' );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_sku( 'IMPORT-GLBUPDATE-S' );
+		$variation->set_attributes( array( 'size' => 'S' ) );
+		$variation->save();
+
+		$data = $this->import_with_update_existing(
+			"Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price\nvariation,IMPORT-GLBUPDATE-S,Import Tee - M,IMPORT-GLBUPDATE-PARENT,Size,M,1,15\n",
+			'import-global-flagged-update-existing.csv'
+		);
+
+		$this->assertContains( $variation->get_id(), $data['updated'], 'Expected the existing variation to be updated' );
+		$this->assertEmpty( $data['skipped'], 'Expected 0 skipped products, got ' . count( $data['skipped'] ) );
+		$this->assertSame( array( 'size' => 'M' ), wc_get_product( $variation->get_id() )->get_attributes(), 'Expected the row\'s value to be stored instead of the attribute being wiped into matching any value' );
+		$this->assertSame( 0, (int) wc_attribute_taxonomy_id_by_name( 'size' ), 'Expected no global "size" attribute to be created by the import' );
+
+		WC_Helper_Product::delete_product( $variation->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that a variation row listed before the parent row that would widen the attribute is skipped, since rows are validated against the parent as it stands when the row is reached.
 	 */
 	public function test_import_skips_new_variations_listed_before_the_parent_row_that_adds_their_value() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The variation validator resolves a global-flagged attribute with the non-creating `get_existing_attribute_taxonomy_id()`, but the save path used `get_attribute_taxonomy_id()`, which creates the missing global attribute. A row flagged global under a parent with a same-named custom attribute passed validation as `size`, saved as `pa_size`, got dropped, and became a catch-all "any" variation plus a stray site-wide attribute. On rows updating an existing variation the validator never runs at all, so the same resolution wiped the variation's stored attribute into "any". Both save-path call sites now resolve the way the validator does; the creating lookup was never useful there, since it only fired when the global attribute was missing, in which case the resolved `pa_*` key could never match the parent.

**BC (developer advisory):**

- What changed: variation-row attribute resolution no longer goes through the public, creating `get_attribute_taxonomy_id()`; it goes through the non-creating, protected `get_existing_attribute_taxonomy_id()` (since 11.1.0), the same method the validator uses. `get_attribute_taxonomy_id()` keeps its behavior and its overrides on all other paths (parent and simple product rows).
- How to detect you're affected: you subclass `WC_Product_Importer` and override `get_attribute_taxonomy_id()` to remap attribute names, and your imports include variation rows with global-flagged attributes.
- Action needed: override `get_existing_attribute_taxonomy_id()` as well, so your mapping applies consistently to both the validation and the save path of variation rows.
- Hook note: `woocommerce_attribute_added` and the `woocommerce_taxonomy_args_pa_*` filters no longer fire from variation rows, since those rows no longer create attributes - they only ever fired there while creating the stray attribute this PR prevents. Parent and simple product rows fire them unchanged.

The affected validator ships in 11.1, so this needs a cherry-pick to `release/11.1`.

Fixes WOOAIRR-133 and WOOAIRR-134 (same defect, filed once per merge).

(For Bug Fixes) The save-path behavior dates back to the original CSV importer (WooCommerce 3.1); the validator added in PR #67959 exposed the mismatch by resolving the same row differently.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a variable product, SKU `GLB-PARENT`, with a custom (non-global) attribute `Size`, options `S | M`, used for variations. Confirm Products > Attributes lists no global `Size` attribute.
2. Go to Products > Import, tick **Update existing products**, and import:
   ```
   Type,SKU,Name,Parent,Attribute 1 name,Attribute 1 value(s),Attribute 1 global,Regular price
   variation,GLB-S,Tee - S,GLB-PARENT,Size,S,1,12
   ```
3. The variation is imported with `Size: S` (not "Any Size"), and Products > Attributes still lists no global `Size` attribute. On trunk the variation saves as "Any Size" and a stray global `Size` attribute appears.

<!-- End testing instructions -->

### Testing that has already taken place:

- Three new unit tests (create, parent-attribute promotion, update of an existing variation) confirmed failing on trunk and passing here; `WC_Product_CSV_Importer_Test` 39/39 and `WC_Tests_Product_CSV_Importer` 16/16 green on wp-env.
- `phpcs-changed` against trunk and PHPStan clean.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually in the branch.

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Implemented with Claude Code; reviewed and tested by me.
