### PR TITLE
Fix: Hide email verification prompt when the notification email is disabled

### DIFF
--- a/plugins/woocommerce/changelog/67879-fix-disabled-verification-email
+++ b/plugins/woocommerce/changelog/67879-fix-disabled-verification-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide the customer email verification prompt when its email notification is disabled.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -224,7 +224,10 @@ class VerificationController {
 			return false;
 		}
 
-		$should_show = wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
+		$email_setting = get_option( 'woocommerce_customer_verify_email_settings', array() );
+		$email_enabled = 'yes' === ( $email_setting['enabled'] ?? 'yes' );
+
+		$should_show = $email_enabled && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
 
 		// A temporary-password account already has a set-password link (which also verifies on use),
 		// surfaced by the temporary-password notice, so skip a second prompt alongside it.

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -151,6 +151,27 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The prompt does not render when the verification email is disabled.
+	 */
+	public function test_prompt_does_not_render_when_verification_email_is_disabled(): void {
+		$user_id = wc_create_new_customer( 'prompt-email-disabled@example.com', 'promptemaildisabled', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$option_name    = 'woocommerce_customer_verify_email_settings';
+		$previous_value = get_option( $option_name, null );
+		$email_settings = is_array( $previous_value ) ? $previous_value : array();
+
+		$email_settings['enabled'] = 'no';
+		update_option( $option_name, $email_settings );
+
+		try {
+			$this->assertSame( '', $this->render_prompt(), 'The prompt should not render when its email is disabled.' );
+		} finally {
+			$this->restore_option( $option_name, $previous_value );
+		}
+	}
+
+	/**
 	 * @testdox should_show_prompt allows filters to override the guest checkout default.
 	 */
 	public function test_should_show_prompt_allows_filter_to_override_guest_checkout_default(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Hide the customer email verification prompt when the `customer_verify_email` notification is disabled. 

Closes #67879.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|    <img width="1500" height="847" alt="image" src="https://github.com/user-attachments/assets/ea8a248d-a2a3-4dec-8083-56524f8bd861" />    |   <img width="1500" height="847" alt="image" src="https://github.com/user-attachments/assets/f1fefd3c-6080-428c-ae22-1b8fb16ae8be" />    |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable guest checkout and log in as an unverified customer.
2. With **Confirm email address** enabled under **WooCommerce > Settings > Emails**, open **My Account > Orders** and confirm the verification prompt appears.
3. Disable **Confirm email address**, reload **My Account > Orders**, and confirm the prompt no longer appears.

<details>
<summary>Detailed instructions</summary>

1. Go to **WooCommerce > Settings > Accounts & Privacy** and enable guest checkout.
2. Log in on the storefront using a customer account whose email is not verified.
3. Go to **WooCommerce > Settings > Emails > Confirm email address**, enable the notification, and save.
4. Open **My Account > Orders** and confirm the email verification prompt appears.
5. Return to **WooCommerce > Settings > Emails > Confirm email address**, disable the notification, and save.
6. Reload **My Account > Orders** and confirm the email verification prompt is absent.

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

- `MyAccountPromptTest`: 17 tests, 24 assertions passed.
- PHPCS passed for changed PHP files.
- PHPStan passed for `VerificationController.php`.
- Branch PHP/JavaScript lint passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A manual changelog entry was added at `plugins/woocommerce/changelog/67879-fix-disabled-verification-email`.

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

OpenAI `gpt-5.6-sol` was used to inspect the existing prompt flow, implement the localized condition, add focused test coverage, and run verification. The final diff and test results were reviewed in the task worktree.
