### PR TITLE
Fix profile email verification filter persistence

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-verification-profile-filter
+++ b/plugins/woocommerce/changelog/fix-email-verification-profile-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent email verification filters from changing persisted status on profile save.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Admin/UserProfileField.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Admin/UserProfileField.php
@@ -70,7 +70,7 @@ class UserProfileField {
 				<th scope="row"><?php esc_html_e( 'Email address confirmed', 'woocommerce' ); ?></th>
 				<td>
 					<label for="<?php echo esc_attr( self::FIELD ); ?>">
-						<input type="checkbox" name="<?php echo esc_attr( self::FIELD ); ?>" id="<?php echo esc_attr( self::FIELD ); ?>" value="1" <?php checked( $this->service->is_verified( $user->ID ) ); ?> />
+						<input type="checkbox" name="<?php echo esc_attr( self::FIELD ); ?>" id="<?php echo esc_attr( self::FIELD ); ?>" value="1" <?php checked( $this->service->has_verified_email( $user->ID ) ); ?> />
 						<?php esc_html_e( 'The customer has confirmed they own this email address.', 'woocommerce' ); ?>
 					</label>
 					<p class="description"><?php esc_html_e( 'Confirming the email address also links any past guest orders placed with it to this account.', 'woocommerce' ); ?></p>

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -100,10 +100,12 @@ class EmailVerificationService {
 	 * 'woocommerce_customer_email_is_verified' filter is not applied — so write paths such as
 	 * {@see self::mark_verified()} stay consistent however extensions filter the reported status.
 	 *
+	 * @since 11.1.0
+	 *
 	 * @param int $user_id WordPress user ID.
 	 * @return bool True when the stored verified email matches the user's current email.
 	 */
-	private function has_verified_email( int $user_id ): bool {
+	public function has_verified_email( int $user_id ): bool {
 		$verified_email = (string) Users::get_site_user_meta( $user_id, self::VERIFIED_META );
 
 		// Both sides are lower-cased (stored that way, get_account_email() normalises), so === is exact.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -99,6 +99,8 @@ class EmailVerificationService {
 	 * Unlike {@see self::is_verified()} this reflects only the persisted state — the
 	 * 'woocommerce_customer_email_is_verified' filter is not applied — so write paths such as
 	 * {@see self::mark_verified()} stay consistent however extensions filter the reported status.
+	 * This method is public for WooCommerce internal use only; extensions should use the
+	 * 'is_verified' method instead.
 	 *
 	 * @since 11.1.0
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
@@ -116,11 +116,13 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 		$filter = '__return_true';
 		add_filter( 'woocommerce_customer_email_is_verified', $filter );
 
-		ob_start();
-		$this->sut->render( $user );
-		$output = ob_get_clean();
-
-		remove_filter( 'woocommerce_customer_email_is_verified', $filter );
+		try {
+			ob_start();
+			$this->sut->render( $user );
+			$output = ob_get_clean();
+		} finally {
+			remove_filter( 'woocommerce_customer_email_is_verified', $filter );
+		}
 
 		$this->assertFalse( $this->service->has_verified_email( $user_id ) );
 		$this->assertStringNotContainsString( 'checked=\'checked\'', $output );
@@ -137,11 +139,13 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 		$filter = '__return_false';
 		add_filter( 'woocommerce_customer_email_is_verified', $filter );
 
-		ob_start();
-		$this->sut->render( $user );
-		$output = ob_get_clean();
-
-		remove_filter( 'woocommerce_customer_email_is_verified', $filter );
+		try {
+			ob_start();
+			$this->sut->render( $user );
+			$output = ob_get_clean();
+		} finally {
+			remove_filter( 'woocommerce_customer_email_is_verified', $filter );
+		}
 
 		$this->assertTrue( $this->service->has_verified_email( $user_id ) );
 		$this->assertStringContainsString( 'checked=\'checked\'', $output );

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
@@ -107,6 +107,47 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The profile checkbox ignores filters that force an unpersisted user to verified.
+	 */
+	public function test_render_uses_persisted_state_when_filter_forces_verified(): void {
+		$user_id = wc_create_new_customer( 'filtered-verified@example.com', 'filteredverified', 'pw' );
+		$user    = get_user_by( 'id', $user_id );
+
+		$filter = '__return_true';
+		add_filter( 'woocommerce_customer_email_is_verified', $filter );
+
+		ob_start();
+		$this->sut->render( $user );
+		$output = ob_get_clean();
+
+		remove_filter( 'woocommerce_customer_email_is_verified', $filter );
+
+		$this->assertFalse( $this->service->has_verified_email( $user_id ) );
+		$this->assertStringNotContainsString( 'checked=\'checked\'', $output );
+	}
+
+	/**
+	 * @testdox The profile checkbox ignores filters that force a persisted user to unverified.
+	 */
+	public function test_render_uses_persisted_state_when_filter_forces_unverified(): void {
+		$user_id = wc_create_new_customer( 'filtered-unverified@example.com', 'filteredunverified', 'pw' );
+		$user    = get_user_by( 'id', $user_id );
+		$this->service->mark_verified( $user_id );
+
+		$filter = '__return_false';
+		add_filter( 'woocommerce_customer_email_is_verified', $filter );
+
+		ob_start();
+		$this->sut->render( $user );
+		$output = ob_get_clean();
+
+		remove_filter( 'woocommerce_customer_email_is_verified', $filter );
+
+		$this->assertTrue( $this->service->has_verified_email( $user_id ) );
+		$this->assertStringContainsString( 'checked=\'checked\'', $output );
+	}
+
+	/**
 	 * @testdox Changing the email and ticking verify in the same save verifies the new address.
 	 */
 	public function test_save_verifies_new_email_when_changed_and_checked_together(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
@@ -116,11 +116,15 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 		$filter = '__return_true';
 		add_filter( 'woocommerce_customer_email_is_verified', $filter );
 
+		$buffer_level = ob_get_level();
 		try {
 			ob_start();
 			$this->sut->render( $user );
 			$output = ob_get_clean();
 		} finally {
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
 			remove_filter( 'woocommerce_customer_email_is_verified', $filter );
 		}
 
@@ -139,11 +143,15 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 		$filter = '__return_false';
 		add_filter( 'woocommerce_customer_email_is_verified', $filter );
 
+		$buffer_level = ob_get_level();
 		try {
 			ob_start();
 			$this->sut->render( $user );
 			$output = ob_get_clean();
 		} finally {
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
 			remove_filter( 'woocommerce_customer_email_is_verified', $filter );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The admin customer profile checkbox should use the legitimate persisted state for a verified email, not the filter value. This fixes a case where an email is not verified but because the filter returns `true`, and if the admin updates the profile then we unintentionally persist the email as verified.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR #67961.

Closes [WOOAIRR-131](https://linear.app/a8c/issue/WOOAIRR-131/ai-regression-reviewrelease111-admin-profile-checkbox-renders-from-the)

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add `add_filter( 'woocommerce_customer_email_is_verified', '__return_true' );` to a test site.
2. Open a customer profile for a user whose email verification is not persisted in WooCommerce meta.
3. Confirm the "Email address confirmed" checkbox remains unchecked, save an unrelated profile change, and confirm WooCommerce does not persist the verified email meta or link past guest orders.
4. Replace the filter with `add_filter( 'woocommerce_customer_email_is_verified', '__return_false' );`, mark a customer email as confirmed, and reopen that profile.
5. Confirm the checkbox remains checked, save an unrelated profile change, and confirm WooCommerce does not clear the persisted verification meta or pending verification key.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter UserProfileFieldTest`
- `composer exec -- phpstan analyse src/Internal/CustomerEmailVerification/EmailVerificationService.php src/Internal/CustomerEmailVerification/Admin/UserProfileField.php --memory-limit=2G`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

This PR was prepared with assistance from OpenAI GPT-5.5 via OpenCode.
