### PR TITLE
Fix: respect filtered enabled status for customer verification email

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-135-email-filter
+++ b/plugins/woocommerce/changelog/fix-wooairr-135-email-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect verification email enabled filters when showing the customer email verification prompt.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
 
+use WC_Email;
+
 /**
  * Drives the customer email-verification UI on My Account and processes its verify-links.
  *
@@ -224,8 +226,8 @@ class VerificationController {
 			return false;
 		}
 
-		$email       = WC()->mailer()->get_emails()['WC_Email_Customer_Verify_Email'];
-		$should_show = $email->is_enabled() && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
+		$email       = WC()->mailer()->get_emails()['WC_Email_Customer_Verify_Email'] ?? null;
+		$should_show = $email instanceof WC_Email && $email->is_enabled() && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
 
 		// A temporary-password account already has a set-password link (which also verifies on use),
 		// surfaced by the temporary-password notice, so skip a second prompt alongside it.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -224,10 +224,8 @@ class VerificationController {
 			return false;
 		}
 
-		$email_setting = get_option( 'woocommerce_customer_verify_email_settings', array() );
-		$email_enabled = 'yes' === ( $email_setting['enabled'] ?? 'yes' );
-
-		$should_show = $email_enabled && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
+		$email       = WC()->mailer()->get_emails()['WC_Email_Customer_Verify_Email'];
+		$should_show = $email->is_enabled() && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
 
 		// A temporary-password account already has a set-password link (which also verifies on use),
 		// surfaced by the temporary-password notice, so skip a second prompt alongside it.

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -172,6 +172,21 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox should_show_prompt returns false when the verification email is disabled by a filter.
+	 */
+	public function test_should_show_prompt_returns_false_when_verification_email_is_filtered_off(): void {
+		$user_id = wc_create_new_customer( 'prompt-email-filtered@example.com', 'promptemailfiltered', 'pw' );
+		wp_set_current_user( $user_id );
+
+		add_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );
+		try {
+			$this->assertFalse( $this->sut->should_show_prompt(), 'The prompt should not show when its email is disabled.' );
+		} finally {
+			remove_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );
+		}
+	}
+
+	/**
 	 * @testdox should_show_prompt allows filters to override the guest checkout default.
 	 */
 	public function test_should_show_prompt_allows_filter_to_override_guest_checkout_default(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -157,17 +157,14 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$user_id = wc_create_new_customer( 'prompt-email-disabled@example.com', 'promptemaildisabled', 'pw' );
 		wp_set_current_user( $user_id );
 
-		$option_name    = 'woocommerce_customer_verify_email_settings';
-		$previous_value = get_option( $option_name, null );
-		$email_settings = is_array( $previous_value ) ? $previous_value : array();
-
-		$email_settings['enabled'] = 'no';
-		update_option( $option_name, $email_settings );
+		$email                  = WC()->mailer()->get_emails()['WC_Email_Customer_Verify_Email'];
+		$previous_email_enabled = $email->enabled;
+		$email->enabled         = 'no';
 
 		try {
 			$this->assertSame( '', $this->render_prompt(), 'The prompt should not render when its email is disabled.' );
 		} finally {
-			$this->restore_option( $option_name, $previous_value );
+			$email->enabled = $previous_email_enabled;
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Previously, I use the option directly for performance reason, but we have a filter for enabled status for each email, so we need to do the heavier operation that initializes all registered emails then check for the status of the Customer Verification Email.

Closes WOOAIRR-135

Bug introduced in PR #67993.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable guest checkout and ensure the **Confirm email address** email is enabled.
2. Sign in as a customer whose email has not been verified, then open **My Account > Orders**. Confirm the email-verification prompt appears.
3. Add the following filter:
   ```php
   add_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );
   ```
4. Refresh **My Account > Orders**. Confirm the email-verification prompt no longer appears.

<details>
<summary>Detailed instructions</summary>

1. Go to **WooCommerce > Settings > Accounts & Privacy**, enable guest checkout, and save.
2. Go to **WooCommerce > Settings > Emails > Confirm email address**, enable the email notification, and save.
3. Create a customer with a known password, or use an existing customer whose email has not been verified.
4. Sign in as that customer and open **My Account > Orders**.
5. Confirm the prompt asking the customer to confirm their email address appears.
6. Load this snippet through a temporary plugin or your local snippet tool:
   ```php
   <?php
   add_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );
   ```
7. Refresh **My Account > Orders**.
8. Confirm the email-verification prompt is absent.

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

- PHP CodeSniffer passed for both changed PHP files.
- Branch PHP lint passed.
- PHPStan passed for `VerificationController.php`.
- `git diff --check` passed.
- Focused PHPUnit was not run locally: the permitted local setup lacked `/tmp/wordpress-tests-lib/includes/functions.php`. Docker/`wp-env` and browser/video testing were skipped.
- PHPStan does not support this PHPUnit test file in the current standalone configuration; it reports existing unresolved `WC_Unit_Test_Case` symbols. Production-file PHPStan passed cleanly.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A patch/fix changelog entry was added manually in `plugins/woocommerce/changelog/fix-wooairr-135-email-filter`.

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Respect verification email enabled filters when showing the customer email verification prompt.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog added manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

OpenAI Codex `openai-codex/gpt-5.6-sol` implemented the localized PHP change, added regression coverage, reviewed the focused diff, and ran lint/static checks. Human direction selected the email-class `is_enabled()` contract and authorized PR creation without browser/video evidence.

