### PR TITLE
Fix: Prevent regenerating a non-existent image size

### DIFF
--- a/plugins/woocommerce/changelog/60577-featured-image-metadata-loss
+++ b/plugins/woocommerce/changelog/60577-featured-image-metadata-loss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent featured image metadata loss when a WooCommerce image size is not registered.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -219,7 +219,7 @@ class WC_Regenerate_Images {
 			return $image;
 		}
 
-		if ( ! has_image_size( $size ) ) {
+		if ( ! is_string( $size ) || ! has_image_size( $size ) ) {
 			return $image;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -219,6 +219,10 @@ class WC_Regenerate_Images {
 			return $image;
 		}
 
+		if ( ! has_image_size( $size ) ) {
+			return $image;
+		}
+
 		$target_size      = wc_get_image_size( $size );
 		$image_width      = $image[1];
 		$image_height     = $image[2];

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -14167,12 +14167,6 @@ parameters:
 			path: includes/class-wc-regenerate-images.php
 
 		-
-			message: '#^Parameter \#3 \$size of static method WC_Regenerate_Images\:\:resize_and_return_image\(\) expects string, array\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-regenerate-images.php
-
-		-
 			message: '#^Access to an undefined property WC_Register_WP_Admin_Settings\:\:\$description\.$#'
 			identifier: property.notFound
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When a deregistered WooCommerce image size is requested, for example classic mini cart, WooCommerce try to generate it on the fly. But the regeneration is false because we use WP function and WP doesn't find the requested image size.

This PR fix the direct cause of #60577. The data loss is real but it goes beyond scope of the original issue and should be addressed in https://github.com/woocommerce/woocommerce/pull/67458.

Closes #60577. Replace #66271.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add this snippet, which removes the WooCommerce thumbnail after WooCommerce registers it:

   ```php
   add_action(
       'init',
       function () {
           remove_image_size( 'woocommerce_thumbnail' );
       },
       20
   );
   ```

2. Upload a new wide JPEG, such as 1600×900, assign it as a product's featured image, and confirm its attachment metadata contains generated WordPress sizes but no `woocommerce_thumbnail` entry.
3. Add the product to the cart so `wc-ajax=get_refreshed_fragments` renders the featured image in the mini-cart.
4. Confirm the attachment metadata still contains its original `sizes` entries. The mini-cart may use the full-image fallback because `woocommerce_thumbnail` was intentionally deregistered.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHP syntax check passed for `class-wc-regenerate-images.php`.
- Changed-file and full-branch PHP lint passed.
- PHPStan passed for `class-wc-regenerate-images.php`.
- Source analysis traced the fragment-rendering and WordPress metadata-generation paths. Browser/runtime testing was not performed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g., for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog file is needed, check the option below and provide a reason. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent featured image metadata loss when a WooCommerce image size is not registered.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

`openai-codex/gpt-5.6-sol` reviewed the implementation, identified the explicit string narrowing required by PHPStan, ran static checks, and prepared the testing instructions.
