### PR TITLE
Fix mini-cart loading skeleton: quantity selector, remove button, and sale badge

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -51,7 +51,7 @@
 	}
 	.wc-block-components-product-price,
 	.wc-block-components-product-metadata,
-	.wc-block-components-quantity-selector {
+	.wc-block-components-product-badge {
 		@include skeleton-animation();
 	}
 	.wc-block-components-product-name {
@@ -64,8 +64,25 @@
 		margin-top: 0.25em;
 		min-width: 8em;
 	}
+	// The quantity selector's real +/- buttons and input have their own borders/backgrounds
+	// that stay visible on top of a skeleton background alone, so it doesn't read as a
+	// placeholder. Hide those real controls and shimmer the wrapper itself instead - same
+	// approach as the remove-link button below.
+	.wc-block-components-quantity-selector {
+		@include skeleton-animation();
+		pointer-events: none;
+
+		> * {
+			visibility: hidden;
+		}
+	}
 	.wc-block-cart-item__remove-link {
-		visibility: hidden;
+		@include skeleton-animation();
+		pointer-events: none;
+
+		svg {
+			visibility: hidden;
+		}
 	}
 	.wc-block-cart-item__image > a {
 		@include skeleton-animation();


### PR DESCRIPTION
## Submission Review Guidelines

- [x] I have followed the [Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have followed the [WooCommerce Coding Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md#coding-guidelines).
- [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
- [x] I have considered, and confirmed that this submission does not introduce any security or privacy concerns.

## Changes proposed in this Pull Request

Fixes #46179.

While the mini-cart is loading (item added asynchronously from the homepage/shop page, cart opened immediately after), the loading skeleton state left three elements either un-styled or misaligned:

1. **Quantity selector** — its real `+`/`-` buttons and text input have their own borders/backgrounds, which stay visible on top of the plain skeleton background applied to the wrapper, so it doesn't read as a placeholder — it looks like broken/half-loaded real UI instead.
2. **Remove-item button** — currently just `visibility: hidden`, i.e. blank space with no shimmer at all, rather than a placeholder shape like every other loading element.
3. **Sale badge** — wasn't included in the skeleton rules at all, so it renders completely unstyled during loading.

## Fix

In `plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss` (shared by both the full cart block and `.wc-block-mini-cart__drawer.is-loading`):

- `.wc-block-components-quantity-selector` and `.wc-block-cart-item__remove-link` now get their own `skeleton-animation()` shimmer, with `pointer-events: none` and their real inner controls (`> *` / `svg`) set to `visibility: hidden` — so only the clean placeholder shape shows, at the same footprint as the real control (no layout shift once real content loads).
- `.wc-block-components-product-badge` (the sale badge) is added to the shared `skeleton-animation()` selector list alongside price/metadata.

## Testing

Reproduction steps from the issue:
1. Go to a store's homepage/shop page.
2. Add 2 items to the cart from there (async add-to-cart + auto-open mini-cart).
3. Observe the mini-cart while the second item is loading.

Verified the SCSS compiles (checked in isolation with `sass`, mixins/vars stubbed) and visually reviewed the rule changes against the existing skeleton pattern used for `.wc-block-components-product-name` / `.wc-block-cart-item__image > a` in the same block.