### PR TITLE
Revert #67997

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-135-email-filter
+++ b/plugins/woocommerce/changelog/fix-wooairr-135-email-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Respect verification email enabled filters when showing the customer email verification prompt.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -3,8 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
 
-use WC_Email;
-
 /**
  * Drives the customer email-verification UI on My Account and processes its verify-links.
  *
@@ -226,8 +224,10 @@ class VerificationController {
 			return false;
 		}
 
-		$email       = WC()->mailer()->get_emails()['WC_Email_Customer_Verify_Email'] ?? null;
-		$should_show = $email instanceof WC_Email && $email->is_enabled() && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
+		$email_setting = get_option( 'woocommerce_customer_verify_email_settings', array() );
+		$email_enabled = 'yes' === ( $email_setting['enabled'] ?? 'yes' );
+
+		$should_show = $email_enabled && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
 
 		// A temporary-password account already has a set-password link (which also verifies on use),
 		// surfaced by the temporary-password notice, so skip a second prompt alongside it.

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -157,29 +157,17 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$user_id = wc_create_new_customer( 'prompt-email-disabled@example.com', 'promptemaildisabled', 'pw' );
 		wp_set_current_user( $user_id );
 
-		$email                  = WC()->mailer()->get_emails()['WC_Email_Customer_Verify_Email'];
-		$previous_email_enabled = $email->enabled;
-		$email->enabled         = 'no';
+		$option_name    = 'woocommerce_customer_verify_email_settings';
+		$previous_value = get_option( $option_name, null );
+		$email_settings = is_array( $previous_value ) ? $previous_value : array();
+
+		$email_settings['enabled'] = 'no';
+		update_option( $option_name, $email_settings );
 
 		try {
 			$this->assertSame( '', $this->render_prompt(), 'The prompt should not render when its email is disabled.' );
 		} finally {
-			$email->enabled = $previous_email_enabled;
-		}
-	}
-
-	/**
-	 * @testdox should_show_prompt returns false when the verification email is disabled by a filter.
-	 */
-	public function test_should_show_prompt_returns_false_when_verification_email_is_filtered_off(): void {
-		$user_id = wc_create_new_customer( 'prompt-email-filtered@example.com', 'promptemailfiltered', 'pw' );
-		wp_set_current_user( $user_id );
-
-		add_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );
-		try {
-			$this->assertFalse( $this->sut->should_show_prompt(), 'The prompt should not show when its email is disabled.' );
-		} finally {
-			remove_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );
+			$this->restore_option( $option_name, $previous_value );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Revert #67997 and restore direct option lookup for customer email-verification prompt visibility. This avoids initializing the mailer and all registered emails while deciding whether to render the prompt.

Backward-compatibility impact: `woocommerce_email_enabled_customer_verify_email` no longer controls prompt visibility; this restores behavior from before #67997.

For me, it's acceptable to lose the filtered enabled state in trade for not initializing emails class on front end.

Closes WOOAIRR-140

### How to test the changes in this Pull Request:

1. Enable guest checkout and the **Confirm email address** email notification.
2. Add `add_filter( 'woocommerce_email_enabled_customer_verify_email', '__return_false' );` through a local snippet or temporary plugin.
3. Sign in as a customer whose email is not verified, then open **My Account > Orders**.
4. Confirm the email-verification prompt still appears.

### Testing that has already taken place:

- PHP CodeSniffer passed for both changed PHP files.
- Branch PHP lint passed.
- PHP syntax checks passed for both changed PHP files.
- PHPStan passed for `VerificationController.php`.
- `git diff --check` passed.
- Focused `MyAccountPromptTest` PHPUnit could not start because standard local setup lacks `/tmp/wordpress-tests-lib/includes/functions.php`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually set it to first available milestone that is not in past.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This reverts an unreleased trunk change and removes its original changelog entry.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

OpenAI Codex `openai-codex/gpt-5.6-sol` applied the exact revert, verified the diff, and ran focused static and lint checks.
