### PR TITLE
Fix email editor back button detection on WordPress 7.1

### DIFF
--- a/packages/js/email-editor/changelog/fix-back-button-wp71-detection
+++ b/packages/js/email-editor/changelog/fix-back-button-wp71-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render the compact back button on WordPress 7.1 again, where the header sizes the back button column by its content

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -21,10 +21,8 @@ import { BackButton } from '../../private-apis';
 import { recordEvent } from '../../events';
 import { storeName } from '../../store';
 
-// The WordPress 7.1+ header reserves a compact 32px slot for the back button
-// and renders it as a plain chevron; older versions reserve a 64px slot filled
-// with a fullscreen-style logo button. The slot width is what our button must
-// fit into, so detect it instead of the WordPress version.
+// We measure the header column while it is still empty. WordPress 7.1 lets it
+// shrink to 0px there, while older versions always keep it 64px wide.
 const COMPACT_SLOT_MAX_WIDTH = 48;
 
 const toggleHomeIconVariants = {
@@ -166,9 +164,10 @@ const DefaultBackButtonContent = () => {
 		const slot = measureRef.current?.closest< HTMLElement >(
 			'.editor-header__back-button'
 		);
-		const slotWidth = slot?.getBoundingClientRect().width ?? 0;
+		const reservedWidth = slot?.getBoundingClientRect().width;
 		setIsCompactSlot(
-			slotWidth > 0 && slotWidth <= COMPACT_SLOT_MAX_WIDTH
+			reservedWidth !== undefined &&
+				reservedWidth <= COMPACT_SLOT_MAX_WIDTH
 		);
 	}, [] );
 

--- a/packages/js/email-editor/src/components/header/test/back-button-content.spec.tsx
+++ b/packages/js/email-editor/src/components/header/test/back-button-content.spec.tsx
@@ -49,13 +49,25 @@ const mockUrls = {
 	send: 'https://example.com/send',
 };
 
-// Renders the component inside the editor header's back button slot with the
-// given width. jsdom has no layout, so getBoundingClientRect is stubbed.
-const renderInSlot = ( slotWidth: number ) => {
+// jsdom does not do layout, so we fake the slot width the way each WordPress
+// version sizes that column.
+type SizeSlot = ( slot: HTMLElement ) => number;
+
+const fixedColumn: SizeSlot = () => 64;
+
+const contentSizedColumn: SizeSlot = ( slot ) =>
+	slot.querySelector( 'button' ) ? 74 : 0;
+
+const renderInSlot = ( sizeSlot: SizeSlot ) => {
 	jest.spyOn(
 		HTMLElement.prototype,
 		'getBoundingClientRect'
-	).mockReturnValue( { width: slotWidth } as DOMRect );
+	).mockImplementation( function ( this: HTMLElement ) {
+		const width = this.classList.contains( 'editor-header__back-button' )
+			? sizeSlot( this )
+			: 0;
+		return { width } as DOMRect;
+	} );
 
 	return render(
 		<div className="editor-header__back-button">
@@ -114,8 +126,8 @@ describe( 'BackButtonContent', () => {
 		expect( button.onclick ).not.toBeNull();
 	} );
 
-	it( 'should render the fullscreen-style button in a wide slot (WordPress ≤ 7.0 header)', () => {
-		const { container } = renderInSlot( 64 );
+	it( 'should render the fullscreen-style button in a fixed 64px slot (WordPress ≤ 7.0 header)', () => {
+		const { container } = renderInSlot( fixedColumn );
 		expect(
 			container.querySelector(
 				'.woocommerce-email-editor__view-mode-toggle'
@@ -123,8 +135,8 @@ describe( 'BackButtonContent', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should render the compact button in a narrow slot (WordPress 7.1+ header)', () => {
-		const { container, getByRole } = renderInSlot( 32 );
+	it( 'should render the compact button in a content-sized slot (WordPress 7.1+ header)', () => {
+		const { container, getByRole } = renderInSlot( contentSizedColumn );
 		expect(
 			container.querySelector(
 				'.woocommerce-email-editor__view-mode-toggle'
@@ -135,12 +147,21 @@ describe( 'BackButtonContent', () => {
 		).toHaveAttribute( 'data-icon', 'chevronLeft' );
 	} );
 
-	it( 'should render the right chevron in a narrow slot in RTL', () => {
+	it( 'should render the right chevron in a content-sized slot in RTL', () => {
 		( isRTL as jest.Mock ).mockReturnValueOnce( true );
-		const { getByRole } = renderInSlot( 32 );
+		const { getByRole } = renderInSlot( contentSizedColumn );
 		expect(
 			getByRole( 'button', { name: 'Close editor' } )
 		).toHaveAttribute( 'data-icon', 'chevronRight' );
+	} );
+
+	it( 'should fall back to the fullscreen-style button when there is no header slot', () => {
+		const { container } = render( <BackButtonContent /> );
+		expect(
+			container.querySelector(
+				'.woocommerce-email-editor__view-mode-toggle'
+			)
+		).toBeInTheDocument();
 	} );
 
 	it( 'should apply woocommerce_email_editor_close_content filter to render custom component', () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

On WordPress 7.1 the editor header shows the old fullscreen WordPress-logo button again instead of the compact chevron added in #67470.

That PR picks the button by measuring the width the header reserves for it, but it ignores a measurement of `0` and treats it as "no header column". WordPress 7.1 sizes that column by its content, so an empty column really is `0px` wide and the check falls back to the old button. WordPress 7.0 and older keep a fixed `64px` column, so they were never affected.

With the changes in this PR, `0` is now a valid measurement. The code falls back to the old button only when there is no column in the DOM at all.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After | After (WordPress 7.0) |
| ------ | ----- | ----- |
| <img width="2468" height="1646" alt="WklC16r50HTUPOox@2x" src="https://github.com/user-attachments/assets/f83fbab0-a0a8-4322-bcba-3a3b6566d998" /> | <img width="2468" height="1646" alt="ZV3ssag98wnQmzLW@2x" src="https://github.com/user-attachments/assets/15c3a0fa-3b06-415d-bc60-3bc2d266770c" /> | <img width="2468" height="1646" alt="4Y97Cs65CFuNmuq7@2x" src="https://github.com/user-attachments/assets/125d3af3-9240-40f9-bd17-e0c988c0704b" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a WordPress 7.1 site with this branch built (`pnpm --filter=@woocommerce/plugin-woocommerce build:admin`), open any email in **WooCommerce → Settings → Emails** (with block-based email editor enabled).
2. Check the top left of the header. You should see a small chevron ("Close editor"), not a dark square with the WordPress logo. Click it and confirm it goes back to the email list.
3. On WordPress 7.0, confirm the fullscreen WordPress-logo button still shows.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
