### PR TITLE
Cache repeated CSV importer original-ID lookups

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-7558-original-id-cache
+++ b/plugins/woocommerce/changelog/fix-wooplug-7558-original-id-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Cache repeated CSV importer original-ID lookups within each import.

--- a/plugins/woocommerce/changelog/fix-wooplug-7558-original-id-cache
+++ b/plugins/woocommerce/changelog/fix-wooplug-7558-original-id-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Cache repeated CSV importer original-ID lookups within each import.
+Cache CSV importer original-ID lookups within each import batch, so CSVs with repeated IDs or many product references (grouped, upsell, cross-sell) no longer run the same postmeta query for every occurrence.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -282,7 +282,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			$existing_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation' ) AND ID = %d;", $id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The importer requires a fresh indexed ID lookup that may include newly created placeholders.
 
 			if ( $existing_id ) {
-				$this->remember_original_id_mapping( $id, $existing_id );
 				return absint( $existing_id );
 			}
 
@@ -357,7 +356,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 			// If row has a SKU, make sure placeholder was not made already.
 			if ( $id_from_sku ) {
-				$this->remember_original_id_mapping( $original_id, $id_from_sku );
 				return $id_from_sku;
 			}
 

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -50,7 +50,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Product IDs keyed by their original CSV IDs for this import request.
 	 *
-	 * @var array<string, int>
+	 * @var array<int, int>
 	 */
 	private $original_id_map = array();
 
@@ -205,8 +205,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Find a product previously mapped from an original CSV ID.
 	 *
-	 * Only successful lookups are cached. A miss can become a match later in the
-	 * same import when a placeholder is created by another row or by a hook.
+	 * Only mappings backed by an `_original_id` meta row are cached: successful
+	 * lookups and placeholders created by this instance. Misses are not cached
+	 * because a later row or a hook can still create the mapping. The cache
+	 * assumes placeholders are not deleted while a batch is being parsed.
 	 *
 	 * @param int $original_id Original product ID from the CSV file.
 	 * @return int Mapped product ID, or 0 when no mapping exists.
@@ -215,33 +217,31 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		global $wpdb;
 
 		$original_id = absint( $original_id );
-		$cache_key   = get_current_blog_id() . ':' . $original_id;
-		if ( isset( $this->original_id_map[ $cache_key ] ) ) {
-			return $this->original_id_map[ $cache_key ];
+		if ( isset( $this->original_id_map[ $original_id ] ) ) {
+			return $this->original_id_map[ $original_id ];
 		}
 
-		$product_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_original_id' AND meta_value = %s;", $original_id ) );
+		$product_id = absint( $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_original_id' AND meta_value = %s;", $original_id ) ) );
 
 		if ( $product_id ) {
-			$this->original_id_map[ $cache_key ] = absint( $product_id );
+			$this->original_id_map[ $original_id ] = $product_id;
 		}
 
-		return $product_id ? absint( $product_id ) : 0;
+		return $product_id;
 	}
 
 	/**
-	 * Remember a product mapping created during this import request.
+	 * Remember a placeholder created for an original CSV ID during this import request.
 	 *
 	 * @param int $original_id Original product ID from the CSV file.
-	 * @param int $product_id  Mapped product ID.
+	 * @param int $product_id  Placeholder product ID.
 	 */
 	private function remember_original_id_mapping( $original_id, $product_id ): void {
 		$original_id = absint( $original_id );
 		$product_id  = absint( $product_id );
 
 		if ( $original_id && $product_id ) {
-			$cache_key                           = get_current_blog_id() . ':' . $original_id;
-			$this->original_id_map[ $cache_key ] = $product_id;
+			$this->original_id_map[ $original_id ] = $product_id;
 		}
 	}
 
@@ -291,9 +291,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$product->set_name( 'Import placeholder for ' . $id );
 				$product->set_status( 'importing' );
 				$product->add_meta_data( '_original_id', $id, true );
-				$original_id = $id;
-				$id          = $product->save();
-				$this->remember_original_id_mapping( $original_id, $id );
+				$placeholder_id = $product->save();
+				$this->remember_original_id_mapping( $id, $placeholder_id );
+
+				return $placeholder_id;
 			}
 
 			return $id;
@@ -340,8 +341,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		}
 
 		// See if this maps to an ID placeholder already.
-		$original_id       = $id;
-		$mapped_product_id = $this->get_product_id_by_original_id( $original_id );
+		$mapped_product_id = $this->get_product_id_by_original_id( $id );
 
 		if ( $mapped_product_id ) {
 			return $mapped_product_id;
@@ -368,11 +368,13 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			if ( $row_sku ) {
 				$product->set_sku( $row_sku );
 			}
-			$id = $product->save();
-			$this->remember_original_id_mapping( $original_id, $id );
+			$placeholder_id = $product->save();
+			$this->remember_original_id_mapping( $id, $placeholder_id );
+
+			return $placeholder_id;
 		}
 
-		return $id && ! is_wp_error( $id ) ? $id : 0;
+		return $id;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -48,6 +48,13 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	private $cogs_is_enabled = false;
 
 	/**
+	 * Product IDs keyed by their original CSV IDs for this import request.
+	 *
+	 * @var array<string, int>
+	 */
+	private $original_id_map = array();
+
+	/**
 	 * Initialize importer.
 	 *
 	 * @param string $file   File to read.
@@ -196,6 +203,49 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
+	 * Find a product previously mapped from an original CSV ID.
+	 *
+	 * Only successful lookups are cached. A miss can become a match later in the
+	 * same import when a placeholder is created by another row or by a hook.
+	 *
+	 * @param int $original_id Original product ID from the CSV file.
+	 * @return int Mapped product ID, or 0 when no mapping exists.
+	 */
+	private function get_product_id_by_original_id( $original_id ): int {
+		global $wpdb;
+
+		$original_id = absint( $original_id );
+		$cache_key   = get_current_blog_id() . ':' . $original_id;
+		if ( isset( $this->original_id_map[ $cache_key ] ) ) {
+			return $this->original_id_map[ $cache_key ];
+		}
+
+		$product_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_original_id' AND meta_value = %s;", $original_id ) );
+
+		if ( $product_id ) {
+			$this->original_id_map[ $cache_key ] = absint( $product_id );
+		}
+
+		return $product_id ? absint( $product_id ) : 0;
+	}
+
+	/**
+	 * Remember a product mapping created during this import request.
+	 *
+	 * @param int $original_id Original product ID from the CSV file.
+	 * @param int $product_id  Mapped product ID.
+	 */
+	private function remember_original_id_mapping( $original_id, $product_id ): void {
+		$original_id = absint( $original_id );
+		$product_id  = absint( $product_id );
+
+		if ( $original_id && $product_id ) {
+			$cache_key                           = get_current_blog_id() . ':' . $original_id;
+			$this->original_id_map[ $cache_key ] = $product_id;
+		}
+	}
+
+	/**
 	 * Parse relative field and return product ID.
 	 *
 	 * Handles `id:xx` and SKUs.
@@ -222,16 +272,17 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			$id = intval( $matches[1] );
 
 			// If original_id is found, use that instead of the given ID since a new placeholder must have been created already.
-			$original_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_original_id' AND meta_value = %s;", $id ) ); // WPCS: db call ok, cache ok.
+			$mapped_product_id = $this->get_product_id_by_original_id( $id );
 
-			if ( $original_id ) {
-				return absint( $original_id );
+			if ( $mapped_product_id ) {
+				return $mapped_product_id;
 			}
 
 			// See if the given ID maps to a valid product already.
 			$existing_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation' ) AND ID = %d;", $id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The importer requires a fresh indexed ID lookup that may include newly created placeholders.
 
 			if ( $existing_id ) {
+				$this->remember_original_id_mapping( $id, $existing_id );
 				return absint( $existing_id );
 			}
 
@@ -241,7 +292,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$product->set_name( 'Import placeholder for ' . $id );
 				$product->set_status( 'importing' );
 				$product->add_meta_data( '_original_id', $id, true );
-				$id = $product->save();
+				$original_id = $id;
+				$id          = $product->save();
+				$this->remember_original_id_mapping( $original_id, $id );
 			}
 
 			return $id;
@@ -281,8 +334,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * @return int
 	 */
 	public function parse_id_field( $value ) {
-		global $wpdb;
-
 		$id = absint( $value );
 
 		if ( ! $id ) {
@@ -290,10 +341,11 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		}
 
 		// See if this maps to an ID placeholder already.
-		$original_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_original_id' AND meta_value = %s;", $id ) ); // WPCS: db call ok, cache ok.
+		$original_id       = $id;
+		$mapped_product_id = $this->get_product_id_by_original_id( $original_id );
 
-		if ( $original_id ) {
-			return absint( $original_id );
+		if ( $mapped_product_id ) {
+			return $mapped_product_id;
 		}
 
 		// Not updating? Make sure we have a new placeholder for this ID.
@@ -305,6 +357,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 			// If row has a SKU, make sure placeholder was not made already.
 			if ( $id_from_sku ) {
+				$this->remember_original_id_mapping( $original_id, $id_from_sku );
 				return $id_from_sku;
 			}
 
@@ -318,6 +371,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$product->set_sku( $row_sku );
 			}
 			$id = $product->save();
+			$this->remember_original_id_mapping( $original_id, $id );
 		}
 
 		return $id && ! is_wp_error( $id ) ? $id : 0;

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -159,10 +159,37 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( $referenced_product_id, $duplicate_product_id );
 		$this->assertSame( $existing_product->get_id(), $first_existing_product_id );
 		$this->assertSame( $existing_product->get_id(), $next_existing_product_id );
-		$this->assertSame( 2, $query_count, 'Each resolved CSV ID should query the original-ID mapping at most once.' );
+		$this->assertSame( 3, $query_count, 'Only mappings backed by _original_id meta are cached; references to existing products still query.' );
 
 		WC_Helper_Product::delete_product( $referenced_product_id );
 		WC_Helper_Product::delete_product( $existing_product->get_id() );
+	}
+
+	/**
+	 * @testdox A reference to an existing product does not map a later row with the same ID onto that product
+	 */
+	public function test_reference_to_existing_product_does_not_map_later_row_with_same_id() {
+		$existing_product = WC_Helper_Product::create_simple_product();
+		$existing_id      = $existing_product->get_id();
+		$importer         = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv', array( 'update_existing' => false ) );
+		$placeholder_id   = 0;
+
+		try {
+			$this->assertSame( $existing_id, $importer->parse_relative_field( 'id:' . $existing_id ) );
+
+			$placeholder_id = $importer->parse_id_field( (string) $existing_id );
+			$placeholder    = wc_get_product( $placeholder_id );
+
+			$this->assertNotSame( $existing_id, $placeholder_id );
+			$this->assertSame( 'importing', $placeholder->get_status() );
+			$this->assertEquals( $existing_id, $placeholder->get_meta( '_original_id' ) );
+			$this->assertSame( $placeholder_id, $importer->parse_relative_field( 'id:' . $existing_id ) );
+		} finally {
+			WC_Helper_Product::delete_product( $existing_id );
+			if ( $placeholder_id ) {
+				WC_Helper_Product::delete_product( $placeholder_id );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -126,6 +126,67 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Resolved original IDs are reused consistently without repeated lookups
+	 */
+	public function test_original_id_mapping_is_reused_within_an_import() {
+		$original_id = 987654321;
+		$importer    = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv' );
+		$query_count = 0;
+		$count_query = static function ( $query ) use ( &$query_count ) {
+			if ( false !== strpos( $query, 'SELECT post_id' ) && false !== strpos( $query, "meta_key = '_original_id'" ) ) {
+				++$query_count;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $count_query );
+
+		try {
+			$referenced_product_id = $importer->parse_relative_field( 'id:' . $original_id );
+			$row_product_id        = $importer->parse_id_field( (string) $original_id );
+			$duplicate_product_id  = $importer->parse_id_field( (string) $original_id );
+
+			$existing_product          = WC_Helper_Product::create_simple_product();
+			$first_existing_product_id = $importer->parse_relative_field( 'id:' . $existing_product->get_id() );
+			$next_existing_product_id  = $importer->parse_relative_field( 'id:' . $existing_product->get_id() );
+		} finally {
+			remove_filter( 'query', $count_query );
+		}
+
+		$this->assertGreaterThan( 0, $referenced_product_id );
+		$this->assertSame( $referenced_product_id, $row_product_id );
+		$this->assertSame( $referenced_product_id, $duplicate_product_id );
+		$this->assertSame( $existing_product->get_id(), $first_existing_product_id );
+		$this->assertSame( $existing_product->get_id(), $next_existing_product_id );
+		$this->assertSame( 2, $query_count, 'Each resolved CSV ID should query the original-ID mapping at most once.' );
+
+		WC_Helper_Product::delete_product( $referenced_product_id );
+		WC_Helper_Product::delete_product( $existing_product->get_id() );
+	}
+
+	/**
+	 * @testdox An original-ID lookup that initially misses can resolve a mapping created later in the import
+	 */
+	public function test_original_id_lookup_does_not_cache_misses() {
+		$original_id = 987654322;
+		$importer    = new WC_Product_CSV_Importer(
+			__DIR__ . '/sample.csv',
+			array( 'update_existing' => true )
+		);
+
+		$this->assertSame( $original_id, $importer->parse_relative_field( 'id:' . $original_id ) );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->add_meta_data( '_original_id', $original_id, true );
+		$product->save();
+
+		$this->assertSame( $product->get_id(), $importer->parse_id_field( (string) $original_id ) );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
 	 * @testdox Test that the importer skips updating products with the same SKU.
 	 */
 	public function test_import_skipping_existing_product_sku_46505() {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -129,16 +129,19 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox Resolved original IDs are reused consistently without repeated lookups
 	 */
 	public function test_original_id_mapping_is_reused_within_an_import() {
-		$original_id = 987654321;
-		$importer    = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv' );
-		$query_count = 0;
-		$count_query = static function ( $query ) use ( &$query_count ) {
+		$original_id      = 987654321;
+		$importer         = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv' );
+		$existing_product = WC_Helper_Product::create_simple_product();
+		$query_count      = 0;
+		$count_query      = static function ( $query ) use ( &$query_count ) {
 			if ( false !== strpos( $query, 'SELECT post_id' ) && false !== strpos( $query, "meta_key = '_original_id'" ) ) {
 				++$query_count;
 			}
 
 			return $query;
 		};
+
+		$referenced_product_id = 0;
 
 		add_filter( 'query', $count_query );
 
@@ -147,22 +150,22 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 			$row_product_id        = $importer->parse_id_field( (string) $original_id );
 			$duplicate_product_id  = $importer->parse_id_field( (string) $original_id );
 
-			$existing_product          = WC_Helper_Product::create_simple_product();
 			$first_existing_product_id = $importer->parse_relative_field( 'id:' . $existing_product->get_id() );
 			$next_existing_product_id  = $importer->parse_relative_field( 'id:' . $existing_product->get_id() );
+
+			$this->assertGreaterThan( 0, $referenced_product_id );
+			$this->assertSame( $referenced_product_id, $row_product_id );
+			$this->assertSame( $referenced_product_id, $duplicate_product_id );
+			$this->assertSame( $existing_product->get_id(), $first_existing_product_id );
+			$this->assertSame( $existing_product->get_id(), $next_existing_product_id );
+			$this->assertSame( 3, $query_count, 'Only mappings backed by _original_id meta are cached; references to existing products still query.' );
 		} finally {
 			remove_filter( 'query', $count_query );
+			WC_Helper_Product::delete_product( $existing_product->get_id() );
+			if ( $referenced_product_id ) {
+				WC_Helper_Product::delete_product( $referenced_product_id );
+			}
 		}
-
-		$this->assertGreaterThan( 0, $referenced_product_id );
-		$this->assertSame( $referenced_product_id, $row_product_id );
-		$this->assertSame( $referenced_product_id, $duplicate_product_id );
-		$this->assertSame( $existing_product->get_id(), $first_existing_product_id );
-		$this->assertSame( $existing_product->get_id(), $next_existing_product_id );
-		$this->assertSame( 3, $query_count, 'Only mappings backed by _original_id meta are cached; references to existing products still query.' );
-
-		WC_Helper_Product::delete_product( $referenced_product_id );
-		WC_Helper_Product::delete_product( $existing_product->get_id() );
 	}
 
 	/**
@@ -208,9 +211,11 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$product->add_meta_data( '_original_id', $original_id, true );
 		$product->save();
 
-		$this->assertSame( $product->get_id(), $importer->parse_id_field( (string) $original_id ) );
-
-		WC_Helper_Product::delete_product( $product->get_id() );
+		try {
+			$this->assertSame( $product->get_id(), $importer->parse_id_field( (string) $original_id ) );
+		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open pull requests for the same change.
- I have reviewed the implementation for security best practices.

### Changes proposed in this Pull Request:

Cache CSV original-ID resolutions for the lifetime of one importer instance (one instance per import batch) and share that cache between ID fields and relative product references. Only mappings backed by an `_original_id` meta row are cached: successful lookups and placeholders created by the instance. This avoids repeating the same `_original_id` lookup for duplicate IDs and references while keeping the cache an exact memo of what the query would return.

Misses deliberately remain uncached, because a later row or extension hook may create the mapping. References that resolve to a pre-existing product by post ID, and rows whose ID resolves through an existing SKU, are not cached either: neither writes an `_original_id` row, so caching them changed what a later row with the same ID resolved to.

The two legacy WPCS comments are removed rather than translated: running PHPCS with annotations disabled emits no database diagnostic for this lookup under the current ruleset.

Backward compatibility: the public importer class, its public method signatures, hooks, and return values are unchanged. The new state and helper methods are private and per-instance; subclasses that override `parse_id_field()` or `parse_relative_field()` bypass the cache and fall back to the database lookup, as before. `parse_id_field()` and `parse_relative_field()` return the same product IDs as trunk for every row ordering, because the cache only ever holds values the `_original_id` query would return. An earlier revision of this PR also cached existing-post and SKU matches, which made a forward `id:N` reference to a pre-existing product cause a later row with ID N (with "update existing" off) to be skipped as already existing instead of getting its own placeholder; that is fixed in the follow-up commits with a regression test. A dead `is_wp_error()` check on an integer was removed; return values are unchanged. Multisite: the cache is per-instance and is populated only while the constructor parses the batch, so it cannot span a `switch_to_blog()`; not exercised end to end on multisite.

Security: original IDs continue to be normalized to integers and passed through a prepared query. No new input surface, capability change, persistent cache, or cross-request state is introduced.

Closes #67851.

### Performance data

Measured in wp-env (PHP 8.1, MySQL) by running trunk and this branch side by side through the real batch flow (30-row batches, `_original_id` meta wiped at 100%) over a 1,000-row reference-heavy CSV: 60 variable products x 12 variations (each with `Parent: id:N`) plus 220 simple products, 210 of which carry two upsell and two cross-sell `id:` references to 10 shared products.

| | trunk | this PR |
| --- | --- | --- |
| `_original_id` lookups | 2,560 | 1,094 (-57%) |
| all queries for the import | ~246k | ~246k (-0.6%) |
| imported / failed / skipped | 1000 / 0 / 0 | identical |

Cost of one `_original_id` lookup (the exact statement, in isolation): 0.19 ms with 1,000 `_original_id` rows in `postmeta`, 2.7 ms with 20,000. It scales linearly with the number of placeholders, because `postmeta` is indexed on `meta_key` only and `meta_value` is scanned; store size does not matter, import size does.

Estimated time saved: about 0.3 s on the 1,000-row import above (~80 s total); roughly 40 s on a 20,000-row import of the same shape (~25-30 min total). A CSV with unique IDs and no `id:` references, or an import with "update existing" enabled, gains nothing, since the cache only pays when the same CSV ID is resolved more than once within a batch. Wall-clock differences between runs (6-8 s) were within run-to-run noise and are not attributable to the change.

The remaining lever is the query itself (a linear scan of `_original_id` rows); preloading the `_original_id` to post ID map once per batch would make that cost independent of how many references a batch contains. That is out of scope here.

### How to test the changes in this Pull Request:

1. Start the WooCommerce PHP test environment.
2. Run `pnpm test:php:env -- --filter WC_Product_CSV_Importer_Test` from `plugins/woocommerce` and confirm all tests pass.
3. In **Products > Import**, import a CSV containing a simple product with an `ID`, followed by a grouped product whose **Grouped products** field is `id:<that ID>`.
4. Confirm both products import once and the grouped product contains the simple product. Repeating the same ID/reference in the CSV must continue to resolve to that same product.

### Testing that has already taken place:

- Focused wp-env PHPUnit suite on PHP 8.1: 42 tests, 124 assertions passed.
- The new regression test `test_reference_to_existing_product_does_not_map_later_row_with_same_id` was verified to fail against the first revision of this PR and pass with the fix.
- Trunk and PR versions of the importer were run side by side in wp-env for the forward-reference-to-existing-product and SKU-reuse sequences to confirm the final revision matches trunk.
- Representative two-row CSV import in an isolated WooCommerce store: two products imported, the grouped product retained its child, and `_original_id` resolution executed once per distinct CSV ID.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed after rebasing onto current trunk.
- Focused PHPStan analysis of `includes/import/class-wc-product-csv-importer.php` passed.
- PHP syntax checks and `git diff --check` passed.
- Critical review covered public API/hook compatibility, late-created mappings, duplicate IDs, multisite cache isolation, integer normalization, prepared SQL, and request-local memory growth.
- Multisite was not exercised end to end; the cache is per-instance, populated only during the constructor's parse, and no persistent or network-scoped state is introduced.
- No screenshot is included because this changes importer query behavior without changing UI output.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A manual patch/performance changelog entry is included at `plugins/woocommerce/changelog/fix-wooplug-7558-original-id-cache`.

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [x] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Cache CSV importer original-ID lookups within each import batch, so CSVs with repeated IDs or many product references (grouped, upsell, cross-sell) no longer run the same postmeta query for every occurrence.

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Codex generated implementation and test drafts and ran the validation commands. A dual review (Claude Code and Codex) found that caching existing-post and SKU matches changed import results; the follow-up fix, simplification, and test commits were implemented with Claude Code. The resulting behavior, tests, backward compatibility, security impact, and hosted diff were critically reviewed by the author.

*\*left by Biff (AI agent) on behalf of Darren*



