### PR TITLE
Fix template markup contracts and shipping label targets

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-126-template-markup-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-126-template-markup-suppressions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Normalize shipping method label targets and document intentional template markup contracts.
+Fix the shipping method label's for attribute so it matches the input ID when a shipping package uses a non-numeric key.

--- a/plugins/woocommerce/changelog/fix-woo6-126-template-markup-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-126-template-markup-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize shipping method label targets and document intentional template markup contracts.

--- a/plugins/woocommerce/templates/cart/cart-shipping.php
+++ b/plugins/woocommerce/templates/cart/cart-shipping.php
@@ -14,7 +14,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.8.0
+ * @version 11.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,11 +33,11 @@ $calculator_text          = '';
 					<li>
 						<?php
 						if ( 1 < count( $available_methods ) ) {
-							printf( '<input type="radio" name="shipping_method[%1$d]" data-index="%1$d" id="shipping_method_%1$d_%2$s" value="%3$s" class="shipping_method" %4$s />', $index, esc_attr( sanitize_title( $method->id ) ), esc_attr( $method->id ), checked( $method->id, $chosen_method, false ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $index is an integer; the remaining values are escaped or safe attribute markup.
+							printf( '<input type="radio" name="shipping_method[%1$d]" data-index="%1$d" id="shipping_method_%1$d_%2$s" value="%3$s" class="shipping_method" %4$s />', $index, esc_attr( sanitize_title( $method->id ) ), esc_attr( $method->id ), checked( $method->id, $chosen_method, false ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- %1$d normalizes the package index; the remaining values are escaped or safe attribute markup.
 						} else {
-							printf( '<input type="hidden" name="shipping_method[%1$d]" data-index="%1$d" id="shipping_method_%1$d_%2$s" value="%3$s" class="shipping_method" />', $index, esc_attr( sanitize_title( $method->id ) ), esc_attr( $method->id ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $index is an integer and the remaining attribute values are escaped.
+							printf( '<input type="hidden" name="shipping_method[%1$d]" data-index="%1$d" id="shipping_method_%1$d_%2$s" value="%3$s" class="shipping_method" />', $index, esc_attr( sanitize_title( $method->id ) ), esc_attr( $method->id ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- %1$d normalizes the package index; the remaining attribute values are escaped.
 						}
-						printf( '<label for="shipping_method_%1$s_%2$s">%3$s</label>', $index, esc_attr( sanitize_title( $method->id ) ), wc_cart_totals_shipping_method_label( $method ) ); // WPCS: XSS ok.
+						printf( '<label for="shipping_method_%1$d_%2$s">%3$s</label>', $index, esc_attr( sanitize_title( $method->id ) ), wc_cart_totals_shipping_method_label( $method ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- %1$d normalizes the package index; the shipping method label is intentionally filterable HTML.
 						do_action( 'woocommerce_after_shipping_rate', $method, $index );
 						?>
 					</li>

--- a/plugins/woocommerce/templates/checkout/payment-method.php
+++ b/plugins/woocommerce/templates/checkout/payment-method.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
 
 	<label for="payment_method_<?php echo esc_attr( $gateway->id ); ?>">
-		<?php echo $gateway->get_title(); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?> <?php echo $gateway->get_icon(); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?>
+		<?php echo $gateway->get_title(); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The base gateway title is sanitized; the public filter intentionally allows HTML. */ ?> <?php echo $gateway->get_icon(); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The base icon attributes are escaped; the public filter intentionally allows HTML. */ ?>
 	</label>
 	<?php if ( $gateway->has_fields() || $gateway->get_description() ) : ?>
 		<div class="payment_box payment_method_<?php echo esc_attr( $gateway->id ); ?>" <?php if ( ! $gateway->chosen ) : /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>style="display:none;"<?php endif; /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>>

--- a/plugins/woocommerce/templates/loop/rating.php
+++ b/plugins/woocommerce/templates/loop/rating.php
@@ -25,4 +25,4 @@ if ( ! wc_review_ratings_enabled() ) {
 	return;
 }
 
-echo wc_get_rating_html( $product->get_average_rating() ); // WordPress.XSS.EscapeOutput.OutputNotEscaped.
+echo wc_get_rating_html( $product->get_average_rating() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The rating helper returns intentionally filterable HTML.

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -23,7 +23,7 @@ if ( ! $product->is_purchasable() ) {
 	return;
 }
 
-echo wc_get_stock_html( $product ); // WPCS: XSS ok.
+echo wc_get_stock_html( $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The stock helper returns intentionally filterable HTML.
 
 if ( $product->is_in_stock() ) : ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
 					<tr>
-						<th class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // WPCS: XSS ok. ?></label></th>
+						<th class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The default attribute label is sanitized; the public filter intentionally allows label markup. ?></label></th>
 						<td class="value">
 							<?php
 								wc_dropdown_variation_attribute_options(

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
 					<tr>
-						<th class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The default attribute label is sanitized; the public filter intentionally allows label markup. ?></label></th>
+						<th class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attribute names are sanitized on save; the filter output may carry markup by design. ?></label></th>
 						<td class="value">
 							<?php
 								wc_dropdown_variation_attribute_options(

--- a/plugins/woocommerce/templates/single-product/rating.php
+++ b/plugins/woocommerce/templates/single-product/rating.php
@@ -32,7 +32,7 @@ $average      = $product->get_average_rating();
 if ( $rating_count > 0 ) : ?>
 
 	<div class="woocommerce-product-rating">
-		<?php echo wc_get_rating_html( $average, $rating_count ); // WPCS: XSS ok. ?>
+		<?php echo wc_get_rating_html( $average, $rating_count ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The rating helper returns intentionally filterable HTML. ?>
 		<?php if ( comments_open() ) : ?>
 			<?php //phpcs:disable ?>
 			<a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . esc_html( $review_count ) . '</span>' ); ?>)</a>

--- a/plugins/woocommerce/templates/single-product/review-rating.php
+++ b/plugins/woocommerce/templates/single-product/review-rating.php
@@ -23,5 +23,5 @@ global $comment;
 $rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
 
 if ( $rating && wc_review_ratings_enabled() ) {
-	echo wc_get_rating_html( $rating ); // WPCS: XSS ok.
+	echo wc_get_rating_html( $rating ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The rating helper returns intentionally filterable HTML.
 }

--- a/plugins/woocommerce/templates/single-product/short-description.php
+++ b/plugins/woocommerce/templates/single-product/short-description.php
@@ -29,5 +29,5 @@ if ( ! $short_description ) {
 
 ?>
 <div class="woocommerce-product-details__short-description">
-	<?php echo $short_description; // WPCS: XSS ok. ?>
+	<?php echo $short_description; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Short descriptions intentionally contain filtered post and extension HTML. ?>
 </div>

--- a/plugins/woocommerce/tests/php/includes/templates/class-wc-cart-shipping-template-test.php
+++ b/plugins/woocommerce/tests/php/includes/templates/class-wc-cart-shipping-template-test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Tests for the cart shipping template.
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Cart shipping template test.
+ */
+class WC_Cart_Shipping_Template_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Shipping method labels target the rendered radio input when a package has a non-numeric key.
+	 */
+	public function test_shipping_method_label_targets_normalized_package_index(): void {
+		$flat_rate     = new WC_Shipping_Rate( 'flat_rate:1', 'Flat rate', 0, array(), 'flat_rate', 1 );
+		$free_shipping = new WC_Shipping_Rate( 'free_shipping:2', 'Free shipping', 0, array(), 'free_shipping', 2 );
+
+		$markup = $this->capture_output_from(
+			'wc_get_template',
+			'cart/cart-shipping.php',
+			array(
+				'package'                  => array( 'destination' => array() ),
+				'available_methods'        => array( $flat_rate, $free_shipping ),
+				'show_package_details'     => false,
+				'show_shipping_calculator' => false,
+				'package_details'          => '',
+				'package_name'             => 'Package',
+				'index'                    => 'vendor-package',
+				'chosen_method'            => $flat_rate->get_id(),
+				'formatted_destination'    => '',
+				'has_calculated_shipping'  => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'id="shipping_method_0_flat_rate1"', $markup, 'The package index should be normalized in the input ID.' );
+		$this->assertStringContainsString( 'for="shipping_method_0_flat_rate1"', $markup, 'The label should target the normalized input ID.' );
+		$this->assertStringNotContainsString( 'vendor-package', $markup, 'The raw package key should not be rendered in an attribute.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -34,27 +34,6 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Render the cart shipping template.
-	 *
-	 * @param array $args Template arguments.
-	 * @return string Rendered template markup.
-	 */
-	private function render_cart_shipping( array $args ): string {
-		$buffer_level = ob_get_level();
-
-		ob_start();
-		try {
-			wc_get_template( 'cart/cart-shipping.php', $args );
-
-			return (string) ob_get_clean();
-		} finally {
-			while ( ob_get_level() > $buffer_level ) {
-				ob_end_clean();
-			}
-		}
-	}
-
-	/**
 	 * Helper: create a parent product category with child categories and products.
 	 *
 	 * @return int Parent category term ID.
@@ -244,32 +223,5 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$markup  = $this->render_loop_add_to_cart( $product );
 
 		$this->assertStringContainsString( 'rel="nofollow"', $markup );
-	}
-
-	/**
-	 * @testdox Shipping method labels target the rendered radio input when a package has a non-numeric key.
-	 */
-	public function test_shipping_method_label_targets_normalized_package_index(): void {
-		$flat_rate     = new WC_Shipping_Rate( 'flat_rate:1', 'Flat rate', 0, array(), 'flat_rate', 1 );
-		$free_shipping = new WC_Shipping_Rate( 'free_shipping:2', 'Free shipping', 0, array(), 'free_shipping', 2 );
-
-		$markup = $this->render_cart_shipping(
-			array(
-				'package'                  => array( 'destination' => array() ),
-				'available_methods'        => array( $flat_rate, $free_shipping ),
-				'show_package_details'     => false,
-				'show_shipping_calculator' => false,
-				'package_details'          => '',
-				'package_name'             => 'Package',
-				'index'                    => 'vendor-package',
-				'chosen_method'            => $flat_rate->get_id(),
-				'formatted_destination'    => '',
-				'has_calculated_shipping'  => true,
-			)
-		);
-
-		$this->assertStringContainsString( 'id="shipping_method_0_flat_rate1"', $markup, 'The package index should be normalized in the input ID.' );
-		$this->assertStringContainsString( 'for="shipping_method_0_flat_rate1"', $markup, 'The label should target the normalized input ID.' );
-		$this->assertStringNotContainsString( 'vendor-package', $markup, 'The raw package key should not be rendered in an attribute.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -34,6 +34,27 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Render the cart shipping template.
+	 *
+	 * @param array $args Template arguments.
+	 * @return string Rendered template markup.
+	 */
+	private function render_cart_shipping( array $args ): string {
+		$buffer_level = ob_get_level();
+
+		ob_start();
+		try {
+			wc_get_template( 'cart/cart-shipping.php', $args );
+
+			return (string) ob_get_clean();
+		} finally {
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
+		}
+	}
+
+	/**
 	 * Helper: create a parent product category with child categories and products.
 	 *
 	 * @return int Parent category term ID.
@@ -223,5 +244,32 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$markup  = $this->render_loop_add_to_cart( $product );
 
 		$this->assertStringContainsString( 'rel="nofollow"', $markup );
+	}
+
+	/**
+	 * @testdox Shipping method labels target the rendered radio input when a package has a non-numeric key.
+	 */
+	public function test_shipping_method_label_targets_normalized_package_index(): void {
+		$flat_rate     = new WC_Shipping_Rate( 'flat_rate:1', 'Flat rate', 0, array(), 'flat_rate', 1 );
+		$free_shipping = new WC_Shipping_Rate( 'free_shipping:2', 'Free shipping', 0, array(), 'free_shipping', 2 );
+
+		$markup = $this->render_cart_shipping(
+			array(
+				'package'                  => array( 'destination' => array() ),
+				'available_methods'        => array( $flat_rate, $free_shipping ),
+				'show_package_details'     => false,
+				'show_shipping_calculator' => false,
+				'package_details'          => '',
+				'package_name'             => 'Package',
+				'index'                    => 'vendor-package',
+				'chosen_method'            => $flat_rate->get_id(),
+				'formatted_destination'    => '',
+				'has_calculated_shipping'  => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'id="shipping_method_0_flat_rate1"', $markup, 'The package index should be normalized in the input ID.' );
+		$this->assertStringContainsString( 'for="shipping_method_0_flat_rate1"', $markup, 'The label should target the normalized input ID.' );
+		$this->assertStringNotContainsString( 'vendor-package', $markup, 'The raw package key should not be rendered in an attribute.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

**Shipping label fix.** In `cart/cart-shipping.php` the shipping method `<input>` has used `%1$d` for its `name`, `data-index`, and `id` since 2015, and the `<label>` originally used `%1$d` too. PR #20345 rewrote that block and changed only the label to `%1$s`, so for any package key that is not a plain integer the label's `for` attribute stops matching the input `id` (no click-to-select, no accessible name for the radio) and the raw key is printed unescaped into the attribute. This PR restores `%1$d` on the label so it matches the input it sits next to, and adds a regression test in `tests/php/includes/templates/class-wc-cart-shipping-template-test.php`.

Bug introduced in PR #20345.

**Backward compatibility.** Output is byte-identical for integer package keys, which is every configuration the classic cart/checkout supports. Non-numeric package keys (possible via `woocommerce_cart_shipping_packages`) are not functional in the classic cart/checkout regardless of this change: the input `name`/`data-index` are already int-cast, so the shopper's choice is posted and stored as `shipping_method[0]` while every reader (`wc_cart_totals_shipping_html()`, `wc_get_chosen_shipping_method_for_package()`, `WC_Checkout`) looks the chosen method up by the raw key, and multiple string-keyed packages collapse into one radio group. `sprintf( '%d', 'vendor-package' )` returns `0` on PHP 7.4 through 8.4 without a warning. No hooks, filter arguments, or public signatures change; `woocommerce_after_shipping_rate` still receives the raw `$index`.

**Template version.** `cart/cart-shipping.php` is bumped to 11.2.0 because its rendered markup changes. The other seven templates only have their PHPCS annotations reworded and are intentionally not bumped: a bump would mark every theme override of those files as outdated in WooCommerce > Status for no output change. This deviates from the literal wording in `AGENTS.md` ("when changing template files") but follows existing practice, e.g. #67752 changed the same kind of comments in `cart-shipping.php` and three other templates without a bump. The `Analyze Branch Changes` job flags those seven files mechanically because it does not distinguish comment-only hunks.

**PHPCS annotations.** The eight templates replace `// WPCS: XSS ok.` and old `WordPress.XSS.*` markers with exact, line-scoped `phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- reason` annotations. The old markers have not been honoured by WPCS for years and `phpcs.xml` does not exclude `templates/`, so these lines were live errors in a full `lint:php` run, hidden only because `phpcs-changed` looks at changed lines. The payment title/icon, rating, stock, attribute label, and short description values keep their existing public filter and HTML contracts; no escaping is added that would strip extension-provided markup.

Performance: no queries, collections, or additional runtime work are introduced.

### Screenshots or screen recordings:

Not applicable. The visible shipping label and other template output are unchanged; the behavior change is the label's `for` attribute for a non-integer package key.

### How to test the changes in this Pull Request:

1. Start the WooCommerce test environment.
2. From `plugins/woocommerce`, run `pnpm test:php:env -- --filter WC_Cart_Shipping_Template_Test`.
3. Confirm it passes: the rendered shipping radio has `id="shipping_method_0_flat_rate1"`, its label has the matching `for="shipping_method_0_flat_rate1"`, and the raw `vendor-package` key is absent from the markup.
4. Optionally, revert the `%1$d` change on the label in `templates/cart/cart-shipping.php` and re-run the test; it fails on the `for` assertion.

### Testing that has already taken place:

- `WC_Cart_Shipping_Template_Test`: 1 test, 3 assertions passed on PHP 8.1.34 against the PR template, and fails on the `for` assertion against the trunk template.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch`: passed.
- PHPCS with `--sniffs=WordPress.Security.EscapeOutput` over all eight templates: only the pre-existing `variable.php:28` diagnostic remains; with `--ignore-annotations` every annotated line reappears with the exact `WordPress.Security.EscapeOutput.OutputNotEscaped` code, confirming each annotation is line-scoped. (Other pre-existing diagnostics from the full ruleset, e.g. missing hook docblocks, are unchanged and out of scope.)
- Hosted `Analyze Branch Changes`: expected failure for the seven comment-only templates, see the template version note above.
- `php -l` and `git diff --check`: passed.
- PHPStan: the legacy templates and the test file are not independently analyzable with the repository configuration (template-scope variables and the PHPUnit bootstrap are unavailable); the hosted PHPStan job passes.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A patch/fix changelog entry was created manually.

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

### Use of AI Tools

Biff, an AI coding agent, assisted with the suppression audit, implementation, focused test, validation, compatibility/security review, and PR preparation.

*\*left by Biff (AI agent) on behalf of Darren*
