### PR TITLE
Fix Catalog sorting label vertical alignment

### DIFF
--- a/plugins/woocommerce/changelog/fix-catalog-sorting-label-alignment
+++ b/plugins/woocommerce/changelog/fix-catalog-sorting-label-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Catalog sorting label vertical alignment

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/edit.tsx
@@ -25,10 +25,7 @@ const CatalogSorting = ( {
 		<>
 			{ useLabel ? (
 				<>
-					<label
-						className="orderby-label"
-						htmlFor="woocommerce-orderby"
-					>
+					<label htmlFor="woocommerce-orderby">
 						{ __( 'Sort by', 'woocommerce' ) }
 					</label>
 					<select className="orderby" id="woocommerce-orderby">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/style.scss
@@ -3,13 +3,16 @@
 		float: none;
 	}
 
-	label.orderby-label {
+	label {
 		margin-right: 0.25rem;
+		margin-bottom: 0;
+		vertical-align: middle;
 	}
 
 	select.orderby {
 		field-sizing: content;
 		font-size: inherit;
+		vertical-align: middle;
 	}
 
 	&.has-text-color {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Catalog Sorting label was not vertically aligned in a few themes. We had some [code in Purple](https://github.com/woocommerce/woo-themes/blob/a1829a7b87abd5be81d3ed66b7f74e114b78ff74/purple/style.css#L316-L343) to fix that, but I think it makes more sense to fix it upstream.

### How to test the changes in this Pull Request:

1. Edit the _Product Catalog_ template and enable _Show visual label_ in the _Catalog Sorting_ block.
2. Check the editor and the frontend and verify there is spacing between the label and the select and they are both verically aligned.
3. Verify with a few different themes.

TT3 | TT4 | TT5
--- | --- | ---
<img width="640" height="606" alt="imatge" src="https://github.com/user-attachments/assets/99ee6efd-f1d3-492f-b543-1b7cc2d67a26" /> | <img width="640" height="606" alt="imatge" src="https://github.com/user-attachments/assets/150de515-00e7-46ba-bdfd-ad1228c8b2ed" /> | <img width="640" height="606" alt="imatge" src="https://github.com/user-attachments/assets/5cc0f7c9-f50e-4bf3-8cae-eb9ba14321fb" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->