### PR TITLE
Product Search block: opt-in live results while typing

### DIFF
--- a/plugins/woocommerce/changelog/add-product-search-live-results
+++ b/plugins/woocommerce/changelog/add-product-search-live-results
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Search block: opt-in "Show products while typing" setting that renders live product results — image, name and price — from the Store API in a dropdown under the search input.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/frontend.ts
@@ -71,10 +71,13 @@ export const attach = ( block: HTMLElement ): void => {
 	panel.className = PANEL_CLASS;
 	panel.id = `${ PANEL_CLASS }-${ ++panelId }`;
 	panel.hidden = true;
+	input.setAttribute( 'role', 'combobox' );
 	input.setAttribute( 'aria-autocomplete', 'list' );
 	input.setAttribute( 'aria-controls', panel.id );
 	input.setAttribute( 'aria-expanded', 'false' );
-	block.style.position = 'relative';
+	if ( window.getComputedStyle( block ).position === 'static' ) {
+		block.style.position = 'relative';
+	}
 	block.appendChild( panel );
 
 	let timer: ReturnType< typeof setTimeout > | undefined;
@@ -83,6 +86,10 @@ export const attach = ( block: HTMLElement ): void => {
 	let active = -1;
 
 	const close = (): void => {
+		// Dismissal also invalidates any in-flight request, so a late
+		// response can never reopen the panel.
+		controller?.abort();
+		requestId++;
 		panel.hidden = true;
 		panel.innerHTML = '';
 		input.setAttribute( 'aria-expanded', 'false' );
@@ -160,12 +167,15 @@ export const attach = ( block: HTMLElement ): void => {
 
 	input.addEventListener( 'input', () => {
 		window.clearTimeout( timer );
-		controller?.abort();
-		requestId++;
 		close();
 		timer = window.setTimeout( search, DEBOUNCE_MS );
 	} );
 	input.addEventListener( 'keydown', ( event: KeyboardEvent ) => {
+		if ( event.key === 'Escape' ) {
+			window.clearTimeout( timer );
+			close();
+			return;
+		}
 		if ( panel.hidden ) {
 			return;
 		}
@@ -185,8 +195,6 @@ export const attach = ( block: HTMLElement ): void => {
 		} else if ( event.key === 'Enter' && active >= 0 && links[ active ] ) {
 			event.preventDefault();
 			window.location.href = links[ active ].href;
-		} else if ( event.key === 'Escape' ) {
-			close();
 		}
 	} );
 	document.addEventListener( 'click', ( event ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/frontend.ts
@@ -1,0 +1,216 @@
+/**
+ * Live results for the Product Search block (opt-in via the "Show products while
+ * typing" setting).
+ *
+ * Enqueued only when a Product Search variation with `liveResults` enabled renders
+ * (see `ProductSearch::enqueue_live_results()`). Debounces keystrokes, queries the
+ * public Store API products search, and renders a listbox of matching products —
+ * image, name and price — under the input. Enter still submits the normal search;
+ * Escape or clicking away dismisses.
+ */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import {
+	formatPrice,
+	getCurrencyFromPriceResponse,
+} from '@woocommerce/price-format';
+import type { CurrencyResponse } from '@woocommerce/types';
+
+interface StoreProductImage {
+	src: string;
+	thumbnail: string;
+}
+
+interface StoreProductPrices extends CurrencyResponse {
+	price: string;
+	price_range: { min_amount: string; max_amount: string } | null;
+}
+
+interface StoreProduct {
+	name: string;
+	permalink: string;
+	images: StoreProductImage[];
+	prices: StoreProductPrices;
+}
+
+const MIN_CHARS = 2;
+const DEBOUNCE_MS = 250;
+const MAX_RESULTS = 8;
+const MARKER_CLASS = 'wc-block-product-search--live';
+const PANEL_CLASS = 'wc-block-product-search__live-results';
+
+let panelId = 0;
+
+const priceText = ( product: StoreProduct ): string => {
+	const prices = product.prices;
+	const currency = getCurrencyFromPriceResponse( prices );
+	const format = ( raw: string ): string => formatPrice( raw, currency );
+	if (
+		prices.price_range &&
+		prices.price_range.min_amount !== prices.price_range.max_amount
+	) {
+		return `${ format( prices.price_range.min_amount ) }+`;
+	}
+	return format( prices.price );
+};
+
+export const attach = ( block: HTMLElement ): void => {
+	const input = block.querySelector< HTMLInputElement >(
+		'input[type="search"], input[name="s"]'
+	);
+	if ( ! input || input.dataset.wcLiveSearch ) {
+		return;
+	}
+	input.dataset.wcLiveSearch = '1';
+	input.setAttribute( 'autocomplete', 'off' );
+
+	const panel = document.createElement( 'div' );
+	panel.className = PANEL_CLASS;
+	panel.id = `${ PANEL_CLASS }-${ ++panelId }`;
+	panel.hidden = true;
+	input.setAttribute( 'aria-autocomplete', 'list' );
+	input.setAttribute( 'aria-controls', panel.id );
+	input.setAttribute( 'aria-expanded', 'false' );
+	block.style.position = 'relative';
+	block.appendChild( panel );
+
+	let timer: ReturnType< typeof setTimeout > | undefined;
+	let controller: AbortController | undefined;
+	let requestId = 0;
+	let active = -1;
+
+	const close = (): void => {
+		panel.hidden = true;
+		panel.innerHTML = '';
+		input.setAttribute( 'aria-expanded', 'false' );
+		input.removeAttribute( 'aria-activedescendant' );
+		active = -1;
+	};
+
+	const render = ( products: StoreProduct[] ): void => {
+		if ( ! products.length ) {
+			close();
+			return;
+		}
+		panel.innerHTML = '';
+		const list = document.createElement( 'ul' );
+		list.setAttribute( 'role', 'listbox' );
+		products.forEach( ( product, index ) => {
+			const item = document.createElement( 'li' );
+			const link = document.createElement( 'a' );
+			link.id = `${ panel.id }-option-${ index }`;
+			link.setAttribute( 'role', 'option' );
+			link.setAttribute( 'aria-selected', 'false' );
+			link.href = product.permalink;
+			const image = product.images?.[ 0 ];
+			if ( image ) {
+				const img = document.createElement( 'img' );
+				img.src = image.thumbnail || image.src;
+				img.alt = '';
+				img.loading = 'lazy';
+				link.appendChild( img );
+			}
+			const name = document.createElement( 'span' );
+			name.className = `${ PANEL_CLASS }-name`;
+			name.textContent = product.name;
+			const price = document.createElement( 'span' );
+			price.className = `${ PANEL_CLASS }-price`;
+			price.textContent = priceText( product );
+			link.appendChild( name );
+			link.appendChild( price );
+			item.appendChild( link );
+			list.appendChild( item );
+		} );
+		panel.appendChild( list );
+		panel.hidden = false;
+		input.setAttribute( 'aria-expanded', 'true' );
+		active = -1;
+	};
+
+	const search = (): void => {
+		const query = input.value.trim();
+		if ( query.length < MIN_CHARS ) {
+			close();
+			return;
+		}
+		const currentRequestId = ++requestId;
+		controller = new AbortController();
+		apiFetch< StoreProduct[] >( {
+			path: `/wc/store/v1/products?search=${ encodeURIComponent(
+				query
+			) }&per_page=${ MAX_RESULTS }`,
+			signal: controller.signal,
+		} )
+			.then( ( products ) => {
+				if (
+					currentRequestId !== requestId ||
+					input.value.trim() !== query
+				) {
+					return;
+				}
+				render( Array.isArray( products ) ? products : [] );
+			} )
+			.catch( () => {
+				// Aborted or failed suggestions are silence, never a shopper-facing error.
+			} );
+	};
+
+	input.addEventListener( 'input', () => {
+		window.clearTimeout( timer );
+		controller?.abort();
+		requestId++;
+		close();
+		timer = window.setTimeout( search, DEBOUNCE_MS );
+	} );
+	input.addEventListener( 'keydown', ( event: KeyboardEvent ) => {
+		if ( panel.hidden ) {
+			return;
+		}
+		const links = panel.querySelectorAll< HTMLAnchorElement >( 'li a' );
+		if ( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) {
+			event.preventDefault();
+			active += event.key === 'ArrowDown' ? 1 : -1;
+			active = Math.max( 0, Math.min( links.length - 1, active ) );
+			links.forEach( ( link, index ) => {
+				link.classList.toggle( 'is-active', index === active );
+				link.setAttribute(
+					'aria-selected',
+					index === active ? 'true' : 'false'
+				);
+			} );
+			input.setAttribute( 'aria-activedescendant', links[ active ].id );
+		} else if ( event.key === 'Enter' && active >= 0 && links[ active ] ) {
+			event.preventDefault();
+			window.location.href = links[ active ].href;
+		} else if ( event.key === 'Escape' ) {
+			close();
+		}
+	} );
+	document.addEventListener( 'click', ( event ) => {
+		if ( ! block.contains( event.target as Node ) ) {
+			close();
+		}
+	} );
+	input.addEventListener( 'blur', () => {
+		window.setTimeout( () => {
+			if ( ! block.contains( block.ownerDocument.activeElement ) ) {
+				close();
+			}
+		} );
+	} );
+};
+
+const boot = (): void => {
+	document
+		.querySelectorAll< HTMLElement >( `.${ MARKER_CLASS }` )
+		.forEach( attach );
+};
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', boot );
+} else {
+	boot();
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/index.tsx
@@ -170,12 +170,20 @@ registerBlockType( SEARCH_VARIATION_NAME, {
 function registerProductSearchNamespace( props: BlockType, blockName: string ) {
 	if ( blockName === 'core/search' ) {
 		// Gracefully handle if settings.attributes is undefined.
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 		// @ts-ignore -- We need this because `attributes` is marked as `readonly`
 		props.attributes = {
 			...props.attributes,
 			namespace: {
 				type: 'string',
+			},
+			/**
+			 * Whether the Product Search variation shows matching products in a
+			 * dropdown while the shopper types (opt-in, frontend only).
+			 */
+			liveResults: {
+				type: 'boolean',
+				default: false,
 			},
 		};
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -33,7 +33,8 @@ import { PositionOptions } from './constants';
 
 const ProductSearchControls = ( props: ProductSearchBlockProps ) => {
 	const { attributes, setAttributes } = props;
-	const { buttonPosition, buttonUseIcon, showLabel } = attributes;
+	const { buttonPosition, buttonUseIcon, liveResults, showLabel } =
+		attributes;
 	const [ initialPosition, setInitialPosition ] =
 		useState< ButtonPositionProps >( buttonPosition );
 
@@ -47,98 +48,132 @@ const ProductSearchControls = ( props: ProductSearchBlockProps ) => {
 	}, [ buttonPosition, initialPosition ] );
 
 	return (
-		<InspectorControls group="styles">
-			<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
-				<RadioControl
-					selected={ getSelectedRadioControlOption( buttonPosition ) }
-					options={ [
-						{
-							label: __( 'Input and button', 'woocommerce' ),
-							value: PositionOptions.INPUT_AND_BUTTON,
-						},
-						{
-							label: __( 'Input only', 'woocommerce' ),
-							value: PositionOptions.NO_BUTTON,
-						},
-						{
-							label: __( 'Button only', 'woocommerce' ),
-							value: PositionOptions.BUTTON_ONLY,
-						},
-					] }
-					onChange={ (
-						selected: Partial< ButtonPositionProps > &
-							PositionOptions.INPUT_AND_BUTTON
-					) => {
-						if ( selected !== PositionOptions.INPUT_AND_BUTTON ) {
-							setAttributes( {
-								buttonPosition: selected,
-							} );
-						} else {
-							const newButtonPosition =
-								getInputAndButtonOption( initialPosition );
-							setAttributes( {
-								buttonPosition: newButtonPosition,
-							} );
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Live results', 'woocommerce' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Show products while typing',
+							'woocommerce'
+						) }
+						help={ __(
+							'Show matching products — image, name and price — in a dropdown as the shopper types.',
+							'woocommerce'
+						) }
+						checked={ !! liveResults }
+						onChange={ ( value: boolean ) =>
+							setAttributes( { liveResults: value } )
 						}
-					} }
-				/>
-				{ buttonPosition !== PositionOptions.NO_BUTTON && (
-					<>
-						{ buttonPosition !== PositionOptions.BUTTON_ONLY && (
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<InspectorControls group="styles">
+				<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
+					<RadioControl
+						selected={ getSelectedRadioControlOption(
+							buttonPosition
+						) }
+						options={ [
+							{
+								label: __( 'Input and button', 'woocommerce' ),
+								value: PositionOptions.INPUT_AND_BUTTON,
+							},
+							{
+								label: __( 'Input only', 'woocommerce' ),
+								value: PositionOptions.NO_BUTTON,
+							},
+							{
+								label: __( 'Button only', 'woocommerce' ),
+								value: PositionOptions.BUTTON_ONLY,
+							},
+						] }
+						onChange={ (
+							selected: Partial< ButtonPositionProps > &
+								PositionOptions.INPUT_AND_BUTTON
+						) => {
+							if (
+								selected !== PositionOptions.INPUT_AND_BUTTON
+							) {
+								setAttributes( {
+									buttonPosition: selected,
+								} );
+							} else {
+								const newButtonPosition =
+									getInputAndButtonOption( initialPosition );
+								setAttributes( {
+									buttonPosition: newButtonPosition,
+								} );
+							}
+						} }
+					/>
+					{ buttonPosition !== PositionOptions.NO_BUTTON && (
+						<>
+							{ buttonPosition !==
+								PositionOptions.BUTTON_ONLY && (
+								<ToggleGroupControl
+									label={ __(
+										'BUTTON POSITION',
+										'woocommerce'
+									) }
+									isBlock
+									onChange={ (
+										value: ButtonPositionProps
+									) => {
+										setAttributes( {
+											buttonPosition: value,
+										} );
+									} }
+									value={ getInputAndButtonOption(
+										buttonPosition
+									) }
+								>
+									<ToggleGroupControlOption
+										value={ PositionOptions.INSIDE }
+										label={ __( 'Inside', 'woocommerce' ) }
+									/>
+									<ToggleGroupControlOption
+										value={ PositionOptions.OUTSIDE }
+										label={ __( 'Outside', 'woocommerce' ) }
+									/>
+								</ToggleGroupControl>
+							) }
 							<ToggleGroupControl
-								label={ __( 'BUTTON POSITION', 'woocommerce' ) }
+								label={ __(
+									'BUTTON APPEARANCE',
+									'woocommerce'
+								) }
 								isBlock
-								onChange={ ( value: ButtonPositionProps ) => {
+								onChange={ ( value: boolean ) => {
 									setAttributes( {
-										buttonPosition: value,
+										buttonUseIcon: value,
 									} );
 								} }
-								value={ getInputAndButtonOption(
-									buttonPosition
-								) }
+								value={ buttonUseIcon }
 							>
 								<ToggleGroupControlOption
-									value={ PositionOptions.INSIDE }
-									label={ __( 'Inside', 'woocommerce' ) }
+									value={ false }
+									label={ __( 'Text', 'woocommerce' ) }
 								/>
 								<ToggleGroupControlOption
-									value={ PositionOptions.OUTSIDE }
-									label={ __( 'Outside', 'woocommerce' ) }
+									value={ true }
+									label={ __( 'Icon', 'woocommerce' ) }
 								/>
 							</ToggleGroupControl>
-						) }
-						<ToggleGroupControl
-							label={ __( 'BUTTON APPEARANCE', 'woocommerce' ) }
-							isBlock
-							onChange={ ( value: boolean ) => {
-								setAttributes( {
-									buttonUseIcon: value,
-								} );
-							} }
-							value={ buttonUseIcon }
-						>
-							<ToggleGroupControlOption
-								value={ false }
-								label={ __( 'Text', 'woocommerce' ) }
-							/>
-							<ToggleGroupControlOption
-								value={ true }
-								label={ __( 'Icon', 'woocommerce' ) }
-							/>
-						</ToggleGroupControl>
-					</>
-				) }
-				<ToggleControl
-					label={ __( 'Show input label', 'woocommerce' ) }
-					checked={ showLabel }
-					onChange={ ( showInputLabel: boolean ) =>
-						setAttributes( {
-							showLabel: showInputLabel,
-						} )
-					}
-				/>
-			</PanelBody>
-		</InspectorControls>
+						</>
+					) }
+					<ToggleControl
+						label={ __( 'Show input label', 'woocommerce' ) }
+						checked={ showLabel }
+						onChange={ ( showInputLabel: boolean ) =>
+							setAttributes( {
+								showLabel: showInputLabel,
+							} )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/style.scss
@@ -36,3 +36,60 @@
 		}
 	}
 }
+
+// Live results dropdown (opt-in "Show products while typing" setting).
+.wc-block-product-search--live {
+	.wc-block-product-search__live-results {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		margin-top: $gap-smallest;
+		background: $white;
+		border: 1px solid $gray-300;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+		max-height: 70vh;
+		overflow-y: auto;
+
+		ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+		}
+
+		li a {
+			display: flex;
+			align-items: center;
+			gap: $gap-small;
+			padding: $gap-smaller $gap-small;
+			text-decoration: none;
+			color: inherit;
+
+			&:hover,
+			&.is-active {
+				background: $gray-100;
+			}
+
+			img {
+				width: 36px;
+				height: auto;
+				flex: 0 0 auto;
+			}
+		}
+	}
+
+	.wc-block-product-search__live-results-name {
+		flex: 1 1 auto;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.wc-block-product-search__live-results-price {
+		flex: 0 0 auto;
+		font-weight: 600;
+		white-space: nowrap;
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/test/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/test/frontend.test.ts
@@ -103,6 +103,25 @@ describe( 'Product Search live results', () => {
 		expect( block ).toHaveTextContent( '1.234,56 €' );
 	} );
 
+	it( 'does not reopen results after the shopper dismisses them', async () => {
+		const response = createDeferred< Product[] >();
+		apiFetchMock.mockReturnValueOnce( response.promise );
+
+		const block = getBlock();
+		const input = getInput( block );
+		attach( block );
+
+		fireEvent.input( input, { target: { value: 'shoes' } } );
+		act( () => jest.advanceTimersByTime( 250 ) );
+
+		fireEvent.keyDown( input, { key: 'Escape' } );
+
+		await act( async () => response.resolve( [ product( 'Shoes' ) ] ) );
+
+		expect( block ).not.toHaveTextContent( 'Shoes' );
+		expect( input ).toHaveAttribute( 'aria-expanded', 'false' );
+	} );
+
 	it( 'exposes results and keyboard selection to assistive technology', async () => {
 		apiFetchMock.mockResolvedValue( [ product( 'Shoes' ) ] );
 		const block = getBlock();
@@ -113,6 +132,7 @@ describe( 'Product Search live results', () => {
 		act( () => jest.advanceTimersByTime( 250 ) );
 		await act( async () => Promise.resolve() );
 
+		expect( input ).toHaveAttribute( 'role', 'combobox' );
 		expect( input ).toHaveAttribute( 'aria-expanded', 'true' );
 		fireEvent.keyDown( input, { key: 'ArrowDown' } );
 		expect( input ).toHaveAttribute( 'aria-activedescendant' );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/test/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/test/frontend.test.ts
@@ -1,0 +1,124 @@
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { act, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { attach } from '../frontend';
+
+const product = ( name: string ) => ( {
+	name,
+	permalink: `https://example.com/product/${ name.toLowerCase() }`,
+	images: [],
+	prices: {
+		price: '123456',
+		currency_code: 'EUR',
+		currency_symbol: '€',
+		currency_minor_unit: 2,
+		currency_decimal_separator: ',',
+		currency_thousand_separator: '.',
+		currency_prefix: '',
+		currency_suffix: ' €',
+		price_range: null,
+	},
+} );
+
+type Product = ReturnType< typeof product >;
+
+const createDeferred = < T >() => {
+	let resolve: ( value: T ) => void = () => {
+		throw new Error(
+			'Deferred promise was resolved before initialization.'
+		);
+	};
+	const promise = new Promise< T >( ( promiseResolve ) => {
+		resolve = promiseResolve;
+	} );
+	return { promise, resolve };
+};
+
+const getBlock = (): HTMLElement => {
+	const block = document.querySelector< HTMLElement >(
+		'.wc-block-product-search--live'
+	);
+	if ( ! block ) {
+		throw new Error( 'Live Product Search block was not rendered.' );
+	}
+	return block;
+};
+
+const getInput = ( block: HTMLElement ): HTMLInputElement => {
+	const input = block.querySelector< HTMLInputElement >( 'input' );
+	if ( ! input ) {
+		throw new Error( 'Live Product Search input was not rendered.' );
+	}
+	return input;
+};
+
+describe( 'Product Search live results', () => {
+	const apiFetchMock = apiFetch as jest.Mock;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		document.body.innerHTML =
+			'<div class="wc-block-product-search--live"><input type="search" name="s" /></div>';
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not show a stale response after the shopper changes the query', async () => {
+		const firstResponse = createDeferred< Product[] >();
+		const secondResponse = createDeferred< Product[] >();
+		apiFetchMock
+			.mockReturnValueOnce( firstResponse.promise )
+			.mockReturnValueOnce( secondResponse.promise );
+
+		const block = getBlock();
+		const input = getInput( block );
+		attach( block );
+
+		fireEvent.input( input, { target: { value: 'shirt' } } );
+		act( () => jest.advanceTimersByTime( 250 ) );
+
+		fireEvent.input( input, { target: { value: 'shoes' } } );
+		act( () => jest.advanceTimersByTime( 250 ) );
+
+		await act( async () =>
+			firstResponse.resolve( [ product( 'Shirt' ) ] )
+		);
+		expect( block ).not.toHaveTextContent( 'Shirt' );
+
+		await act( async () =>
+			secondResponse.resolve( [ product( 'Shoes' ) ] )
+		);
+		expect( block ).toHaveTextContent( 'Shoes' );
+		expect( block ).toHaveTextContent( '1.234,56 €' );
+	} );
+
+	it( 'exposes results and keyboard selection to assistive technology', async () => {
+		apiFetchMock.mockResolvedValue( [ product( 'Shoes' ) ] );
+		const block = getBlock();
+		const input = getInput( block );
+		attach( block );
+
+		fireEvent.input( input, { target: { value: 'shoes' } } );
+		act( () => jest.advanceTimersByTime( 250 ) );
+		await act( async () => Promise.resolve() );
+
+		expect( input ).toHaveAttribute( 'aria-expanded', 'true' );
+		fireEvent.keyDown( input, { key: 'ArrowDown' } );
+		expect( input ).toHaveAttribute( 'aria-activedescendant' );
+		expect( block.querySelector( '[role="option"]' ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-search/types.ts
@@ -15,6 +15,7 @@ export interface SearchBlockAttributes {
 	buttonUseIcon: boolean;
 	isSearchFieldHidden: boolean;
 	label?: string;
+	liveResults?: boolean;
 	namespace?: string;
 	placeholder?: string;
 	showLabel: boolean;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSearch.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSearch.php
@@ -19,7 +19,7 @@ class ProductSearch extends AbstractBlock {
 	/**
 	 * Initialize this block type.
 	 */
-	protected function initialize() {
+	protected function initialize(): void {
 		parent::initialize();
 		add_filter( 'render_block_core/search', array( $this, 'add_live_results' ), 10, 2 );
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSearch.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSearch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 /**
@@ -14,6 +17,14 @@ class ProductSearch extends AbstractBlock {
 	protected $block_name = 'product-search';
 
 	/**
+	 * Initialize this block type.
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_filter( 'render_block_core/search', array( $this, 'add_live_results' ), 10, 2 );
+	}
+
+	/**
 	 * Get the frontend script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.
@@ -21,6 +32,47 @@ class ProductSearch extends AbstractBlock {
 	 */
 	protected function get_block_type_script( $key = null ) {
 		return null;
+	}
+
+	/**
+	 * Enable live results on a Product Search variation that opted in.
+	 *
+	 * The Product Search block is a variation of `core/search`, so its frontend
+	 * behaviour attaches at render time: when the rendered block carries this
+	 * variation's namespace and the `liveResults` attribute, the wrapper gains a
+	 * marker class and the view script (which attaches only to marked blocks)
+	 * is enqueued.
+	 *
+	 * @param string $block_content Rendered block content.
+	 * @param array  $block         Parsed block data.
+	 * @return string
+	 */
+	public function add_live_results( $block_content, $block ) {
+		$attributes = $block['attrs'] ?? array();
+		if (
+			'woocommerce/product-search' !== ( $attributes['namespace'] ?? '' )
+			|| empty( $attributes['liveResults'] )
+		) {
+			return $block_content;
+		}
+
+		$handle = 'wc-' . $this->block_name . '-block-frontend';
+		if ( ! wp_script_is( $handle, 'registered' ) ) {
+			$this->asset_api->register_script(
+				$handle,
+				$this->asset_api->get_block_asset_build_path( $this->block_name . '-frontend' ),
+				array()
+			);
+		}
+		wp_enqueue_script( $handle );
+		wp_enqueue_style( 'wc-blocks-style-' . $this->block_name );
+
+		return preg_replace(
+			'/\bwp-block-search\b/',
+			'wp-block-search wc-block-product-search--live',
+			$block_content,
+			1
+		) ?? $block_content;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSearch.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSearch.php
@@ -51,10 +51,16 @@ class ProductSearch extends AbstractBlock {
 		$attributes = $block['attrs'] ?? array();
 		if (
 			'woocommerce/product-search' !== ( $attributes['namespace'] ?? '' )
-			|| empty( $attributes['liveResults'] )
+			|| true !== ( $attributes['liveResults'] ?? false )
 		) {
 			return $block_content;
 		}
+
+		$processor = new \WP_HTML_Tag_Processor( $block_content );
+		if ( ! $processor->next_tag( array( 'class_name' => 'wp-block-search' ) ) ) {
+			return $block_content;
+		}
+		$processor->add_class( 'wc-block-product-search--live' );
 
 		$handle = 'wc-' . $this->block_name . '-block-frontend';
 		if ( ! wp_script_is( $handle, 'registered' ) ) {
@@ -67,12 +73,7 @@ class ProductSearch extends AbstractBlock {
 		wp_enqueue_script( $handle );
 		wp_enqueue_style( 'wc-blocks-style-' . $this->block_name );
 
-		return preg_replace(
-			'/\bwp-block-search\b/',
-			'wp-block-search wc-block-product-search--live',
-			$block_content,
-			1
-		) ?? $block_content;
+		return $processor->get_updated_html();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSearchTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSearchTest.php
@@ -22,6 +22,11 @@ class ProductSearchTest extends WC_Unit_Test_Case {
 	private const LIVE_RESULTS_SCRIPT_HANDLE = 'wc-product-search-block-frontend';
 
 	/**
+	 * The block stylesheet handle enqueued alongside live results.
+	 */
+	private const LIVE_RESULTS_STYLE_HANDLE = 'wc-blocks-style-product-search';
+
+	/**
 	 * Create a Product Search instance without registering the deprecated block.
 	 *
 	 * @return ProductSearch
@@ -41,10 +46,11 @@ class ProductSearchTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Reset global script state between tests.
+	 * Reset global asset state between tests.
 	 */
 	public function tearDown(): void {
 		wp_dequeue_script( self::LIVE_RESULTS_SCRIPT_HANDLE );
+		wp_dequeue_style( self::LIVE_RESULTS_STYLE_HANDLE );
 		parent::tearDown();
 	}
 
@@ -67,25 +73,27 @@ class ProductSearchTest extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'wc-block-product-search--live', $result );
 		$this->assertTrue( wp_script_is( self::LIVE_RESULTS_SCRIPT_HANDLE, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( self::LIVE_RESULTS_STYLE_HANDLE, 'enqueued' ) );
 	}
 
 	/**
 	 * @testdox Leaves core Search blocks and opt-out Product Search blocks unchanged.
+	 *
+	 * @testWith [{"namespace": "woocommerce/product-search"}]
+	 *           [{"namespace": "woocommerce/product-search", "liveResults": false}]
+	 *           [{"namespace": "woocommerce/product-search", "liveResults": "false"}]
+	 *           [{"liveResults": true}]
+	 *
+	 * @param array $attrs Parsed block attributes without a valid opt-in.
 	 */
-	public function test_add_live_results_skips_blocks_without_the_opt_in(): void {
+	public function test_add_live_results_skips_blocks_without_the_opt_in( array $attrs ): void {
 		$block   = $this->create_block();
 		$content = '<form class="wp-block-search"><input type="search" /></form>';
 
-		$result = $block->add_live_results(
-			$content,
-			array(
-				'attrs' => array(
-					'namespace' => 'woocommerce/product-search',
-				),
-			)
-		);
+		$result = $block->add_live_results( $content, array( 'attrs' => $attrs ) );
 
 		$this->assertSame( $content, $result );
 		$this->assertFalse( wp_script_is( self::LIVE_RESULTS_SCRIPT_HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( self::LIVE_RESULTS_STYLE_HANDLE, 'enqueued' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSearchTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSearchTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\BlockTypes\ProductSearch;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use Automattic\WooCommerce\Blocks\Package;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Product Search block type.
+ */
+class ProductSearchTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The live-results script handle.
+	 */
+	private const LIVE_RESULTS_SCRIPT_HANDLE = 'wc-product-search-block-frontend';
+
+	/**
+	 * Create a Product Search instance without registering the deprecated block.
+	 *
+	 * @return ProductSearch
+	 */
+	private function create_block(): ProductSearch {
+		return new class(
+			Package::container()->get( Api::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry()
+		) extends ProductSearch {
+			/**
+			 * Registration is already handled by WooCommerce during test bootstrap.
+			 */
+			protected function initialize() {
+			}
+		};
+	}
+
+	/**
+	 * Reset global script state between tests.
+	 */
+	protected function tearDown(): void {
+		wp_dequeue_script( self::LIVE_RESULTS_SCRIPT_HANDLE );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Adds live results only to the opted-in Product Search variation.
+	 */
+	public function test_add_live_results_for_opted_in_product_search(): void {
+		$block   = $this->create_block();
+		$content = '<form class="wp-block-search"><input type="search" /></form>';
+
+		$result = $block->add_live_results(
+			$content,
+			array(
+				'attrs' => array(
+					'namespace'   => 'woocommerce/product-search',
+					'liveResults' => true,
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'wc-block-product-search--live', $result );
+		$this->assertTrue( wp_script_is( self::LIVE_RESULTS_SCRIPT_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * @testdox Leaves core Search blocks and opt-out Product Search blocks unchanged.
+	 */
+	public function test_add_live_results_skips_blocks_without_the_opt_in(): void {
+		$block   = $this->create_block();
+		$content = '<form class="wp-block-search"><input type="search" /></form>';
+
+		$result = $block->add_live_results(
+			$content,
+			array(
+				'attrs' => array(
+					'namespace' => 'woocommerce/product-search',
+				),
+			)
+		);
+
+		$this->assertSame( $content, $result );
+		$this->assertFalse( wp_script_is( self::LIVE_RESULTS_SCRIPT_HANDLE, 'enqueued' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSearchTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSearchTest.php
@@ -35,7 +35,7 @@ class ProductSearchTest extends WC_Unit_Test_Case {
 			/**
 			 * Registration is already handled by WooCommerce during test bootstrap.
 			 */
-			protected function initialize() {
+			protected function initialize(): void {
 			}
 		};
 	}
@@ -43,7 +43,7 @@ class ProductSearchTest extends WC_Unit_Test_Case {
 	/**
 	 * Reset global script state between tests.
 	 */
-	protected function tearDown(): void {
+	public function tearDown(): void {
 		wp_dequeue_script( self::LIVE_RESULTS_SCRIPT_HANDLE );
 		parent::tearDown();
 	}


### PR DESCRIPTION
## What

Adds an opt-in **“Show products while typing”** setting to the **Product Search** block (the `core/search` variation). When enabled, the block’s view script debounces input and queries the public Store API:

```
GET /wc/store/v1/products?search={q}&per_page=8
```

and renders a listbox under the input — product image, name, and price (using `prices.price_range` for variable products) — linking to each product’s permalink. Enter still submits the normal search; Escape or clicking away dismisses; arrow keys navigate.

Default is **off**: zero behaviour change for existing stores.

## Why

Shoppers on modern storefronts expect matching products to appear while typing, before submitting. The gap is large enough that an entire plugin category exists to fill it (FiboSearch, SearchWP, Jetpack Search, and most premium themes ship their own) — every one re-implementing a small UI on top of data WooCommerce already serves publicly. The data source here is core’s own public Store API; the UI is a small dependency-free view script; the setting is one attribute on an existing block.

## How

- `liveResults` attribute registered on `core/search` alongside the existing `namespace` attribute (`registerProductSearchNamespace`), default `false`.
- Toggle in the Product Search variation’s inspector settings (`ProductSearchControls`, settings group).
- `ProductSearch::add_live_results()` (`render_block_core/search`): when the rendered block carries the variation namespace and `liveResults`, the wrapper gains `wc-block-product-search--live` and the view script + block style are enqueued.
- `product-search/frontend.ts`: attaches to marked blocks only; debounced (250 ms), in-flight requests aborted with a stale-response guard (a late-arriving earlier response can never clobber a newer query), results via `@wordpress/api-fetch` (root-aware, plain-permalink safe), prices formatted with `@woocommerce/price-format`.
- ARIA combobox semantics: `role="combobox"` with `aria-autocomplete`/`aria-controls`/`aria-expanded` on the input, `role="option"` + `aria-selected` in the listbox, `aria-activedescendant` tracking keyboard selection, and blur dismissal that respects focus moving into the results.
- Tests: Jest coverage for the stale-response race and the assistive-technology contract; PHPUnit coverage that the render filter only ever activates on the opted-in Product Search variation.

## Notes for reviewers

- **Compatibility:** `ProductSearch::add_live_results()` is a new public method on `Automattic\WooCommerce\Blocks\BlockTypes\ProductSearch`, registered by `initialize()` as a `render_block_core/search` filter callback (public visibility is required for the hook). It is additive — no existing method signature or behaviour changes; with the attribute absent or not `true` it returns the content untouched.

- Scope is deliberately minimal: products only (this is the *Product* Search variation), no query-suggestion sections, no relevance changes — whatever `search=` returns is what the dropdown shows.
- Happy to rework the view script onto the Interactivity API if that is the preferred direction for new frontend behaviour.
- `declare( strict_types = 1 )` is added to `ProductSearch.php` in passing (44 of 148 BlockTypes files already declare it); can split out if preferred.

## Testing instructions

1. Add the **Product Search** block to a template (e.g. the header).
2. In the block settings, enable **Show products while typing**.
3. On the frontend, type at least two characters of a product name.
4. Matching products appear in a dropdown with image, name and price; clicking one opens its page; Enter submits the normal search; the toggle off restores the previous behaviour exactly.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

