### PR TITLE
Fix fatal error from malformed product query args (legacy storage)

### DIFF
--- a/plugins/woocommerce/changelog/58259-fix-legacy-order-query-fatal-guard
+++ b/plugins/woocommerce/changelog/58259-fix-legacy-order-query-fatal-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent malformed date, status and customer arguments to wc_get_orders() from raising an uncaught fatal error on legacy post storage, so an invalid query returns an empty result set instead of taking down the request.

--- a/plugins/woocommerce/changelog/58259-fix-legacy-product-query-fatal-guard
+++ b/plugins/woocommerce/changelog/58259-fix-legacy-product-query-fatal-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent malformed date and status arguments to wc_get_products() from raising an uncaught fatal error on legacy post storage, so an invalid query returns an empty result set instead of taking down the request.

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -505,6 +505,156 @@ class WC_Data_Store_WP {
 	}
 
 	/**
+	 * Query failures already logged this request, keyed by error code and query var.
+	 *
+	 * A malformed query no longer stops the caller, so a loop over bad data would otherwise write
+	 * one log line per iteration.
+	 *
+	 * @var array
+	 */
+	private static $logged_query_failures = array();
+
+	/**
+	 * Checks whether a query arg value can safely be used where a string is expected.
+	 *
+	 * PHP 8 raises a TypeError when an array or non-stringable object reaches a string-typed
+	 * parameter or an internal string function, and an Error when a non-stringable object is
+	 * concatenated. An array concatenated only warns. None is an Exception, so none is caught by
+	 * the try/catch blocks on this path.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $value The value to check.
+	 * @return bool True if the value can be used as a string, false otherwise.
+	 */
+	protected function is_usable_as_string( $value ) {
+		return is_scalar( $value ) || ( is_object( $value ) && method_exists( $value, '__toString' ) );
+	}
+
+	/**
+	 * Checks whether an order status value would raise an Error when the 'wc-' prefix is concatenated.
+	 *
+	 * Only objects without a __toString() method qualify. Arrays and null merely warn or convert
+	 * silently and are then reduced to '' by WP_Query's sanitize_key(), so they must keep their
+	 * pre-existing behaviour of dropping the status clause rather than emptying the result set.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $status The status value to check.
+	 * @return bool True if concatenating the value would raise an Error.
+	 */
+	protected function is_unusable_status( $status ) {
+		return is_object( $status ) && ! method_exists( $status, '__toString' );
+	}
+
+	/**
+	 * Checks whether a status value would actually narrow the query.
+	 *
+	 * WP_Query builds its status clause by intersecting the requested list with get_post_stati(),
+	 * so a value naming no registered status contributes nothing and the clause disappears.
+	 * Truthiness is not the test: 'not-a-status' is truthy and still filters nothing. 'any' is the
+	 * exception, since WP_Query turns it into exclusion clauses instead.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $status The status value to check.
+	 * @return bool True if the value narrows the query, false otherwise.
+	 */
+	protected function status_narrows_query( $status ) {
+		if ( 'any' === $status ) {
+			return true;
+		}
+
+		return in_array( sanitize_key( $status ), get_post_stati(), true );
+	}
+
+	/**
+	 * Checks whether any leaf of a query arg value cannot be used where a string is expected.
+	 *
+	 * Recurses because a nested array is a supported grouping construct for some args, so an array
+	 * is only unusable when something inside it is.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $value The value to check.
+	 * @return bool True if any leaf cannot be used as a string, false otherwise.
+	 */
+	protected function contains_unusable_value( $value ) {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				if ( $this->contains_unusable_value( $item ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return ! $this->is_usable_as_string( $value );
+	}
+
+	/**
+	 * Marks a query as unsatisfiable, so it returns nothing rather than running without the
+	 * filter the caller asked for.
+	 *
+	 * Two mechanisms are used together. `errors` is what the calling store's query() checks to skip
+	 * WP_Query entirely, but it is only reachable if the args survive the
+	 * the store's get_..._query filter that fires afterwards, and a
+	 * callback that rebuilds the array can drop it. `post__in => array( 0 )` is a normal query arg
+	 * that such a callback carries forward, and no post has ID 0, so the query still matches
+	 * nothing if `errors` is lost. Any caller-supplied `p` is removed alongside it, because
+	 * WP_Query honours `p` in preference to `post__in`.
+	 *
+	 * @since 11.2.0
+	 * @param array  $wp_query_args WP_Query args, passed by reference.
+	 * @param string $code          Error code.
+	 * @param string $message       Error message.
+	 * @param array  $context       Reporting context: 'key' the offending query var, 'value' its
+	 *                              value, 'function' the entry point to name, 'source' the log
+	 *                              source. Supplied by the calling store, which knows which of
+	 *                              its args failed and what to call itself.
+	 * @return void
+	 */
+	protected function fail_query_closed( &$wp_query_args, $code, $message, $context = array() ) {
+		$wp_query_args['errors'][] = new WP_Error( $code, $message );
+		$wp_query_args['post__in'] = array( 0 );
+
+		// WP_Query honours 'p' and its aliases in preference to post__in, so a caller-supplied
+		// 'p' would return that order despite the query being failed closed.
+		unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
+
+		$key      = isset( $context['key'] ) ? $context['key'] : '';
+		$type     = array_key_exists( 'value', $context ) ? gettype( $context['value'] ) : 'unknown';
+		$function = isset( $context['function'] ) ? $context['function'] : 'wc_get_objects';
+		$source   = isset( $context['source'] ) ? $context['source'] : 'legacy-query';
+
+		$detail = sprintf(
+			/* translators: 1: query argument name, 2: PHP type of the value passed. */
+			__( 'The "%1$s" argument was passed a %2$s, which cannot be used here. Returning an empty result set.', 'woocommerce' ),
+			esc_html( $key ),
+			esc_html( $type )
+		);
+
+		// One log line per distinct failure per process, keyed by code and query var so that a
+		// second, different bad arg is still reported. Later occurrences of the same one in a
+		// long-running process (WP-CLI, cron) are not logged, though the query still fails closed.
+		$dedup_key = $code . '|' . $key;
+
+		if ( isset( self::$logged_query_failures[ $dedup_key ] ) ) {
+			return;
+		}
+
+		self::$logged_query_failures[ $dedup_key ] = true;
+
+		wc_get_logger()->warning(
+			$detail,
+			array(
+				'code'   => $code,
+				'key'    => $key,
+				'type'   => $type,
+				'origin' => $function,
+				'source' => $source,
+			)
+		);
+	}
+
+	/**
 	 * Return list of internal meta keys.
 	 *
 	 * @since 3.2.0

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -335,7 +335,8 @@ class WC_Data_Store_WP {
 	 * Also accepts a WC_DateTime object.
 	 *
 	 * @since 3.2.0
-	 * @param mixed  $query_var A valid date format.
+	 * @param mixed  $query_var A valid date format. Values that cannot be used as a string are
+	 *                          treated as an unparseable date.
 	 * @param string $key meta or db column key.
 	 * @param array  $wp_query_args WP_Query args.
 	 * @return array Modified $wp_query_args
@@ -350,13 +351,21 @@ class WC_Data_Store_WP {
 		$dates    = array();
 		$operator = '=';
 
+		// Reaches preg_match() below, which raises a TypeError that escapes the catch. Treated as
+		// an unparseable date, like other malformed values. Note this is fail-open for meta-backed
+		// keys, whose clause compares as a string: callers needing to fail closed must check first.
+		if ( ! is_scalar( $query_var ) && ! ( is_object( $query_var ) && method_exists( $query_var, '__toString' ) ) ) {
+			$query_var = '';
+		}
+
 		try {
 			// Specific time query with a WC_DateTime.
-			if ( is_a( $query_var, 'WC_DateTime' ) ) {
+			if ( $query_var instanceof WC_DateTime ) {
 				$dates[] = $query_var;
 			} elseif ( is_numeric( $query_var ) ) { // Specific time query with a timestamp.
 				$dates[] = new WC_DateTime( "@{$query_var}", new DateTimeZone( 'UTC' ) );
-			} elseif ( preg_match( $query_parse_regex, $query_var, $sections ) ) { // Query with operators and possible range of dates.
+			} elseif ( preg_match( $query_parse_regex, (string) $query_var, $sections ) ) {
+				// Query with operators and possible range of dates.
 				if ( ! empty( $sections[1] ) ) {
 					$dates[] = is_numeric( $sections[1] ) ? new WC_DateTime( "@{$sections[1]}", new DateTimeZone( 'UTC' ) ) : wc_string_to_datetime( $sections[1] );
 				}
@@ -368,7 +377,7 @@ class WC_Data_Store_WP {
 					$precision = 'day';
 				}
 			} else { // Specific time query with a string.
-				$dates[]   = wc_string_to_datetime( $query_var );
+				$dates[]   = wc_string_to_datetime( (string) $query_var );
 				$precision = 'day';
 			}
 		} catch ( Exception $e ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -911,136 +911,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
-	 * Query failures already logged this request, keyed by error code.
-	 *
-	 * A malformed query no longer stops the caller, so a loop over bad data would otherwise write
-	 * one log line per iteration.
-	 *
-	 * @var array
-	 */
-	private static $logged_query_failures = array();
-
-	/**
-	 * Checks whether a query arg value can safely be used where a string is expected.
-	 *
-	 * PHP 8 raises a TypeError when an array or non-stringable object reaches a string-typed
-	 * parameter or an internal string function, and an Error when a non-stringable object is
-	 * concatenated. An array concatenated only warns. None is an Exception, so none is caught by
-	 * the try/catch blocks on this path.
-	 *
-	 * @since 11.2.0
-	 * @param mixed $value The value to check.
-	 * @return bool True if the value can be used as a string, false otherwise.
-	 */
-	private function is_usable_as_string( $value ) {
-		return is_scalar( $value ) || ( is_object( $value ) && method_exists( $value, '__toString' ) );
-	}
-
-	/**
-	 * Checks whether an order status value would raise an Error when the 'wc-' prefix is concatenated.
-	 *
-	 * Only objects without a __toString() method qualify. Arrays and null merely warn or convert
-	 * silently and are then reduced to '' by WP_Query's sanitize_key(), so they must keep their
-	 * pre-existing behaviour of dropping the status clause rather than emptying the result set.
-	 *
-	 * @since 11.2.0
-	 * @param mixed $status The status value to check.
-	 * @return bool True if concatenating the value would raise an Error.
-	 */
-	private function is_unusable_status( $status ) {
-		return is_object( $status ) && ! method_exists( $status, '__toString' );
-	}
-
-	/**
-	 * Checks whether a status value would actually narrow the query.
-	 *
-	 * WP_Query builds its status clause by intersecting the requested list with get_post_stati(),
-	 * so a value naming no registered status contributes nothing and the clause disappears.
-	 * Truthiness is not the test: 'not-a-status' is truthy and still filters nothing. 'any' is the
-	 * exception, since WP_Query turns it into exclusion clauses instead.
-	 *
-	 * @since 11.2.0
-	 * @param mixed $status The status value to check.
-	 * @return bool True if the value narrows the query, false otherwise.
-	 */
-	private function status_narrows_query( $status ) {
-		if ( 'any' === $status ) {
-			return true;
-		}
-
-		return in_array( sanitize_key( $status ), get_post_stati(), true );
-	}
-
-	/**
-	 * Checks whether any leaf of a query arg value cannot be used where a string is expected.
-	 *
-	 * Recurses because a nested array is a supported grouping construct for some args, so an array
-	 * is only unusable when something inside it is.
-	 *
-	 * @since 11.2.0
-	 * @param mixed $value The value to check.
-	 * @return bool True if any leaf cannot be used as a string, false otherwise.
-	 */
-	private function contains_unusable_value( $value ) {
-		if ( is_array( $value ) ) {
-			foreach ( $value as $item ) {
-				if ( $this->contains_unusable_value( $item ) ) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		return ! $this->is_usable_as_string( $value );
-	}
-
-	/**
-	 * Marks a query as unsatisfiable, so it returns no orders rather than running without the
-	 * filter the caller asked for.
-	 *
-	 * Two mechanisms are used together. `errors` is what {@see self::query()} checks to skip
-	 * WP_Query entirely, but it is only reachable if the args survive the
-	 * `woocommerce_order_data_store_cpt_get_orders_query` filter that fires afterwards, and a
-	 * callback that rebuilds the array can drop it. `post__in => array( 0 )` is a normal query arg
-	 * that such a callback carries forward, and no post has ID 0, so the query still matches
-	 * nothing if `errors` is lost. Any caller-supplied `p` is removed alongside it, because
-	 * WP_Query honours `p` in preference to `post__in`.
-	 *
-	 * @since 11.2.0
-	 * @param array  $wp_query_args WP_Query args, passed by reference.
-	 * @param string $code          Error code.
-	 * @param string $message       Error message.
-	 * @return void
-	 */
-	private function fail_query_closed( &$wp_query_args, $code, $message ) {
-		$wp_query_args['errors'][] = new WP_Error( $code, $message );
-		$wp_query_args['post__in'] = array( 0 );
-
-		// WP_Query honours 'p' and its aliases in preference to post__in, so a caller-supplied
-		// 'p' would return that order despite the query being failed closed.
-		unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
-
-		// One line per distinct failure per process, since a loop over stored bad data would
-		// otherwise log every iteration. Later occurrences in a long-running process (WP-CLI,
-		// cron) are not logged, though the query still fails closed each time.
-		if ( isset( self::$logged_query_failures[ $code ] ) ) {
-			return;
-		}
-
-		self::$logged_query_failures[ $code ] = true;
-
-		wc_get_logger()->warning(
-			__( 'Malformed order query args. Returning no orders.', 'woocommerce' ),
-			array(
-				'code'   => $code,
-				'origin' => __METHOD__,
-				'source' => 'legacy-order-query',
-			)
-		);
-	}
-
-	/**
 	 * Get valid WP_Query args from a WC_Order_Query's query variables.
 	 *
 	 * @since 3.1.0
@@ -1073,7 +943,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		// rejected, because only that raises an Error on the concatenation. Arrays and null are
 		// reduced to '' by WP_Query's sanitize_key(), which drops the status clause, so rejecting
 		// them would turn a working query into an empty one.
-		$has_unusable_status = false;
+		$has_unusable_status   = false;
+		$unusable_status_value = null;
 
 		if ( ! empty( $query_vars['post_status'] ) ) {
 			if ( is_array( $query_vars['post_status'] ) ) {
@@ -1081,7 +952,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 				foreach ( $query_vars['post_status'] as $status ) {
 					if ( $this->is_unusable_status( $status ) ) {
-						$has_unusable_status = true;
+						$has_unusable_status   = true;
+						$unusable_status_value = $status;
 						continue;
 					}
 
@@ -1100,7 +972,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					unset( $query_vars['post_status'] );
 				}
 			} elseif ( $this->is_unusable_status( $query_vars['post_status'] ) ) {
-				$has_unusable_status = true;
+				$has_unusable_status   = true;
+				$unusable_status_value = $query_vars['post_status'];
 				unset( $query_vars['post_status'] );
 			} else {
 				$query_vars['post_status'] = wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
@@ -1114,7 +987,13 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$this->fail_query_closed(
 				$wp_query_args,
 				'woocommerce_order_query_invalid_status',
-				__( 'Invalid order status.', 'woocommerce' )
+				__( 'Invalid order status.', 'woocommerce' ),
+				array(
+					'key'      => 'status',
+					'value'    => $unusable_status_value,
+					'function' => 'wc_get_orders',
+					'source'   => 'legacy-order-query',
+				)
 			);
 		}
 
@@ -1153,7 +1032,13 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					$this->fail_query_closed(
 						$wp_query_args,
 						'woocommerce_order_query_invalid_date',
-						__( 'Invalid date query.', 'woocommerce' )
+						__( 'Invalid date query.', 'woocommerce' ),
+						array(
+							'key'      => $query_var_key,
+							'value'    => $date_value,
+							'function' => 'wc_get_orders',
+							'source'   => 'legacy-order-query',
+						)
 					);
 				}
 
@@ -1178,7 +1063,13 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				$this->fail_query_closed(
 					$wp_query_args,
 					'woocommerce_order_query_invalid_customer',
-					__( 'Invalid customer query.', 'woocommerce' )
+					__( 'Invalid customer query.', 'woocommerce' ),
+					array(
+						'key'      => 'customer',
+						'value'    => $query_vars['customer'],
+						'function' => 'wc_get_orders',
+						'source'   => 'legacy-order-query',
+					)
 				);
 			} else {
 				$customer_query = $this->get_orders_generate_customer_meta_query( $values );

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -911,6 +911,136 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
+	 * Query failures already logged this request, keyed by error code.
+	 *
+	 * A malformed query no longer stops the caller, so a loop over bad data would otherwise write
+	 * one log line per iteration.
+	 *
+	 * @var array
+	 */
+	private static $logged_query_failures = array();
+
+	/**
+	 * Checks whether a query arg value can safely be used where a string is expected.
+	 *
+	 * PHP 8 raises a TypeError when an array or non-stringable object reaches a string-typed
+	 * parameter or an internal string function, and an Error when a non-stringable object is
+	 * concatenated. An array concatenated only warns. None is an Exception, so none is caught by
+	 * the try/catch blocks on this path.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $value The value to check.
+	 * @return bool True if the value can be used as a string, false otherwise.
+	 */
+	private function is_usable_as_string( $value ) {
+		return is_scalar( $value ) || ( is_object( $value ) && method_exists( $value, '__toString' ) );
+	}
+
+	/**
+	 * Checks whether an order status value would raise an Error when the 'wc-' prefix is concatenated.
+	 *
+	 * Only objects without a __toString() method qualify. Arrays and null merely warn or convert
+	 * silently and are then reduced to '' by WP_Query's sanitize_key(), so they must keep their
+	 * pre-existing behaviour of dropping the status clause rather than emptying the result set.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $status The status value to check.
+	 * @return bool True if concatenating the value would raise an Error.
+	 */
+	private function is_unusable_status( $status ) {
+		return is_object( $status ) && ! method_exists( $status, '__toString' );
+	}
+
+	/**
+	 * Checks whether a status value would actually narrow the query.
+	 *
+	 * WP_Query builds its status clause by intersecting the requested list with get_post_stati(),
+	 * so a value naming no registered status contributes nothing and the clause disappears.
+	 * Truthiness is not the test: 'not-a-status' is truthy and still filters nothing. 'any' is the
+	 * exception, since WP_Query turns it into exclusion clauses instead.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $status The status value to check.
+	 * @return bool True if the value narrows the query, false otherwise.
+	 */
+	private function status_narrows_query( $status ) {
+		if ( 'any' === $status ) {
+			return true;
+		}
+
+		return in_array( sanitize_key( $status ), get_post_stati(), true );
+	}
+
+	/**
+	 * Checks whether any leaf of a query arg value cannot be used where a string is expected.
+	 *
+	 * Recurses because a nested array is a supported grouping construct for some args, so an array
+	 * is only unusable when something inside it is.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $value The value to check.
+	 * @return bool True if any leaf cannot be used as a string, false otherwise.
+	 */
+	private function contains_unusable_value( $value ) {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				if ( $this->contains_unusable_value( $item ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return ! $this->is_usable_as_string( $value );
+	}
+
+	/**
+	 * Marks a query as unsatisfiable, so it returns no orders rather than running without the
+	 * filter the caller asked for.
+	 *
+	 * Two mechanisms are used together. `errors` is what {@see self::query()} checks to skip
+	 * WP_Query entirely, but it is only reachable if the args survive the
+	 * `woocommerce_order_data_store_cpt_get_orders_query` filter that fires afterwards, and a
+	 * callback that rebuilds the array can drop it. `post__in => array( 0 )` is a normal query arg
+	 * that such a callback carries forward, and no post has ID 0, so the query still matches
+	 * nothing if `errors` is lost. Any caller-supplied `p` is removed alongside it, because
+	 * WP_Query honours `p` in preference to `post__in`.
+	 *
+	 * @since 11.2.0
+	 * @param array  $wp_query_args WP_Query args, passed by reference.
+	 * @param string $code          Error code.
+	 * @param string $message       Error message.
+	 * @return void
+	 */
+	private function fail_query_closed( &$wp_query_args, $code, $message ) {
+		$wp_query_args['errors'][] = new WP_Error( $code, $message );
+		$wp_query_args['post__in'] = array( 0 );
+
+		// WP_Query honours 'p' and its aliases in preference to post__in, so a caller-supplied
+		// 'p' would return that order despite the query being failed closed.
+		unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
+
+		// One line per distinct failure per process, since a loop over stored bad data would
+		// otherwise log every iteration. Later occurrences in a long-running process (WP-CLI,
+		// cron) are not logged, though the query still fails closed each time.
+		if ( isset( self::$logged_query_failures[ $code ] ) ) {
+			return;
+		}
+
+		self::$logged_query_failures[ $code ] = true;
+
+		wc_get_logger()->warning(
+			__( 'Malformed order query args. Returning no orders.', 'woocommerce' ),
+			array(
+				'code'   => $code,
+				'origin' => __METHOD__,
+				'source' => 'legacy-order-query',
+			)
+		);
+	}
+
+	/**
 	 * Get valid WP_Query args from a WC_Order_Query's query variables.
 	 *
 	 * @since 3.1.0
@@ -939,18 +1069,54 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
-		// Add the 'wc-' prefix to status if needed.
+		// Add the 'wc-' prefix to status if needed. Only an object without __toString() is
+		// rejected, because only that raises an Error on the concatenation. Arrays and null are
+		// reduced to '' by WP_Query's sanitize_key(), which drops the status clause, so rejecting
+		// them would turn a working query into an empty one.
+		$has_unusable_status = false;
+
 		if ( ! empty( $query_vars['post_status'] ) ) {
 			if ( is_array( $query_vars['post_status'] ) ) {
-				foreach ( $query_vars['post_status'] as &$status ) {
-					$status = wc_is_order_status( 'wc-' . $status ) ? 'wc-' . $status : $status;
+				$usable_statuses = array();
+
+				foreach ( $query_vars['post_status'] as $status ) {
+					if ( $this->is_unusable_status( $status ) ) {
+						$has_unusable_status = true;
+						continue;
+					}
+
+					$usable_statuses[] = wc_is_order_status( 'wc-' . $status ) ? 'wc-' . $status : $status;
 				}
+
+				// Keep usable siblings and drop only the offending entries, but only when a
+				// survivor still narrows the query. A survivor that names no registered status
+				// contributes no clause at all, so counting it would drop the status filter
+				// entirely and return every order, including trashed ones.
+				$query_vars['post_status'] = $usable_statuses;
+				$has_unusable_status       = $has_unusable_status
+					&& ! array_filter( $usable_statuses, array( $this, 'status_narrows_query' ) );
+
+				if ( $has_unusable_status ) {
+					unset( $query_vars['post_status'] );
+				}
+			} elseif ( $this->is_unusable_status( $query_vars['post_status'] ) ) {
+				$has_unusable_status = true;
+				unset( $query_vars['post_status'] );
 			} else {
 				$query_vars['post_status'] = wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
 			}
 		}
 
 		$wp_query_args = parent::get_wp_query_args( $query_vars );
+
+		if ( $has_unusable_status ) {
+			unset( $wp_query_args['post_status'] );
+			$this->fail_query_closed(
+				$wp_query_args,
+				'woocommerce_order_query_invalid_status',
+				__( 'Invalid order status.', 'woocommerce' )
+			);
+		}
 
 		if ( ! isset( $wp_query_args['date_query'] ) ) {
 			$wp_query_args['date_query'] = array();
@@ -977,6 +1143,19 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		);
 		foreach ( $date_queries as $query_var_key => $db_key ) {
 			if ( isset( $query_vars[ $query_var_key ] ) && '' !== $query_vars[ $query_var_key ] ) {
+				$date_value = $query_vars[ $query_var_key ];
+
+				// Fail closed rather than run without the filter: for the meta-backed keys
+				// (_date_paid, _date_completed) the clause compares as a string, so dropping it
+				// returns every order that has the meta. The value still goes through the public,
+				// overridable parse_date_for_wp_query() so an extension's override is not skipped.
+				if ( ! $this->is_usable_as_string( $date_value ) ) {
+					$this->fail_query_closed(
+						$wp_query_args,
+						'woocommerce_order_query_invalid_date',
+						__( 'Invalid date query.', 'woocommerce' )
+					);
+				}
 
 				// Remove any existing meta queries for the same keys to prevent conflicts.
 				$existing_queries = wp_list_pluck( $wp_query_args['meta_query'], 'key', true );
@@ -990,12 +1169,24 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		}
 
 		if ( isset( $query_vars['customer'] ) && '' !== $query_vars['customer'] && array() !== $query_vars['customer'] ) {
-			$values         = is_array( $query_vars['customer'] ) ? $query_vars['customer'] : array( $query_vars['customer'] );
-			$customer_query = $this->get_orders_generate_customer_meta_query( $values );
-			if ( is_wp_error( $customer_query ) ) {
-				$wp_query_args['errors'][] = $customer_query;
+			$values = is_array( $query_vars['customer'] ) ? $query_vars['customer'] : array( $query_vars['customer'] );
+
+			// Reaches is_email()/strlen() in WP core and fatals before
+			// get_orders_generate_customer_meta_query() can return its WP_Error. The check recurses
+			// because a nested array is a supported AND-group shape, not malformed input.
+			if ( $this->contains_unusable_value( $values ) ) {
+				$this->fail_query_closed(
+					$wp_query_args,
+					'woocommerce_order_query_invalid_customer',
+					__( 'Invalid customer query.', 'woocommerce' )
+				);
 			} else {
-				$wp_query_args['meta_query'][] = $customer_query;
+				$customer_query = $this->get_orders_generate_customer_meta_query( $values );
+				if ( is_wp_error( $customer_query ) ) {
+					$wp_query_args['errors'][] = $customer_query;
+				} else {
+					$wp_query_args['meta_query'][] = $customer_query;
+				}
 			}
 		}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2286,7 +2286,61 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 		}
 
+		// 'status' is mapped to 'post_status' above and passed to WP_Query untouched, where a
+		// non-stringable value reaches array_unique() and fatals. Only an object without
+		// __toString() is rejected, because arrays and null merely degrade to an empty status
+		// clause, which is pre-existing behaviour.
+		$has_unusable_status   = false;
+		$unusable_status_value = null;
+
+		if ( ! empty( $query_vars['post_status'] ) ) {
+			if ( is_array( $query_vars['post_status'] ) ) {
+				$usable_statuses = array();
+
+				foreach ( $query_vars['post_status'] as $status ) {
+					if ( $this->is_unusable_status( $status ) ) {
+						$has_unusable_status   = true;
+						$unusable_status_value = $status;
+						continue;
+					}
+
+					$usable_statuses[] = $status;
+				}
+
+				// Keep usable siblings and drop only the offending entries, but only when a
+				// survivor still narrows the query. A survivor that names no registered status
+				// contributes no clause at all, so counting it would drop the status filter
+				// entirely and return every product, including trashed and draft ones.
+				$query_vars['post_status'] = $usable_statuses;
+				$has_unusable_status       = $has_unusable_status
+					&& ! array_filter( $usable_statuses, array( $this, 'status_narrows_query' ) );
+
+				if ( $has_unusable_status ) {
+					unset( $query_vars['post_status'] );
+				}
+			} elseif ( $this->is_unusable_status( $query_vars['post_status'] ) ) {
+				$has_unusable_status   = true;
+				$unusable_status_value = $query_vars['post_status'];
+				unset( $query_vars['post_status'] );
+			}
+		}
+
 		$wp_query_args = parent::get_wp_query_args( $query_vars );
+
+		if ( $has_unusable_status ) {
+			unset( $wp_query_args['post_status'] );
+			$this->fail_query_closed(
+				$wp_query_args,
+				'woocommerce_product_query_invalid_status',
+				__( 'Invalid product status.', 'woocommerce' ),
+				array(
+					'key'      => 'status',
+					'value'    => $unusable_status_value,
+					'function' => 'wc_get_products',
+					'source'   => 'legacy-product-query',
+				)
+			);
+		}
 
 		if ( ! isset( $wp_query_args['date_query'] ) ) {
 			$wp_query_args['date_query'] = array();
@@ -2468,6 +2522,27 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		);
 		foreach ( $date_queries as $query_var_key => $db_key ) {
 			if ( isset( $query_vars[ $query_var_key ] ) && '' !== $query_vars[ $query_var_key ] ) {
+				// Fail closed rather than run without the filter. That matters most for the two
+				// meta-backed sale-date keys, whose clause compares as a string, so dropping it
+				// returns every product that has a sale date; date_created and date_modified are
+				// post columns and are treated the same way for consistency.
+				//
+				// The value still goes through parse_date_for_wp_query() below, because that
+				// method is public and overridable and skipping it would silently disable an
+				// extension's override. It normalises an unusable value on its own.
+				if ( ! $this->is_usable_as_string( $query_vars[ $query_var_key ] ) ) {
+					$this->fail_query_closed(
+						$wp_query_args,
+						'woocommerce_product_query_invalid_date',
+						__( 'Invalid date query.', 'woocommerce' ),
+						array(
+							'key'      => $query_var_key,
+							'value'    => $query_vars[ $query_var_key ],
+							'function' => 'wc_get_products',
+							'source'   => 'legacy-product-query',
+						)
+					);
+				}
 
 				// Remove any existing meta queries for the same keys to prevent conflicts.
 				$existing_queries = wp_list_pluck( $wp_query_args['meta_query'], 'key', true );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -47,4 +47,63 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 
 		$product->delete();
 	}
+
+	/**
+	 * Values that cannot be used as a string and used to raise an uncaught TypeError.
+	 *
+	 * `parse_date_for_wp_query()` guards its parsing with `catch ( Exception )`, but PHP 8 raises a
+	 * `TypeError` when such a value reaches `preg_match()`. `TypeError` extends `Error`, so it
+	 * escaped that guard and surfaced as a fatal error.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function provider_unusable_date_query_vars(): array {
+		return array(
+			'array'        => array( array( 'foo' ) ),
+			'nested array' => array( array( array() ) ),
+			'empty array'  => array( array() ),
+			'object'       => array( new stdClass() ),
+		);
+	}
+
+	/**
+	 * @dataProvider provider_unusable_date_query_vars
+	 * @testdox parse_date_for_wp_query treats values that cannot be used as a string like an unparseable date.
+	 *
+	 * @param mixed $query_var The malformed date value.
+	 */
+	public function test_parse_date_for_wp_query_handles_unusable_values( $query_var ): void {
+		$store = new WC_Order_Data_Store_CPT();
+
+		$expected = $store->parse_date_for_wp_query( 'not-a-date', 'post_date', array() );
+		$actual   = $store->parse_date_for_wp_query( $query_var, 'post_date', array() );
+
+		$this->assertSame(
+			$expected,
+			$actual,
+			'Unusable date values should produce the same query as any other unparseable date.'
+		);
+	}
+
+	/**
+	 * @testdox parse_date_for_wp_query keeps working for values it already accepted.
+	 */
+	public function test_parse_date_for_wp_query_accepts_valid_values(): void {
+		$store = new WC_Order_Data_Store_CPT();
+
+		$from_string = $store->parse_date_for_wp_query( '2024-07-04', 'post_date', array() );
+		$this->assertSame( '2024', $from_string['date_query'][0]['year'] );
+		$this->assertSame( '7', $from_string['date_query'][0]['month'] );
+		$this->assertSame( '4', $from_string['date_query'][0]['day'] );
+
+		$from_datetime = $store->parse_date_for_wp_query(
+			new WC_DateTime( '2024-07-04 12:00:00', new DateTimeZone( 'UTC' ) ),
+			'post_date',
+			array()
+		);
+		$this->assertNotEmpty( $from_datetime['date_query'], 'WC_DateTime values must still build a date query.' );
+
+		$from_shorthand = $store->parse_date_for_wp_query( '>=2024-07-04', 'post_date', array() );
+		$this->assertArrayHasKey( 'after', $from_shorthand['date_query'][0], 'Shorthand operators must still be honoured.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1532,4 +1532,540 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			$this->assertGreaterThan( 0, $item->get_product_id(), 'Item should have a product ID from cached meta' );
 		}
 	}
+
+	/**
+	 * Malformed `wc_get_orders()` args that used to raise an uncaught TypeError on the CPT data store.
+	 *
+	 * @return array<string, array{0: array<string, mixed>}>
+	 */
+	public function provider_malformed_legacy_query_args(): array {
+		return array(
+			'date_created as array'       => array( array( 'date_created' => array( 'foo' ) ) ),
+			'date_created as object'      => array( array( 'date_created' => new stdClass() ) ),
+			'date_paid as array'          => array( array( 'date_paid' => array( 'foo' ) ) ),
+			'date_modified as array'      => array( array( 'date_modified' => array( 'foo' ) ) ),
+			'status as object'            => array( array( 'status' => new stdClass() ) ),
+			'status as array with object' => array( array( 'status' => array( new stdClass() ) ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider provider_malformed_legacy_query_args
+	 * @testdox Malformed query args do not raise a fatal error on the CPT order data store.
+	 *
+	 * @param array $args Malformed args to pass to `wc_get_orders()`.
+	 */
+	public function test_malformed_query_args_do_not_fatal( array $args ): void {
+		OrderHelper::create_order();
+
+		$args['return'] = 'ids';
+		$args['limit']  = -1;
+
+		$result = wc_get_orders( $args );
+
+		// assertSame( array() ), not assertIsArray(): a type-only check would pass even if the
+		// arg were dropped and the query widened.
+		$this->assertSame( array(), $result, 'A malformed restricting arg must match no orders.' );
+	}
+
+	/**
+	 * Status values that are not usable but never raised a fatal error.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function provider_inert_status_values(): array {
+		return array(
+			'array entry' => array( array( array() ) ),
+			'null entry'  => array( array( null ) ),
+		);
+	}
+
+	/**
+	 * @testdox Status values that were inert before the guard still return every order.
+	 *
+	 * @dataProvider provider_inert_status_values
+	 *
+	 * @param mixed $status The status value to query with.
+	 */
+	public function test_inert_status_values_still_return_every_order( $status ): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		// WP_Query reduces these to '' and drops the status clause, so they match every order.
+		// Rejecting them would turn a working query into an empty one. The handler swallows the
+		// array-to-string notice, which phpunit would otherwise convert into an exception.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test-only: keeps a pre-existing PHP notice from failing the assertion.
+		set_error_handler( static fn() => true, E_WARNING | E_NOTICE );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'status' => $status,
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertContains( $order->get_id(), $result, 'An inert status value must not empty the result set.' );
+	}
+
+	/**
+	 * WP_Query vars that resolve to 'p', which takes precedence over post__in.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_post_id_query_vars(): array {
+		return array(
+			'p'             => array( 'p' ),
+			'page_id'       => array( 'page_id' ),
+			'attachment_id' => array( 'attachment_id' ),
+			'subpost_id'    => array( 'subpost_id' ),
+		);
+	}
+
+	/**
+	 * @testdox A failed-closed query stays closed even if a filter drops the errors key.
+	 *
+	 * @dataProvider provider_post_id_query_vars
+	 *
+	 * @param string $id_var The WP_Query var carrying the order ID.
+	 */
+	public function test_fail_closed_query_survives_a_filter_dropping_errors( string $id_var ): void {
+		$order = OrderHelper::create_order();
+
+		$drop_errors = static function ( $args ) {
+			unset( $args['errors'] );
+			return $args;
+		};
+
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $drop_errors, 99 );
+
+		try {
+			// WP_Query honours 'p' over post__in, so the backstop only holds if 'p' is removed.
+			$result = wc_get_orders(
+				array(
+					'status' => new stdClass(),
+					$id_var  => $order->get_id(),
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $drop_errors, 99 );
+		}
+
+		$this->assertSame( array(), $result, 'post__in must not be bypassed by a caller-supplied p.' );
+	}
+
+	/**
+	 * @testdox Malformed date args match no orders rather than returning every order.
+	 *
+	 * @dataProvider provider_malformed_date_keys
+	 *
+	 * @param string $date_key The date query arg to set.
+	 */
+	public function test_malformed_date_args_match_no_orders( string $date_key ): void {
+		OrderHelper::create_order();
+
+		// A result count cannot distinguish the guard from incidental misses, since an unguarded
+		// value normalises to the Unix epoch. Assert on the fail-closed markers instead.
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		$result = wc_get_orders(
+			array(
+				$date_key => array( 'foo' ),
+				'return'  => 'ids',
+				'limit'   => -1,
+				'status'  => 'any',
+			)
+		);
+
+		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		$this->assertSame(
+			array(),
+			$result,
+			'An unusable date filter must fail closed rather than dropping the filter and returning every order.'
+		);
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed in case a filter drops the errors key.' );
+	}
+
+	/**
+	 * @testdox An unusable customer fails the query closed instead of fatalling in WP core.
+	 */
+	public function test_unusable_customer_matches_no_orders(): void {
+		OrderHelper::create_order();
+
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		$result = wc_get_orders(
+			array(
+				'customer' => new stdClass(),
+				'return'   => 'ids',
+				'limit'    => -1,
+				'status'   => 'any',
+			)
+		);
+
+		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		$this->assertSame( array(), $result, 'An unusable customer must not return orders.' );
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed.' );
+	}
+
+	/**
+	 * @testdox A nested customer array still builds an AND group rather than failing closed.
+	 *
+	 * Nested arrays are a supported grouping shape that get_orders_generate_customer_meta_query()
+	 * recurses into, so the guard must only reject unusable leaves. Mirrors the HPOS coverage in
+	 * OrdersTableDataStoreTests.
+	 */
+	public function test_nested_customer_array_still_matches_orders(): void {
+		$order = OrderHelper::create_order();
+		$order->set_billing_email( 'nested-probe@example.com' );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$matched = wc_get_orders(
+			array(
+				'customer' => array( array( 'nested-probe@example.com', 0 ) ),
+				'return'   => 'ids',
+				'limit'    => -1,
+				'status'   => 'any',
+			)
+		);
+
+		$this->assertContains(
+			$order->get_id(),
+			$matched,
+			'A nested customer array must build an AND group, not fail the query closed.'
+		);
+	}
+
+
+	/**
+	 * Date query args, covering both the post-column and the meta-backed keys.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_malformed_date_keys(): array {
+		return array(
+			'date_created (post column)'  => array( 'date_created' ),
+			'date_modified (post column)' => array( 'date_modified' ),
+			'date_paid (meta)'            => array( 'date_paid' ),
+			'date_completed (meta)'       => array( 'date_completed' ),
+		);
+	}
+
+
+	/**
+	 * @testdox An unusable status fails closed, matching no orders rather than every order.
+	 */
+	public function test_unusable_status_matches_no_orders(): void {
+		OrderHelper::create_order();
+
+		// A result count would pass with the guard removed: unsetting post_status leaves
+		// WP_Query's 'publish' default, which no wc-* order matches. Capture the
+		// built args so the fail-closed markers themselves are what the test depends on.
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		$result = wc_get_orders(
+			array(
+				'status' => new stdClass(),
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		$this->assertSame(
+			array(),
+			$result,
+			'A status that cannot be used as a string must not fall back to querying every order.'
+		);
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed in case a filter drops the errors key.' );
+	}
+
+
+	/**
+	 * Valid query args, paired with the order property they must match on.
+	 *
+	 * @return array<string, array{0: string, 1: mixed, 2: string, 3: mixed}>
+	 */
+	public function provider_valid_query_args(): array {
+		return array(
+			'date range'     => array( 'set_date_created', '2024-07-04T12:00:00', 'date_created', '2024-01-01...2024-12-31' ),
+			'customer email' => array( 'set_billing_email', 'guard-probe@example.com', 'customer', 'guard-probe@example.com' ),
+			'status'         => array( 'set_status', OrderStatus::COMPLETED, 'status', OrderStatus::COMPLETED ),
+		);
+	}
+
+	/**
+	 * @testdox Valid query args still match the orders they should on the CPT data store.
+	 *
+	 * @dataProvider provider_valid_query_args
+	 *
+	 * @param string $setter    Order setter for the property being queried.
+	 * @param mixed  $value     Value to set on the order.
+	 * @param string $query_key Query arg to filter by.
+	 * @param mixed  $query_val Value for that query arg.
+	 */
+	public function test_valid_query_args_still_match_orders( string $setter, $value, string $query_key, $query_val ): void {
+		$order = OrderHelper::create_order();
+		$order->{$setter}( $value );
+		$order->save();
+
+		// A second order that the arg must NOT match, so the assertion depends on the filter
+		// actually being applied rather than on there being only one order.
+		$other = OrderHelper::create_order();
+		$other->set_status( OrderStatus::ON_HOLD );
+		$other->set_billing_email( 'other@example.com' );
+		$other->set_date_created( '2019-01-01T00:00:00' );
+		$other->save();
+
+		// 'status' is a default and goes FIRST: a later key wins in a literal, and one provider
+		// row queries by status, which this would otherwise overwrite with 'any'.
+		$matched = wc_get_orders(
+			array_merge(
+				array( 'status' => 'any' ),
+				array(
+					$query_key => $query_val,
+					'return'   => 'ids',
+					'limit'    => -1,
+				)
+			)
+		);
+
+		$this->assertContains( $order->get_id(), $matched, 'A valid query arg must still match its order.' );
+		$this->assertNotContains( $other->get_id(), $matched, 'The arg must still exclude a non-matching order.' );
+	}
+
+	/**
+	 * Status lists whose only surviving entry filters nothing.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provider_unusable_status_with_inert_sibling(): array {
+		return array(
+			'object and empty string' => array( array( new stdClass(), '' ) ),
+			'object and null'         => array( array( new stdClass(), null ) ),
+			'object and array'        => array( array( new stdClass(), array() ) ),
+		);
+	}
+
+	/**
+	 * @testdox An unusable status fails closed even when an inert entry sits beside it.
+	 *
+	 * The inert entry survives the usability loop but filters no status, so treating it as a
+	 * usable sibling would drop the clause and return every order, trashed ones included. Trunk
+	 * fatalled on this input, so nothing depends on it returning rows.
+	 *
+	 * @dataProvider provider_unusable_status_with_inert_sibling
+	 *
+	 * @param array $status Status list mixing an unusable entry with an inert one.
+	 */
+	public function test_unusable_status_with_inert_sibling_fails_closed( array $status ): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$captured = null;
+		$capture  = function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 99 );
+
+		// An array entry warns on the 'wc-' concatenation exactly as it did before this change.
+		// Swallow it and continue, as production does, rather than let phpunit convert it.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test-only: reproduces production error semantics.
+		set_error_handler( static fn() => true );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'status' => $status,
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			restore_error_handler();
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 99 );
+		}
+
+		$this->assertSame( array(), $result, 'The query must match no orders.' );
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed.' );
+	}
+
+	/**
+	 * @testdox A status list keeps its usable entries and only the unusable ones are dropped.
+	 */
+	public function test_partially_usable_status_list_keeps_working(): void {
+		$completed = OrderHelper::create_order();
+		$completed->set_status( OrderStatus::COMPLETED );
+		$completed->save();
+
+		$pending = OrderHelper::create_order();
+		$pending->set_status( OrderStatus::PENDING );
+		$pending->save();
+
+		$result = wc_get_orders(
+			array(
+				// An object is the only entry that would raise an Error, so it is the only one the
+				// guard drops. An array entry is left to WP_Query, exactly as before this change.
+				'status' => array( OrderStatus::COMPLETED, new stdClass() ),
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		$this->assertContains( $completed->get_id(), $result, 'The usable status must still be applied.' );
+		$this->assertNotContains( $pending->get_id(), $result, 'Dropping an unusable entry must not drop the whole status filter.' );
+	}
+
+	/**
+	 * @testdox The 'all' and 'any' status shorthands are unaffected by the status guard.
+	 *
+	 * @dataProvider provider_status_shorthands
+	 *
+	 * @param mixed $status The status shorthand.
+	 */
+	public function test_status_shorthands_still_match_orders( $status ): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$result = wc_get_orders(
+			array(
+				'status' => $status,
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		$this->assertContains( $order->get_id(), $result, 'Status shorthands must keep matching orders.' );
+	}
+
+	/**
+	 * Status shorthands that resolve to an empty or full status list internally.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function provider_status_shorthands(): array {
+		return array(
+			"'all'"        => array( 'all' ),
+			"'any'"        => array( 'any' ),
+			"array('all')" => array( array( 'all' ) ),
+			"array('any')" => array( array( 'any' ) ),
+		);
+	}
+
+	/**
+	 * Status lists pairing an unusable entry with a truthy sibling that names no status.
+	 *
+	 * Truthiness alone does not make a survivor useful: WP_Query keeps only entries that match a
+	 * registered status, so these narrow nothing and the clause would vanish.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provider_unusable_status_with_non_filtering_sibling(): array {
+		return array(
+			'unregistered string sibling' => array( array( new stdClass(), 'bogus-not-a-status' ) ),
+			'non-empty array sibling'     => array( array( new stdClass(), array( 'x' ) ) ),
+			'zero string sibling'         => array( array( new stdClass(), '0' ) ),
+		);
+	}
+
+	/**
+	 * @testdox An unusable status whose only siblings filter nothing fails the query closed.
+	 *
+	 * @dataProvider provider_unusable_status_with_non_filtering_sibling
+	 *
+	 * @param array $status Status list mixing an unusable entry with a non-filtering one.
+	 */
+	public function test_unusable_status_with_non_filtering_sibling_fails_closed( array $status ): void {
+		$completed = OrderHelper::create_order();
+		$completed->set_status( OrderStatus::COMPLETED );
+		$completed->save();
+
+		$trashed = OrderHelper::create_order();
+		$trashed->set_status( OrderStatus::COMPLETED );
+		$trashed->save();
+		wp_trash_post( $trashed->get_id() );
+
+		// A non-empty array entry warns on the 'wc-' concatenation. Swallow it and continue, as
+		// production does, rather than let phpunit convert it.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test-only: reproduces production error semantics.
+		set_error_handler( static fn() => true, E_WARNING | E_NOTICE );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'status' => $status,
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		// Dropping the clause here would return more than an unfiltered query does, because
+		// WC_Order_Query's default status list excludes trash.
+		$this->assertSame( array(), $result, 'The query must match no orders.' );
+		$this->assertNotContains( $trashed->get_id(), $result, 'A trashed order must never leak through a failed-closed status query.' );
+	}
+
+	/**
+	 * @testdox An unregistered status string does not poison its siblings.
+	 */
+	public function test_unregistered_status_string_keeps_sibling(): void {
+		$completed = OrderHelper::create_order();
+		$completed->set_status( OrderStatus::COMPLETED );
+		$completed->save();
+
+		$pending = OrderHelper::create_order();
+		$pending->set_status( OrderStatus::PENDING );
+		$pending->save();
+
+		// The pre-existing contract the unusable-object case is aligned with: a status naming
+		// nothing is carried into the clause and matches no rows, leaving a valid sibling
+		// filtering as the caller asked.
+		$result = wc_get_orders(
+			array(
+				'status' => array( OrderStatus::COMPLETED, 'bogus-not-a-status' ),
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		$this->assertContains( $completed->get_id(), $result, 'An unregistered status must not drop a valid sibling.' );
+		$this->assertNotContains( $pending->get_id(), $result, 'The valid status must still restrict the query.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -735,4 +735,142 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$store->update_product_sales( $product_id, 30.5, 'set' );
 		$this->assertSame( '30.500000', get_post_meta( $product_id, 'total_sales', true ) );
 	}
+
+	/**
+	 * Product date query args whose clause compares as a string when it survives.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_malformed_product_date_keys(): array {
+		return array(
+			'date_created'      => array( 'date_created' ),
+			'date_modified'     => array( 'date_modified' ),
+			'date_on_sale_from' => array( 'date_on_sale_from' ),
+			'date_on_sale_to'   => array( 'date_on_sale_to' ),
+		);
+	}
+
+	/**
+	 * @testdox A malformed product date arg fails the query closed instead of returning every product.
+	 *
+	 * @dataProvider provider_malformed_product_date_keys
+	 *
+	 * @param string $date_key The date query arg to set.
+	 */
+	public function test_malformed_product_date_args_match_no_products( string $date_key ): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_date_on_sale_from( '2024-01-01' );
+		$product->save();
+
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_product_data_store_cpt_get_products_query', $capture, 1 );
+
+		try {
+			$result = wc_get_products(
+				array(
+					$date_key => array( 'foo' ),
+					'return'  => 'ids',
+					'limit'   => -1,
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_product_data_store_cpt_get_products_query', $capture, 1 );
+		}
+
+		$this->assertSame( array(), $result, 'An unusable date filter must fail closed rather than returning every product with a sale date.' );
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed in case a filter drops the errors key.' );
+	}
+
+	/**
+	 * @testdox An unusable product status fails the query closed instead of fatalling in WP_Query.
+	 */
+	public function test_unusable_product_status_matches_no_products(): void {
+		WC_Helper_Product::create_simple_product();
+
+		$result = wc_get_products(
+			array(
+				'status' => new stdClass(),
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		$this->assertSame( array(), $result, 'An unusable status must fail the query closed.' );
+	}
+
+	/**
+	 * @testdox An unusable product status entry is dropped while a usable sibling keeps filtering.
+	 */
+	public function test_partially_usable_product_status_list_keeps_working(): void {
+		$published = WC_Helper_Product::create_simple_product();
+
+		$draft = WC_Helper_Product::create_simple_product();
+		$draft->set_status( 'draft' );
+		$draft->save();
+
+		$result = wc_get_products(
+			array(
+				'status' => array( 'publish', new stdClass() ),
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		$this->assertContains( $published->get_id(), $result, 'A usable sibling must keep filtering.' );
+		$this->assertNotContains( $draft->get_id(), $result, 'The surviving status must still restrict the query.' );
+	}
+
+	/**
+	 * @testdox An unusable product status whose only sibling filters nothing fails the query closed.
+	 */
+	public function test_unusable_product_status_with_non_filtering_sibling_fails_closed(): void {
+		$published = WC_Helper_Product::create_simple_product();
+
+		$trashed = WC_Helper_Product::create_simple_product();
+		wp_trash_post( $trashed->get_id() );
+
+		$result = wc_get_products(
+			array(
+				'status' => array( new stdClass(), 'bogus-not-a-status' ),
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+
+		$this->assertSame( array(), $result, 'The query must match no products.' );
+		$this->assertNotContains( $trashed->get_id(), $result, 'A trashed product must never leak through a failed-closed status query.' );
+		$this->assertNotContains( $published->get_id(), $result, 'The query must not fall back to an unfiltered result set.' );
+	}
+
+	/**
+	 * @testdox Valid product date and status args still match products.
+	 */
+	public function test_valid_product_query_args_still_match_products(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_date_on_sale_from( '2024-01-01' );
+		$product->save();
+
+		$by_date = wc_get_products(
+			array(
+				'date_on_sale_from' => '>2023-01-01',
+				'return'            => 'ids',
+				'limit'             => -1,
+			)
+		);
+		$this->assertContains( $product->get_id(), $by_date, 'A valid sale-date filter must still match.' );
+
+		$by_status = wc_get_products(
+			array(
+				'status' => 'publish',
+				'return' => 'ids',
+				'limit'  => -1,
+			)
+		);
+		$this->assertContains( $product->get_id(), $by_status, 'A valid status filter must still match.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`wc_get_products()` shares `parse_date_for_wp_query()` with the order store, so the same `TypeError` that escapes its `catch ( Exception )` takes down a product query given a date value that cannot be used as a string. A status value fails separately: it is mapped to `post_status` and passed to WP_Query untouched, where `array_unique()` string-compares the list and raises an `Error` on a non-stringable entry, before `sanitize_key()` ever sees it.

This applies the guard the order store already uses. Both stores descend from `WC_Data_Store_WP`, so the stringability checks and the fail-closed marking move there rather than being repeated per store. Failing closed rather than dropping the filter matters most for the two meta-backed sale-date keys, whose clause compares as a string: dropping it returns every product that has a sale date at all.

Status follows the order store exactly, including keeping the entries that still filter when only some are unusable, and failing closed only when no survivor names a registered status.

**Stacked on #67971**, which guards the order store and introduces the mechanism. Review or merge that one first. Refs #58259.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store with **HPOS off**, create a few products, at least one with a sale-from date and one saved as a draft.
2. Add to a mu-plugin:
   ```php
   add_action( 'init', function () {
       if ( ! isset( $_GET['qa_58259p'] ) ) { return; }
       $out = array();
       $out['date_on_sale_from'] = count( wc_get_products( array( 'date_on_sale_from' => array( 'foo' ), 'return' => 'ids', 'limit' => -1 ) ) );
       $out['status_object']     = count( wc_get_products( array( 'status' => new stdClass(), 'return' => 'ids', 'limit' => -1 ) ) );
       $out['status_mixed']      = count( wc_get_products( array( 'status' => array( 'publish', new stdClass() ), 'return' => 'ids', 'limit' => -1 ) ) );
       echo '<!-- QA: ' . wp_json_encode( $out ) . ' -->';
   } );
   ```
3. Visit `/wp-admin/?qa_58259p=1`.
   - Before: HTTP 500, `TypeError: preg_replace()` or `Error: Object of class stdClass could not be converted to string`.
   - After: the page renders. `date_on_sale_from` and `status_object` are `0`; `status_mixed` equals your published product count, because the usable sibling still filters.
4. Confirm valid queries still work: `wc_get_products( array( 'date_on_sale_from' => '2024-01-01' ) )` and `status => 'publish'` return what they did before, and the draft product is not returned.
5. Confirm the fail-closed case does not widen: with a trashed product present, `status => array( new stdClass(), 'bogus-not-a-status' )` must return nothing rather than every product.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified in wp-env (PHP 8.1.34, WordPress 7.1, WooCommerce 11.2.0-dev) end-to-end through `wc_get_products()`.

- Every targeted vector returns an empty result instead of fatalling, and no input that returned rows before returns fewer.
- The array-status fatal was confirmed to be real before guarding it: `new WP_Query( array( 'post_status' => array( 'publish', new stdClass() ) ) )` raises `Error: Object of class stdClass could not be converted to string` at `wp-includes/class-wp-query.php:1134`, inside `array_unique()`, which is the inner call in `array_map( 'sanitize_key', array_unique( … ) )` and therefore runs before `sanitize_key()`'s `is_scalar()` guard.
- Valid date and status args still match; a mixed valid/invalid status array still filters on the valid entry; a trashed product does not leak through a failed-closed query.
- 124 tests / 452 assertions on the target suites, 1181 / 4363 across the data-store and query suites.
- `phpcs` and PHPStan clean on every changed line, no baseline additions.

Not tested on multisite. No options, paths, capabilities or site-scoped state are touched.

### Backward compatibility

Five `protected` methods are added to `WC_Data_Store_WP`: `is_usable_as_string()`, `is_unusable_status()`, `status_narrows_query()`, `contains_unusable_value()` and `fail_query_closed()`.

This is additive for callers but **not** for subclasses, and both of the following are uncatchable compile-time fatals, confirmed by execution:

- a subclass that already declares any of these names `private` fails to load with `Access level to Child::is_usable_as_string() must be protected (as in class Base) or weaker`;
- a subclass overriding `fail_query_closed( $args, … )` without the `&` on the first parameter fails with `Declaration … must be compatible with …`.

None of the five names exists anywhere else in this repo, and all 11 in-tree subclasses were checked. Out-of-tree subclasses cannot be enumerated, so the names are deliberately specific to this guard rather than generic. `fail_query_closed()` is introduced with its final four-parameter signature so that the follow-up diagnostics PR does not change it afterwards.

`wc_get_products()` returns an empty result set for malformed input instead of fatalling. Args that returned rows are unaffected. No hook added, removed, reordered, or given different arguments.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

AI tooling (Claude Code) was used substantially: reproducing the issue, implementing the fix, running adversarial reviews, and drafting this description. Findings were verified by hand against a running install before being acted on, and I have reviewed and take responsibility for the result.
