### PR TITLE
Report the argument that degraded a legacy order or product query

### DIFF
--- a/plugins/woocommerce/changelog/58259-add-legacy-query-arg-diagnostics
+++ b/plugins/woocommerce/changelog/58259-add-legacy-query-arg-diagnostics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Report the offending argument and its type when a malformed argument to wc_get_orders() or wc_get_products() degrades a legacy query, so the calling code can be located instead of the query silently returning nothing.

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -619,21 +619,56 @@ class WC_Data_Store_WP {
 		// 'p' would return that order despite the query being failed closed.
 		unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
 
+		unset( $context['recovered'] );
+		$this->report_invalid_query_arg( $code, $context );
+	}
+
+	/**
+	 * Reports a malformed query arg, which otherwise degrades the query silently.
+	 *
+	 * Separate from {@see self::fail_query_closed()} so that a caller which recovered from the bad
+	 * value, by dropping it and keeping a filter that still narrows the query, can still say so.
+	 * Locating the code that passed the value is the point, and that code is just as wrong when
+	 * the query happened to survive.
+	 *
+	 * Not wc_doing_it_wrong(): that writes to error_log() unconditionally on REST and AJAX
+	 * requests, which a loop over stored bad data would flood. _doing_it_wrong() only outputs
+	 * under WP_DEBUG, and carries the backtrace that locates the offending caller.
+	 *
+	 * @since 11.2.0
+	 * @param string $code    Error code.
+	 * @param array  $context Reporting context, see {@see self::fail_query_closed()}, plus
+	 *                        'recovered' true when the query still runs.
+	 * @return void
+	 */
+	protected function report_invalid_query_arg( $code, $context = array() ) {
 		$key      = isset( $context['key'] ) ? $context['key'] : '';
 		$type     = array_key_exists( 'value', $context ) ? gettype( $context['value'] ) : 'unknown';
 		$function = isset( $context['function'] ) ? $context['function'] : 'wc_get_objects';
 		$source   = isset( $context['source'] ) ? $context['source'] : 'legacy-query';
 
-		$detail = sprintf(
-			/* translators: 1: query argument name, 2: PHP type of the value passed. */
-			__( 'The "%1$s" argument was passed a %2$s, which cannot be used here. Returning an empty result set.', 'woocommerce' ),
-			esc_html( $key ),
-			esc_html( $type )
-		);
+		if ( empty( $context['recovered'] ) ) {
+			$detail = sprintf(
+				/* translators: 1: query argument name, 2: PHP type of the value passed. */
+				__( 'The "%1$s" argument was passed a %2$s, which cannot be used here. Returning an empty result set.', 'woocommerce' ),
+				esc_html( $key ),
+				esc_html( $type )
+			);
+		} else {
+			$detail = sprintf(
+				/* translators: 1: query argument name, 2: PHP type of the value passed. */
+				__( 'The "%1$s" argument was passed a %2$s, which cannot be used here. It was ignored and the rest of the argument still applies.', 'woocommerce' ),
+				esc_html( $key ),
+				esc_html( $type )
+			);
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Translated literal; the two interpolated values are escaped above.
+		_doing_it_wrong( esc_html( $function ), $detail, '11.2.0' );
 
 		// One log line per distinct failure per process, keyed by code and query var so that a
 		// second, different bad arg is still reported. Later occurrences of the same one in a
-		// long-running process (WP-CLI, cron) are not logged, though the query still fails closed.
+		// long-running process (WP-CLI, cron) are not logged, though the guard still applies.
 		$dedup_key = $code . '|' . $key;
 
 		if ( isset( self::$logged_query_failures[ $dedup_key ] ) ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -943,8 +943,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		// rejected, because only that raises an Error on the concatenation. Arrays and null are
 		// reduced to '' by WP_Query's sanitize_key(), which drops the status clause, so rejecting
 		// them would turn a working query into an empty one.
-		$has_unusable_status   = false;
-		$unusable_status_value = null;
+		$has_unusable_status     = false;
+		$dropped_unusable_status = false;
+		$unusable_status_value   = null;
 
 		if ( ! empty( $query_vars['post_status'] ) ) {
 			if ( is_array( $query_vars['post_status'] ) ) {
@@ -952,8 +953,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 				foreach ( $query_vars['post_status'] as $status ) {
 					if ( $this->is_unusable_status( $status ) ) {
-						$has_unusable_status   = true;
-						$unusable_status_value = $status;
+						$has_unusable_status     = true;
+						$dropped_unusable_status = true;
+						$unusable_status_value   = $status;
 						continue;
 					}
 
@@ -972,8 +974,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					unset( $query_vars['post_status'] );
 				}
 			} elseif ( $this->is_unusable_status( $query_vars['post_status'] ) ) {
-				$has_unusable_status   = true;
-				$unusable_status_value = $query_vars['post_status'];
+				$has_unusable_status     = true;
+				$dropped_unusable_status = true;
+				$unusable_status_value   = $query_vars['post_status'];
 				unset( $query_vars['post_status'] );
 			} else {
 				$query_vars['post_status'] = wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
@@ -993,6 +996,19 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					'value'    => $unusable_status_value,
 					'function' => 'wc_get_orders',
 					'source'   => 'legacy-order-query',
+				)
+			);
+		} elseif ( $dropped_unusable_status ) {
+			// The query still runs, on a narrower filter than the caller wrote. Say so anyway:
+			// locating the code that passes the bad value is the point of the report.
+			$this->report_invalid_query_arg(
+				'woocommerce_order_query_invalid_status',
+				array(
+					'key'       => 'status',
+					'value'     => $unusable_status_value,
+					'function'  => 'wc_get_orders',
+					'source'    => 'legacy-order-query',
+					'recovered' => true,
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2290,8 +2290,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// non-stringable value reaches array_unique() and fatals. Only an object without
 		// __toString() is rejected, because arrays and null merely degrade to an empty status
 		// clause, which is pre-existing behaviour.
-		$has_unusable_status   = false;
-		$unusable_status_value = null;
+		$has_unusable_status     = false;
+		$dropped_unusable_status = false;
+		$unusable_status_value   = null;
 
 		if ( ! empty( $query_vars['post_status'] ) ) {
 			if ( is_array( $query_vars['post_status'] ) ) {
@@ -2299,8 +2300,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 				foreach ( $query_vars['post_status'] as $status ) {
 					if ( $this->is_unusable_status( $status ) ) {
-						$has_unusable_status   = true;
-						$unusable_status_value = $status;
+						$has_unusable_status     = true;
+						$dropped_unusable_status = true;
+						$unusable_status_value   = $status;
 						continue;
 					}
 
@@ -2319,8 +2321,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					unset( $query_vars['post_status'] );
 				}
 			} elseif ( $this->is_unusable_status( $query_vars['post_status'] ) ) {
-				$has_unusable_status   = true;
-				$unusable_status_value = $query_vars['post_status'];
+				$has_unusable_status     = true;
+				$dropped_unusable_status = true;
+				$unusable_status_value   = $query_vars['post_status'];
 				unset( $query_vars['post_status'] );
 			}
 		}
@@ -2338,6 +2341,19 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					'value'    => $unusable_status_value,
 					'function' => 'wc_get_products',
 					'source'   => 'legacy-product-query',
+				)
+			);
+		} elseif ( $dropped_unusable_status ) {
+			// The query still runs, on a narrower filter than the caller wrote. Say so anyway:
+			// locating the code that passes the bad value is the point of the report.
+			$this->report_invalid_query_arg(
+				'woocommerce_product_query_invalid_status',
+				array(
+					'key'       => 'status',
+					'value'     => $unusable_status_value,
+					'function'  => 'wc_get_products',
+					'source'    => 'legacy-product-query',
+					'recovered' => true,
 				)
 			);
 		}

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1556,6 +1556,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param array $args Malformed args to pass to `wc_get_orders()`.
 	 */
 	public function test_malformed_query_args_do_not_fatal( array $args ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		OrderHelper::create_order();
 
 		$args['return'] = 'ids';
@@ -1635,6 +1639,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param string $id_var The WP_Query var carrying the order ID.
 	 */
 	public function test_fail_closed_query_survives_a_filter_dropping_errors( string $id_var ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		$order = OrderHelper::create_order();
 
 		$drop_errors = static function ( $args ) {
@@ -1669,6 +1677,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param string $date_key The date query arg to set.
 	 */
 	public function test_malformed_date_args_match_no_orders( string $date_key ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		OrderHelper::create_order();
 
 		// A result count cannot distinguish the guard from incidental misses, since an unguarded
@@ -1704,6 +1716,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testdox An unusable customer fails the query closed instead of fatalling in WP core.
 	 */
 	public function test_unusable_customer_matches_no_orders(): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		OrderHelper::create_order();
 
 		$captured = null;
@@ -1778,6 +1794,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testdox An unusable status fails closed, matching no orders rather than every order.
 	 */
 	public function test_unusable_status_matches_no_orders(): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		OrderHelper::create_order();
 
 		// A result count would pass with the guard removed: unsetting post_status leaves
@@ -1888,6 +1908,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param array $status Status list mixing an unusable entry with an inert one.
 	 */
 	public function test_unusable_status_with_inert_sibling_fails_closed( array $status ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		$order = OrderHelper::create_order();
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
@@ -1927,6 +1951,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testdox A status list keeps its usable entries and only the unusable ones are dropped.
 	 */
 	public function test_partially_usable_status_list_keeps_working(): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		$completed = OrderHelper::create_order();
 		$completed->set_status( OrderStatus::COMPLETED );
 		$completed->save();
@@ -2010,6 +2038,10 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param array $status Status list mixing an unusable entry with a non-filtering one.
 	 */
 	public function test_unusable_status_with_non_filtering_sibling_fails_closed( array $status ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
 		$completed = OrderHelper::create_order();
 		$completed->set_status( OrderStatus::COMPLETED );
 		$completed->save();

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -758,6 +758,10 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param string $date_key The date query arg to set.
 	 */
 	public function test_malformed_product_date_args_match_no_products( string $date_key ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_products' );
+
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_date_on_sale_from( '2024-01-01' );
 		$product->save();
@@ -790,6 +794,10 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testdox An unusable product status fails the query closed instead of fatalling in WP_Query.
 	 */
 	public function test_unusable_product_status_matches_no_products(): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_products' );
+
 		WC_Helper_Product::create_simple_product();
 
 		$result = wc_get_products(
@@ -807,6 +815,10 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testdox An unusable product status entry is dropped while a usable sibling keeps filtering.
 	 */
 	public function test_partially_usable_product_status_list_keeps_working(): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_products' );
+
 		$published = WC_Helper_Product::create_simple_product();
 
 		$draft = WC_Helper_Product::create_simple_product();
@@ -829,6 +841,10 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testdox An unusable product status whose only sibling filters nothing fails the query closed.
 	 */
 	public function test_unusable_product_status_with_non_filtering_sibling_fails_closed(): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_products' );
+
 		$published = WC_Helper_Product::create_simple_product();
 
 		$trashed = WC_Helper_Product::create_simple_product();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Guarding the legacy order and product queries against malformed args turns a fatal into an empty result set, which is the right outcome for the request but leaves nothing for a store owner to act on. #58259 traced its fatals to a third-party snippet, and that snippet is exactly what a degraded query gives no way to find.

This reports the offending query var and the PHP type it was given, through `_doing_it_wrong()` for the developer and a logged warning for the store owner. The value itself is never recorded, only its type, so a customer email or any other caller-supplied content stays out of the logs.

Not `wc_doing_it_wrong()`: that writes to `error_log()` unconditionally on REST and AJAX requests, which a loop over stored bad data would flood. `_doing_it_wrong()` only outputs under `WP_DEBUG` and carries the backtrace that locates the caller. The log is deduplicated per error code and query var, so a loop does not flood it while a second, different bad argument is still reported.

Reporting is separate from failing the query closed, so a query that recovered, by dropping the bad entry and keeping a filter that still narrows the result, is reported too. The code that passed the value is just as wrong when the query happened to survive, and that case would otherwise be the one silent path.

**Stacked on #68031**, which is itself stacked on #67971. Review or merge those first. Refs #58259.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store with **HPOS off**, set `WP_DEBUG` and `WP_DEBUG_LOG` to `true`, and create at least one completed order.
2. Add to a mu-plugin:
   ```php
   add_action( 'init', function () {
       if ( ! isset( $_GET['qa_58259d'] ) ) { return; }
       wc_get_orders( array( 'date_paid' => array( 'foo' ), 'return' => 'ids', 'limit' => -1 ) );
       wc_get_orders( array( 'status' => array( 'completed', new stdClass() ), 'return' => 'ids', 'limit' => -1 ) );
       wc_get_products( array( 'date_on_sale_from' => array( 'foo' ), 'return' => 'ids', 'limit' => -1 ) );
   } );
   ```
3. Visit `/wp-admin/?qa_58259d=1`, then check `wp-content/debug.log` and WooCommerce → Status → Logs.
   - Each malformed arg is reported once, naming the argument and its type, for example `The "date_paid" argument was passed a array, which cannot be used here. Returning an empty result set.`
   - The status case, which still returns the completed order, is reported with `It was ignored and the rest of the argument still applies.` — the query ran, and the bad value is still surfaced.
   - The order entries are logged under source `legacy-order-query` and the product entry under `legacy-product-query`.
4. Reload the page several times within one request lifecycle, or loop the same malformed query: the log records each distinct code and argument once per process, not once per iteration.
5. Confirm nothing is reported for valid queries, and that the offending **value** never appears in the log — only its type.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified in wp-env (PHP 8.1.34, WordPress 7.1, WooCommerce 11.2.0-dev).

- Both reporting channels fire with the argument name and `gettype()` output, and the raw value is never written.
- The recovered path is reported without failing the query closed, and the failed-closed path still returns an empty result set.
- Dedup is keyed by error code plus query var, so a second, different bad argument is still reported.
- 124 tests / 482 assertions on the target suites, 1181 / 4393 across the data-store and query suites. Twelve existing tests gained `setExpectedIncorrectUsage()` declarations, which also assert the notice actually fires: WP fails the test both if an undeclared notice is raised and if a declared one never is.
- `phpcs` and PHPStan clean on every changed line, no baseline additions.

Not tested on multisite. No options, paths, capabilities or site-scoped state are touched.

### Backward compatibility

- One `protected` method is added to `WC_Data_Store_WP`: `report_invalid_query_arg()`. The same subclass caveat as #68031 applies — a subclass already declaring that name `private`, or with an incompatible signature, fails to load. The name does not exist elsewhere in this repo.
- `fail_query_closed()` keeps the four-parameter signature introduced in #68031. This PR does not change it.
- `_doing_it_wrong()` fires the `doing_it_wrong_run` action on every degraded query, so a listener such as Query Monitor will record these. Output itself is gated on `WP_DEBUG`.
- No hook added, removed, reordered, or given different arguments.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

AI tooling (Claude Code) was used substantially: reproducing the issue, implementing the fix, running adversarial reviews, and drafting this description. Findings were verified by hand against a running install before being acted on, and I have reviewed and take responsibility for the result.
