### PR TITLE
Fix fatal error and memory exhaustion from a malformed date_query (legacy storage)

### DIFF
--- a/plugins/woocommerce/changelog/58259-fix-legacy-date-query-fatal-guard
+++ b/plugins/woocommerce/changelog/58259-fix-legacy-date-query-fatal-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a malformed date_query argument to wc_get_orders() or wc_get_products() from raising an uncaught fatal error, or exhausting memory, on legacy post storage.

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -566,6 +566,21 @@ class WC_Data_Store_WP {
 	}
 
 	/**
+	 * Checks whether a value can be used as one of WP_Date_Query's numeric date components.
+	 *
+	 * They reach mktime(), which declares ?int, so a Stringable object or a non-numeric string
+	 * fatals there even though both are usable as strings. null, booleans and arrays are left
+	 * alone: WP_Date_Query tolerates them today and the clause simply carries no restriction.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $value The value to check.
+	 * @return bool True if the value is safe to pass to mktime(), false otherwise.
+	 */
+	protected function is_usable_as_date_component( $value ) {
+		return is_null( $value ) || is_bool( $value ) || is_array( $value ) || is_numeric( $value );
+	}
+
+	/**
 	 * Checks whether a caller-supplied date_query contains a value WP_Date_Query cannot use.
 	 *
 	 * WP_Date_Query ignores keys it does not recognise, so an extension is free to carry its own
@@ -615,9 +630,19 @@ class WC_Data_Store_WP {
 			}
 
 			// A time key is consumed here. 'before' and 'after' also accept an array of parts.
+			//
+			// Only 'before' and 'after' given a single value reach a string consumer. Everything
+			// else is a date component that reaches mktime(), which declares ?int: a Stringable
+			// object or a non-numeric string fatals there despite being usable as a string.
 			if ( in_array( $key, $time_keys, true ) ) {
+				$is_string_consumer = in_array( $key, array( 'before', 'after' ), true ) && ! is_array( $value );
+
 				foreach ( is_array( $value ) ? $value : array( $value ) as $part ) {
-					if ( ! $this->is_usable_as_string( $part ) ) {
+					$usable = $is_string_consumer
+						? $this->is_usable_as_string( $part )
+						: $this->is_usable_as_date_component( $part );
+
+					if ( ! $usable ) {
 						return true;
 					}
 				}

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -566,6 +566,76 @@ class WC_Data_Store_WP {
 	}
 
 	/**
+	 * Checks whether a caller-supplied date_query contains a value WP_Date_Query cannot use.
+	 *
+	 * WP_Date_Query ignores keys it does not recognise, so an extension is free to carry its own
+	 * data in a clause and checking every leaf would reject queries that work today. The keys it
+	 * consumes are its own $time_keys plus 'compare' and 'relation', which reach mktime(),
+	 * preg_match() or strtoupper() and fail on a value that cannot be used there. 'column' is not
+	 * included: an unusable column is ignored rather than fatal.
+	 *
+	 * A nested array under any key other than a time key is another clause, which is how
+	 * WP_Date_Query itself walks the structure, so this recurses the same way.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $date_query The caller-supplied date_query arg.
+	 * @return bool True if some consumed value cannot be used, false otherwise.
+	 */
+	protected function date_query_contains_unusable_value( $date_query ) {
+		if ( ! is_array( $date_query ) ) {
+			return false;
+		}
+
+		$time_keys = array(
+			'after',
+			'before',
+			'year',
+			'month',
+			'monthnum',
+			'week',
+			'w',
+			'dayofyear',
+			'day',
+			'dayofweek',
+			'dayofweek_iso',
+			'hour',
+			'minute',
+			'second',
+		);
+
+		foreach ( $date_query as $key => $value ) {
+			// 'compare' and 'relation' are single values. An array is not merely unusable there:
+			// WP_Date_Query treats it as another clause and recurses until memory runs out.
+			if ( in_array( $key, array( 'compare', 'relation' ), true ) ) {
+				if ( ! $this->is_usable_as_string( $value ) ) {
+					return true;
+				}
+
+				continue;
+			}
+
+			// A time key is consumed here. 'before' and 'after' also accept an array of parts.
+			if ( in_array( $key, $time_keys, true ) ) {
+				foreach ( is_array( $value ) ? $value : array( $value ) as $part ) {
+					if ( ! $this->is_usable_as_string( $part ) ) {
+						return true;
+					}
+				}
+
+				continue;
+			}
+
+			// Anything else that is an array is another clause, which is how WP_Date_Query walks
+			// the structure. A non-array under an unrecognised key is ignored by it entirely.
+			if ( is_array( $value ) && $this->date_query_contains_unusable_value( $value ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Checks whether any leaf of a query arg value cannot be used where a string is expected.
 	 *
 	 * Recurses because a nested array is a supported grouping construct for some args, so an array

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -983,7 +983,34 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
+		// A caller-supplied date_query goes to WP_Date_Query untouched, where an unusable value
+		// reaches mktime(), preg_match() or strtoupper(). An unusable 'compare' is worse than a
+		// fatal: WP_Date_Query recurses on it until memory is exhausted.
+		$unusable_date_query     = null;
+		$has_unusable_date_query = isset( $query_vars['date_query'] )
+			&& $this->date_query_contains_unusable_value( $query_vars['date_query'] );
+
+		if ( $has_unusable_date_query ) {
+			$unusable_date_query = $query_vars['date_query'];
+			unset( $query_vars['date_query'] );
+		}
+
 		$wp_query_args = parent::get_wp_query_args( $query_vars );
+
+		if ( $has_unusable_date_query ) {
+			unset( $wp_query_args['date_query'] );
+			$this->fail_query_closed(
+				$wp_query_args,
+				'woocommerce_order_query_invalid_date_query',
+				__( 'Invalid date query.', 'woocommerce' ),
+				array(
+					'key'      => 'date_query',
+					'value'    => $unusable_date_query,
+					'function' => 'wc_get_orders',
+					'source'   => 'legacy-order-query',
+				)
+			);
+		}
 
 		if ( $has_unusable_status ) {
 			unset( $wp_query_args['post_status'] );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2328,7 +2328,34 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 		}
 
+		// A caller-supplied date_query goes to WP_Date_Query untouched, where an unusable value
+		// reaches mktime(), preg_match() or strtoupper(). An unusable 'compare' is worse than a
+		// fatal: WP_Date_Query recurses on it until memory is exhausted.
+		$unusable_date_query     = null;
+		$has_unusable_date_query = isset( $query_vars['date_query'] )
+			&& $this->date_query_contains_unusable_value( $query_vars['date_query'] );
+
+		if ( $has_unusable_date_query ) {
+			$unusable_date_query = $query_vars['date_query'];
+			unset( $query_vars['date_query'] );
+		}
+
 		$wp_query_args = parent::get_wp_query_args( $query_vars );
+
+		if ( $has_unusable_date_query ) {
+			unset( $wp_query_args['date_query'] );
+			$this->fail_query_closed(
+				$wp_query_args,
+				'woocommerce_product_query_invalid_date_query',
+				__( 'Invalid date query.', 'woocommerce' ),
+				array(
+					'key'      => 'date_query',
+					'value'    => $unusable_date_query,
+					'function' => 'wc_get_products',
+					'source'   => 'legacy-product-query',
+				)
+			);
+		}
 
 		if ( $has_unusable_status ) {
 			unset( $wp_query_args['post_status'] );

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -367,6 +367,7 @@ class WC_Unit_Tests_Bootstrap {
 		require_once dirname( $this->tests_dir ) . '/php/helpers/SerializingCacheTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/LoggerSpyTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/MetaDataAssertionTrait.php';
+		require_once dirname( $this->tests_dir ) . '/php/helpers/DateQueryGuardTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/CorePayPalGatewayTrait.php';
 	}
 

--- a/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
@@ -32,15 +32,64 @@ trait DateQueryGuardTrait {
 	public function provider_date_query_must_match(): array {
 		return array(
 			'year scalar'      => array( array( array( 'year' => 2024 ) ) ),
-			'year IN'          => array( array( array( 'year' => array( 2024, 2025 ), 'compare' => 'IN' ) ) ),
-			'year NOT IN'      => array( array( array( 'year' => array( 2019, 2020 ), 'compare' => 'NOT IN' ) ) ),
-			'year BETWEEN'     => array( array( array( 'year' => array( 2023, 2025 ), 'compare' => 'BETWEEN' ) ) ),
-			'month IN'         => array( array( array( 'month' => array( 5, 6 ), 'compare' => 'IN' ) ) ),
-			'day NOT IN'       => array( array( array( 'day' => array( 9, 10 ), 'compare' => 'NOT IN' ) ) ),
+			'year IN'          => array(
+				array(
+					array(
+						'year'    => array( 2024, 2025 ),
+						'compare' => 'IN',
+					),
+				),
+			),
+			'year NOT IN'      => array(
+				array(
+					array(
+						'year'    => array( 2019, 2020 ),
+						'compare' => 'NOT IN',
+					),
+				),
+			),
+			'year BETWEEN'     => array(
+				array(
+					array(
+						'year'    => array( 2023, 2025 ),
+						'compare' => 'BETWEEN',
+					),
+				),
+			),
+			'month IN'         => array(
+				array(
+					array(
+						'month'   => array( 5, 6 ),
+						'compare' => 'IN',
+					),
+				),
+			),
+			'day NOT IN'       => array(
+				array(
+					array(
+						'day'     => array( 9, 10 ),
+						'compare' => 'NOT IN',
+					),
+				),
+			),
 			'after date parts' => array( array( array( 'after' => array( 'year' => 2023 ) ) ) ),
-			'year empty list'  => array( array( array( 'year' => array(), 'compare' => 'IN' ) ) ),
+			'year empty list'  => array(
+				array(
+					array(
+						'year'    => array(),
+						'compare' => 'IN',
+					),
+				),
+			),
 			'after empty list' => array( array( array( 'after' => array() ) ) ),
-			'unrecognised key' => array( array( array( 'year' => 2024, 'ext_ctx' => 'anything' ) ) ),
+			'unrecognised key' => array(
+				array(
+					array(
+						'year'    => 2024,
+						'ext_ctx' => 'anything',
+					),
+				),
+			),
 		);
 	}
 
@@ -56,13 +105,44 @@ trait DateQueryGuardTrait {
 	public function provider_date_query_must_fail_closed(): array {
 		return array(
 			'year object'          => array( array( array( 'year' => new \stdClass() ) ) ),
-			'year list w/ object'  => array( array( array( 'year' => array( 2024, new \stdClass() ), 'compare' => 'IN' ) ) ),
+			'year list w/ object'  => array(
+				array(
+					array(
+						'year'    => array( 2024, new \stdClass() ),
+						'compare' => 'IN',
+					),
+				),
+			),
 			'after object'         => array( array( array( 'after' => new \stdClass() ) ) ),
 			'before parts object'  => array( array( array( 'before' => array( 'year' => new \stdClass() ) ) ) ),
-			'relation empty array' => array( array( 'relation' => array(), array( 'year' => 2024 ) ) ),
-			'relation object'      => array( array( 'relation' => new \stdClass(), array( 'year' => 2024 ) ) ),
-			'compare empty array'  => array( array( array( 'compare' => array(), 'year' => 2024 ) ) ),
-			'compare object'       => array( array( array( 'compare' => new \stdClass(), 'year' => 2024 ) ) ),
+			'relation empty array' => array(
+				array(
+					'relation' => array(),
+					array( 'year' => 2024 ),
+				),
+			),
+			'relation object'      => array(
+				array(
+					'relation' => new \stdClass(),
+					array( 'year' => 2024 ),
+				),
+			),
+			'compare empty array'  => array(
+				array(
+					array(
+						'compare' => array(),
+						'year'    => 2024,
+					),
+				),
+			),
+			'compare object'       => array(
+				array(
+					array(
+						'compare' => new \stdClass(),
+						'year'    => 2024,
+					),
+				),
+			),
 			'nested unknown key'   => array( array( array( 'ext_ctx' => array( 'year' => new \stdClass() ) ) ) ),
 		);
 	}

--- a/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
@@ -1,0 +1,69 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Helpers;
+
+/**
+ * Trait DateQueryGuardTrait.
+ *
+ * Shared date_query cases for the order stores, so the HPOS and legacy guards are held to the same
+ * contract. The two are separate implementations that cannot share code, and they have drifted
+ * apart four times: on status sibling handling, on whether a time key accepts a list, and twice on
+ * the ordering between the clause args and the array-aware check. Each drift shipped a defect that
+ * the suites did not catch, because each suite only exercised its own backend.
+ *
+ * Cases where the backends legitimately differ are deliberately absent rather than forced into
+ * agreement. 'column' is the example: an unusable column fatals inside the HPOS column validation
+ * but is ignored by WP_Query, so the two correctly answer it differently.
+ */
+trait DateQueryGuardTrait {
+
+	/**
+	 * date_query clauses that must keep matching, seeded against an order created 2024-06-01.
+	 *
+	 * The list forms are how WP_Date_Query expresses IN, NOT IN, BETWEEN and NOT BETWEEN, and are
+	 * documented as supported, so a guard must validate their elements rather than the list. An
+	 * empty list is included because it is the shape that broke twice: a guard that iterates the
+	 * elements sees nothing to reject, which is correct here and wrong for 'compare' and
+	 * 'relation' below.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provider_date_query_must_match(): array {
+		return array(
+			'year scalar'      => array( array( array( 'year' => 2024 ) ) ),
+			'year IN'          => array( array( array( 'year' => array( 2024, 2025 ), 'compare' => 'IN' ) ) ),
+			'year NOT IN'      => array( array( array( 'year' => array( 2019, 2020 ), 'compare' => 'NOT IN' ) ) ),
+			'year BETWEEN'     => array( array( array( 'year' => array( 2023, 2025 ), 'compare' => 'BETWEEN' ) ) ),
+			'month IN'         => array( array( array( 'month' => array( 5, 6 ), 'compare' => 'IN' ) ) ),
+			'day NOT IN'       => array( array( array( 'day' => array( 9, 10 ), 'compare' => 'NOT IN' ) ) ),
+			'after date parts' => array( array( array( 'after' => array( 'year' => 2023 ) ) ) ),
+			'year empty list'  => array( array( array( 'year' => array(), 'compare' => 'IN' ) ) ),
+			'after empty list' => array( array( array( 'after' => array() ) ) ),
+			'unrecognised key' => array( array( array( 'year' => 2024, 'ext_ctx' => 'anything' ) ) ),
+		);
+	}
+
+	/**
+	 * date_query clauses that must return nothing rather than fatal, and never widen the query.
+	 *
+	 * 'compare' and 'relation' holding an array are the dangerous pair: WP_Date_Query reads an
+	 * array under either as another clause and recurses on it until memory runs out, so a guard
+	 * that iterates the array instead of rejecting it takes the process down.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provider_date_query_must_fail_closed(): array {
+		return array(
+			'year object'          => array( array( array( 'year' => new \stdClass() ) ) ),
+			'year list w/ object'  => array( array( array( 'year' => array( 2024, new \stdClass() ), 'compare' => 'IN' ) ) ),
+			'after object'         => array( array( array( 'after' => new \stdClass() ) ) ),
+			'before parts object'  => array( array( array( 'before' => array( 'year' => new \stdClass() ) ) ) ),
+			'relation empty array' => array( array( 'relation' => array(), array( 'year' => 2024 ) ) ),
+			'relation object'      => array( array( 'relation' => new \stdClass(), array( 'year' => 2024 ) ) ),
+			'compare empty array'  => array( array( array( 'compare' => array(), 'year' => 2024 ) ) ),
+			'compare object'       => array( array( array( 'compare' => new \stdClass(), 'year' => 2024 ) ) ),
+			'nested unknown key'   => array( array( array( 'ext_ctx' => array( 'year' => new \stdClass() ) ) ) ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
@@ -25,9 +25,10 @@ trait DateQueryGuardTrait {
 	 * documented as supported, so a guard must validate their elements rather than the list. An
 	 * empty list is included because it is the shape that broke twice: a guard that iterates the
 	 * elements sees nothing to reject, which is correct here and wrong for 'compare' and
-	 * 'relation' below.
+	 * 'relation' below. The unrecognised key carries an object rather than a string, so that a
+	 * guard checking every leaf instead of the consumed keys fails here.
 	 *
-	 * @return array<string, array{0: array}>
+	 * @return array<string, array{0: array, 1: bool}>
 	 */
 	public function provider_date_query_must_match(): array {
 		return array(
@@ -82,11 +83,20 @@ trait DateQueryGuardTrait {
 				),
 			),
 			'after empty list' => array( array( array( 'after' => array() ) ) ),
+			'year IN no match' => array(
+				array(
+					array(
+						'year'    => array( 2019, 2020 ),
+						'compare' => 'IN',
+					),
+				),
+				false,
+			),
 			'unrecognised key' => array(
 				array(
 					array(
 						'year'    => 2024,
-						'ext_ctx' => 'anything',
+						'ext_ctx' => new \stdClass(),
 					),
 				),
 			),

--- a/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/DateQueryGuardTrait.php
@@ -19,6 +19,27 @@ namespace Automattic\WooCommerce\Tests\Helpers;
 trait DateQueryGuardTrait {
 
 	/**
+	 * A value usable as a string but not as a date component.
+	 *
+	 * WP_Date_Query hands numeric components to mktime(), which declares ?int, so this fatals
+	 * there while passing any stringability check.
+	 *
+	 * @return object
+	 */
+	private static function stringable_date_component() {
+		return new class() {
+			/**
+			 * Renders as a plausible year.
+			 *
+			 * @return string
+			 */
+			public function __toString(): string {
+				return '2024';
+			}
+		};
+	}
+
+	/**
 	 * date_query clauses that must keep matching, seeded against an order created 2024-06-01.
 	 *
 	 * The list forms are how WP_Date_Query expresses IN, NOT IN, BETWEEN and NOT BETWEEN, and are
@@ -92,6 +113,7 @@ trait DateQueryGuardTrait {
 				),
 				false,
 			),
+			'numeric string'   => array( array( array( 'year' => '2024' ) ) ),
 			'unrecognised key' => array(
 				array(
 					array(
@@ -153,6 +175,17 @@ trait DateQueryGuardTrait {
 					),
 				),
 			),
+			'stringable year'      => array(
+				array(
+					array( 'year' => self::stringable_date_component() ),
+				),
+			),
+			'stringable before'    => array(
+				array(
+					array( 'before' => array( 'year' => self::stringable_date_component() ) ),
+				),
+			),
+			'non-numeric year'     => array( array( array( 'year' => 'abc' ) ) ),
 			'nested unknown key'   => array( array( array( 'ext_ctx' => array( 'year' => new \stdClass() ) ) ) ),
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -2,6 +2,7 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use Automattic\WooCommerce\Tests\Helpers\DateQueryGuardTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
 
@@ -12,6 +13,8 @@ use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
  * @group order-query-tests
  */
 class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
+	use DateQueryGuardTrait;
+
 	use CogsAwareUnitTestSuiteTrait;
 
 	/**
@@ -2213,5 +2216,57 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		);
 
 		$this->assertContains( $order->get_id(), $result, 'A valid date_query must still match.' );
+	}
+
+	/**
+	 * @testdox A date_query the guard must honour still matches, shared with the HPOS suite.
+	 *
+	 * @dataProvider provider_date_query_must_match
+	 *
+	 * @param array $date_query The clause under test.
+	 */
+	public function test_shared_date_query_must_match( array $date_query ): void {
+		$order = OrderHelper::create_order();
+		$order->set_date_created( '2024-06-01' );
+		$order->save();
+
+		$result = wc_get_orders(
+			array(
+				'date_query' => $date_query,
+				'return'     => 'ids',
+				'limit'      => -1,
+				'status'     => 'any',
+			)
+		);
+
+		$this->assertContains( $order->get_id(), $result, 'A supported date_query must keep matching.' );
+	}
+
+	/**
+	 * @testdox A date_query the guard must reject returns nothing, shared with the HPOS suite.
+	 *
+	 * @dataProvider provider_date_query_must_fail_closed
+	 *
+	 * @param array $date_query The clause under test.
+	 */
+	public function test_shared_date_query_must_fail_closed( array $date_query ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
+		$order = OrderHelper::create_order();
+		$order->set_date_created( '2024-06-01' );
+		$order->save();
+
+		$result = wc_get_orders(
+			array(
+				'date_query' => $date_query,
+				'return'     => 'ids',
+				'limit'      => -1,
+				'status'     => 'any',
+			)
+		);
+
+		$this->assertSame( array(), $result, 'An unusable date_query must fail closed rather than widen the query.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -2100,4 +2100,118 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertContains( $completed->get_id(), $result, 'An unregistered status must not drop a valid sibling.' );
 		$this->assertNotContains( $pending->get_id(), $result, 'The valid status must still restrict the query.' );
 	}
+
+	/**
+	 * date_query shapes that reached WP_Date_Query and failed there.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provider_unusable_date_query(): array {
+		return array(
+			'year object'        => array( array( array( 'year' => new stdClass() ) ) ),
+			'after object'       => array( array( array( 'after' => new stdClass() ) ) ),
+			'before array part'  => array( array( array( 'before' => array( 'year' => new stdClass() ) ) ) ),
+			'relation array'     => array(
+				array(
+					'relation' => array(),
+					array( 'year' => 2020 ),
+				),
+			),
+			'compare array'      => array(
+				array(
+					array(
+						'column'  => 'post_date',
+						'compare' => array(),
+						'year'    => 2020,
+					),
+				),
+			),
+			'nested unknown key' => array( array( array( 'ext_ctx' => array( 'year' => new stdClass() ) ) ) ),
+		);
+	}
+
+	/**
+	 * @testdox An unusable date_query fails the query closed instead of fatalling in WP_Date_Query.
+	 *
+	 * @dataProvider provider_unusable_date_query
+	 *
+	 * @param array $date_query The malformed date_query arg.
+	 */
+	public function test_unusable_date_query_matches_no_orders( array $date_query ): void {
+		// Also asserts the notice fires: WP fails the test both if an undeclared
+		// incorrect-usage notice is raised and if a declared one never is.
+		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
+
+		OrderHelper::create_order();
+
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'date_query' => $date_query,
+					'return'     => 'ids',
+					'limit'      => -1,
+					'status'     => 'any',
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+		}
+
+		$this->assertSame( array(), $result, 'An unusable date_query must fail the query closed.' );
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable.' );
+		$this->assertArrayNotHasKey( 'date_query', array_filter( (array) ( $captured['date_query'] ?? array() ) ), 'The unusable clause must not reach WP_Query.' );
+	}
+
+	/**
+	 * @testdox A date_query key WP_Date_Query ignores does not reject the clause it does build.
+	 */
+	public function test_unknown_date_query_key_does_not_reject_the_clause(): void {
+		$order = OrderHelper::create_order();
+		$order->set_date_created( '2020-06-01' );
+		$order->save();
+
+		// An extension carrying its own data in a clause must not lose the year filter.
+		$result = wc_get_orders(
+			array(
+				'date_query' => array(
+					array(
+						'year'              => 2020,
+						'extension_context' => new stdClass(),
+					),
+				),
+				'return'     => 'ids',
+				'limit'      => -1,
+				'status'     => 'any',
+			)
+		);
+
+		$this->assertContains( $order->get_id(), $result, 'An unrecognised date_query key must not discard the clause.' );
+	}
+
+	/**
+	 * @testdox A valid date_query still matches orders.
+	 */
+	public function test_valid_date_query_still_matches_orders(): void {
+		$order = OrderHelper::create_order();
+		$order->set_date_created( '2020-06-01' );
+		$order->save();
+
+		$result = wc_get_orders(
+			array(
+				'date_query' => array( array( 'year' => 2020 ) ),
+				'return'     => 'ids',
+				'limit'      => -1,
+				'status'     => 'any',
+			)
+		);
+
+		$this->assertContains( $order->get_id(), $result, 'A valid date_query must still match.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -675,7 +675,8 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			$current_status = $order->get_status( 'edit' );
 			$order->set_status( $status );
 			$order_data_store_cpt->update( $order );
-			$order->set_status( 'checkout-draft' ); // Revert back to draft.
+			$order->set_status( 'checkout-draft' );
+			// Revert back to draft.
 			$order->save();
 			$this->assertEquals(
 				$k + 1,

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -2106,127 +2106,14 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * date_query shapes that reached WP_Date_Query and failed there.
-	 *
-	 * @return array<string, array{0: array}>
-	 */
-	public function provider_unusable_date_query(): array {
-		return array(
-			'year object'        => array( array( array( 'year' => new stdClass() ) ) ),
-			'after object'       => array( array( array( 'after' => new stdClass() ) ) ),
-			'before array part'  => array( array( array( 'before' => array( 'year' => new stdClass() ) ) ) ),
-			'relation array'     => array(
-				array(
-					'relation' => array(),
-					array( 'year' => 2020 ),
-				),
-			),
-			'compare array'      => array(
-				array(
-					array(
-						'column'  => 'post_date',
-						'compare' => array(),
-						'year'    => 2020,
-					),
-				),
-			),
-			'nested unknown key' => array( array( array( 'ext_ctx' => array( 'year' => new stdClass() ) ) ) ),
-		);
-	}
-
-	/**
-	 * @testdox An unusable date_query fails the query closed instead of fatalling in WP_Date_Query.
-	 *
-	 * @dataProvider provider_unusable_date_query
-	 *
-	 * @param array $date_query The malformed date_query arg.
-	 */
-	public function test_unusable_date_query_matches_no_orders( array $date_query ): void {
-		// Also asserts the notice fires: WP fails the test both if an undeclared
-		// incorrect-usage notice is raised and if a declared one never is.
-		$this->setExpectedIncorrectUsage( 'wc_get_orders' );
-
-		OrderHelper::create_order();
-
-		$captured = null;
-		$capture  = static function ( $args ) use ( &$captured ) {
-			$captured = $args;
-			return $args;
-		};
-		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
-
-		try {
-			$result = wc_get_orders(
-				array(
-					'date_query' => $date_query,
-					'return'     => 'ids',
-					'limit'      => -1,
-					'status'     => 'any',
-				)
-			);
-		} finally {
-			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
-		}
-
-		$this->assertSame( array(), $result, 'An unusable date_query must fail the query closed.' );
-		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable.' );
-		$this->assertArrayNotHasKey( 'date_query', array_filter( (array) ( $captured['date_query'] ?? array() ) ), 'The unusable clause must not reach WP_Query.' );
-	}
-
-	/**
-	 * @testdox A date_query key WP_Date_Query ignores does not reject the clause it does build.
-	 */
-	public function test_unknown_date_query_key_does_not_reject_the_clause(): void {
-		$order = OrderHelper::create_order();
-		$order->set_date_created( '2020-06-01' );
-		$order->save();
-
-		// An extension carrying its own data in a clause must not lose the year filter.
-		$result = wc_get_orders(
-			array(
-				'date_query' => array(
-					array(
-						'year'              => 2020,
-						'extension_context' => new stdClass(),
-					),
-				),
-				'return'     => 'ids',
-				'limit'      => -1,
-				'status'     => 'any',
-			)
-		);
-
-		$this->assertContains( $order->get_id(), $result, 'An unrecognised date_query key must not discard the clause.' );
-	}
-
-	/**
-	 * @testdox A valid date_query still matches orders.
-	 */
-	public function test_valid_date_query_still_matches_orders(): void {
-		$order = OrderHelper::create_order();
-		$order->set_date_created( '2020-06-01' );
-		$order->save();
-
-		$result = wc_get_orders(
-			array(
-				'date_query' => array( array( 'year' => 2020 ) ),
-				'return'     => 'ids',
-				'limit'      => -1,
-				'status'     => 'any',
-			)
-		);
-
-		$this->assertContains( $order->get_id(), $result, 'A valid date_query must still match.' );
-	}
-
-	/**
 	 * @testdox A date_query the guard must honour still matches, shared with the HPOS suite.
 	 *
 	 * @dataProvider provider_date_query_must_match
 	 *
-	 * @param array $date_query The clause under test.
+	 * @param array $date_query   The clause under test.
+	 * @param bool  $should_match Whether the seeded order should be returned.
 	 */
-	public function test_shared_date_query_must_match( array $date_query ): void {
+	public function test_shared_date_query_must_match( array $date_query, bool $should_match = true ): void {
 		$order = OrderHelper::create_order();
 		$order->set_date_created( '2024-06-01' );
 		$order->save();
@@ -2240,7 +2127,11 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertContains( $order->get_id(), $result, 'A supported date_query must keep matching.' );
+		if ( $should_match ) {
+			$this->assertContains( $order->get_id(), $result, 'A supported date_query must keep matching.' );
+		} else {
+			$this->assertNotContains( $order->get_id(), $result, 'The clause must still restrict the query.' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

A caller-supplied `date_query` goes from `wc_get_orders()` and `wc_get_products()` straight into `WP_Date_Query` on legacy post storage, where several shapes fail before any WooCommerce code sees them:

| `date_query` value | Result on trunk |
| --- | --- |
| `compare => array()` | **memory exhausted** |
| `year => object` | `TypeError` from `mktime()` |
| `after => object` | `TypeError` from `preg_match()` |
| `before => array( 'year' => object )` | `TypeError` from `mktime()` |
| `relation => array()` | `TypeError` from `strtoupper()` |
| unrecognised key holding `year => object` | `TypeError` from `mktime()` |

The first row is the worst of them. `WP_Date_Query` treats an array under a key that is not a time key as another clause and recurses on it, so an array `compare` does not fatal: it consumes the request's memory and takes the process down. Confirmed at `wp-includes/class-wp-date-query.php:246` with a 128M limit.

This validates the values `WP_Date_Query` consumes, and only those: its own `$time_keys` plus `compare` and `relation`. Keys it does not recognise are left alone, because it ignores them, and rejecting them would empty a query that works today, for example an extension carrying its own data alongside a `year`. `column` is not covered either, since an unusable column is ignored rather than fatal.

A nested array under any other key is another clause, which is how `WP_Date_Query` itself walks the structure, so the check recurses the same way and still reaches a time key buried under a name it does not know.

An unusable `date_query` fails the query closed through the mechanism the other guards already use, rather than dropping the clause, which would widen the query to every order or product.

**Stacked on #68032**, which is stacked on #68031 and #67971. Review or merge those first. The HPOS store guards the same arg at its own interpretation points in #67970. Refs #58259.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store with **HPOS off**, create at least one order and one product.
2. Add to a mu-plugin:
   ```php
   add_action( 'init', function () {
       if ( ! isset( $_GET['qa_dq'] ) ) { return; }
       $out = array();
       foreach ( array(
           'year'     => array( array( 'year' => new stdClass() ) ),
           'after'    => array( array( 'after' => new stdClass() ) ),
           'relation' => array( 'relation' => array(), array( 'year' => 2020 ) ),
           'compare'  => array( array( 'column' => 'post_date', 'compare' => array(), 'year' => 2020 ) ),
       ) as $key => $dq ) {
           $out[ $key ] = count( wc_get_orders( array( 'date_query' => $dq, 'return' => 'ids', 'limit' => -1, 'status' => 'any' ) ) );
       }
       echo '<!-- QA: ' . wp_json_encode( $out ) . ' -->';
   } );
   ```
3. Visit `/wp-admin/?qa_dq=1`.
   - Before: HTTP 500. The `compare` case exhausts memory rather than raising a `TypeError`, so it may take the request down harder than the others.
   - After: the page renders and the source contains `<!-- QA: {"year":0,"after":0,"relation":0,"compare":0} -->`.
4. Confirm a valid `date_query` still matches: an order created in 2020 is returned by `date_query => array( array( 'year' => 2020 ) )`.
5. Confirm an unrecognised key does not discard the clause: `date_query => array( array( 'year' => 2020, 'extension_context' => new stdClass() ) )` must still return that order.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified in wp-env (PHP 8.1.34, WordPress 7.1, WooCommerce 11.2.0-dev).

- Each vector in the table above was reproduced on trunk before being guarded, and returns an empty result set afterwards. The `compare` case was isolated with a 128M memory limit to confirm exhaustion rather than a fatal, and it killed the phpunit runner twice before the guard was in place.
- An unrecognised `date_query` key still returns the order the clause actually selects, so the guard does not repeat the over-broad validation that an earlier revision of the HPOS PR had.
- A valid `date_query` still matches.
- 132 tests / 508 assertions on the target suites, 1189 / 4419 across the data-store and query suites.
- `phpcs` and PHPStan clean on every changed line, no baseline additions.

Not tested on multisite. No options, paths, capabilities or site-scoped state are touched.

### Backward compatibility

- One `protected` method is added to `WC_Data_Store_WP`: `date_query_contains_unusable_value()`. The same subclass caveat as #68031 applies: a subclass already declaring that name `private`, or with an incompatible signature, fails to load. The name does not exist elsewhere in this repo.
- `wc_get_orders()` and `wc_get_products()` return an empty result set for a malformed `date_query` instead of fatalling. A `date_query` that returned rows is unaffected, including one carrying keys `WP_Date_Query` ignores.
- No hook added, removed, reordered, or given different arguments.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

AI tooling (Claude Code) was used substantially: reproducing the issue, implementing the fix, running adversarial reviews, and drafting this description. Findings were verified by hand against a running install before being acted on, and I have reviewed and take responsibility for the result.
