### PR TITLE
Add support for text and background color styles in the Product Quantity block

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -262,7 +262,7 @@ Display an input field customers can use to select the number of products to add
 - **Name:** woocommerce/add-to-cart-with-options-quantity-selector
 - **Category:** woocommerce-product-elements
 - **Ancestor:** woocommerce/add-to-cart-with-options
-- **Supports:** interactivity
+- **Supports:** color (background, text), interactivity
 
 ## Variation Description (Beta) - woocommerce/add-to-cart-with-options-variation-description
 

--- a/plugins/woocommerce/changelog/add-quantity-selector-background-color
+++ b/plugins/woocommerce/changelog/add-quantity-selector-background-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for text and background color styles in the Product Quantity block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -10,12 +10,16 @@
 	"apiVersion": 3,
 	"supports": {
 		"interactivity": true,
+		"color": {
+			"background": true,
+			"text": true
+		},
 		"__experimentalBorder": {
 			"radius": true
 		}
 	},
 	"selectors": {
-		"border": ".wp-block-woocommerce-add-to-cart-with-options-quantity-selector, .wc-block-add-to-cart-with-options-grouped-product-item-selector .wc-block-components-quantity-selector"
+		"root": ".wp-block-woocommerce-add-to-cart-with-options-quantity-selector, .wc-block-add-to-cart-with-options-grouped-product-item-selector .wc-block-components-quantity-selector"
 	},
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"viewScriptModule": "woocommerce/add-to-cart-with-options-quantity-selector"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/68000 but for text and background colors.

I'm not adding tests because I think the tests from #68000 already cover the fact that styles are applied to the block.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Styles > Blocks > Product Quantity (Beta).
2. Change the text and background color.
3. Verify the styles are applied in the editor and the frontend. Test also grouped products and verify the Grouped Product: Item Selector blocks inherits the same styles.

Style 1 | Style 2 | No style
--- | --- | ---
<img width="485" height="372" alt="imatge" src="https://github.com/user-attachments/assets/5f255d04-f2fc-4da8-8872-d3f31fac1621" /> | <img width="485" height="372" alt="imatge" src="https://github.com/user-attachments/assets/a7915fe3-1f4a-4102-9173-4dce6dadcb86" /> | <img width="485" height="372" alt="imatge" src="https://github.com/user-attachments/assets/553afc00-42fd-415a-898d-d9368a5629a2" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->