### PR TITLE
Fix the webhooks REST API ignoring the offset parameter

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-7139-webhooks-rest-offset
+++ b/plugins/woocommerce/changelog/fix-wooplug-7139-webhooks-rest-offset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the webhooks REST API ignoring the offset parameter.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
@@ -252,6 +252,8 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 
 		if ( empty( $request['offset'] ) ) {
 			$args['offset'] = 1 < $request['page'] ? ( $request['page'] - 1 ) * $args['limit'] : 0;
+		} else {
+			$args['offset'] = $request['offset'];
 		}
 
 		/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
@@ -1,0 +1,111 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Webhooks controller tests for the V3 REST API.
+ */
+class WC_REST_Webhooks_Controller_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * IDs of the webhooks created for each test, in creation order.
+	 *
+	 * @var int[]
+	 */
+	private $webhook_ids = array();
+
+	/**
+	 * Create an admin user and five webhooks to paginate over.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->webhook_ids = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$webhook = new WC_Webhook();
+			$webhook->set_name( "Webhook {$i}" );
+			$webhook->set_topic( 'order.created' );
+			$webhook->set_delivery_url( "https://example.com/webhook-{$i}" );
+			$webhook->save();
+			$this->webhook_ids[] = $webhook->get_id();
+		}
+	}
+
+	/**
+	 * List webhooks with the given query parameters and return their IDs.
+	 *
+	 * @param array $params Query parameters for the request.
+	 * @return int[]
+	 */
+	private function get_listed_ids( array $params ): array {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/webhooks' );
+		$request->set_query_params(
+			array_merge(
+				array(
+					'orderby' => 'id',
+					'order'   => 'asc',
+				),
+				$params
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		return array_column( $response->get_data(), 'id' );
+	}
+
+	/**
+	 * @testdox The offset parameter skips the given number of results.
+	 */
+	public function test_offset_offsets_the_result_set() {
+		$this->assertSame(
+			array_slice( $this->webhook_ids, 2, 2 ),
+			$this->get_listed_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => 2,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox The offset and page parameters produce the same slice for equivalent values.
+	 */
+	public function test_offset_matches_equivalent_page() {
+		$page_ids = $this->get_listed_ids(
+			array(
+				'per_page' => 2,
+				'page'     => 2,
+			)
+		);
+
+		$this->assertSame( array_slice( $this->webhook_ids, 2, 2 ), $page_ids );
+		$this->assertSame(
+			$page_ids,
+			$this->get_listed_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => 2,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox An offset past the end of the result set returns no results.
+	 */
+	public function test_offset_past_the_end_returns_empty() {
+		$this->assertSame(
+			array(),
+			$this->get_listed_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => count( $this->webhook_ids ),
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The webhooks endpoints document an `offset` collection parameter, but `get_items()` never applied it. The branch that derives an offset from `page` only ran when `offset` was absent, and there was no else to copy a supplied offset into the `search_webhooks()` args, so the query always ran with offset 0 and every request returned the first page. Reading the unset args key later in the method also raised an undefined array key warning on PHP 8.

-   Copy the request's `offset` (sanitized to an integer by the param schema) into the query args when it is provided.
-   As in the other REST controllers, an explicit `offset` takes precedence over `page`. V2 and V3 inherit this `get_items()`, so the fix covers all three namespaces.
-   Add controller tests for the offset slice, the offset/page equivalence, and an offset past the end of the result set.

Bug introduced in PR #17939.

Closes #66818.
Closes WOOPLUG-7139.

### How to test the changes in this Pull Request:

1. Create 5 webhooks (WooCommerce > Settings > Advanced > Webhooks, or via `POST /wp-json/wc/v3/webhooks`).
2. Request `GET /wp-json/wc/v3/webhooks?per_page=2&offset=2&orderby=id&order=asc` and note the returned IDs.
3. They should be the 3rd and 4th webhooks. Before this fix, the response contained the 1st and 2nd regardless of the offset value.
4. Request `GET /wp-json/wc/v3/webhooks?per_page=2&page=2&orderby=id&order=asc` and confirm it returns the same two webhooks.

### Testing that has already taken place:

-   New unit tests pass with the fix and all three error without it (verified by reverting the change).
-   The full webhook test suite (`--filter Webhook`, 114 tests) passes.
-   phpcs, branch lint, and PHPStan are clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry was created manually and is included in this PR.

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)
