### PR TITLE
Fix LYS test-order count and cleanup stopping at the first page

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-6965-lys-test-orders-count
+++ b/plugins/woocommerce/changelog/fix-wooplug-6965-lys-test-orders-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Launch Your Store test-order count and cleanup stopping at the first page of orders.

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -160,6 +160,8 @@ class LaunchYourStore {
 			return new \WP_REST_Response( array( 'count' => $count ) );
 		};
 
+		// A paginated query counts every matching order in the database; fetching
+		// ids would cap the count at the query's limit (posts_per_page by default).
 		$orders = wc_get_orders(
 			array(
 				// phpcs:ignore
@@ -167,10 +169,12 @@ class LaunchYourStore {
 				// phpcs:ignore
 				'meta_value' => 'test',
 				'return'     => 'ids',
+				'limit'      => 1,
+				'paginate'   => true,
 			)
 		);
 
-		return $return( count( $orders ) );
+		return $return( is_object( $orders ) ? (int) $orders->total : count( $orders ) );
 	}
 
 	/**
@@ -183,18 +187,33 @@ class LaunchYourStore {
 			return new \WP_REST_Response( null, $status );
 		};
 
-		$orders = wc_get_orders(
-			array(
-				// phpcs:ignore
-				'meta_key'   => '_wcpay_mode',
-				// phpcs:ignore
-				'meta_value' => 'test',
-			)
-		);
+		$batch_size = 100;
 
-		foreach ( $orders as $order ) {
-			$order->delete();
-		}
+		// Delete in batches so a large store never loads every test order at once.
+		// Trashed orders drop out of the query's default statuses, so refetching the
+		// first page walks the whole set; a full batch that deletes nothing means the
+		// remaining orders are undeletable, so stop rather than loop on them.
+		do {
+			$order_ids = wc_get_orders(
+				array(
+					// phpcs:ignore
+					'meta_key'   => '_wcpay_mode',
+					// phpcs:ignore
+					'meta_value' => 'test',
+					'return'     => 'ids',
+					'limit'      => $batch_size,
+				)
+			);
+
+			$fetched = count( $order_ids );
+			$deleted = 0;
+			foreach ( $order_ids as $order_id ) {
+				$order = wc_get_order( $order_id );
+				if ( $order && $order->delete() ) {
+					++$deleted;
+				}
+			}
+		} while ( $fetched === $batch_size && $deleted > 0 );
 
 		return $return();
 	}

--- a/plugins/woocommerce/tests/php/src/Admin/API/LaunchYourStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/LaunchYourStoreTest.php
@@ -56,6 +56,20 @@ class LaunchYourStoreTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Add lightweight test-mode orders, without line items, for volume tests.
+	 *
+	 * @param int $count How many orders to create.
+	 * @return void
+	 */
+	protected function add_empty_test_orders( int $count ) {
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = wc_create_order();
+			$order->update_meta_data( '_wcpay_mode', 'test' );
+			$order->save();
+		}
+	}
+
+	/**
 	 * Test order count.
 	 *
 	 * @return void
@@ -91,5 +105,39 @@ class LaunchYourStoreTest extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'DELETE', self::ENDPOINT . '/woopayments/test-orders' );
 		$this->server->dispatch( $request );
 		$this->assertEquals( 0, $this->get_order_count() );
+	}
+
+	/**
+	 * The count must cover every test order, not just the first page of results.
+	 *
+	 * @return void
+	 */
+	public function test_count_is_not_capped_by_posts_per_page() {
+		update_option( 'posts_per_page', 5 );
+
+		$this->add_empty_test_orders( 8 );
+		wc_create_order();
+
+		$this->assertSame( 8, $this->get_order_count(), 'Every test order should be counted, and orders without test-mode meta should not be.' );
+	}
+
+	/**
+	 * Deletion must remove every test order, including past the first batch of 100.
+	 *
+	 * @return void
+	 */
+	public function test_delete_endpoint_deletes_all_test_orders_across_batches() {
+		$this->add_empty_test_orders( 105 );
+		$live_order = wc_create_order();
+
+		$request = new WP_REST_Request( 'DELETE', self::ENDPOINT . '/woopayments/test-orders' );
+		$status  = $this->server->dispatch( $request )->get_status();
+
+		$this->assertEquals( 204, $status );
+		$this->assertSame( 0, $this->get_order_count(), 'Every test order should be gone after the delete request.' );
+
+		$live_order = wc_get_order( $live_order->get_id() );
+		$this->assertNotFalse( $live_order, 'Orders without test-mode meta should survive the delete request.' );
+		$this->assertNotSame( 'trash', $live_order->get_status(), 'Orders without test-mode meta should not be trashed.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Launch Your Store WooPayments test-order endpoints query `wc_get_orders()` without a `limit`, which does not mean unlimited: the default limit is the `posts_per_page` option (usually 10). Contrary to the issue's framing, the query was never unbounded. It was capped, which caused two correctness bugs:

-   The count endpoint reported at most one page of test orders, so the "Remove %d test orders" sidebar copy showed at most 10.
-   The delete endpoint, called once when a merchant launches with "remove test orders" checked, silently trashed only the first page and left the rest.

Changes:

-   Count with a paginated query (`'limit' => 1, 'paginate' => true`) so the database returns the real total without loading ids.
-   Delete in batches of 100 ids until the query comes back empty. Trashed orders drop out of the query's default statuses, so refetching the first page walks the whole set; a full batch that deletes nothing stops the loop so undeletable orders can't spin it forever.
-   Add tests: an uncapped-count test (8 orders with `posts_per_page` 5) and a delete test spanning two batches (105 orders), both verified to fail against the previous code. A non-test order is asserted to survive the cleanup.

This also addresses the performance concern the issue raised: neither endpoint materializes the full order set on large stores. The delete endpoint keeps trashing (not force-deleting) orders, unchanged from before.

Bug introduced in PR #47832.

Closes #66224.
Closes WOOPLUG-6965.

### How to test the changes in this Pull Request:

1. With WooPayments in test mode, create more test orders than your `posts_per_page` setting (for example 15 orders with `posts_per_page` 10). Each needs the `_wcpay_mode` meta set to `test`.
2. Request `GET /wp-json/wc-admin/launch-your-store/woopayments/test-orders/count` and confirm the count matches the real number (15), not `posts_per_page`.
3. Request `DELETE /wp-json/wc-admin/launch-your-store/woopayments/test-orders`, then repeat the count request and confirm it returns 0 and all the test orders are trashed.

### Testing that has already taken place:

-   New unit tests pass with the fix and fail against the previous code (count capped at 5, delete leaving 95 of 105).
-   The capped-at-`posts_per_page` behavior was reproduced empirically on a live HPOS store before writing the fix.
-   phpcs, branch lint, and PHPStan are clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry was created manually and is included in this PR.

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)
