### PR TITLE
[Performance] Backfill review verified owner meta

### DIFF
--- a/plugins/woocommerce/changelog/batch-review-verified-owner
+++ b/plugins/woocommerce/changelog/batch-review-verified-owner
@@ -1,4 +1,4 @@
 Significance: minor
 Type: performance
 
-Resolve the verified-owner status for all reviews on a product page in a single query instead of one purchase-history query per review.
+Backfill the verified-owner status for a product's reviews via an off-hours Action Scheduler task (one query per product) instead of a purchase-history query per review on read.

--- a/plugins/woocommerce/changelog/batch-review-verified-owner
+++ b/plugins/woocommerce/changelog/batch-review-verified-owner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Resolve the verified-owner status for all reviews on a product page in a single query instead of one purchase-history query per review.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -9,7 +9,7 @@
  */
 
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil;
-use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationQuery;
+use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationService;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -85,9 +85,7 @@ class WC_Comments {
 		add_action( 'comment_post', array( __CLASS__, 'add_comment_purchase_verification' ) );
 
 		// Backfill "verified owner" status for a product's reviews off-hours, in one query.
-		add_filter( 'comments_array', array( __CLASS__, 'schedule_review_verification_backfill' ), 10, 2 );
-		add_action( 'wp_insert_comment', array( __CLASS__, 'schedule_review_verification_backfill_for_new_review' ), 10, 2 );
-		add_action( ReviewVerificationQuery::BACKFILL_ACTION, array( __CLASS__, 'run_review_verification_backfill' ) );
+		wc_get_container()->get( ReviewVerificationService::class )->register();
 
 		// Set comment type.
 		add_action( 'preprocess_comment', array( __CLASS__, 'update_comment_type' ), 1 );
@@ -515,52 +513,6 @@ class WC_Comments {
 			add_comment_meta( $comment_id, 'verified', (int) $verified, true );
 		}
 		return $verified;
-	}
-
-	/**
-	 * Schedule an off-hours backfill of "verified owner" status when a product page shows reviews
-	 * that still need it. Hooked on `comments_array`; returns the comments unchanged.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param mixed $comments The comments for the current post (WP_Comment[] when it is a list).
-	 * @param int   $post_id  The post (product) ID whose comments are displayed.
-	 * @return mixed The unchanged comments array.
-	 */
-	public static function schedule_review_verification_backfill( $comments, $post_id ) {
-		if ( empty( $comments ) || ! is_array( $comments ) ) {
-			return $comments;
-		}
-		return ( new ReviewVerificationQuery() )->schedule_for_page( $comments, (int) $post_id );
-	}
-
-	/**
-	 * Schedule an off-hours backfill when a new product review is inserted.
-	 *
-	 * Hooked on `wp_insert_comment`.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param int        $comment_id The new comment ID.
-	 * @param WP_Comment $comment    The new comment object.
-	 * @return void
-	 */
-	public static function schedule_review_verification_backfill_for_new_review( $comment_id, $comment ) {
-		( new ReviewVerificationQuery() )->schedule_for_new_review( (int) $comment_id, $comment );
-	}
-
-	/**
-	 * Run a product's scheduled "verified owner" backfill.
-	 *
-	 * Hooked on the Action Scheduler backfill action.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param int $product_id The product (post) ID to backfill.
-	 * @return void
-	 */
-	public static function run_review_verification_backfill( $product_id ) {
-		( new ReviewVerificationQuery() )->backfill( (int) $product_id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -84,8 +84,10 @@ class WC_Comments {
 		// Review of verified purchase.
 		add_action( 'comment_post', array( __CLASS__, 'add_comment_purchase_verification' ) );
 
-		// Resolve "verified owner" status for all reviews on a product page in one query.
-		add_filter( 'comments_array', array( __CLASS__, 'prime_review_verification_meta' ), 10, 2 );
+		// Backfill "verified owner" status for a product's reviews off-hours, in one query.
+		add_filter( 'comments_array', array( __CLASS__, 'schedule_review_verification_backfill' ), 10, 2 );
+		add_action( 'wp_insert_comment', array( __CLASS__, 'schedule_review_verification_backfill_for_new_review' ), 10, 2 );
+		add_action( ReviewVerificationQuery::BACKFILL_ACTION, array( __CLASS__, 'run_review_verification_backfill' ) );
 
 		// Set comment type.
 		add_action( 'preprocess_comment', array( __CLASS__, 'update_comment_type' ), 1 );
@@ -516,10 +518,8 @@ class WC_Comments {
 	}
 
 	/**
-	 * Batch-resolve "verified owner" status for a product page's reviews in a single query.
-	 *
-	 * Hooked on `comments_array`; delegates to ReviewVerificationQuery so the per-review badge
-	 * checks become O(1) reads. See that class for the rationale.
+	 * Schedule an off-hours backfill of "verified owner" status when a product page shows reviews
+	 * that still need it. Hooked on `comments_array`; returns the comments unchanged.
 	 *
 	 * @since 11.0.0
 	 *
@@ -527,11 +527,40 @@ class WC_Comments {
 	 * @param int   $post_id  The post (product) ID whose comments are displayed.
 	 * @return mixed The unchanged comments array.
 	 */
-	public static function prime_review_verification_meta( $comments, $post_id ) {
+	public static function schedule_review_verification_backfill( $comments, $post_id ) {
 		if ( empty( $comments ) || ! is_array( $comments ) ) {
 			return $comments;
 		}
-		return ( new ReviewVerificationQuery() )->prime( $comments, (int) $post_id );
+		return ( new ReviewVerificationQuery() )->schedule_for_page( $comments, (int) $post_id );
+	}
+
+	/**
+	 * Schedule an off-hours backfill when a new product review is inserted.
+	 *
+	 * Hooked on `wp_insert_comment`.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int        $comment_id The new comment ID.
+	 * @param WP_Comment $comment    The new comment object.
+	 * @return void
+	 */
+	public static function schedule_review_verification_backfill_for_new_review( $comment_id, $comment ) {
+		( new ReviewVerificationQuery() )->schedule_for_new_review( (int) $comment_id, $comment );
+	}
+
+	/**
+	 * Run a product's scheduled "verified owner" backfill.
+	 *
+	 * Hooked on the Action Scheduler backfill action.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $product_id The product (post) ID to backfill.
+	 * @return void
+	 */
+	public static function run_review_verification_backfill( $product_id ) {
+		( new ReviewVerificationQuery() )->backfill( (int) $product_id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil;
+use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationQuery;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -82,6 +83,9 @@ class WC_Comments {
 
 		// Review of verified purchase.
 		add_action( 'comment_post', array( __CLASS__, 'add_comment_purchase_verification' ) );
+
+		// Resolve "verified owner" status for all reviews on a product page in one query.
+		add_filter( 'comments_array', array( __CLASS__, 'prime_review_verification_meta' ), 10, 2 );
 
 		// Set comment type.
 		add_action( 'preprocess_comment', array( __CLASS__, 'update_comment_type' ), 1 );
@@ -509,6 +513,25 @@ class WC_Comments {
 			add_comment_meta( $comment_id, 'verified', (int) $verified, true );
 		}
 		return $verified;
+	}
+
+	/**
+	 * Batch-resolve "verified owner" status for a product page's reviews in a single query.
+	 *
+	 * Hooked on `comments_array`; delegates to ReviewVerificationQuery so the per-review badge
+	 * checks become O(1) reads. See that class for the rationale.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param mixed $comments The comments for the current post (WP_Comment[] when it is a list).
+	 * @param int   $post_id  The post (product) ID whose comments are displayed.
+	 * @return mixed The unchanged comments array.
+	 */
+	public static function prime_review_verification_meta( $comments, $post_id ) {
+		if ( empty( $comments ) || ! is_array( $comments ) ) {
+			return $comments;
+		}
+		return ( new ReviewVerificationQuery() )->prime( $comments, (int) $post_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationDataStore.php
@@ -23,6 +23,15 @@ defined( 'ABSPATH' ) || exit;
 class ReviewVerificationDataStore {
 
 	/**
+	 * Comment types WooCommerce recognizes as product reviews. Front-end submissions normalize to
+	 * 'review', but imported or migrated reviews keep the default '' or 'comment' type; core counts
+	 * all three as reviews (see WC_Comments::get_review_counts_for_product_ids()).
+	 *
+	 * @var string[]
+	 */
+	public const REVIEW_COMMENT_TYPES = array( 'review', 'comment', '' );
+
+	/**
 	 * Whether the bulk verification path applies to this product.
 	 *
 	 * @param int $product_id The product (post) ID.
@@ -74,7 +83,7 @@ class ReviewVerificationDataStore {
 			(array) get_comments(
 				array(
 					'post_id'    => $product_id,
-					'type'       => 'review',
+					'type__in'   => self::REVIEW_COMMENT_TYPES,
 					'status'     => 'approve',
 					'number'     => $limit,
 					'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off off-hours backfill.
@@ -112,7 +121,7 @@ class ReviewVerificationDataStore {
 		$emails   = array();
 
 		foreach ( $comments as $comment ) {
-			if ( 'review' !== $comment->comment_type ) {
+			if ( ! in_array( $comment->comment_type, self::REVIEW_COMMENT_TYPES, true ) ) {
 				continue;
 			}
 			$comment_id = (int) $comment->comment_ID;

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationDataStore.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ReviewVerificationQuery class file.
+ * ReviewVerificationDataStore class file.
  */
 
 declare( strict_types=1 );
@@ -13,103 +13,62 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Backfills the "verified owner" status for a product's reviews outside business hours.
+ * Resolves the "verified owner" status of product reviews in bulk.
  *
- * The badge check (wc_review_is_from_verified_owner()) runs one purchase-history query per review
- * missing its 'verified' meta — an N+1 that scales with review count. Rather than resolve that on
- * read, this schedules a per-product Action Scheduler task that resolves every unverified review for
- * the product in a single query and persists the same 'verified' meta, so the per-review checks
- * become O(1) reads with results identical to the per-review path. The per-review path stays as the
- * fallback for reviews not yet backfilled.
+ * The per-review badge check (wc_review_is_from_verified_owner()) runs one purchase-history query
+ * per review missing its 'verified' meta — an N+1 that scales with review count. This resolves every
+ * unverified review of a product in a single query and persists the same 'verified' meta, so the
+ * per-review checks become O(1) reads with results identical to the per-review path.
  */
-class ReviewVerificationQuery {
+class ReviewVerificationDataStore {
 
 	/**
-	 * Action Scheduler hook that runs a product's backfill.
+	 * Whether the bulk verification path applies to this product.
+	 *
+	 * @param int $product_id The product (post) ID.
+	 * @return bool
 	 */
-	public const BACKFILL_ACTION = 'woocommerce_backfill_review_verification';
-
-	/**
-	 * Action Scheduler group for the backfill actions.
-	 */
-	private const BACKFILL_GROUP = 'woocommerce-review-verification';
-
-	/**
-	 * Schedule a backfill for a product page when any displayed review still needs its status.
-	 *
-	 * Hooked on `comments_array`; returns the comments unchanged.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param \WP_Comment[] $comments The comments for the current post.
-	 * @param int           $post_id  The product (post) ID whose comments are displayed.
-	 * @return \WP_Comment[] The unchanged comments array.
-	 */
-	public function schedule_for_page( array $comments, int $post_id ): array {
-		$post_id = absint( $post_id );
-		if ( empty( $comments ) || ! $this->is_enabled( $post_id ) ) {
-			return $comments;
-		}
-
-		foreach ( $comments as $comment ) {
-			if ( $comment instanceof \WP_Comment && 'review' === $comment->comment_type && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
-				$this->schedule_backfill( $post_id );
-				break;
-			}
-		}
-
-		return $comments;
-	}
-
-	/**
-	 * Schedule a backfill when a new product review is inserted.
-	 *
-	 * Hooked on `wp_insert_comment`.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param int         $comment_id The new comment ID.
-	 * @param \WP_Comment $comment    The new comment object.
-	 * @return void
-	 */
-	public function schedule_for_new_review( int $comment_id, $comment ): void {
-		if ( ! $comment instanceof \WP_Comment || 'review' !== $comment->comment_type ) {
-			return;
-		}
-
-		$product_id = absint( $comment->comment_post_ID );
-		if ( $this->is_enabled( $product_id ) ) {
-			$this->schedule_backfill( $product_id );
-		}
-	}
-
-	/**
-	 * Resolve and persist "verified owner" status for every unverified review of a product.
-	 *
-	 * Runs from the scheduled Action Scheduler task.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param int $product_id The product (post) ID to backfill.
-	 * @return void
-	 */
-	public function backfill( int $product_id ): void {
-		$product_id = absint( $product_id );
-		if ( ! $this->is_enabled( $product_id ) ) {
-			return;
-		}
-
+	public function is_enabled( int $product_id ): bool {
 		/**
-		 * Filters how many of a product's reviews are resolved per backfill run. Any remainder is
-		 * picked up by a rescheduled follow-up, keeping memory and the query's IN() list bounded on
-		 * products with very many reviews.
+		 * Filters whether to resolve the "verified owner" status for a product's reviews in bulk.
+		 * Return false to keep the per-review path only.
 		 *
 		 * @since 11.0.0
 		 *
-		 * @param int $batch_size Reviews resolved per run.
-		 * @param int $product_id The product (post) ID being backfilled.
+		 * @param bool $enabled    Whether to resolve verified-owner status in bulk.
+		 * @param int  $product_id The product (post) ID whose reviews are being resolved.
 		 */
-		$batch_size = max( 1, (int) apply_filters( 'woocommerce_review_verification_backfill_batch_size', 500, $product_id ) );
+		if ( ! apply_filters( 'woocommerce_prime_review_verification_meta', true, $product_id ) ) {
+			return false;
+		}
+
+		if ( ! $product_id || 'product' !== get_post_type( $product_id ) ) {
+			return false;
+		}
+
+		// An extension short-circuiting wc_customer_bought_product() owns the result; the bulk query
+		// would bypass it and persist a different answer, so defer to the per-review path when hooked.
+		if ( has_filter( 'woocommerce_pre_customer_bought_product' ) ) {
+			return false;
+		}
+
+		// The lookup-tables path has its own caching/versioning; defer to the per-review path there.
+		return ! has_filter( 'woocommerce_customer_bought_product_use_lookup_tables' );
+	}
+
+	/**
+	 * Resolve and persist "verified owner" status for a product's unverified reviews.
+	 *
+	 * @param int $product_id The product (post) ID to resolve.
+	 * @param int $limit      Maximum reviews to resolve in this run (bounds the IN() list and memory).
+	 * @return int Number of reviews fetched for this run — a full batch signals a caller to follow up.
+	 */
+	public function backfill( int $product_id, int $limit ): int {
+		$product_id = absint( $product_id );
+		$limit      = max( 1, $limit );
+		if ( ! $this->is_enabled( $product_id ) ) {
+			return 0;
+		}
 
 		$comments = array_filter(
 			(array) get_comments(
@@ -117,7 +76,7 @@ class ReviewVerificationQuery {
 					'post_id'    => $product_id,
 					'type'       => 'review',
 					'status'     => 'approve',
-					'number'     => $batch_size,
+					'number'     => $limit,
 					'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off off-hours backfill.
 						array(
 							'key'     => 'verified',
@@ -130,117 +89,14 @@ class ReviewVerificationQuery {
 		);
 
 		if ( empty( $comments ) ) {
-			return;
+			return 0;
 		}
 
 		$this->resolve_and_persist( $comments, $product_id );
 
-		// A full batch means more may remain; pick them up shortly rather than waiting a full day.
-		if ( count( $comments ) >= $batch_size ) {
-			$this->reschedule_remaining( $product_id );
-		}
-	}
-
-	/**
-	 * Whether the bulk verification path applies to this product.
-	 *
-	 * @param int $product_id The product (post) ID.
-	 * @return bool
-	 */
-	private function is_enabled( int $product_id ): bool {
-		/**
-		 * Filters whether to backfill the "verified owner" status for a product's reviews in bulk.
-		 * Return false to keep the per-review path only.
-		 *
-		 * @since 11.0.0
-		 *
-		 * @param bool $enabled    Whether to backfill verified-owner status in bulk.
-		 * @param int  $product_id The product (post) ID whose reviews are being resolved.
-		 */
-		if ( ! apply_filters( 'woocommerce_prime_review_verification_meta', true, $product_id ) ) {
-			return false;
-		}
-
-		if ( ! $product_id || 'product' !== get_post_type( $product_id ) ) {
-			return false;
-		}
-
-		// An extension short-circuiting wc_customer_bought_product() owns the result; the batch would
-		// bypass it and persist a different answer, so defer to the per-review path when it is hooked.
-		if ( has_filter( 'woocommerce_pre_customer_bought_product' ) ) {
-			return false;
-		}
-
-		// The lookup-tables path has its own caching/versioning; defer to the per-review path there.
-		return ! has_filter( 'woocommerce_customer_bought_product_use_lookup_tables' );
-	}
-
-	/**
-	 * Schedule a single, deduplicated backfill for a product in the next off-hours window.
-	 *
-	 * @param int $product_id The product (post) ID.
-	 * @return void
-	 */
-	private function schedule_backfill( int $product_id ): void {
-		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
-			return;
-		}
-
-		$args = array( 'product_id' => $product_id );
-		if ( as_has_scheduled_action( self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP ) ) {
-			return;
-		}
-
-		// The unique flag makes the dedup atomic against a concurrent request that passed the check above.
-		as_schedule_single_action( $this->next_run_timestamp(), self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP, true );
-	}
-
-	/**
-	 * Schedule a prompt follow-up run for a product whose backfill filled its batch.
-	 *
-	 * Called from within a running backfill for the same product, so the executing action itself
-	 * matches as_has_scheduled_action() (which counts in-progress). Dedup on the PENDING state only,
-	 * and without the unique flag, so the follow-up is not rejected by the still-running action.
-	 *
-	 * @param int $product_id The product (post) ID.
-	 * @return void
-	 */
-	private function reschedule_remaining( int $product_id ): void {
-		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_get_scheduled_actions' ) ) {
-			return;
-		}
-
-		$args    = array( 'product_id' => $product_id );
-		$pending = as_get_scheduled_actions(
-			array(
-				'hook'     => self::BACKFILL_ACTION,
-				'args'     => $args,
-				'group'    => self::BACKFILL_GROUP,
-				'status'   => \ActionScheduler_Store::STATUS_PENDING,
-				'per_page' => 1,
-			),
-			'ids'
-		);
-		if ( ! empty( $pending ) ) {
-			return;
-		}
-
-		as_schedule_single_action( time() + MINUTE_IN_SECONDS, self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP );
-	}
-
-	/**
-	 * Timestamp of the next 06:00 in the site's timezone (before business hours).
-	 *
-	 * @return int
-	 */
-	private function next_run_timestamp(): int {
-		$timezone = wp_timezone();
-		$now      = new \DateTime( 'now', $timezone );
-		$next     = new \DateTime( 'today 06:00', $timezone );
-		if ( $next <= $now ) {
-			$next->modify( '+1 day' );
-		}
-		return $next->getTimestamp();
+		// Report the fetched batch size (not the resolved subset) so a full batch reliably triggers a
+		// follow-up even if some rows were already primed between the fetch and the meta read.
+		return count( $comments );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationQuery.php
@@ -13,17 +13,31 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Batch-resolves the "verified owner" status for the reviews shown on a product page.
+ * Backfills the "verified owner" status for a product's reviews outside business hours.
  *
- * The badge check (wc_review_is_from_verified_owner()) runs one purchase-history query per
- * review missing its 'verified' meta — an N+1 that scales with review count. This resolves all
- * such reviewers in a single query and persists the same 'verified' meta, so the per-review
- * checks become O(1) reads with results identical to the per-review path.
+ * The badge check (wc_review_is_from_verified_owner()) runs one purchase-history query per review
+ * missing its 'verified' meta — an N+1 that scales with review count. Rather than resolve that on
+ * read, this schedules a per-product Action Scheduler task that resolves every unverified review for
+ * the product in a single query and persists the same 'verified' meta, so the per-review checks
+ * become O(1) reads with results identical to the per-review path. The per-review path stays as the
+ * fallback for reviews not yet backfilled.
  */
 class ReviewVerificationQuery {
 
 	/**
-	 * Pre-resolve and persist "verified owner" status for a product page's reviews.
+	 * Action Scheduler hook that runs a product's backfill.
+	 */
+	public const BACKFILL_ACTION = 'woocommerce_backfill_review_verification';
+
+	/**
+	 * Action Scheduler group for the backfill actions.
+	 */
+	private const BACKFILL_GROUP = 'woocommerce-review-verification';
+
+	/**
+	 * Schedule a backfill for a product page when any displayed review still needs its status.
+	 *
+	 * Hooked on `comments_array`; returns the comments unchanged.
 	 *
 	 * @since 11.0.0
 	 *
@@ -31,37 +45,212 @@ class ReviewVerificationQuery {
 	 * @param int           $post_id  The product (post) ID whose comments are displayed.
 	 * @return \WP_Comment[] The unchanged comments array.
 	 */
-	public function prime( array $comments, int $post_id ): array {
-		if ( empty( $comments ) ) {
+	public function schedule_for_page( array $comments, int $post_id ): array {
+		$post_id = absint( $post_id );
+		if ( empty( $comments ) || ! $this->is_enabled( $post_id ) ) {
 			return $comments;
 		}
 
-		$post_id = absint( $post_id );
+		foreach ( $comments as $comment ) {
+			if ( 'review' === $comment->comment_type && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
+				$this->schedule_backfill( $post_id );
+				break;
+			}
+		}
+
+		return $comments;
+	}
+
+	/**
+	 * Schedule a backfill when a new product review is inserted.
+	 *
+	 * Hooked on `wp_insert_comment`.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int         $comment_id The new comment ID.
+	 * @param \WP_Comment $comment    The new comment object.
+	 * @return void
+	 */
+	public function schedule_for_new_review( int $comment_id, $comment ): void {
+		if ( ! $comment instanceof \WP_Comment || 'review' !== $comment->comment_type ) {
+			return;
+		}
+
+		$product_id = absint( $comment->comment_post_ID );
+		if ( $this->is_enabled( $product_id ) ) {
+			$this->schedule_backfill( $product_id );
+		}
+	}
+
+	/**
+	 * Resolve and persist "verified owner" status for every unverified review of a product.
+	 *
+	 * Runs from the scheduled Action Scheduler task.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $product_id The product (post) ID to backfill.
+	 * @return void
+	 */
+	public function backfill( int $product_id ): void {
+		$product_id = absint( $product_id );
+		if ( ! $this->is_enabled( $product_id ) ) {
+			return;
+		}
 
 		/**
-		 * Filters whether to batch-resolve the "verified owner" status for a product's reviews.
-		 * Return false to fall back to the per-review path.
+		 * Filters how many of a product's reviews are resolved per backfill run. Any remainder is
+		 * picked up by a rescheduled follow-up, keeping memory and the query's IN() list bounded on
+		 * products with very many reviews.
 		 *
 		 * @since 11.0.0
 		 *
-		 * @param bool $enabled Whether to pre-resolve verified-owner status in bulk.
-		 * @param int  $post_id The product (post) ID whose reviews are being displayed.
+		 * @param int $batch_size Reviews resolved per run.
+		 * @param int $product_id The product (post) ID being backfilled.
 		 */
-		if ( ! apply_filters( 'woocommerce_prime_review_verification_meta', true, $post_id ) ) {
-			return $comments;
+		$batch_size = max( 1, (int) apply_filters( 'woocommerce_review_verification_backfill_batch_size', 500, $product_id ) );
+
+		$comments = array_filter(
+			(array) get_comments(
+				array(
+					'post_id'    => $product_id,
+					'type'       => 'review',
+					'status'     => 'approve',
+					'number'     => $batch_size,
+					'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off off-hours backfill.
+						array(
+							'key'     => 'verified',
+							'compare' => 'NOT EXISTS',
+						),
+					),
+				)
+			),
+			static fn( $comment ) => $comment instanceof \WP_Comment
+		);
+
+		if ( empty( $comments ) ) {
+			return;
 		}
 
-		if ( ! $post_id || 'product' !== get_post_type( $post_id ) ) {
-			return $comments;
+		$this->resolve_and_persist( $comments, $product_id );
+
+		// A full batch means more may remain; pick them up shortly rather than waiting a full day.
+		if ( count( $comments ) >= $batch_size ) {
+			$this->reschedule_remaining( $product_id );
+		}
+	}
+
+	/**
+	 * Whether the bulk verification path applies to this product.
+	 *
+	 * @param int $product_id The product (post) ID.
+	 * @return bool
+	 */
+	private function is_enabled( int $product_id ): bool {
+		/**
+		 * Filters whether to backfill the "verified owner" status for a product's reviews in bulk.
+		 * Return false to keep the per-review path only.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param bool $enabled    Whether to backfill verified-owner status in bulk.
+		 * @param int  $product_id The product (post) ID whose reviews are being resolved.
+		 */
+		if ( ! apply_filters( 'woocommerce_prime_review_verification_meta', true, $product_id ) ) {
+			return false;
+		}
+
+		if ( ! $product_id || 'product' !== get_post_type( $product_id ) ) {
+			return false;
+		}
+
+		// An extension short-circuiting wc_customer_bought_product() owns the result; the batch would
+		// bypass it and persist a different answer, so defer to the per-review path when it is hooked.
+		if ( has_filter( 'woocommerce_pre_customer_bought_product' ) ) {
+			return false;
 		}
 
 		// The lookup-tables path has its own caching/versioning; defer to the per-review path there.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Documented in includes/wc-user-functions.php.
-		if ( apply_filters( 'woocommerce_customer_bought_product_use_lookup_tables', false, '', 0, $post_id ) ) {
-			return $comments;
+		return ! has_filter( 'woocommerce_customer_bought_product_use_lookup_tables' );
+	}
+
+	/**
+	 * Schedule a single, deduplicated backfill for a product in the next off-hours window.
+	 *
+	 * @param int $product_id The product (post) ID.
+	 * @return void
+	 */
+	private function schedule_backfill( int $product_id ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
 		}
 
-		// Collect reviews that still need their verified status computed.
+		$args = array( 'product_id' => $product_id );
+		if ( as_has_scheduled_action( self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP ) ) {
+			return;
+		}
+
+		// The unique flag makes the dedup atomic against a concurrent request that passed the check above.
+		as_schedule_single_action( $this->next_run_timestamp(), self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP, true );
+	}
+
+	/**
+	 * Schedule a prompt follow-up run for a product whose backfill filled its batch.
+	 *
+	 * Called from within a running backfill for the same product, so the executing action itself
+	 * matches as_has_scheduled_action() (which counts in-progress). Dedup on the PENDING state only,
+	 * and without the unique flag, so the follow-up is not rejected by the still-running action.
+	 *
+	 * @param int $product_id The product (post) ID.
+	 * @return void
+	 */
+	private function reschedule_remaining( int $product_id ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return;
+		}
+
+		$args    = array( 'product_id' => $product_id );
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'     => self::BACKFILL_ACTION,
+				'args'     => $args,
+				'group'    => self::BACKFILL_GROUP,
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => 1,
+			),
+			'ids'
+		);
+		if ( ! empty( $pending ) ) {
+			return;
+		}
+
+		as_schedule_single_action( time() + MINUTE_IN_SECONDS, self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP );
+	}
+
+	/**
+	 * Timestamp of the next 06:00 in the site's timezone (before business hours).
+	 *
+	 * @return int
+	 */
+	private function next_run_timestamp(): int {
+		$timezone = wp_timezone();
+		$now      = new \DateTime( 'now', $timezone );
+		$next     = new \DateTime( 'today 06:00', $timezone );
+		if ( $next <= $now ) {
+			$next->modify( '+1 day' );
+		}
+		return $next->getTimestamp();
+	}
+
+	/**
+	 * Resolve the given review comments in one query and persist their 'verified' meta.
+	 *
+	 * @param \WP_Comment[] $comments   Review comments to resolve.
+	 * @param int           $product_id The product (post) ID being reviewed.
+	 * @return void
+	 */
+	private function resolve_and_persist( array $comments, int $product_id ): void {
 		$pending  = array();
 		$user_ids = array();
 		$emails   = array();
@@ -71,7 +260,6 @@ class ReviewVerificationQuery {
 				continue;
 			}
 			$comment_id = (int) $comment->comment_ID;
-			// Skip reviews whose verified status is already resolved and persisted.
 			if ( '' !== get_comment_meta( $comment_id, 'verified', true ) ) {
 				continue;
 			}
@@ -87,7 +275,10 @@ class ReviewVerificationQuery {
 				$resolved_id = $user ? absint( $user->ID ) : 0;
 			}
 
-			$email = ( $email && is_email( $email ) ) ? $email : '';
+			// Lowercase so the PHP match below is case-insensitive, matching the DB collation the
+			// per-review wc_customer_bought_product() relies on (else a case difference between the
+			// review email and the order billing email would persist a wrong "not verified").
+			$email = ( $email && is_email( $email ) ) ? strtolower( $email ) : '';
 
 			$pending[ $comment_id ] = array(
 				'user_id' => $resolved_id,
@@ -102,11 +293,11 @@ class ReviewVerificationQuery {
 			}
 		}
 
-		if ( empty( $pending ) || ( empty( $user_ids ) && empty( $emails ) ) ) {
-			return $comments;
+		if ( empty( $pending ) ) {
+			return;
 		}
 
-		$bought = $this->query_bought_identities( $post_id, $user_ids, $emails );
+		$bought = $this->query_bought_identities( $product_id, $user_ids, $emails );
 
 		foreach ( $pending as $comment_id => $identity ) {
 			$verified = ( $identity['user_id'] && isset( $bought['customer_ids'][ $identity['user_id'] ] ) )
@@ -115,8 +306,6 @@ class ReviewVerificationQuery {
 			// Persist the same way the per-review path does, so later reads are O(1).
 			add_comment_meta( (int) $comment_id, 'verified', (int) $verified, true );
 		}
-
-		return $comments;
 	}
 
 	/**
@@ -138,6 +327,10 @@ class ReviewVerificationQuery {
 			'customer_ids' => array(),
 			'emails'       => array(),
 		);
+
+		if ( empty( $user_ids ) && empty( $emails ) ) {
+			return $matched;
+		}
 
 		$escape = static function ( $value ): string {
 			$escaped = esc_sql( (string) $value );
@@ -202,7 +395,7 @@ class ReviewVerificationQuery {
 			if ( $customer_id ) {
 				$matched['customer_ids'][ $customer_id ] = $customer_id;
 			}
-			$billing_email = (string) $row['billing_email'];
+			$billing_email = strtolower( (string) $row['billing_email'] );
 			if ( '' !== $billing_email ) {
 				$matched['emails'][ $billing_email ] = $billing_email;
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationQuery.php
@@ -52,7 +52,7 @@ class ReviewVerificationQuery {
 		}
 
 		foreach ( $comments as $comment ) {
-			if ( 'review' === $comment->comment_type && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
+			if ( $comment instanceof \WP_Comment && 'review' === $comment->comment_type && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
 				$this->schedule_backfill( $post_id );
 				break;
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationQuery.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * ReviewVerificationQuery class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\DataStores\Reviews;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Batch-resolves the "verified owner" status for the reviews shown on a product page.
+ *
+ * The badge check (wc_review_is_from_verified_owner()) runs one purchase-history query per
+ * review missing its 'verified' meta — an N+1 that scales with review count. This resolves all
+ * such reviewers in a single query and persists the same 'verified' meta, so the per-review
+ * checks become O(1) reads with results identical to the per-review path.
+ */
+class ReviewVerificationQuery {
+
+	/**
+	 * Pre-resolve and persist "verified owner" status for a product page's reviews.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param \WP_Comment[] $comments The comments for the current post.
+	 * @param int           $post_id  The product (post) ID whose comments are displayed.
+	 * @return \WP_Comment[] The unchanged comments array.
+	 */
+	public function prime( array $comments, int $post_id ): array {
+		if ( empty( $comments ) ) {
+			return $comments;
+		}
+
+		$post_id = absint( $post_id );
+
+		/**
+		 * Filters whether to batch-resolve the "verified owner" status for a product's reviews.
+		 * Return false to fall back to the per-review path.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param bool $enabled Whether to pre-resolve verified-owner status in bulk.
+		 * @param int  $post_id The product (post) ID whose reviews are being displayed.
+		 */
+		if ( ! apply_filters( 'woocommerce_prime_review_verification_meta', true, $post_id ) ) {
+			return $comments;
+		}
+
+		if ( ! $post_id || 'product' !== get_post_type( $post_id ) ) {
+			return $comments;
+		}
+
+		// The lookup-tables path has its own caching/versioning; defer to the per-review path there.
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Documented in includes/wc-user-functions.php.
+		if ( apply_filters( 'woocommerce_customer_bought_product_use_lookup_tables', false, '', 0, $post_id ) ) {
+			return $comments;
+		}
+
+		// Collect reviews that still need their verified status computed.
+		$pending  = array();
+		$user_ids = array();
+		$emails   = array();
+
+		foreach ( $comments as $comment ) {
+			if ( 'review' !== $comment->comment_type ) {
+				continue;
+			}
+			$comment_id = (int) $comment->comment_ID;
+			// Skip reviews whose verified status is already resolved and persisted.
+			if ( '' !== get_comment_meta( $comment_id, 'verified', true ) ) {
+				continue;
+			}
+
+			// Mirror add_comment_purchase_verification(): prefer the user id over the email.
+			$user_id = absint( $comment->user_id );
+			$email   = $user_id ? '' : $comment->comment_author_email;
+
+			// Mirror wc_customer_bought_product(): resolve a guest email to a user id.
+			$resolved_id = $user_id;
+			if ( ! $resolved_id && $email && is_email( $email ) ) {
+				$user        = get_user_by( 'email', $email );
+				$resolved_id = $user ? absint( $user->ID ) : 0;
+			}
+
+			$email = ( $email && is_email( $email ) ) ? $email : '';
+
+			$pending[ $comment_id ] = array(
+				'user_id' => $resolved_id,
+				'email'   => $email,
+			);
+
+			if ( $resolved_id ) {
+				$user_ids[ $resolved_id ] = $resolved_id;
+			}
+			if ( '' !== $email ) {
+				$emails[ $email ] = $email;
+			}
+		}
+
+		if ( empty( $pending ) || ( empty( $user_ids ) && empty( $emails ) ) ) {
+			return $comments;
+		}
+
+		$bought = $this->query_bought_identities( $post_id, $user_ids, $emails );
+
+		foreach ( $pending as $comment_id => $identity ) {
+			$verified = ( $identity['user_id'] && isset( $bought['customer_ids'][ $identity['user_id'] ] ) )
+				|| ( '' !== $identity['email'] && isset( $bought['emails'][ $identity['email'] ] ) );
+
+			// Persist the same way the per-review path does, so later reads are O(1).
+			add_comment_meta( (int) $comment_id, 'verified', (int) $verified, true );
+		}
+
+		return $comments;
+	}
+
+	/**
+	 * Resolve, in a single query, which of the given reviewer identities have a paid order
+	 * containing the product. Mirrors the non-lookup-table branches of
+	 * wc_customer_bought_product() (both HPOS and legacy post-based storage).
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int      $product_id The product (post) ID being reviewed.
+	 * @param int[]    $user_ids   Candidate customer user ids.
+	 * @param string[] $emails     Candidate billing emails.
+	 * @return array{customer_ids: array<int,int>, emails: array<string,string>} Matched identities, keyed for O(1) lookup.
+	 */
+	private function query_bought_identities( int $product_id, array $user_ids, array $emails ): array {
+		global $wpdb;
+
+		$matched = array(
+			'customer_ids' => array(),
+			'emails'       => array(),
+		);
+
+		$escape = static function ( $value ): string {
+			$escaped = esc_sql( (string) $value );
+			return is_string( $escaped ) ? $escaped : '';
+		};
+
+		$statuses = array_map( $escape, wc_get_is_paid_statuses() );
+		$user_ids = array_map( 'absint', $user_ids );
+		$emails   = array_map( $escape, $emails );
+
+		$emails_in = empty( $emails ) ? '' : "'" . implode( "','", $emails ) . "'";
+		$ids_in    = empty( $user_ids ) ? '' : implode( ',', $user_ids );
+
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$statuses    = array_map( static fn( $status ) => "wc-$status", $statuses );
+			$order_table = OrdersTableDataStore::get_orders_table_name();
+
+			$identity_clause = array();
+			if ( '' !== $ids_in ) {
+				$identity_clause[] = "orders.customer_id IN ( $ids_in )";
+			}
+			if ( '' !== $emails_in ) {
+				$identity_clause[] = "orders.billing_email IN ( $emails_in )";
+			}
+			$identity_clause = implode( ' OR ', $identity_clause );
+
+			$sql = "SELECT DISTINCT orders.customer_id AS customer_id, orders.billing_email AS billing_email
+				FROM $order_table AS orders
+					INNER JOIN {$wpdb->prefix}woocommerce_order_items AS items ON orders.id = items.order_id
+					INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
+				WHERE orders.status IN ( '" . implode( "','", $statuses ) . "' )
+					AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
+					AND itemmeta.meta_value = '" . absint( $product_id ) . "'
+					AND ( $identity_clause )";
+		} else {
+			$identity_clause = array();
+			if ( '' !== $ids_in ) {
+				$identity_clause[] = "pm_customer.meta_value IN ( $ids_in )";
+			}
+			if ( '' !== $emails_in ) {
+				$identity_clause[] = "pm_email.meta_value IN ( $emails_in )";
+			}
+			$identity_clause = implode( ' OR ', $identity_clause );
+
+			$sql = "SELECT DISTINCT pm_customer.meta_value AS customer_id, pm_email.meta_value AS billing_email
+				FROM {$wpdb->posts} AS posts
+					INNER JOIN {$wpdb->prefix}woocommerce_order_items AS items ON posts.ID = items.order_id
+					INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
+					LEFT JOIN {$wpdb->postmeta} AS pm_customer ON posts.ID = pm_customer.post_id AND pm_customer.meta_key = '_customer_user'
+					LEFT JOIN {$wpdb->postmeta} AS pm_email ON posts.ID = pm_email.post_id AND pm_email.meta_key = '_billing_email'
+				WHERE posts.post_type   = 'shop_order'
+					AND posts.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
+					AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
+					AND itemmeta.meta_value = '" . absint( $product_id ) . "'
+					AND ( $identity_clause )";
+		}
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		foreach ( (array) $rows as $row ) {
+			$customer_id = absint( $row['customer_id'] );
+			if ( $customer_id ) {
+				$matched['customer_ids'][ $customer_id ] = $customer_id;
+			}
+			$billing_email = (string) $row['billing_email'];
+			if ( '' !== $billing_email ) {
+				$matched['emails'][ $billing_email ] = $billing_email;
+			}
+		}
+
+		return $matched;
+	}
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationService.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationService.php
@@ -83,7 +83,7 @@ class ReviewVerificationService implements RegisterHooksInterface {
 		}
 
 		foreach ( $comments as $comment ) {
-			if ( $comment instanceof \WP_Comment && 'review' === $comment->comment_type && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
+			if ( $comment instanceof \WP_Comment && in_array( $comment->comment_type, ReviewVerificationDataStore::REVIEW_COMMENT_TYPES, true ) && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
 				$this->schedule_backfill( $post_id );
 				break;
 			}
@@ -104,7 +104,7 @@ class ReviewVerificationService implements RegisterHooksInterface {
 	 * @return void
 	 */
 	public function schedule_for_new_review( $comment_id, $comment ): void {
-		if ( ! $comment instanceof \WP_Comment || 'review' !== $comment->comment_type ) {
+		if ( ! $comment instanceof \WP_Comment || ! in_array( $comment->comment_type, ReviewVerificationDataStore::REVIEW_COMMENT_TYPES, true ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationService.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Reviews/ReviewVerificationService.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * ReviewVerificationService class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\DataStores\Reviews;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Schedules off-hours backfills of the "verified owner" status for product reviews.
+ *
+ * Rather than resolve the per-review N+1 on read, this schedules a per-product Action Scheduler
+ * task that resolves every unverified review for the product in a single query (via
+ * ReviewVerificationDataStore) and persists the same 'verified' meta. The per-review path stays as
+ * the fallback for reviews not yet backfilled.
+ */
+class ReviewVerificationService implements RegisterHooksInterface {
+
+	/**
+	 * Action Scheduler hook that runs a product's backfill.
+	 */
+	public const BACKFILL_ACTION = 'woocommerce_backfill_review_verification';
+
+	/**
+	 * Action Scheduler group for the backfill actions.
+	 */
+	private const BACKFILL_GROUP = 'woocommerce-review-verification';
+
+	/**
+	 * The data store that resolves and persists the verified-owner status.
+	 *
+	 * @var ReviewVerificationDataStore
+	 */
+	private ReviewVerificationDataStore $data_store;
+
+	/**
+	 * Inject dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param ReviewVerificationDataStore $data_store The verified-owner data store.
+	 * @return void
+	 */
+	final public function init( ReviewVerificationDataStore $data_store ): void {
+		$this->data_store = $data_store;
+	}
+
+	/**
+	 * Register the scheduling hooks.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_filter( 'comments_array', array( $this, 'schedule_for_page' ), 10, 2 );
+		add_action( 'wp_insert_comment', array( $this, 'schedule_for_new_review' ), 10, 2 );
+		add_action( self::BACKFILL_ACTION, array( $this, 'run_backfill' ) );
+	}
+
+	/**
+	 * Schedule a backfill for a product page when any displayed review still needs its status.
+	 *
+	 * Hooked on `comments_array`; returns the comments unchanged.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param mixed $comments The comments for the current post (WP_Comment[] when it is a list).
+	 * @param int   $post_id  The product (post) ID whose comments are displayed.
+	 * @return mixed The unchanged comments array.
+	 */
+	public function schedule_for_page( $comments, $post_id ) {
+		if ( empty( $comments ) || ! is_array( $comments ) ) {
+			return $comments;
+		}
+
+		$post_id = absint( $post_id );
+		if ( ! $this->data_store->is_enabled( $post_id ) ) {
+			return $comments;
+		}
+
+		foreach ( $comments as $comment ) {
+			if ( $comment instanceof \WP_Comment && 'review' === $comment->comment_type && '' === get_comment_meta( (int) $comment->comment_ID, 'verified', true ) ) {
+				$this->schedule_backfill( $post_id );
+				break;
+			}
+		}
+
+		return $comments;
+	}
+
+	/**
+	 * Schedule a backfill when a new product review is inserted.
+	 *
+	 * Hooked on `wp_insert_comment`.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int         $comment_id The new comment ID.
+	 * @param \WP_Comment $comment    The new comment object.
+	 * @return void
+	 */
+	public function schedule_for_new_review( $comment_id, $comment ): void {
+		if ( ! $comment instanceof \WP_Comment || 'review' !== $comment->comment_type ) {
+			return;
+		}
+
+		$product_id = absint( $comment->comment_post_ID );
+		if ( $this->data_store->is_enabled( $product_id ) ) {
+			$this->schedule_backfill( $product_id );
+		}
+	}
+
+	/**
+	 * Run a product's scheduled backfill, rescheduling a follow-up when a batch fills.
+	 *
+	 * Hooked on the Action Scheduler backfill action.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $product_id The product (post) ID to backfill.
+	 * @return void
+	 */
+	public function run_backfill( $product_id ): void {
+		$product_id = absint( $product_id );
+
+		/**
+		 * Filters how many of a product's reviews are resolved per backfill run. Any remainder is
+		 * picked up by a rescheduled follow-up, keeping memory and the query's IN() list bounded on
+		 * products with very many reviews.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param int $batch_size Reviews resolved per run.
+		 * @param int $product_id The product (post) ID being backfilled.
+		 */
+		$batch_size = max( 1, (int) apply_filters( 'woocommerce_review_verification_backfill_batch_size', 500, $product_id ) );
+
+		$resolved = $this->data_store->backfill( $product_id, $batch_size );
+
+		// A full batch means more may remain; pick them up shortly rather than waiting a full day.
+		if ( $resolved >= $batch_size ) {
+			$this->reschedule_remaining( $product_id );
+		}
+	}
+
+	/**
+	 * Schedule a single, deduplicated backfill for a product in the next off-hours window.
+	 *
+	 * @param int $product_id The product (post) ID.
+	 * @return void
+	 */
+	private function schedule_backfill( int $product_id ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+
+		$args = array( 'product_id' => $product_id );
+		if ( as_has_scheduled_action( self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP ) ) {
+			return;
+		}
+
+		// The unique flag makes the dedup atomic against a concurrent request that passed the check above.
+		as_schedule_single_action( $this->next_run_timestamp(), self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP, true );
+	}
+
+	/**
+	 * Schedule a prompt follow-up run for a product whose backfill filled its batch.
+	 *
+	 * Called from within a running backfill for the same product, so the executing action itself
+	 * matches as_has_scheduled_action() (which counts in-progress). Dedup on the PENDING state only,
+	 * and without the unique flag, so the follow-up is not rejected by the still-running action.
+	 *
+	 * @param int $product_id The product (post) ID.
+	 * @return void
+	 */
+	private function reschedule_remaining( int $product_id ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return;
+		}
+
+		$args    = array( 'product_id' => $product_id );
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'     => self::BACKFILL_ACTION,
+				'args'     => $args,
+				'group'    => self::BACKFILL_GROUP,
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => 1,
+			),
+			'ids'
+		);
+		if ( ! empty( $pending ) ) {
+			return;
+		}
+
+		as_schedule_single_action( time() + MINUTE_IN_SECONDS, self::BACKFILL_ACTION, $args, self::BACKFILL_GROUP );
+	}
+
+	/**
+	 * Timestamp of the next 06:00 in the site's timezone (before business hours).
+	 *
+	 * @return int
+	 */
+	private function next_run_timestamp(): int {
+		$timezone = wp_timezone();
+		$now      = new \DateTime( 'now', $timezone );
+		$next     = new \DateTime( 'today 06:00', $timezone );
+		if ( $next <= $now ) {
+			$next->modify( '+1 day' );
+		}
+		return $next->getTimestamp();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationQueryTest.php
@@ -1,0 +1,216 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\DataStores\Reviews;
+
+use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationQuery;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
+
+/**
+ * Tests for ReviewVerificationQuery.
+ */
+class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Create a paid order containing a product for a given identity.
+	 *
+	 * @param \WC_Product $product  Product to add.
+	 * @param int         $customer Customer user id (0 for guest).
+	 * @param string      $email    Billing email.
+	 * @return \WC_Order
+	 */
+	private function create_paid_order_for( $product, int $customer, string $email ) {
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		if ( $customer ) {
+			$order->set_customer_id( $customer );
+		}
+		$order->set_billing_email( $email );
+		$order->calculate_totals();
+		$order->set_status( 'completed' );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Insert an approved product review WITHOUT the verified meta (mirrors imported reviews).
+	 *
+	 * @param int    $product_id Product post id.
+	 * @param string $email      Author email.
+	 * @param int    $user_id    Author user id (0 for guest).
+	 * @return int Comment id.
+	 */
+	private function insert_unverified_review( int $product_id, string $email, int $user_id = 0 ) {
+		return (int) wp_insert_comment(
+			array(
+				'comment_post_ID'      => $product_id,
+				'comment_author'       => 'Reviewer',
+				'comment_author_email' => $email,
+				'comment_content'      => 'A review.',
+				'comment_type'         => 'review',
+				'comment_approved'     => 1,
+				'user_id'              => $user_id,
+			)
+		);
+	}
+
+	/**
+	 * Build the verified-owner badge fixture: one product with registered-buyer,
+	 * guest-buyer and non-buyer reviews. Returns [ product, comment_id => expected_verified ].
+	 *
+	 * @return array{0: \WC_Product, 1: array<int,bool>}
+	 */
+	private function build_verified_owner_fixture(): array {
+		static $seq = 0;
+		$tag        = ++$seq;
+
+		$product    = ProductHelper::create_simple_product();
+		$product_id = $product->get_id();
+
+		$expected = array();
+
+		// Registered buyer (verified via customer_id).
+		$buyer_id = self::factory()->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => "buyer-$tag@example.test",
+			)
+		);
+		$this->create_paid_order_for( $product, $buyer_id, "buyer-$tag@example.test" );
+		$expected[ $this->insert_unverified_review( $product_id, '', $buyer_id ) ] = true;
+
+		// Guest buyer (verified via billing email).
+		$this->create_paid_order_for( $product, 0, "guest-$tag@example.test" );
+		$expected[ $this->insert_unverified_review( $product_id, "guest-$tag@example.test", 0 ) ] = true;
+
+		// Registered non-buyer.
+		$nonbuyer_id = self::factory()->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => "nobuy-$tag@example.test",
+			)
+		);
+		$expected[ $this->insert_unverified_review( $product_id, '', $nonbuyer_id ) ] = false;
+
+		// Guest non-buyer.
+		$expected[ $this->insert_unverified_review( $product_id, "nobuy-guest-$tag@example.test", 0 ) ] = false;
+
+		return array( $product, $expected );
+	}
+
+	/**
+	 * Count the heavy "bought product" order-join queries while running a callback.
+	 *
+	 * @param callable $callback Code to execute.
+	 * @return int Number of heavy queries observed.
+	 */
+	private function count_bought_product_queries( callable $callback ): int {
+		$count = 0;
+		$spy   = function ( $query ) use ( &$count ) {
+			if ( false !== stripos( $query, 'woocommerce_order_itemmeta' ) && false !== stripos( $query, '_variation_id' ) ) {
+				++$count;
+			}
+			return $query;
+		};
+		add_filter( 'query', $spy );
+		$callback();
+		remove_filter( 'query', $spy );
+		return $count;
+	}
+
+	/**
+	 * The batched prime must resolve every reviewer in a single query and persist
+	 * the verified meta, so the per-review badge path issues no further queries.
+	 */
+	public function test_prime_resolves_all_in_single_query(): void {
+		list( $product, $expected ) = $this->build_verified_owner_fixture();
+		$comments                   = get_comments(
+			array(
+				'post_id' => $product->get_id(),
+				'type'    => 'review',
+				'status'  => 'approve',
+			)
+		);
+
+		wp_cache_flush();
+		$prime_queries = $this->count_bought_product_queries(
+			function () use ( $comments, $product ) {
+				( new ReviewVerificationQuery() )->prime( $comments, $product->get_id() );
+			}
+		);
+
+		// One query for the whole page of reviews, regardless of reviewer count.
+		$this->assertSame( 1, $prime_queries, 'Batched prime should run exactly one bought-product query.' );
+
+		// Verified meta is persisted with the correct value for every review.
+		foreach ( $expected as $comment_id => $is_verified ) {
+			$this->assertSame( $is_verified ? '1' : '0', get_comment_meta( $comment_id, 'verified', true ), "Wrong verified meta for comment $comment_id." );
+		}
+
+		// The per-review badge path now hits the persisted meta: zero further heavy queries.
+		$badge_queries = $this->count_bought_product_queries(
+			function () use ( $expected ) {
+				foreach ( array_keys( $expected ) as $comment_id ) {
+					wc_review_is_from_verified_owner( $comment_id );
+				}
+			}
+		);
+		$this->assertSame( 0, $badge_queries, 'Verified-owner badge should not query after the batched prime.' );
+	}
+
+	/**
+	 * The batched result must be byte-identical to the per-review (unbatched) path.
+	 */
+	public function test_prime_matches_per_review_path(): void {
+		// Unbatched baseline via the filter gate.
+		list( $product_a, $expected_a ) = $this->build_verified_owner_fixture();
+		add_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
+		$unbatched = array();
+		foreach ( array_keys( $expected_a ) as $comment_id ) {
+			$unbatched[ $comment_id ] = wc_review_is_from_verified_owner( $comment_id );
+		}
+		remove_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
+
+		foreach ( $expected_a as $comment_id => $is_verified ) {
+			$this->assertSame( $is_verified, $unbatched[ $comment_id ], "Unbatched path wrong for comment $comment_id." );
+		}
+
+		// Batched path on a fresh fixture.
+		list( $product_b, $expected_b ) = $this->build_verified_owner_fixture();
+		$comments                       = get_comments(
+			array(
+				'post_id' => $product_b->get_id(),
+				'type'    => 'review',
+				'status'  => 'approve',
+			)
+		);
+		( new ReviewVerificationQuery() )->prime( $comments, $product_b->get_id() );
+
+		foreach ( $expected_b as $comment_id => $is_verified ) {
+			$this->assertSame( $is_verified, wc_review_is_from_verified_owner( $comment_id ), "Batched path wrong for comment $comment_id." );
+		}
+	}
+
+	/**
+	 * When disabled via filter, the prime is a no-op and leaves resolution to the per-review path.
+	 */
+	public function test_prime_can_be_disabled_via_filter(): void {
+		list( $product, $expected ) = $this->build_verified_owner_fixture();
+		$comments                   = get_comments(
+			array(
+				'post_id' => $product->get_id(),
+				'type'    => 'review',
+				'status'  => 'approve',
+			)
+		);
+
+		add_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
+		( new ReviewVerificationQuery() )->prime( $comments, $product->get_id() );
+		remove_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
+
+		// No meta should have been written by the disabled prime.
+		foreach ( array_keys( $expected ) as $comment_id ) {
+			$this->assertSame( '', get_comment_meta( $comment_id, 'verified', true ), "Disabled prime should not write meta for $comment_id." );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationQueryTest.php
@@ -12,6 +12,16 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 
 	/**
+	 * Clear any backfill actions scheduled by fixtures or prior tests.
+	 */
+	public function tearDown(): void {
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		}
+		parent::tearDown();
+	}
+
+	/**
 	 * Create a paid order containing a product for a given identity.
 	 *
 	 * @param \WC_Product $product  Product to add.
@@ -99,6 +109,41 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Fetch the approved review comments for a product.
+	 *
+	 * @param int $product_id Product post id.
+	 * @return \WP_Comment[]
+	 */
+	private function get_product_reviews( int $product_id ): array {
+		return get_comments(
+			array(
+				'post_id' => $product_id,
+				'type'    => 'review',
+				'status'  => 'approve',
+			)
+		);
+	}
+
+	/**
+	 * Count the pending backfill actions scheduled for a product.
+	 *
+	 * @param int $product_id Product post id.
+	 * @return int
+	 */
+	private function count_scheduled_backfills( int $product_id ): int {
+		$ids = as_get_scheduled_actions(
+			array(
+				'hook'     => ReviewVerificationQuery::BACKFILL_ACTION,
+				'args'     => array( 'product_id' => $product_id ),
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+		return count( $ids );
+	}
+
+	/**
 	 * Count the heavy "bought product" order-join queries while running a callback.
 	 *
 	 * @param callable $callback Code to execute.
@@ -119,28 +164,21 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * The batched prime must resolve every reviewer in a single query and persist
-	 * the verified meta, so the per-review badge path issues no further queries.
+	 * The backfill must resolve every reviewer in a single query and persist the verified meta,
+	 * so the per-review badge path then issues no further queries.
 	 */
-	public function test_prime_resolves_all_in_single_query(): void {
+	public function test_backfill_resolves_all_in_single_query(): void {
 		list( $product, $expected ) = $this->build_verified_owner_fixture();
-		$comments                   = get_comments(
-			array(
-				'post_id' => $product->get_id(),
-				'type'    => 'review',
-				'status'  => 'approve',
-			)
-		);
 
 		wp_cache_flush();
-		$prime_queries = $this->count_bought_product_queries(
-			function () use ( $comments, $product ) {
-				( new ReviewVerificationQuery() )->prime( $comments, $product->get_id() );
+		$backfill_queries = $this->count_bought_product_queries(
+			function () use ( $product ) {
+				( new ReviewVerificationQuery() )->backfill( $product->get_id() );
 			}
 		);
 
-		// One query for the whole page of reviews, regardless of reviewer count.
-		$this->assertSame( 1, $prime_queries, 'Batched prime should run exactly one bought-product query.' );
+		// One query for the whole product, regardless of reviewer count.
+		$this->assertSame( 1, $backfill_queries, 'Backfill should run exactly one bought-product query.' );
 
 		// Verified meta is persisted with the correct value for every review.
 		foreach ( $expected as $comment_id => $is_verified ) {
@@ -155,13 +193,13 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 				}
 			}
 		);
-		$this->assertSame( 0, $badge_queries, 'Verified-owner badge should not query after the batched prime.' );
+		$this->assertSame( 0, $badge_queries, 'Verified-owner badge should not query after the backfill.' );
 	}
 
 	/**
-	 * The batched result must be byte-identical to the per-review (unbatched) path.
+	 * The backfilled result must match the per-review (unbatched) path.
 	 */
-	public function test_prime_matches_per_review_path(): void {
+	public function test_backfill_matches_per_review_path(): void {
 		// Unbatched baseline via the filter gate.
 		list( , $expected_a ) = $this->build_verified_owner_fixture();
 		add_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
@@ -175,42 +213,207 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 			$this->assertSame( $is_verified, $unbatched[ $comment_id ], "Unbatched path wrong for comment $comment_id." );
 		}
 
-		// Batched path on a fresh fixture.
+		// Backfilled path on a fresh fixture.
 		list( $product_b, $expected_b ) = $this->build_verified_owner_fixture();
-		$comments                       = get_comments(
-			array(
-				'post_id' => $product_b->get_id(),
-				'type'    => 'review',
-				'status'  => 'approve',
-			)
-		);
-		( new ReviewVerificationQuery() )->prime( $comments, $product_b->get_id() );
+		( new ReviewVerificationQuery() )->backfill( $product_b->get_id() );
 
 		foreach ( $expected_b as $comment_id => $is_verified ) {
-			$this->assertSame( $is_verified, wc_review_is_from_verified_owner( $comment_id ), "Batched path wrong for comment $comment_id." );
+			$this->assertSame( $is_verified, wc_review_is_from_verified_owner( $comment_id ), "Backfilled path wrong for comment $comment_id." );
 		}
 	}
 
 	/**
-	 * When disabled via filter, the prime is a no-op and leaves resolution to the per-review path.
+	 * When disabled via filter, the backfill is a no-op and leaves resolution to the per-review path.
 	 */
-	public function test_prime_can_be_disabled_via_filter(): void {
+	public function test_backfill_can_be_disabled_via_filter(): void {
 		list( $product, $expected ) = $this->build_verified_owner_fixture();
-		$comments                   = get_comments(
-			array(
-				'post_id' => $product->get_id(),
-				'type'    => 'review',
-				'status'  => 'approve',
-			)
-		);
 
 		add_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
-		( new ReviewVerificationQuery() )->prime( $comments, $product->get_id() );
+		( new ReviewVerificationQuery() )->backfill( $product->get_id() );
 		remove_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
 
-		// No meta should have been written by the disabled prime.
+		// No meta should have been written by the disabled backfill.
 		foreach ( array_keys( $expected ) as $comment_id ) {
-			$this->assertSame( '', get_comment_meta( $comment_id, 'verified', true ), "Disabled prime should not write meta for $comment_id." );
+			$this->assertSame( '', get_comment_meta( $comment_id, 'verified', true ), "Disabled backfill should not write meta for $comment_id." );
 		}
+	}
+
+	/**
+	 * A product page with unresolved reviews must schedule a backfill without resolving on read,
+	 * and repeated scheduling must be deduplicated to a single pending action.
+	 */
+	public function test_schedule_for_page_enqueues_single_backfill_without_resolving(): void {
+		list( $product, $expected ) = $this->build_verified_owner_fixture();
+		$product_id                 = $product->get_id();
+		$comments                   = $this->get_product_reviews( $product_id );
+
+		// Clear the action the fixture's inserts already scheduled, to assert scheduling cleanly.
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+
+		$read_queries = $this->count_bought_product_queries(
+			function () use ( $comments, $product_id ) {
+				$query = new ReviewVerificationQuery();
+				$query->schedule_for_page( $comments, $product_id );
+				$query->schedule_for_page( $comments, $product_id );
+			}
+		);
+
+		$this->assertSame( 0, $read_queries, 'Scheduling on read must not run the bought-product query.' );
+		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'Repeated scheduling must dedupe to one pending backfill.' );
+
+		// Nothing resolved yet: meta stays empty until the scheduled task runs.
+		foreach ( array_keys( $expected ) as $comment_id ) {
+			$this->assertSame( '', get_comment_meta( $comment_id, 'verified', true ), "Scheduling must not resolve comment $comment_id on read." );
+		}
+	}
+
+	/**
+	 * A page whose reviews are all already resolved must not schedule a backfill.
+	 */
+	public function test_schedule_for_page_skips_when_all_resolved(): void {
+		list( $product ) = $this->build_verified_owner_fixture();
+		$product_id      = $product->get_id();
+
+		( new ReviewVerificationQuery() )->backfill( $product_id );
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+
+		( new ReviewVerificationQuery() )->schedule_for_page( $this->get_product_reviews( $product_id ), $product_id );
+
+		$this->assertSame( 0, $this->count_scheduled_backfills( $product_id ), 'A fully resolved page must not schedule a backfill.' );
+	}
+
+	/**
+	 * A review whose email differs in case from the order billing email must still resolve verified,
+	 * matching the case-insensitive DB collation the per-review path relies on.
+	 */
+	public function test_backfill_matches_verified_owner_across_email_case(): void {
+		$product    = ProductHelper::create_simple_product();
+		$product_id = $product->get_id();
+
+		$this->create_paid_order_for( $product, 0, 'buyer@example.test' );
+		$comment_id = $this->insert_unverified_review( $product_id, 'Buyer@Example.TEST', 0 );
+
+		( new ReviewVerificationQuery() )->backfill( $product_id );
+
+		$this->assertSame( '1', get_comment_meta( $comment_id, 'verified', true ), 'A case-different guest email must still resolve as a verified owner.' );
+		$this->assertTrue( wc_review_is_from_verified_owner( $comment_id ), 'The per-review path must agree.' );
+	}
+
+	/**
+	 * A hooked woocommerce_pre_customer_bought_product filter owns the result, so the batch must
+	 * defer to the per-review path rather than persist its own answer.
+	 */
+	public function test_backfill_defers_when_pre_check_filter_is_hooked(): void {
+		list( $product, $expected ) = $this->build_verified_owner_fixture();
+
+		add_filter( 'woocommerce_pre_customer_bought_product', '__return_true' );
+		( new ReviewVerificationQuery() )->backfill( $product->get_id() );
+		remove_filter( 'woocommerce_pre_customer_bought_product', '__return_true' );
+
+		foreach ( array_keys( $expected ) as $comment_id ) {
+			$this->assertSame( '', get_comment_meta( $comment_id, 'verified', true ), "Backfill must not persist over a pre-check filter for $comment_id." );
+		}
+	}
+
+	/**
+	 * A non-review comment must not schedule a backfill.
+	 */
+	public function test_schedule_for_new_review_ignores_non_reviews(): void {
+		$product_id = ProductHelper::create_simple_product()->get_id();
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+
+		$comment_id = (int) wp_insert_comment(
+			array(
+				'comment_post_ID'  => $product_id,
+				'comment_content'  => 'Not a review.',
+				'comment_type'     => 'comment',
+				'comment_approved' => 1,
+			)
+		);
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+
+		( new ReviewVerificationQuery() )->schedule_for_new_review( $comment_id, get_comment( $comment_id ) );
+
+		$this->assertSame( 0, $this->count_scheduled_backfills( $product_id ), 'A non-review comment must not schedule a backfill.' );
+	}
+
+	/**
+	 * A backfill run that fills its batch must reschedule a follow-up for the remaining reviews.
+	 */
+	public function test_backfill_reschedules_when_batch_is_full(): void {
+		list( $product ) = $this->build_verified_owner_fixture();
+		$product_id      = $product->get_id();
+
+		// Force a batch smaller than the 4-review fixture so the first run is "full".
+		add_filter( 'woocommerce_review_verification_backfill_batch_size', fn() => 2 );
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		( new ReviewVerificationQuery() )->backfill( $product_id );
+		remove_all_filters( 'woocommerce_review_verification_backfill_batch_size' );
+
+		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'A full batch must reschedule a follow-up for the remainder.' );
+	}
+
+	/**
+	 * The follow-up must be scheduled even while an action for the same product is in progress — the
+	 * real state when a backfill reschedules itself. A pending-and-running dedup would drop it.
+	 */
+	public function test_backfill_reschedules_while_an_action_is_running(): void {
+		if ( ! class_exists( '\ActionScheduler_Action' ) || ! class_exists( '\ActionScheduler_SimpleSchedule' ) ) {
+			$this->markTestSkipped( 'Action Scheduler classes unavailable.' );
+		}
+
+		list( $product ) = $this->build_verified_owner_fixture();
+		$product_id      = $product->get_id();
+
+		add_filter( 'woocommerce_review_verification_backfill_batch_size', fn() => 2 );
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+
+		// Persist an action for this product and mark it in-progress, mirroring the scheduler runner.
+		$store      = \ActionScheduler::store();
+		$action     = new \ActionScheduler_Action(
+			ReviewVerificationQuery::BACKFILL_ACTION,
+			array( 'product_id' => $product_id ),
+			new \ActionScheduler_SimpleSchedule( as_get_datetime_object() ),
+			'woocommerce-review-verification'
+		);
+		$running_id = $store->save_action( $action );
+		$store->log_execution( $running_id );
+
+		( new ReviewVerificationQuery() )->backfill( $product_id );
+		remove_all_filters( 'woocommerce_review_verification_backfill_batch_size' );
+
+		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'A follow-up must schedule even while a backfill action for the product is running.' );
+	}
+
+	/**
+	 * A follow-up must not stack on top of one already pending for the same product.
+	 */
+	public function test_backfill_reschedule_dedupes_pending(): void {
+		list( $product ) = $this->build_verified_owner_fixture();
+		$product_id      = $product->get_id();
+
+		add_filter( 'woocommerce_review_verification_backfill_batch_size', fn() => 2 );
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		( new ReviewVerificationQuery() )->backfill( $product_id );
+		( new ReviewVerificationQuery() )->backfill( $product_id );
+		remove_all_filters( 'woocommerce_review_verification_backfill_batch_size' );
+
+		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'Repeated full-batch runs must not stack pending follow-ups.' );
+	}
+
+	/**
+	 * Inserting a new product review must schedule a backfill for its product.
+	 */
+	public function test_schedule_for_new_review_enqueues_backfill(): void {
+		$product    = ProductHelper::create_simple_product();
+		$product_id = $product->get_id();
+		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+
+		$comment_id = $this->insert_unverified_review( $product_id, 'someone@example.test', 0 );
+		$comment    = get_comment( $comment_id );
+
+		( new ReviewVerificationQuery() )->schedule_for_new_review( $comment_id, $comment );
+
+		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'A new product review must schedule a backfill.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationQueryTest.php
@@ -163,7 +163,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_prime_matches_per_review_path(): void {
 		// Unbatched baseline via the filter gate.
-		list( $product_a, $expected_a ) = $this->build_verified_owner_fixture();
+		list( , $expected_a ) = $this->build_verified_owner_fixture();
 		add_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
 		$unbatched = array();
 		foreach ( array_keys( $expected_a ) as $comment_id ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationServiceTest.php
@@ -3,20 +3,44 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\DataStores\Reviews;
 
-use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationQuery;
+use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationDataStore;
+use Automattic\WooCommerce\Internal\DataStores\Reviews\ReviewVerificationService;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 
 /**
- * Tests for ReviewVerificationQuery.
+ * Tests for ReviewVerificationService and ReviewVerificationDataStore.
  */
-class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
+class ReviewVerificationServiceTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * The scheduling service under test.
+	 *
+	 * @var ReviewVerificationService
+	 */
+	private ReviewVerificationService $service;
+
+	/**
+	 * The resolving data store under test.
+	 *
+	 * @var ReviewVerificationDataStore
+	 */
+	private ReviewVerificationDataStore $data_store;
+
+	/**
+	 * Resolve the service and data store from the container.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->service    = wc_get_container()->get( ReviewVerificationService::class );
+		$this->data_store = wc_get_container()->get( ReviewVerificationDataStore::class );
+	}
 
 	/**
 	 * Clear any backfill actions scheduled by fixtures or prior tests.
 	 */
 	public function tearDown(): void {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+			as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 		}
 		parent::tearDown();
 	}
@@ -133,7 +157,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	private function count_scheduled_backfills( int $product_id ): int {
 		$ids = as_get_scheduled_actions(
 			array(
-				'hook'     => ReviewVerificationQuery::BACKFILL_ACTION,
+				'hook'     => ReviewVerificationService::BACKFILL_ACTION,
 				'args'     => array( 'product_id' => $product_id ),
 				'status'   => \ActionScheduler_Store::STATUS_PENDING,
 				'per_page' => -1,
@@ -164,7 +188,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * The backfill must resolve every reviewer in a single query and persist the verified meta,
+	 * The data store must resolve every reviewer in a single query and persist the verified meta,
 	 * so the per-review badge path then issues no further queries.
 	 */
 	public function test_backfill_resolves_all_in_single_query(): void {
@@ -173,7 +197,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		wp_cache_flush();
 		$backfill_queries = $this->count_bought_product_queries(
 			function () use ( $product ) {
-				( new ReviewVerificationQuery() )->backfill( $product->get_id() );
+				$this->data_store->backfill( $product->get_id(), 500 );
 			}
 		);
 
@@ -215,7 +239,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 
 		// Backfilled path on a fresh fixture.
 		list( $product_b, $expected_b ) = $this->build_verified_owner_fixture();
-		( new ReviewVerificationQuery() )->backfill( $product_b->get_id() );
+		$this->data_store->backfill( $product_b->get_id(), 500 );
 
 		foreach ( $expected_b as $comment_id => $is_verified ) {
 			$this->assertSame( $is_verified, wc_review_is_from_verified_owner( $comment_id ), "Backfilled path wrong for comment $comment_id." );
@@ -229,7 +253,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		list( $product, $expected ) = $this->build_verified_owner_fixture();
 
 		add_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
-		( new ReviewVerificationQuery() )->backfill( $product->get_id() );
+		$this->data_store->backfill( $product->get_id(), 500 );
 		remove_filter( 'woocommerce_prime_review_verification_meta', '__return_false' );
 
 		// No meta should have been written by the disabled backfill.
@@ -248,13 +272,12 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		$comments                   = $this->get_product_reviews( $product_id );
 
 		// Clear the action the fixture's inserts already scheduled, to assert scheduling cleanly.
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 
 		$read_queries = $this->count_bought_product_queries(
 			function () use ( $comments, $product_id ) {
-				$query = new ReviewVerificationQuery();
-				$query->schedule_for_page( $comments, $product_id );
-				$query->schedule_for_page( $comments, $product_id );
+				$this->service->schedule_for_page( $comments, $product_id );
+				$this->service->schedule_for_page( $comments, $product_id );
 			}
 		);
 
@@ -274,10 +297,10 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		list( $product ) = $this->build_verified_owner_fixture();
 		$product_id      = $product->get_id();
 
-		( new ReviewVerificationQuery() )->backfill( $product_id );
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		$this->data_store->backfill( $product_id, 500 );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 
-		( new ReviewVerificationQuery() )->schedule_for_page( $this->get_product_reviews( $product_id ), $product_id );
+		$this->service->schedule_for_page( $this->get_product_reviews( $product_id ), $product_id );
 
 		$this->assertSame( 0, $this->count_scheduled_backfills( $product_id ), 'A fully resolved page must not schedule a backfill.' );
 	}
@@ -293,7 +316,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		$this->create_paid_order_for( $product, 0, 'buyer@example.test' );
 		$comment_id = $this->insert_unverified_review( $product_id, 'Buyer@Example.TEST', 0 );
 
-		( new ReviewVerificationQuery() )->backfill( $product_id );
+		$this->data_store->backfill( $product_id, 500 );
 
 		$this->assertSame( '1', get_comment_meta( $comment_id, 'verified', true ), 'A case-different guest email must still resolve as a verified owner.' );
 		$this->assertTrue( wc_review_is_from_verified_owner( $comment_id ), 'The per-review path must agree.' );
@@ -307,7 +330,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		list( $product, $expected ) = $this->build_verified_owner_fixture();
 
 		add_filter( 'woocommerce_pre_customer_bought_product', '__return_true' );
-		( new ReviewVerificationQuery() )->backfill( $product->get_id() );
+		$this->data_store->backfill( $product->get_id(), 500 );
 		remove_filter( 'woocommerce_pre_customer_bought_product', '__return_true' );
 
 		foreach ( array_keys( $expected ) as $comment_id ) {
@@ -320,7 +343,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_schedule_for_new_review_ignores_non_reviews(): void {
 		$product_id = ProductHelper::create_simple_product()->get_id();
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 
 		$comment_id = (int) wp_insert_comment(
 			array(
@@ -330,9 +353,9 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 				'comment_approved' => 1,
 			)
 		);
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 
-		( new ReviewVerificationQuery() )->schedule_for_new_review( $comment_id, get_comment( $comment_id ) );
+		$this->service->schedule_for_new_review( $comment_id, get_comment( $comment_id ) );
 
 		$this->assertSame( 0, $this->count_scheduled_backfills( $product_id ), 'A non-review comment must not schedule a backfill.' );
 	}
@@ -346,8 +369,8 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 
 		// Force a batch smaller than the 4-review fixture so the first run is "full".
 		add_filter( 'woocommerce_review_verification_backfill_batch_size', fn() => 2 );
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
-		( new ReviewVerificationQuery() )->backfill( $product_id );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
+		$this->service->run_backfill( $product_id );
 		remove_all_filters( 'woocommerce_review_verification_backfill_batch_size' );
 
 		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'A full batch must reschedule a follow-up for the remainder.' );
@@ -366,12 +389,12 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		$product_id      = $product->get_id();
 
 		add_filter( 'woocommerce_review_verification_backfill_batch_size', fn() => 2 );
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 
 		// Persist an action for this product and mark it in-progress, mirroring the scheduler runner.
 		$store      = \ActionScheduler::store();
 		$action     = new \ActionScheduler_Action(
-			ReviewVerificationQuery::BACKFILL_ACTION,
+			ReviewVerificationService::BACKFILL_ACTION,
 			array( 'product_id' => $product_id ),
 			new \ActionScheduler_SimpleSchedule( as_get_datetime_object() ),
 			'woocommerce-review-verification'
@@ -379,7 +402,7 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		$running_id = $store->save_action( $action );
 		$store->log_execution( $running_id );
 
-		( new ReviewVerificationQuery() )->backfill( $product_id );
+		$this->service->run_backfill( $product_id );
 		remove_all_filters( 'woocommerce_review_verification_backfill_batch_size' );
 
 		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'A follow-up must schedule even while a backfill action for the product is running.' );
@@ -393,9 +416,9 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 		$product_id      = $product->get_id();
 
 		add_filter( 'woocommerce_review_verification_backfill_batch_size', fn() => 2 );
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
-		( new ReviewVerificationQuery() )->backfill( $product_id );
-		( new ReviewVerificationQuery() )->backfill( $product_id );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
+		$this->service->run_backfill( $product_id );
+		$this->service->run_backfill( $product_id );
 		remove_all_filters( 'woocommerce_review_verification_backfill_batch_size' );
 
 		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'Repeated full-batch runs must not stack pending follow-ups.' );
@@ -407,12 +430,12 @@ class ReviewVerificationQueryTest extends \WC_Unit_Test_Case {
 	public function test_schedule_for_new_review_enqueues_backfill(): void {
 		$product    = ProductHelper::create_simple_product();
 		$product_id = $product->get_id();
-		as_unschedule_all_actions( ReviewVerificationQuery::BACKFILL_ACTION );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
 
 		$comment_id = $this->insert_unverified_review( $product_id, 'someone@example.test', 0 );
 		$comment    = get_comment( $comment_id );
 
-		( new ReviewVerificationQuery() )->schedule_for_new_review( $comment_id, $comment );
+		$this->service->schedule_for_new_review( $comment_id, $comment );
 
 		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), 'A new product review must schedule a backfill.' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Reviews/ReviewVerificationServiceTest.php
@@ -72,20 +72,32 @@ class ReviewVerificationServiceTest extends \WC_Unit_Test_Case {
 	 * @param int    $product_id Product post id.
 	 * @param string $email      Author email.
 	 * @param int    $user_id    Author user id (0 for guest).
+	 * @param string $type       Stored comment type.
 	 * @return int Comment id.
 	 */
-	private function insert_unverified_review( int $product_id, string $email, int $user_id = 0 ) {
-		return (int) wp_insert_comment(
+	private function insert_unverified_review( int $product_id, string $email, int $user_id = 0, string $type = 'review' ) {
+		global $wpdb;
+
+		$comment_id = (int) wp_insert_comment(
 			array(
 				'comment_post_ID'      => $product_id,
 				'comment_author'       => 'Reviewer',
 				'comment_author_email' => $email,
 				'comment_content'      => 'A review.',
-				'comment_type'         => 'review',
+				'comment_type'         => $type,
 				'comment_approved'     => 1,
 				'user_id'              => $user_id,
 			)
 		);
+
+		// wp_insert_comment() coerces an empty comment_type to 'comment', so force the '' type that
+		// imported/migrated reviews actually carry directly on the row.
+		if ( '' === $type ) {
+			$wpdb->update( $wpdb->comments, array( 'comment_type' => '' ), array( 'comment_ID' => $comment_id ) );
+			clean_comment_cache( $comment_id );
+		}
+
+		return $comment_id;
 	}
 
 	/**
@@ -339,7 +351,7 @@ class ReviewVerificationServiceTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A non-review comment must not schedule a backfill.
+	 * A genuine non-review (a pingback) must not schedule a backfill.
 	 */
 	public function test_schedule_for_new_review_ignores_non_reviews(): void {
 		$product_id = ProductHelper::create_simple_product()->get_id();
@@ -349,7 +361,7 @@ class ReviewVerificationServiceTest extends \WC_Unit_Test_Case {
 			array(
 				'comment_post_ID'  => $product_id,
 				'comment_content'  => 'Not a review.',
-				'comment_type'     => 'comment',
+				'comment_type'     => 'pingback',
 				'comment_approved' => 1,
 			)
 		);
@@ -357,7 +369,60 @@ class ReviewVerificationServiceTest extends \WC_Unit_Test_Case {
 
 		$this->service->schedule_for_new_review( $comment_id, get_comment( $comment_id ) );
 
-		$this->assertSame( 0, $this->count_scheduled_backfills( $product_id ), 'A non-review comment must not schedule a backfill.' );
+		$this->assertSame( 0, $this->count_scheduled_backfills( $product_id ), 'A genuine non-review (pingback) must not schedule a backfill.' );
+	}
+
+	/**
+	 * All comment types core recognizes as product reviews.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function provider_review_comment_types(): array {
+		return array(
+			'review type'         => array( 'review' ),
+			'legacy comment type' => array( 'comment' ),
+			'default empty type'  => array( '' ),
+		);
+	}
+
+	/**
+	 * Every comment type core counts as a product review — including the '' and 'comment' types kept
+	 * by imported or REST-created reviews — must schedule a backfill.
+	 *
+	 * @dataProvider provider_review_comment_types
+	 *
+	 * @param string $comment_type The stored comment type.
+	 */
+	public function test_schedule_for_new_review_schedules_all_review_types( string $comment_type ): void {
+		$product_id = ProductHelper::create_simple_product()->get_id();
+
+		$comment_id = $this->insert_unverified_review( $product_id, 'someone@example.test', 0, $comment_type );
+		as_unschedule_all_actions( ReviewVerificationService::BACKFILL_ACTION );
+
+		$this->service->schedule_for_new_review( $comment_id, get_comment( $comment_id ) );
+
+		$this->assertSame( 1, $this->count_scheduled_backfills( $product_id ), "A '$comment_type'-type product review must schedule a backfill." );
+	}
+
+	/**
+	 * Reviews stored with the '' or 'comment' comment types (imported, migrated or REST-created)
+	 * must be resolved and persisted by the backfill just like 'review'-type ones.
+	 *
+	 * @dataProvider provider_review_comment_types
+	 *
+	 * @param string $comment_type The stored comment type.
+	 */
+	public function test_backfill_resolves_all_review_types( string $comment_type ): void {
+		$product    = ProductHelper::create_simple_product();
+		$product_id = $product->get_id();
+
+		$this->create_paid_order_for( $product, 0, 'legacy-buyer@example.test' );
+		$comment_id = $this->insert_unverified_review( $product_id, 'legacy-buyer@example.test', 0, $comment_type );
+
+		$this->data_store->backfill( $product_id, 500 );
+
+		$this->assertSame( '1', get_comment_meta( $comment_id, 'verified', true ), "Backfill must persist verified meta for a '$comment_type'-type review." );
+		$this->assertTrue( wc_review_is_from_verified_owner( $comment_id ), 'The per-review path must agree.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Supersedes https://github.com/woocommerce/woocommerce/pull/66394

Problem we are solving: extensions/customizations removing the `\WC_Comments::add_comment_purchase_verification` callback for `comment_post` or programmatically/via REST adding reviews will cause bypassing of pre-existing optimizations relying on the comment `verified` meta and causing `wc_customer_bought_product` invocations on the product page. Although `wc_customer_bought_product` has been optimized in multiple rounds, it remains heavy, and meta population is critical for scaling stores with reviews/comments enabled.

This PR introduces a new recurring task that gradually backfills the meta in an HVM/cluster-friendly way: predictable batched processing (the task runs at 3 am, executes relatively heavy SQL, and schedules batch processing over the next 24 hours at 15-minute intervals; next time it moves further thru the reviews queue).

Assuming there are enough entries to backfill, the tasks will produce 30 nightly runs and up to 30 x 24 x 4 = 2880 batch backfilling runs in a single month (max 144K backfilled entries monthly). Once the backfill catches up and starts processing new entries, the number of batches processing is expected to stabilize, and Action Scheduler tables will start shrinking (along with Action Scheduler cleanup routines), assuming the same operation dynamics for the store.

### How to test the changes in this Pull Request:

- Switch to this branch
- Navigate to `Tools -> Scheduled Actions -> Pending` in the admin area
- Search for `action_scheduler_run_recurring_actions_schedule_hook`
- Run it (it's expected to find a single pending entry for it and for the run to succeed)
- Search for `woocommerce_review_verification_schedule_backfill_batches`
- Run it (it's expected to find a single pending entry for it and for the run to succeed)
- If you have entries to backfill, new `woocommerce_review_verification_process_backfill_batch` actions will be scheduled
- Run those and verify the meta appeared for the processed entries (IDs can be discovered from the task parameters)
