### PR TITLE
Add date field type to additional checkout fields

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -254,7 +254,7 @@ Text fields don't have any additional options beyond the general options listed 
 
 Date fields don't have any additional options beyond the general options listed above.
 
-The rendered value will follow the site’s date format, set in **Settings → General**.
+The input value will follow the browser's locale settings, the DB value will be in YYYY-MM-DD, and the final rendered value (in pages and emails) will follow the site's date format, set in **Settings -> General**.
 
 #### Options for `select` fields
 

--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -192,6 +192,7 @@ The following field types are supported:
 - `select`
 - `text`
 - `checkbox`
+- `date`
 
 There are plans to expand this list, but for now these are the types available.
 
@@ -219,7 +220,7 @@ These options apply to all field types (except in a few circumstances which are 
 | `label` | The label shown on your field. This will be the placeholder too. | Yes | `How did you hear about us?` | No default - this must be provided. |
 | `optionalLabel` | The label shown on your field if it is optional. This will be the placeholder too. | No | `How did you hear about us? (Optional)` | The default value will be the value of `label` with `(optional)` appended. |
 | `location` | The location to render your field. | Yes | `contact`, `address`, or `order` | No default - this must be provided. |
-| `type` | The type of field you're rendering. It defaults to `text` and must match one of the supported field types. | No | `text`, `select`, or `checkbox` | `text` |
+| `type` | The type of field you're rendering. It defaults to `text` and must match one of the supported field types. | No | `text`, `select`, `checkbox`, or `date` | `text` |
 | `attributes` | An array of additional attributes to render on the field's input element. This is _not_ supported for `select` fields. | No | `[	'data-custom-data' => 'my-custom-data' ]` | `[]` |
 | `required` | Can be a boolean or a JSON Schema array. If boolean and `true`, the shopper _must_ provide a value for this field during the checkout process. For checkbox fields, the shopper must check the box to place the order. If a JSON Schema array, the field will be required based on the schema conditions. See [Conditional visibility and validation via JSON Schema](#conditional-visibility-and-validation-via-json-schema). | No | `true` or `["type" => "object", "properties" => [...]]` | `false` |
 | `hidden` | Can be a boolean or a JSON Schema array. Must be `false` when used as a boolean. If a JSON Schema array, the field will be hidden based on the schema conditions. See [Conditional visibility and validation via JSON Schema](#conditional-visibility-and-validation-via-json-schema). | No | `false` or `["type" => "object", "properties" => [...]]` | `false` |
@@ -248,6 +249,12 @@ These options apply to all field types (except in a few circumstances which are 
 #### Options for `text` fields
 
 Text fields don't have any additional options beyond the general options listed above.
+
+#### Options for `date` fields
+
+Date fields don't have any additional options beyond the general options listed above.
+
+The rendered value will follow the site’s date format, set in **Settings → General**.
 
 #### Options for `select` fields
 

--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -299,7 +299,7 @@ As well as the options above, checkbox field support showing an error message if
 
 ### Attributes
 
-Adding additional attributes to checkbox and text fields is supported. Adding them to select fields is **not possible for now**.
+Adding additional attributes to checkbox, text, and date fields is supported. Adding them to select fields is **not possible for now**.
 
 These attributes have a 1:1 mapping to the HTML attributes on `input` elements (except `pattern` on checkbox).
 

--- a/docs/block-development/tutorials/how-to-additional-checkout-fields-guide.md
+++ b/docs/block-development/tutorials/how-to-additional-checkout-fields-guide.md
@@ -28,7 +28,7 @@ add_action( 'woocommerce_init', function() {
             'id'       => 'your-namespace/field-name',
             'label'    => __( 'Your Field Label', 'your-text-domain'),
             'location' => 'contact', // or 'address' or 'order'
-            'type'     => 'text',    // or 'select' or 'checkbox'
+            'type'     => 'text',    // or 'select', 'checkbox' or 'date'
             'required' => false,
         )
     );
@@ -100,7 +100,7 @@ woocommerce_register_additional_checkout_field(
 
 ## Supported Field Types
 
-The API supports three field types:
+The API supports four field types:
 
 ### Text Fields
 
@@ -163,6 +163,24 @@ woocommerce_register_additional_checkout_field(
     )
 );
 ```
+
+### Date Fields
+
+Ideal for non-time-zone-sensitive dates like delivery dates, birthdays, and specific dates:
+
+```php
+woocommerce_register_additional_checkout_field(
+    array(
+        'id'       => 'my-plugin/delivery-date',
+        'label'    => __('Preferred delivery date', 'your-text-domain'),
+        'location' => 'order',
+        'type'     => 'date',
+        'required' => true,
+    )
+);
+```
+
+The field will render the browser default date picker. The value is stored in `Y-m-d` format and rendered using the site rendering format in emails and other places.
 
 ## Adding Field Attributes
 

--- a/docs/block-development/tutorials/how-to-additional-checkout-fields-guide.md
+++ b/docs/block-development/tutorials/how-to-additional-checkout-fields-guide.md
@@ -180,7 +180,7 @@ woocommerce_register_additional_checkout_field(
 );
 ```
 
-The field will render the browser default date picker. The value is stored in `Y-m-d` format and rendered using the site rendering format in emails and other places.
+The field input value will follows the shopper's browser and OS locale. The value is always stored as `YYYY-MM-DD`, and it is displayed using the site's date format (**Settings → General**) in emails, order screens, and other places the value is rendered.
 
 ## Adding Field Attributes
 

--- a/plugins/woocommerce/changelog/wooplug-6456-add-date-field-type
+++ b/plugins/woocommerce/changelog/wooplug-6456-add-date-field-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for the `date` field type in the additional checkout fields API.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -28,6 +28,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { dispatch, select } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { Icon, calendar } from '@wordpress/icons';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import clsx from 'clsx';
 import fastDeepEqual from 'fast-deep-equal/es6';
@@ -421,6 +422,16 @@ const Form = <
 						}
 						{ ...fieldProps }
 						type={ field.type }
+						icon={
+							field.type === 'date' ? (
+								<span
+									className="wc-block-components-text-input__date-icon"
+									aria-hidden="true"
+								>
+									<Icon icon={ calendar } size={ 24 } />
+								</span>
+							) : null
+						}
 						ariaDescribedBy={ ariaDescribedBy }
 						value={
 							decodeEntities(

--- a/plugins/woocommerce/client/blocks/changelog/wooplug-6456-date-field-calendar-icon
+++ b/plugins/woocommerce/client/blocks/changelog/wooplug-6456-date-field-calendar-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a calendar icon to date-type additional checkout fields and fix native date input styling on Firefox.

--- a/plugins/woocommerce/client/blocks/changelog/wooplug-6456-date-field-calendar-icon
+++ b/plugins/woocommerce/client/blocks/changelog/wooplug-6456-date-field-calendar-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add a calendar icon to date-type additional checkout fields and fix native date input styling on Firefox.

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
@@ -78,13 +78,12 @@
 
 	&:not(.is-active) input[type="date"] {
 		// Hide browser default mask (dd/mm/YYYY) when a date field is not active (no value, not focused).
-		// text-indent rather than a transparent color, because Firefox paints its calendar icon with currentColor.
+		// Use text-indent here because using transparent would conflict with our calendar icon-hiding hack.
 		text-indent: -9999px;
 
 		&::-webkit-datetime-edit {
 			// Focusing the input would cause browsers to highlight the dd before it's done animating, so we hide it as well.
 			opacity: 0;
-			// Hidden instantly, so nothing is still on its way out when the label drops back over it.
 			transition: none;
 		}
 	}
@@ -118,7 +117,7 @@
 	}
 
 	// The native webkit indicator is hidden but kept in place as the click target that opens the picker.
-	// The visible icon is our own (.wc-block-components-text-input__date-icon), identical in every browser.
+	// The visible icon is our own so that we can control its position freely.
 	input[type="date"]::-webkit-calendar-picker-indicator {
 		position: absolute;
 		top: 25px;
@@ -161,8 +160,6 @@
 		}
 	}
 
-	// Our own calendar icon for date fields. Purely decorative: clicks pass through to the native picker
-	// click target underneath (the invisible webkit indicator, or Firefox's hidden native button).
 	.wc-block-components-text-input__date-icon {
 		position: absolute;
 		top: 25px;
@@ -170,6 +167,7 @@
 		transform: translateY(-50%);
 		width: 24px;
 		height: 24px;
+		// The icon is decorative only, and clicks should pass through to the native hidden calendar button.
 		pointer-events: none;
 		color: $input-text-light;
 

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
@@ -78,29 +78,24 @@
 
 	&:not(.is-active) input[type="date"] {
 		// Hide browser default mask (dd/mm/YYYY) when a date field is not active (no value, not focused).
-		color: transparent;
-		// Hidden instantly, so nothing is still on its way out when the label drops back over it.
-		transition: none;
+		// text-indent rather than a transparent color, because Firefox paints its calendar icon with currentColor.
+		text-indent: -9999px;
+
 		&::-webkit-datetime-edit {
 			// Focusing the input would cause browsers to highlight the dd before it's done animating, so we hide it as well.
 			opacity: 0;
+			// Hidden instantly, so nothing is still on its way out when the label drops back over it.
 			transition: none;
 		}
 	}
 
-	// We delay the animation out so that it doesn't sit behind.
-	input[type="date"] {
-		transition: color 150ms ease 150ms;
-		&::-webkit-datetime-edit {
-			transition: opacity 150ms ease 150ms;
-		}
+	// We delay the reveal so the mask doesn't sit behind the label while it floats up.
+	input[type="date"]::-webkit-datetime-edit {
+		transition: opacity 150ms ease 150ms;
 	}
 
 	@media screen and (prefers-reduced-motion: reduce) {
-		input[type="date"],
-		&:not(.is-active) input[type="date"],
-		input[type="date"]::-webkit-datetime-edit,
-		&:not(.is-active) input[type="date"]::-webkit-datetime-edit {
+		input[type="date"]::-webkit-datetime-edit {
 			transition: none;
 		}
 	}
@@ -122,16 +117,70 @@
 		}
 	}
 
-	// Reposition the date input calendar input so that it sits
-	// vertically centered to the div, not the input.
+	// The native webkit indicator is hidden but kept in place as the click target that opens the picker.
+	// The visible icon is our own (.wc-block-components-text-input__date-icon), identical in every browser.
 	input[type="date"]::-webkit-calendar-picker-indicator {
 		position: absolute;
-		top: 50%;
+		top: 25px;
 		inset-inline-end: $gap-small;
 		transform: translateY(-50%);
+		width: 24px;
+		height: 24px;
 		margin: 0;
 		padding: 0;
+		opacity: 0;
 		cursor: pointer;
+	}
+
+	// Firefox paints its native calendar icon with currentColor and exposes no pseudo-element to hide it,
+	// so we make the color transparent (hiding the icon) and repaint the text via -webkit-text-fill-color.
+	// The focus border also uses currentColor, so it gets an explicit color instead.
+	@supports (-moz-appearance: none) {
+		input[type="date"] {
+			&,
+			&:focus {
+				color: transparent;
+				-webkit-text-fill-color: $input-text-light;
+			}
+
+			&:focus {
+				border-color: $input-text-light;
+			}
+
+			.has-dark-controls & {
+				&,
+				&:focus {
+					color: transparent;
+					-webkit-text-fill-color: $input-text-dark;
+				}
+
+				&:focus {
+					border-color: $input-text-dark;
+				}
+			}
+		}
+	}
+
+	// Our own calendar icon for date fields. Purely decorative: clicks pass through to the native picker
+	// click target underneath (the invisible webkit indicator, or Firefox's hidden native button).
+	.wc-block-components-text-input__date-icon {
+		position: absolute;
+		top: 25px;
+		inset-inline-end: $gap-small;
+		transform: translateY(-50%);
+		width: 24px;
+		height: 24px;
+		pointer-events: none;
+		color: $input-text-light;
+
+		svg {
+			display: block;
+			fill: currentColor;
+		}
+
+		.has-dark-controls & {
+			color: $input-text-dark;
+		}
 	}
 
 	input[type="number"] {

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
@@ -40,7 +40,8 @@
 	input[type="text"],
 	input[type="number"],
 	input[type="password"],
-	input[type="email"] {
+	input[type="email"],
+	input[type="date"] {
 		@include reset-typography();
 		@include font-for-inputs-locked();
 		padding: $gap $gap-small;
@@ -75,6 +76,64 @@
 		}
 	}
 
+	&:not(.is-active) input[type="date"] {
+		// Hide browser default mask (dd/mm/YYYY) when a date field is not active (no value, not focused).
+		color: transparent;
+		// Hidden instantly, so nothing is still on its way out when the label drops back over it.
+		transition: none;
+		&::-webkit-datetime-edit {
+			// Focusing the input would cause browsers to highlight the dd before it's done animating, so we hide it as well.
+			opacity: 0;
+			transition: none;
+		}
+	}
+
+	// We delay the animation out so that it doesn't sit behind.
+	input[type="date"] {
+		transition: color 150ms ease 150ms;
+		&::-webkit-datetime-edit {
+			transition: opacity 150ms ease 150ms;
+		}
+	}
+
+	@media screen and (prefers-reduced-motion: reduce) {
+		input[type="date"],
+		&:not(.is-active) input[type="date"],
+		input[type="date"]::-webkit-datetime-edit,
+		&:not(.is-active) input[type="date"]::-webkit-datetime-edit {
+			transition: none;
+		}
+	}
+
+	// Clean out chrome default padding on segments that makes the field visually off compared to other fields.
+	input[type="date"] {
+		&::-webkit-datetime-edit,
+		&::-webkit-datetime-edit-fields-wrapper {
+			padding: 0;
+		}
+
+		&::-webkit-datetime-edit-day-field,
+		&::-webkit-datetime-edit-month-field,
+		&::-webkit-datetime-edit-year-field,
+		&::-webkit-datetime-edit-text {
+			padding-inline: 0;
+			// Overrides the tabular figures back to normal.
+			font-variant-numeric: normal;
+		}
+	}
+
+	// Reposition the date input calendar input so that it sits
+	// vertically centered to the div, not the input.
+	input[type="date"]::-webkit-calendar-picker-indicator {
+		position: absolute;
+		top: 50%;
+		inset-inline-end: $gap-small;
+		transform: translateY(-50%);
+		margin: 0;
+		padding: 0;
+		cursor: pointer;
+	}
+
 	input[type="number"] {
 		appearance: textfield;
 		-moz-appearance: textfield;
@@ -92,7 +151,8 @@
 	&.is-active input[type="text"],
 	&.is-active input[type="number"],
 	&.is-active input[type="password"],
-	&.is-active input[type="email"] {
+	&.is-active input[type="email"],
+	&.is-active input[type="date"] {
 		padding: $gap-large $gap-smaller + 1px $gap-smaller;
 
 		&:focus {

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/style.scss
@@ -133,9 +133,13 @@
 
 	// Firefox paints its native calendar icon with currentColor and exposes no pseudo-element to hide it,
 	// so we make the color transparent (hiding the icon) and repaint the text via -webkit-text-fill-color.
-	// The focus border also uses currentColor, so it gets an explicit color instead.
+	// Both borders derive from currentColor too, so they get explicit colors instead.
 	@supports (-moz-appearance: none) {
 		input[type="date"] {
+			// $universal-border-strong is derived from currentColor, so the resting border needs its own
+			// explicit color. The dark variant already has one.
+			border-color: color-mix(in srgb, $input-text-light 80%, transparent);
+
 			&,
 			&:focus {
 				color: transparent;

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/text-input.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import { forwardRef, isValidElement, useState } from '@wordpress/element';
+import {
+	forwardRef,
+	isValidElement,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import type { InputHTMLAttributes, ReactNode } from 'react';
 
@@ -58,6 +63,15 @@ const TextInput = forwardRef< HTMLInputElement, TextInputProps >(
 	) => {
 		const [ isActive, setIsActive ] = useState( false );
 
+		// Date-like inputs report a value the browser can't parse (e.g. the 31st of a 30-day month) as an
+		// empty `value`, so the input is asked directly. Focus and blur both re-render, which is when this
+		// can have changed while the field is not active.
+		const isFieldActive = useMemo( () => {
+			const input = typeof ref === 'object' ? ref?.current : null;
+
+			return isActive || !! value || !! input?.validity?.badInput;
+		}, [ isActive, value, ref ] );
+
 		const inputWithLabel = (
 			<>
 				<input
@@ -100,7 +114,7 @@ const TextInput = forwardRef< HTMLInputElement, TextInputProps >(
 		return (
 			<div
 				className={ clsx( 'wc-block-components-text-input', className, {
-					'is-active': isActive || value,
+					'is-active': isFieldActive,
 				} ) }
 			>
 				{ isValidElement( icon ) ? (

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
@@ -25,6 +25,12 @@ import { ValidationInputError } from '../validation-input-error';
 import { getValidityMessageForInput } from '../../blocks-checkout/utils';
 import { ValidatedTextInputProps } from './types';
 
+/**
+ * Input types whose value the browser parses rather than storing verbatim. Assigning to `value` on these
+ * clears anything the shopper has partially entered, so their value is left untouched before validating.
+ */
+const PARSED_INPUT_TYPES = [ 'date', 'datetime-local', 'month', 'time', 'week' ];
+
 export type ValidatedTextInputHandle = {
 	focus?: () => void;
 	revalidate: () => void;
@@ -118,7 +124,9 @@ const ValidatedTextInput = forwardRef<
 				}
 
 				// Trim white space before validation.
-				inputObject.value = inputObject.value.trim();
+				if ( ! PARSED_INPUT_TYPES.includes( inputObject.type ) ) {
+					inputObject.value = inputObject.value.trim();
+				}
 				inputObject.setCustomValidity( '' );
 
 				if (

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
@@ -29,7 +29,13 @@ import { ValidatedTextInputProps } from './types';
  * Input types whose value the browser parses rather than storing verbatim. Assigning to `value` on these
  * clears anything the shopper has partially entered, so their value is left untouched before validating.
  */
-const PARSED_INPUT_TYPES = [ 'date', 'datetime-local', 'month', 'time', 'week' ];
+const PARSED_INPUT_TYPES = [
+	'date',
+	'datetime-local',
+	'month',
+	'time',
+	'week',
+];
 
 export type ValidatedTextInputHandle = {
 	focus?: () => void;

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
@@ -315,7 +315,11 @@ const ValidatedTextInput = forwardRef<
 					}
 				} }
 				onBlur={ () => {
-					const isEmpty = ! inputRef.current?.value.trim();
+					// A value the browser can't parse reads back as an empty `value`, but the shopper did
+					// enter something, so it gets the same immediate error as any other invalid entry.
+					const isEmpty =
+						! inputRef.current?.value.trim() &&
+						! inputRef.current?.validity?.badInput;
 
 					if ( isEmpty ) {
 						// If the error was already shown (e.g. after form

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -1525,7 +1525,9 @@ class CheckoutFields {
 			// Parsed in the site timezone so the stored calendar date cannot shift a day when it is formatted.
 			$date = \DateTime::createFromFormat( '!Y-m-d', $value, wp_timezone() );
 
-			if ( $date ) {
+			// The round trip check keeps a value PHP would roll forward, such as 2026-02-31, displayed as
+			// stored rather than silently turned into a different date.
+			if ( $date && $date->format( 'Y-m-d' ) === $value ) {
 				$value = wp_date( wc_date_format(), $date->getTimestamp() );
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -37,7 +37,7 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $supported_field_types = [ 'text', 'select', 'checkbox' ];
+	private $supported_field_types = [ 'text', 'select', 'checkbox', 'date' ];
 
 	/**
 	 * Groups of fields to be saved.
@@ -157,7 +157,11 @@ class CheckoutFields {
 	 * @param array $field Field data.
 	 * @return mixed
 	 */
-	public function default_sanitize_callback( $value, $field ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function default_sanitize_callback( $value, $field ) {
+		if ( 'date' === ( $field['type'] ?? '' ) && is_string( $value ) ) {
+			return trim( $value );
+		}
+
 		return $value;
 	}
 
@@ -886,6 +890,39 @@ class CheckoutFields {
 	}
 
 	/**
+	 * Validates a value against the constraints of its field type.
+	 *
+	 * This runs for every field regardless of the validate_callback it was registered with, so type level
+	 * constraints cannot be bypassed by supplying a custom callback.
+	 *
+	 * @param array $field       The field.
+	 * @param mixed $field_value The value of the field.
+	 * @return WP_Error|null Error if the value is not valid for the field type, null otherwise.
+	 */
+	private function validate_field_type( $field, $field_value ) {
+		// An empty value is not a type error. Required fields are handled by the field's validation callback.
+		if ( 'date' !== ( $field['type'] ?? '' ) || null === $field_value || '' === $field_value ) {
+			return null;
+		}
+
+		$date = is_string( $field_value ) ? \DateTime::createFromFormat( '!Y-m-d', $field_value, wp_timezone() ) : false;
+
+		// Comparing the round trip rejects impossible dates such as 2026-02-31, which PHP would otherwise roll forward.
+		if ( ! $date || $date->format( 'Y-m-d' ) !== $field_value ) {
+			return new WP_Error(
+				'woocommerce_invalid_checkout_field',
+				sprintf(
+					/* translators: %s: is the field label */
+					__( 'Please provide a valid %s in YYYY-MM-DD format.', 'woocommerce' ),
+					$field['label']
+				)
+			);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Validate an additional field.
 	 *
 	 * @since 8.6.0
@@ -900,6 +937,13 @@ class CheckoutFields {
 		try {
 			// Only validate if we have a field.
 			if ( ! $field ) {
+				return $errors;
+			}
+
+			$type_error = $this->validate_field_type( $field, $field_value );
+
+			if ( is_wp_error( $type_error ) ) {
+				$errors->merge_from( $type_error );
 				return $errors;
 			}
 
@@ -1475,6 +1519,15 @@ class CheckoutFields {
 		if ( 'select' === $field['type'] ) {
 			$options = array_column( $field['options'], 'label', 'value' );
 			$value   = isset( $options[ $value ] ) ? $options[ $value ] : $value;
+		}
+
+		if ( 'date' === $field['type'] && is_string( $value ) && '' !== $value ) {
+			// Parsed in the site timezone so the stored calendar date cannot shift a day when it is formatted.
+			$date = \DateTime::createFromFormat( '!Y-m-d', $value, wp_timezone() );
+
+			if ( $date ) {
+				$value = wp_date( wc_date_format(), $date->getTimestamp() );
+			}
 		}
 
 		return $value;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Utilities\TimeUtil;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFieldsSchema\{
 	DocumentObject, Validation
 };
@@ -905,10 +906,7 @@ class CheckoutFields {
 			return null;
 		}
 
-		$date = is_string( $field_value ) ? \DateTime::createFromFormat( '!Y-m-d', $field_value, wp_timezone() ) : false;
-
-		// Comparing the round trip rejects impossible dates such as 2026-02-31, which PHP would otherwise roll forward.
-		if ( ! $date || $date->format( 'Y-m-d' ) !== $field_value ) {
+		if ( ! is_string( $field_value ) || ! TimeUtil::is_valid_date( $field_value, 'Y-m-d' ) ) {
 			return new WP_Error(
 				'woocommerce_invalid_checkout_field',
 				sprintf(
@@ -944,7 +942,6 @@ class CheckoutFields {
 
 			if ( is_wp_error( $type_error ) ) {
 				$errors->merge_from( $type_error );
-				return $errors;
 			}
 
 			if ( ! empty( $field['validate_callback'] ) && is_callable( $field['validate_callback'] ) ) {
@@ -1521,13 +1518,11 @@ class CheckoutFields {
 			$value   = isset( $options[ $value ] ) ? $options[ $value ] : $value;
 		}
 
-		if ( 'date' === $field['type'] && is_string( $value ) && '' !== $value ) {
+		if ( 'date' === $field['type'] && is_string( $value ) && TimeUtil::is_valid_date( $value, 'Y-m-d' ) ) {
 			// Parsed in the site timezone so the stored calendar date cannot shift a day when it is formatted.
 			$date = \DateTime::createFromFormat( '!Y-m-d', $value, wp_timezone() );
 
-			// The round trip check keeps a value PHP would roll forward, such as 2026-02-31, displayed as
-			// stored rather than silently turned into a different date.
-			if ( $date && $date->format( 'Y-m-d' ) === $value ) {
+			if ( $date ) {
 				$value = wp_date( wc_date_format(), $date->getTimestamp() );
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -311,6 +311,10 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 				$field_schema['type'] = 'boolean';
 			}
 
+			if ( 'date' === $field['type'] ) {
+				$field_schema['pattern'] = '^(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))?$';
+			}
+
 			$schema[ $key ] = $field_schema;
 		}
 		return $schema;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Utilities\TimeUtil;
 
 /**
  * AddressSchema class.
@@ -244,13 +245,29 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			}
 		}
 
-		// Get additional field keys here as we need to know if they are present in the address for validation.
-		$additional_keys = array_keys( $this->get_additional_address_fields_schema() );
+		$additional_fields = array_intersect_key(
+			$this->additional_fields_controller->get_additional_fields(),
+			$this->get_additional_address_fields_schema()
+		);
 
 		foreach ( array_keys( $address ) as $key ) {
 			// Skip email here it will be validated in BillingAddressSchema.
 			if ( 'email' === $key ) {
 				continue;
+			}
+
+			$field_value = $address[ $key ];
+			if ( 'date' === ( $additional_fields[ $key ]['type'] ?? '' ) && '' !== $field_value ) {
+				if ( ! is_string( $field_value ) || ! TimeUtil::is_valid_date( $field_value, 'Y-m-d' ) ) {
+					$errors->add(
+						'invalid_' . $key,
+						sprintf(
+							/* translators: %s: is the field label */
+							__( 'Please provide a valid %s in YYYY-MM-DD format.', 'woocommerce' ),
+							$additional_fields[ $key ]['label']
+						)
+					);
+				}
 			}
 
 			// Only run specific validation on properties that are defined in the schema and present in the address.
@@ -309,10 +326,6 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 
 			if ( 'checkbox' === $field['type'] ) {
 				$field_schema['type'] = 'boolean';
-			}
-
-			if ( 'date' === $field['type'] ) {
-				$field_schema['pattern'] = '^(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))?$';
 			}
 
 			$schema[ $key ] = $field_schema;

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -247,6 +247,28 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Date values that are not a real calendar date are displayed as stored.
+	 *
+	 * @testWith ["2026-02-31"]
+	 *           ["2026-13-01"]
+	 *           ["not-a-date"]
+	 *           [""]
+	 *
+	 * @param string $value The stored value.
+	 */
+	public function test_invalid_date_field_value_is_not_reformatted( string $value ) {
+		update_option( 'date_format', 'F j, Y' );
+
+		$fields = $this->controller->get_additional_fields();
+
+		$this->assertSame(
+			$value,
+			$this->controller->format_additional_field_value( $value, $fields['plugin-namespace/delivery-date'] ),
+			'A value that is not a real date should be shown as stored rather than rolled forward.'
+		);
+	}
+
+	/**
 	 * Registering a field before after_setup_theme warns the developer.
 	 */
 	public function test_registering_before_after_setup_theme_triggers_notice() {

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -92,6 +92,12 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 				'type'     => 'checkbox',
 			),
 			array(
+				'id'       => 'plugin-namespace/delivery-date',
+				'label'    => 'Preferred delivery date',
+				'location' => 'order',
+				'type'     => 'date',
+			),
+			array(
 				'id'         => 'namespace/vat-number',
 				'label'      => 'VAT Number',
 				'location'   => 'address',
@@ -187,6 +193,57 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$fields = $this->controller->get_contextual_fields_for_location( 'address', $document_object );
 		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
 		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields );
+	}
+
+	/**
+	 * @testdox Date fields can be registered.
+	 */
+	public function test_date_fields_can_be_registered() {
+		$fields = $this->controller->get_additional_fields();
+
+		$this->assertArrayHasKey( 'plugin-namespace/delivery-date', $fields, 'Date fields should be a supported field type.' );
+		$this->assertSame( 'date', $fields['plugin-namespace/delivery-date']['type'] );
+	}
+
+	/**
+	 * @testdox Date fields only accept a real calendar date in Y-m-d format.
+	 *
+	 * @testWith ["2026-08-26", false]
+	 *           ["", false]
+	 *           ["2026-02-31", true]
+	 *           ["2026-8-6", true]
+	 *           ["26-08-2026", true]
+	 *           ["not-a-date", true]
+	 *
+	 * @param string $value       The submitted value.
+	 * @param bool   $has_errors  Whether the value should be rejected.
+	 */
+	public function test_date_field_validation( string $value, bool $has_errors ) {
+		$fields = $this->controller->get_additional_fields();
+		$errors = $this->controller->validate_field( $fields['plugin-namespace/delivery-date'], $value );
+
+		$this->assertSame( $has_errors, $errors->has_errors(), sprintf( 'Unexpected validation result for "%s".', $value ) );
+	}
+
+	/**
+	 * @testdox Date field values are displayed using the site date format, in the site timezone.
+	 *
+	 * @testWith ["UTC", "F j, Y", "August 26, 2026"]
+	 *           ["America/New_York", "Y-m-d", "2026-08-26"]
+	 *           ["Pacific/Auckland", "Y-m-d", "2026-08-26"]
+	 *
+	 * @param string $timezone    The site timezone.
+	 * @param string $date_format The site date format.
+	 * @param string $expected    The expected formatted value.
+	 */
+	public function test_date_field_value_formatting( string $timezone, string $date_format, string $expected ) {
+		update_option( 'timezone_string', $timezone );
+		update_option( 'date_format', $date_format );
+
+		$fields = $this->controller->get_additional_fields();
+		$value  = $this->controller->format_additional_field_value( '2026-08-26', $fields['plugin-namespace/delivery-date'] );
+
+		$this->assertSame( $expected, $value, 'The stored calendar date should never shift when it is formatted.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -209,8 +209,10 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	 * @testdox Date fields only accept a real calendar date in Y-m-d format.
 	 *
 	 * @testWith ["2026-08-26", false]
+	 *           ["2024-02-29", false]
 	 *           ["", false]
 	 *           ["2026-02-31", true]
+	 *           ["2026-02-29", true]
 	 *           ["2026-8-6", true]
 	 *           ["26-08-2026", true]
 	 *           ["not-a-date", true]
@@ -223,6 +225,49 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$errors = $this->controller->validate_field( $fields['plugin-namespace/delivery-date'], $value );
 
 		$this->assertSame( $has_errors, $errors->has_errors(), sprintf( 'Unexpected validation result for "%s".', $value ) );
+	}
+
+	/**
+	 * @testdox Invalid dates still reach custom validation and both validation hooks.
+	 */
+	public function test_invalid_date_runs_custom_validation_and_hooks(): void {
+		$calls = array();
+		$field = $this->controller->get_additional_fields()['plugin-namespace/delivery-date'];
+
+		$field['validate_callback'] = static function ( $value ) use ( &$calls ) {
+			$calls['callback'] = $value;
+			return new \WP_Error( 'custom_date_error', 'Custom validation error.' );
+		};
+
+		$hooks = array(
+			'__experimental_woocommerce_blocks_validate_additional_field',
+			'woocommerce_validate_additional_field',
+		);
+		$this->setExpectedDeprecated( $hooks[0] );
+
+		foreach ( $hooks as $hook ) {
+			add_action(
+				$hook,
+				static function ( $errors, $key, $value ) use ( &$calls, $hook ) {
+					$calls[ $hook ] = array( $key, $value, $errors->get_error_codes() );
+				},
+				10,
+				3
+			);
+		}
+
+		$errors = $this->controller->validate_field( $field, '2026-02-31' );
+
+		$this->assertSame( '2026-02-31', $calls['callback'] ?? null );
+		$this->assertContains( 'woocommerce_invalid_checkout_field', $errors->get_error_codes() );
+		$this->assertContains( 'custom_date_error', $errors->get_error_codes() );
+		foreach ( $hooks as $hook ) {
+			$this->assertArrayHasKey( $hook, $calls, 'Both validation hooks must run after a type error.' );
+			$this->assertSame( $field['id'], $calls[ $hook ][0] );
+			$this->assertSame( '2026-02-31', $calls[ $hook ][1] );
+			$this->assertContains( 'woocommerce_invalid_checkout_field', $calls[ $hook ][2] );
+			$this->assertContains( 'custom_date_error', $calls[ $hook ][2] );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -627,7 +627,7 @@ class AdditionalFields extends \WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Ensure an error is triggered when a field is registered with an invalid type (text, select, checkbox).
+	 * Ensure an error is triggered when a field is registered with an invalid type (text, select, checkbox, date).
 	 */
 	public function test_invalid_type_in_registration() {
 		$this->setExpectedIncorrectUsage( 'woocommerce_register_additional_checkout_field' );
@@ -641,7 +641,7 @@ class AdditionalFields extends \WP_Test_REST_TestCase {
 						'Unable to register field with id: "%s". Registering a field with type "%s" is not supported. The supported types are: %s.',
 						$id,
 						'invalid',
-						implode( ', ', array( 'text', 'select', 'checkbox' ) )
+						implode( ', ', array( 'text', 'select', 'checkbox', 'date' ) )
 					)
 				),
 			)

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1440,6 +1440,95 @@ class AdditionalFields extends \WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * @testdox Date fields reject invalid dates before persistence and accept clean optional values.
+	 *
+	 * @testWith ["cart/update-customer", "billing", "2026-02-31", 400]
+	 *           ["cart/update-customer", "shipping", "2026-02-29", 400]
+	 *           ["cart/update-customer", "billing", "not-a-date", 400]
+	 *           ["cart/update-customer", "billing", "0", 400]
+	 *           ["cart/update-customer", "billing", "2024-02-29", 200]
+	 *           ["cart/update-customer", "shipping", " 2026-08-26 ", 200]
+	 *           ["cart/update-customer", "billing", "", 200]
+	 *           ["cart/update-customer", "billing", null, 200]
+	 *           ["checkout", "billing", "2026-02-31", 400]
+	 *           ["checkout", "shipping", "2026-02-29", 400]
+	 *           ["checkout", "billing", " 2026-08-26 ", 200]
+	 *           ["checkout", "shipping", "", 200]
+	 *           ["checkout", "contact", "2026-02-31", 400]
+	 *           ["checkout", "order", "2026-02-29", 400]
+	 *           ["checkout", "contact", " 2026-08-26 ", 200]
+	 *           ["checkout", "order", " 2026-08-26 ", 200]
+	 *
+	 * @param string      $route           Store API route.
+	 * @param string      $location        Field location or address group.
+	 * @param string|null $value           Submitted date, or null to omit the field.
+	 * @param int         $expected_status Expected response status.
+	 */
+	public function test_date_field_validation_before_persistence( string $route, string $location, ?string $value, int $expected_status ): void {
+		$this->unregister_fields();
+		$id         = 'test/delivery-date';
+		$is_address = in_array( $location, array( 'billing', 'shipping' ), true );
+		$group      = $is_address ? $location : 'other';
+		$param      = $is_address ? $location . '_address' : 'additional_fields';
+
+		$callback_calls = 0;
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                => $id,
+				'label'             => 'Delivery date',
+				'location'          => $is_address ? 'address' : $location,
+				'type'              => 'date',
+				'validate_callback' => static function () use ( &$callback_calls ) {
+					++$callback_calls;
+					return true;
+				},
+			)
+		);
+		$this->controller->persist_field_for_customer( $id, '2026-08-01', WC()->customer, $group );
+
+		$address = array(
+			'first_name' => 'Jane',
+			'last_name'  => 'Doe',
+			'address_1'  => '123 Main Street',
+			'city'       => 'New York',
+			'state'      => 'NY',
+			'postcode'   => '10001',
+			'country'    => 'US',
+		);
+		$params  = array(
+			'billing_address'   => array_merge( $address, array( 'email' => 'jane@example.com' ) ),
+			'shipping_address'  => $address,
+			'payment_method'    => WC_Gateway_BACS::ID,
+			'additional_fields' => array(),
+		);
+		if ( null !== $value ) {
+			$params[ $param ][ $id ] = $value;
+		}
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/' . $route );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params( $params );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( $expected_status, $response->get_status(), wp_json_encode( $data ) );
+		if ( 'cart/update-customer' === $route ) {
+			$this->assertSame( 0, $callback_calls, 'Address type validation must not add calls to extension callbacks.' );
+		}
+		if ( 400 === $expected_status ) {
+			$this->assertSame( 'rest_invalid_param', $data['code'] );
+			$this->assertStringContainsString( 'Delivery date', wp_json_encode( $data['data']['details'] ) );
+			$this->assertSame( '2026-08-01', $this->controller->get_field_from_object( $id, WC()->customer, $group ) );
+			return;
+		}
+
+		$object   = 'checkout' === $route ? wc_get_order( $data['order_id'] ) : WC()->customer;
+		$expected = null === $value ? '2026-08-01' : trim( $value );
+		$this->assertSame( $expected, $this->controller->get_field_from_object( $id, $object, $group ) );
+	}
+
+	/**
 	 * Ensures that placing an order with the correct values actually work.
 	 */
 	public function test_placing_order_with_valid_fields() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a date field to the additional checkout fields API. This PR only adds the field and doens't add support for any constraints like min and max. It also doesn't add support for a time picker, datetime, or a date range.

The field uses the browser native date picker instead of innovating there, as the default one works very well on mobile.

The PR also replaces the default calendar icon with a custom one because we can't reposition that icon on firefox.

The field value is timezone agnostic and therefore ideally should only be used when the date is timezone agnostic (dates, birthdays...).

Closes WOOPLUG-6456

### Backward compatibility

Date fields are new in this PR. The address API now checks real calendar dates after sanitization, so valid dates with surrounding whitespace are accepted and impossible dates are rejected before saving. Existing field types keep their validation behavior.

Custom validation callbacks and both additional-field validation hooks still run when a date has a type error. Hook names, arguments, and existing method signatures are unchanged. The address type check does not add calls to extension validation callbacks.

The change uses the current site's field definitions and date settings. It adds no network-wide state. Multisite was not tested.

### Testing that has already taken place

- 129 affected PHP tests passed, with 487 assertions, on PHP 8.1.34 and PHPUnit 9.6.35 in a single-site wp-env test environment.
- The new regression tests fail against the old source in six cases and pass with the fix.
- Both PHP lint checks passed. PHPStan passed for both changed source files; the normal PHPStan configuration does not support the WordPress test classes.
- The broader branch lint command exited successfully but reported four existing JavaScript warnings. A separate blocks lint attempt stopped in the local webpack configuration. This fix changes no JavaScript.
- No E2E tests ran.

### Screenshots or screen recordings

How it render on firefox:
<https://github.com/user-attachments/assets/7cc9b525-6aaf-44e3-9a63-3599d07e4937>

How it render on admin page:
<img width="198" height="62" alt="dyn-2c4099d0162a14bd465caadcb6dd1d16" src="https://github.com/user-attachments/assets/8f7dacc1-3567-4a16-9852-602ac0def8a6" />
<img width="305" height="82" alt="dyn-83a7bfe354ac7fc328abbad91302fa5d" src="https://github.com/user-attachments/assets/19250214-66ac-4d8f-9740-b3cd4089a125" />

How it render in my account -> Orders page:
<img width="746" height="149" alt="file-6efd45f031c270d74b9345a3da0acc71" src="https://github.com/user-attachments/assets/12b07dab-b273-45f9-afef-e5f5b5fb9133" />

How it render in my account -> account details
<img width="702" height="107" alt="image" src="https://github.com/user-attachments/assets/63f8399c-4192-48e9-adb1-f08f52f0c2f4" />

How it render in my account -> addresses
<img width="258" height="274" alt="image" src="https://github.com/user-attachments/assets/719b2096-c0c2-41f0-80bf-d2c57f44db65" />

With error state:
<img width="657" height="181" alt="image" src="https://github.com/user-attachments/assets/36e54e15-db72-4d42-94f2-3b927e29626c" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- @TODO: rewrite -->

1. Register a `date` field via `woocommerce_register_additional_checkout_field`.

```php

add_action(
	'woocommerce_init',
	function () {
		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'my-plugin/delivery-date',
				'label'    => 'Preferred delivery date',
				'location' => 'order',
				'type'     => 'date',
				'required' => true,
			)
		);
	}
);

add_action(
	'woocommerce_init',
	function () {
		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'my-plugin/birthday-date',
				'label'    => 'Birthday',
				'location' => 'contact',
				'type'     => 'date',
				'required' => true,
			)
		);
	}
);

add_action(
	'woocommerce_init',
	function () {
		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'my-plugin/valid-till',
				'label'    => 'Valid till',
				'location' => 'address',
				'type'     => 'date',
				'required' => true,
			)
		);
	}
);

```

1. Test the field in different browsers, ensure the icon is rendering fine, animation is not overlapping, and values are accepted.

<!-- End testing instructions -->

<details>
<summary>Milestone</summary>

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

</details>

<details>
<summary>Changelog entry</summary>

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

</details>

<details>
<summary>Release Communication</summary>

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

Selected labels are applied when the pull request is merged.
</details>

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->