### PR TITLE
Add localized thousands separators to legacy report counts

### DIFF
--- a/plugins/woocommerce/changelog/67978-add-localized-thousands-separators-to-legacy-report-counts
+++ b/plugins/woocommerce/changelog/67978-add-localized-thousands-separators-to-legacy-report-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Format count values in the legacy Reports chart legends with locale-aware thousands separators.

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -116,7 +116,7 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 
 		$legend[] = array(
 			/* translators: %s: coupons amount */
-			'title'            => sprintf( __( '%s coupons used in total', 'woocommerce' ), '<strong>' . $total_coupons . '</strong>' ),
+			'title'            => sprintf( __( '%s coupons used in total', 'woocommerce' ), '<strong>' . number_format_i18n( $total_coupons ) . '</strong>' ),
 			'color'            => $this->chart_colours['coupon_count'],
 			'highlight_series' => 0,
 		);

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-customers.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-customers.php
@@ -41,7 +41,7 @@ class WC_Report_Customers extends WC_Admin_Report {
 
 		$legend[] = array(
 			/* translators: %s: signups amount */
-			'title'            => sprintf( __( '%s signups in this period', 'woocommerce' ), '<strong>' . count( $this->customers ) . '</strong>' ),
+			'title'            => sprintf( __( '%s signups in this period', 'woocommerce' ), '<strong>' . number_format_i18n( count( $this->customers ) ) . '</strong>' ),
 			'color'            => $this->chart_colours['signups'],
 			'highlight_series' => 2,
 		);

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -523,7 +523,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'title'            => sprintf(
 				/* translators: %s: total orders */
 				__( '%s orders placed', 'woocommerce' ),
-				'<strong>' . $data->total_orders . '</strong>'
+				'<strong>' . number_format_i18n( absint( $data->total_orders ) ) . '</strong>'
 			),
 			'color'            => $this->chart_colours['order_count'],
 			'highlight_series' => 1,
@@ -533,7 +533,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'title'            => sprintf(
 				/* translators: %s: total items */
 				__( '%s items purchased', 'woocommerce' ),
-				'<strong>' . $data->total_items . '</strong>'
+				'<strong>' . number_format_i18n( absint( $data->total_items ) ) . '</strong>'
 			),
 			'color'            => $this->chart_colours['item_count'],
 			'highlight_series' => 0,
@@ -541,10 +541,10 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		$legend[] = array(
 			'title'            => sprintf(
 				/* translators: 1: total refunds 2: total refunded orders 3: refunded items */
-				_n( '%1$s refunded %2$d order (%3$d item)', '%1$s refunded %2$d orders (%3$d items)', $this->report_data->total_refunded_orders, 'woocommerce' ),
+				_n( '%1$s refunded %2$s order (%3$s item)', '%1$s refunded %2$s orders (%3$s items)', $this->report_data->total_refunded_orders, 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_refunds ) . '</strong>',
-				$this->report_data->total_refunded_orders,
-				$this->report_data->refunded_order_items
+				number_format_i18n( absint( $this->report_data->total_refunded_orders ) ),
+				number_format_i18n( absint( $this->report_data->refunded_order_items ) )
 			),
 			'color'            => $this->chart_colours['refund_amount'],
 			'highlight_series' => 8,

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -519,6 +519,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			);
 		}
 
+		// The counts below are already absint()'d in query_report_data(), but a woocommerce_admin_report_data
+		// callback can replace them with anything, and number_format() fatals on a non-numeric string.
 		$legend[] = array(
 			'title'            => sprintf(
 				/* translators: %s: total orders */

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -519,8 +519,6 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			);
 		}
 
-		// The counts below are already absint()'d in query_report_data(), but a woocommerce_admin_report_data
-		// callback can replace them with anything, and number_format() fatals on a non-numeric string.
 		$legend[] = array(
 			'title'            => sprintf(
 				/* translators: %s: total orders */

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -127,7 +127,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 
 		$legend[] = array(
 			/* translators: %s: total items purchased */
-			'title'            => sprintf( __( '%s purchases for the selected items', 'woocommerce' ), '<strong>' . ( $total_items ) . '</strong>' ),
+			'title'            => sprintf( __( '%s purchases for the selected items', 'woocommerce' ), '<strong>' . number_format_i18n( $total_items ) . '</strong>' ),
 			'color'            => $this->chart_colours['item_count'],
 			'highlight_series' => 0,
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-customers.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Class WC_Tests_Report_Customers file.
+ *
+ * @package WooCommerce\Tests\Admin\Reports
+ */
+
+declare(strict_types=1);
+
+/**
+ * Tests for the WC_Report_Customers class.
+ */
+class WC_Tests_Report_Customers extends WC_Unit_Test_Case {
+
+	/**
+	 * Thousands separator to restore after a test overrides it.
+	 *
+	 * @var string|null
+	 */
+	private $original_thousands_sep = null;
+
+	/**
+	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-report-customers.php';
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tearDown(): void {
+		global $wp_locale;
+
+		if ( null !== $this->original_thousands_sep ) {
+			$wp_locale->number_format['thousands_sep'] = $this->original_thousands_sep;
+			$this->original_thousands_sep              = null;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should format the signup count with the locale thousands separator.
+	 */
+	public function test_get_chart_legend_formats_signups_with_locale_separator() {
+		global $wp_locale;
+
+		$this->original_thousands_sep              = $wp_locale->number_format['thousands_sep'];
+		$wp_locale->number_format['thousands_sep'] = '.';
+
+		$report                = new WC_Report_Customers();
+		$report->customers     = array_fill( 0, 1500, 0 );
+		$report->chart_colours = array( 'signups' => '#000000' );
+
+		$legend = implode( ' ', wp_list_pluck( $report->get_chart_legend(), 'title' ) );
+
+		$this->assertStringContainsString( '<strong>1.500</strong> signups in this period', $legend );
+	}
+}

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -13,6 +13,13 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 	/**
+	 * Thousands separator to restore after a test overrides it.
+	 *
+	 * @var string|null
+	 */
+	private $original_thousands_sep = null;
+
+	/**
 	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
 	 */
 	public static function setUpBeforeClass(): void {
@@ -23,13 +30,17 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Set up the test.
+	 * Tear down the test.
 	 */
-	public function setUp(): void {
-		parent::setUp();
-		if ( \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$this->markTestSkipped( 'This test is not compatible with the custom orders table.' );
+	public function tearDown(): void {
+		global $wp_locale;
+
+		if ( null !== $this->original_thousands_sep ) {
+			$wp_locale->number_format['thousands_sep'] = $this->original_thousands_sep;
+			$this->original_thousands_sep              = null;
 		}
+
+		parent::tearDown();
 	}
 
 	/**
@@ -45,6 +56,10 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 	 * Test: get_report_data
 	 */
 	public function test_get_report_data() {
+		if ( \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$this->markTestSkipped( 'This test is not compatible with the custom orders table.' );
+		}
+
 		update_option( 'woocommerce_default_customer_address', 'base' );
 		update_option( 'woocommerce_tax_based_on', 'base' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
@@ -158,5 +173,48 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, $data->total_shipping_refunded );
 		$this->assertEquals( 0, $data->total_shipping_tax_refunded );
 		$this->assertEquals( 0, $data->total_refunded_orders );
+	}
+
+	/**
+	 * @testdox Should format chart legend counts with the locale thousands separator.
+	 */
+	public function test_get_chart_legend_formats_counts_with_locale_separator() {
+		global $wp_locale;
+
+		$this->original_thousands_sep              = $wp_locale->number_format['thousands_sep'];
+		$wp_locale->number_format['thousands_sep'] = '.';
+
+		add_filter( 'woocommerce_admin_report_data', array( $this, 'inflate_report_counts' ) );
+
+		$report                 = new WC_Report_Sales_By_Date();
+		$report->chart_colours  = array_fill_keys(
+			array( 'sales_amount', 'average', 'net_sales_amount', 'net_average', 'order_count', 'item_count', 'refund_amount', 'shipping_amount', 'coupon_amount' ),
+			'#000000'
+		);
+		$report->start_date     = strtotime( '-1 month' );
+		$report->end_date       = time();
+		$report->chart_groupby  = 'day';
+		$report->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
+
+		$legend = implode( ' ', wp_list_pluck( $report->get_chart_legend(), 'title' ) );
+
+		$this->assertStringContainsString( '<strong>12.345</strong> orders placed', $legend, 'Orders placed should use the locale thousands separator.' );
+		$this->assertStringContainsString( '<strong>67.890</strong> items purchased', $legend, 'Items purchased should use the locale thousands separator.' );
+		$this->assertStringContainsString( 'refunded 1.234 orders (5.678 items)', $legend, 'Refunded orders and items should use the locale thousands separator.' );
+	}
+
+	/**
+	 * Give the report counts that are large enough to be grouped.
+	 *
+	 * @param stdClass $data Report data.
+	 * @return stdClass
+	 */
+	public function inflate_report_counts( $data ) {
+		$data->total_orders          = 12345;
+		$data->total_items           = 67890;
+		$data->total_refunded_orders = 1234;
+		$data->refunded_order_items  = 5678;
+
+		return $data;
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -20,6 +20,13 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 	private $original_thousands_sep = null;
 
 	/**
+	 * Counts to give the report through the woocommerce_admin_report_data filter.
+	 *
+	 * @var array
+	 */
+	private $report_counts = array();
+
+	/**
 	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
 	 */
 	public static function setUpBeforeClass(): void {
@@ -177,14 +184,20 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox Should format chart legend counts with the locale thousands separator.
+	 *
+	 * @dataProvider provide_legend_counts
+	 *
+	 * @param array    $counts   Counts to give the report.
+	 * @param string[] $expected Strings the legend should contain.
 	 */
-	public function test_get_chart_legend_formats_counts_with_locale_separator() {
+	public function test_get_chart_legend_formats_counts_with_locale_separator( $counts, $expected ) {
 		global $wp_locale;
 
 		$this->original_thousands_sep              = $wp_locale->number_format['thousands_sep'];
 		$wp_locale->number_format['thousands_sep'] = '.';
 
-		add_filter( 'woocommerce_admin_report_data', array( $this, 'inflate_report_counts' ) );
+		$this->report_counts = $counts;
+		add_filter( 'woocommerce_admin_report_data', array( $this, 'set_report_counts' ) );
 
 		$report                 = new WC_Report_Sales_By_Date();
 		$report->chart_colours  = array_fill_keys(
@@ -198,22 +211,59 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 		$legend = implode( ' ', wp_list_pluck( $report->get_chart_legend(), 'title' ) );
 
-		$this->assertStringContainsString( '<strong>12.345</strong> orders placed', $legend, 'Orders placed should use the locale thousands separator.' );
-		$this->assertStringContainsString( '<strong>67.890</strong> items purchased', $legend, 'Items purchased should use the locale thousands separator.' );
-		$this->assertStringContainsString( 'refunded 1.234 orders (5.678 items)', $legend, 'Refunded orders and items should use the locale thousands separator.' );
+		foreach ( $expected as $needle ) {
+			$this->assertStringContainsString( $needle, $legend, 'Legend counts should use the locale thousands separator.' );
+		}
 	}
 
 	/**
-	 * Give the report counts that are large enough to be grouped.
+	 * Counts to render the legend with, and the strings they should produce.
+	 *
+	 * The refund line is a _n() string, so it needs a case for each form.
+	 *
+	 * @return array[]
+	 */
+	public function provide_legend_counts() {
+		return array(
+			'plural refunds'  => array(
+				array(
+					'total_orders'          => 12345,
+					'total_items'           => 67890,
+					'total_refunded_orders' => 1234,
+					'refunded_order_items'  => 5678,
+				),
+				array(
+					'<strong>12.345</strong> orders placed',
+					'<strong>67.890</strong> items purchased',
+					'refunded 1.234 orders (5.678 items)',
+				),
+			),
+			'singular refund' => array(
+				array(
+					'total_orders'          => 1000,
+					'total_items'           => 2000,
+					'total_refunded_orders' => 1,
+					'refunded_order_items'  => 1500,
+				),
+				array(
+					'<strong>1.000</strong> orders placed',
+					'<strong>2.000</strong> items purchased',
+					'refunded 1 order (1.500 item)',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Give the report the counts the running test needs.
 	 *
 	 * @param stdClass $data Report data.
 	 * @return stdClass
 	 */
-	public function inflate_report_counts( $data ) {
-		$data->total_orders          = 12345;
-		$data->total_items           = 67890;
-		$data->total_refunded_orders = 1234;
-		$data->refunded_order_items  = 5678;
+	public function set_report_counts( $data ) {
+		foreach ( $this->report_counts as $key => $value ) {
+			$data->$key = $value;
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Counts in the legacy Reports legends were printed as raw integers, so a busy store saw "1250 orders placed" next to a grouped "€45,576.00". They now go through `number_format_i18n()`.

Covers orders placed, items purchased and the refunded counts in Sales by date, plus coupons used, signups, and purchases in the other three reports. Money values are unchanged. No signature or hook changes.

One translation note. The refunded line is a `_n()` string, so its count placeholders had to go from `%d` to `%s` for the formatting to survive the `sprintf()`. That rewrites the msgid, so the existing translations for it stop matching and the line falls back to English until translate.wordpress.org catches up. The other legend strings are untouched.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #67978.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Sales by date, with 1,250 orders and 3,750 items:

| Before | After |
| ------ | ----- |
| <img width="498" height="1336" alt="sales-by-date-before" src="https://github.com/user-attachments/assets/d29edc18-692d-4175-9dcd-8c49bc839d86" /> | <img width="498" height="1336" alt="sales-by-date-after" src="https://github.com/user-attachments/assets/14ecaedd-db35-4188-9204-8288ed5f4605" /> |

Sales by product:

| Before | After |
| ------ | ----- |
| <img width="498" height="364" alt="sales-by-product-before" src="https://github.com/user-attachments/assets/c51338ae-e6bc-4065-a4dc-9a9997ce2919" /> | <img width="498" height="364" alt="sales-by-product-after" src="https://github.com/user-attachments/assets/d36a0ad9-f157-4bae-91d5-e04f48091439" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Generate more than 1,000 orders, for example `wp wc generate orders 1200` with wc-smooth-generator.
2. Go to **WooCommerce > Reports > Orders > Sales by date** and pick **This month**. The legend should read `1,200 orders placed`, not `1200`.
3. Set **Settings > General > Site Language** to Deutsch and reload. The separator should switch to `.`.
4. Check **Sales by product**, **Coupons by date**, and the **Customers** tab. Their counts should be grouped too, and the prices in all four legends unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Local dev env on `11.2.0-dev`, HPOS off, seeded with 1,250 orders, 3,750 items and 120 refunds. Checked all four legends in `en_US` and `de_DE`, and forced the refunded counts past 1,000 through the filter to confirm grouping and that the singular form still reads `refunded 1 order (1 item)`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

The entry was created manually and is in the branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code. I reviewed the change, and ran the linting, tests and dev env checks above before opening this.

