### PR TITLE
Fix stale Revenue report rows when an extension filter changes

### DIFF
--- a/plugins/woocommerce/changelog/66520-fix-revenue-table-stale-rows
+++ b/plugins/woocommerce/changelog/66520-fix-revenue-table-stale-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Analytics Revenue table rows keeping the first dataset loaded when an extension report filter changes.

--- a/plugins/woocommerce/client/admin/client/analytics/report/revenue/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/revenue/table.js
@@ -291,6 +291,8 @@ RevenueReportTable.contextType = CurrencyContext;
  * @param {boolean} isRequesting
  * @param {Object}  tableQuery
  * @param {Object}  revenueData
+ * @param {string}  dateType
+ * @param {Object}  filteredTableQuery The query the data was fetched with, including report filter params.
  * @return {Object} formatted tableData prop
  */
 const formatProps = memoize(
@@ -306,11 +308,18 @@ const formatProps = memoize(
 		},
 		dateType,
 	} ),
-	( isError, isRequesting, tableQuery, revenueData, dateType ) =>
+	(
+		isError,
+		isRequesting,
+		tableQuery,
+		revenueData,
+		dateType,
+		filteredTableQuery
+	) =>
 		[
 			isError,
 			isRequesting,
-			stringify( tableQuery ),
+			stringify( filteredTableQuery ),
 			get( revenueData, [ 'totalResults' ], 0 ),
 			get( revenueData, [ 'data', 'intervals' ], EMPTY_ARRAY ).length,
 			dateType,
@@ -390,7 +399,8 @@ export default compose(
 			isRequesting,
 			tableQuery,
 			revenueData,
-			dateType
+			dateType,
+			filteredTableQuery
 		);
 	} )
 )( RevenueReportTable );

--- a/plugins/woocommerce/client/admin/client/analytics/report/revenue/test/table.test.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/revenue/test/table.test.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import RevenueReportTable from '../table';
+
+const mockCaptured = { tableData: null };
+
+// Report filter registered the way an extension would, through
+// woocommerce_admin_revenue_report_filters.
+const mockFilters = [
+	{
+		label: 'Order size',
+		param: 'big_only',
+		staticParams: [],
+		showFilters: () => true,
+		defaultValue: 'all',
+		filters: [
+			{ label: 'All orders', value: 'all' },
+			{ label: 'Over 100 only', value: '1' },
+		],
+	},
+];
+
+const mockInterval = ( date, ordersCount ) => ( {
+	interval: date,
+	date_start: `${ date } 00:00:00`,
+	date_end: `${ date } 23:59:59`,
+	subtotals: {
+		orders_count: ordersCount,
+		gross_sales: ordersCount * 100,
+		total_sales: ordersCount * 100,
+		net_revenue: ordersCount * 100,
+		refunds: 0,
+		coupons: 0,
+		taxes: 0,
+		shipping: 0,
+	},
+} );
+
+// Both datasets have the same number of intervals and the same totalResults,
+// like the Revenue report does: one row per day, whatever the filter.
+const mockUnfiltered = {
+	totalResults: 2,
+	data: {
+		intervals: [
+			mockInterval( '2023-01-01', 2 ),
+			mockInterval( '2023-01-02', 2 ),
+		],
+	},
+};
+
+const mockFiltered = {
+	totalResults: 2,
+	data: {
+		intervals: [
+			mockInterval( '2023-01-01', 1 ),
+			mockInterval( '2023-01-02', 1 ),
+		],
+	},
+};
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const { createElement } = jest.requireActual( '@wordpress/element' );
+
+	return {
+		...actual,
+		withSelect: ( mapSelectToProps ) => ( Wrapped ) => ( props ) =>
+			createElement( Wrapped, {
+				...props,
+				...mapSelectToProps( global.mockSelect, props ),
+			} ),
+	};
+} );
+
+jest.mock( '../../../components/report-table', () => ( {
+	__esModule: true,
+	default: ( props ) => {
+		mockCaptured.tableData = props.tableData;
+		return null;
+	},
+} ) );
+
+describe( 'RevenueReportTable', () => {
+	beforeEach( () => {
+		mockCaptured.tableData = null;
+
+		global.mockSelect = () => ( {
+			getSetting: () => ( {
+				woocommerce_default_date_range:
+					'period=custom&compare=previous_period&after=2023-01-01&before=2023-01-02',
+			} ),
+			getOption: () => 'date_paid',
+			getReportStats: ( endpoint, query ) =>
+				query.big_only === '1' ? mockFiltered : mockUnfiltered,
+			getReportStatsError: () => null,
+			isResolving: () => false,
+		} );
+	} );
+
+	const renderWithQuery = ( query ) => {
+		render(
+			<RevenueReportTable
+				query={ query }
+				filters={ mockFilters }
+				advancedFilters={ {} }
+			/>
+		);
+
+		return mockCaptured.tableData.items.data.map(
+			( row ) => row.subtotals.orders_count
+		);
+	};
+
+	it( 'renders the rows for the active report filter', () => {
+		const baseQuery = {
+			period: 'custom',
+			compare: 'previous_period',
+			after: '2023-01-01',
+			before: '2023-01-02',
+		};
+
+		expect( renderWithQuery( baseQuery ) ).toEqual( [ 2, 2 ] );
+
+		// Same date range, same row count, only the filter param changes. The
+		// rows have to follow it instead of coming back from a stale cache.
+		expect( renderWithQuery( { ...baseQuery, big_only: '1' } ) ).toEqual( [
+			1, 1,
+		] );
+
+		expect( renderWithQuery( baseQuery ) ).toEqual( [ 2, 2 ] );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/analytics/report/revenue/test/table.test.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/revenue/test/table.test.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { memoize } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import RevenueReportTable from '../table';
-
-const mockCaptured = { tableData: null };
 
 // Report filter registered the way an extension would, through
 // woocommerce_admin_revenue_report_filters.
@@ -64,6 +63,22 @@ const mockFiltered = {
 	},
 };
 
+// table.js memoizes at module scope, so those caches outlive each test. Hand
+// the tests a way to reset them by tracking every function memoize() returns.
+jest.mock( 'lodash', () => {
+	const actual = jest.requireActual( 'lodash' );
+	const memoized = [];
+
+	const mockMemoize = ( ...args ) => {
+		const fn = actual.memoize( ...args );
+		memoized.push( fn );
+		return fn;
+	};
+	mockMemoize.clearAll = () => memoized.forEach( ( fn ) => fn.cache.clear() );
+
+	return { ...actual, memoize: mockMemoize };
+} );
+
 jest.mock( '@wordpress/data', () => {
 	const actual = jest.requireActual( '@wordpress/data' );
 	const { createElement } = jest.requireActual( '@wordpress/element' );
@@ -78,17 +93,40 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
-jest.mock( '../../../components/report-table', () => ( {
-	__esModule: true,
-	default: ( props ) => {
-		mockCaptured.tableData = props.tableData;
-		return null;
-	},
-} ) );
+// Stand-in for ReportTable rendering a row per interval, so the assertions can
+// read the dates and order counts back off the rendered table.
+jest.mock( '../../../components/report-table', () => {
+	const { createElement } = jest.requireActual( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		default: ( { tableData } ) =>
+			createElement(
+				'table',
+				null,
+				createElement(
+					'tbody',
+					null,
+					tableData.items.data.map( ( row ) =>
+						createElement(
+							'tr',
+							{ key: row.interval },
+							createElement( 'td', null, row.interval ),
+							createElement(
+								'td',
+								null,
+								row.subtotals.orders_count
+							)
+						)
+					)
+				)
+			),
+	};
+} );
 
 describe( 'RevenueReportTable', () => {
 	beforeEach( () => {
-		mockCaptured.tableData = null;
+		memoize.clearAll();
 
 		global.mockSelect = () => ( {
 			getSetting: () => ( {
@@ -103,19 +141,20 @@ describe( 'RevenueReportTable', () => {
 		} );
 	} );
 
-	const renderWithQuery = ( query ) => {
-		render(
-			<RevenueReportTable
-				query={ query }
-				filters={ mockFilters }
-				advancedFilters={ {} }
-			/>
-		);
+	const revenueTable = ( query ) => (
+		<RevenueReportTable
+			query={ query }
+			filters={ mockFilters }
+			advancedFilters={ {} }
+		/>
+	);
 
-		return mockCaptured.tableData.items.data.map(
-			( row ) => row.subtotals.orders_count
-		);
-	};
+	const getRenderedOrderCounts = () =>
+		screen
+			.getAllByRole( 'row' )
+			.map(
+				( row ) => within( row ).getAllByRole( 'cell' )[ 1 ].textContent
+			);
 
 	it( 'renders the rows for the active report filter', () => {
 		const baseQuery = {
@@ -125,14 +164,15 @@ describe( 'RevenueReportTable', () => {
 			before: '2023-01-02',
 		};
 
-		expect( renderWithQuery( baseQuery ) ).toEqual( [ 2, 2 ] );
+		const { rerender } = render( revenueTable( baseQuery ) );
+		expect( getRenderedOrderCounts() ).toEqual( [ '2', '2' ] );
 
 		// Same date range, same row count, only the filter param changes. The
 		// rows have to follow it instead of coming back from a stale cache.
-		expect( renderWithQuery( { ...baseQuery, big_only: '1' } ) ).toEqual( [
-			1, 1,
-		] );
+		rerender( revenueTable( { ...baseQuery, big_only: '1' } ) );
+		expect( getRenderedOrderCounts() ).toEqual( [ '1', '1' ] );
 
-		expect( renderWithQuery( baseQuery ) ).toEqual( [ 2, 2 ] );
+		rerender( revenueTable( baseQuery ) );
+		expect( getRenderedOrderCounts() ).toEqual( [ '2', '2' ] );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Revenue table keeps its first dataset when an extension filter changes. Tiles, chart and the table footer update, the rows don't, so the table contradicts its own footer. A reload fixes it.

The `formatProps` memoize resolver keyed on `tableQuery`, which only holds interval, sort and pagination params. Filter params live in `filteredTableQuery`, the query `getReportStats` is actually called with. Same date range plus a different filter value means an identical cache key, and lodash hands back the first result. The other key parts don't help: this table has one row per day, so `totalResults` and `intervals.length` are the same either way.

The resolver now keys on `filteredTableQuery`. It's a superset of `tableQuery`, so date range, sorting and pagination are unchanged.

Core ships no Revenue filters, so this only shows up for extensions.

Closes #66520.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Week to date, "Order size" switched to "Over $100 only" without a reload. Tiles and footer report 3 orders / €600.00 in both.

| Before | After |
| ------ | ----- |
| <img alt="Before: rows show 2 orders / €220.00 while the footer says 3 orders / €600.00" src="https://github.com/user-attachments/assets/8b1ca7b5-aea8-4815-a6fd-5d7841715047" /> | <img alt="After: rows show 1 order / €200.00 and match the footer" src="https://github.com/user-attachments/assets/4efce128-9959-432b-b55e-02183d714364" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use a store with some orders above and some below $100 in the current period.
2. Register a Revenue filter the way an extension would. Put this in `wp-content/mu-plugins/repro-66520.php`:

   ```php
   add_filter( 'woocommerce_analytics_revenue_query_args', function ( $args ) {
       if ( isset( $_GET['big_only'] ) && '1' === $_GET['big_only'] ) {
           $args['big_only'] = 1; // Keeps the report cache key distinct.
       }
       return $args;
   } );

   add_filter( 'woocommerce_analytics_clauses_where', function ( $clauses ) {
       if ( isset( $_GET['big_only'] ) && '1' === $_GET['big_only'] ) {
           global $wpdb;
           $clauses[] = "AND {$wpdb->prefix}wc_order_stats.net_total > 100";
       }
       return $clauses;
   } );

   add_action( 'admin_enqueue_scripts', function () {
       if ( isset( $_GET['page'] ) && 'wc-admin' === $_GET['page'] ) {
           wp_enqueue_script( 'repro-66520', content_url( 'mu-plugins/repro-66520/repro.js' ), array( 'wp-hooks' ), '1.0', false );
       }
   } );
   ```

   And this in `wp-content/mu-plugins/repro-66520/repro.js`:

   ```js
   wp.hooks.addFilter(
       'woocommerce_admin_revenue_report_filters',
       'repro',
       ( filters ) => [
           {
               label: 'Order size',
               param: 'big_only',
               staticParams: [ 'chartType', 'paged', 'per_page', 'period', 'compare', 'before', 'after' ],
               showFilters: () => true,
               defaultValue: 'all',
               filters: [
                   { label: 'All orders', value: 'all' },
                   { label: 'Over $100 only', value: '1' },
               ],
           },
           ...filters,
       ]
   );
   ```

3. Open Analytics → Revenue and let the table load.
4. Switch "Order size" to "Over $100 only" without reloading. Rows, tiles, chart and footer all show the restricted numbers. On trunk the rows keep the unfiltered ones.
5. Switch back to "All orders" and confirm the rows follow.
6. Confirm date range, sorting and rows per page still update the table.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Tested on a local dev env (HPOS enabled) with 10 orders, 5 above and 5 below $100, over five days. Reproduced the stale rows on an unpatched build, then confirmed the fix on a patched one: filter both ways, date range change, sorting by Orders.

Added `revenue/test/table.test.js`. Its two datasets have the same `totalResults` and interval count and differ only by the filter param, which is what defeated the old key. It fails on the old resolver and passes on the new one.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code reproduced the bug on a local dev env, wrote the fix and the test, and drafted this description. I reviewed it.
