### PR TITLE
Split CI across runner pools: e2e on arm64 — experiment (do not merge)

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -59,29 +59,29 @@ runs:
           uses: 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9' # v6.1.0
           with:
               path: "${{ env.PNPM_STORE_PATH }}"
-              key: "${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ ( inputs.build-type == 'backend' && 'backend' ) || 'full' }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
-              restore-keys: "${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ ( inputs.build-type == 'backend' && 'backend' ) || 'full' }}-"
+              key: "${{ runner.os }}-${{ runner.arch }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ ( inputs.build-type == 'backend' && 'backend' ) || 'full' }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
+              restore-keys: "${{ runner.os }}-${{ runner.arch }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ ( inputs.build-type == 'backend' && 'backend' ) || 'full' }}-"
         - name: 'Cache: node cache'
           if: ${{ inputs.pull-package-deps != 'false' && inputs.build-type != 'backend' }}
           uses: 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9' # v6.1.0
           with:
               path: './node_modules/.cache'
-              key: "${{ runner.os }}-node-cache-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
-              restore-keys: '${{ runner.os }}-node-cache-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-'
+              key: "${{ runner.os }}-${{ runner.arch }}-node-cache-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
+              restore-keys: '${{ runner.os }}-${{ runner.arch }}-node-cache-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-'
         - name: 'Cache Composer Dependencies'
           if: ${{ inputs.pull-package-deps != 'false' || inputs.pull-package-composer-deps != 'false' }}
           uses: 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9' # v6.1.0
           with:
               path: '~/.cache/composer/files'
-              key: "${{ runner.os }}-composer-${{ ( inputs.pull-package-deps != 'false' && inputs.pull-package-deps ) || inputs.pull-package-composer-deps }}-build:${{ inputs.build-type }}-${{ hashFiles( 'packages/*/*/composer.lock', 'plugins/*/composer.lock' ) }}"
-              restore-keys: "${{ runner.os }}-composer-${{ ( inputs.pull-package-deps != 'false' && inputs.pull-package-deps ) || inputs.pull-package-composer-deps }}-build:${{ inputs.build-type }}-"
+              key: "${{ runner.os }}-${{ runner.arch }}-composer-${{ ( inputs.pull-package-deps != 'false' && inputs.pull-package-deps ) || inputs.pull-package-composer-deps }}-build:${{ inputs.build-type }}-${{ hashFiles( 'packages/*/*/composer.lock', 'plugins/*/composer.lock' ) }}"
+              restore-keys: "${{ runner.os }}-${{ runner.arch }}-composer-${{ ( inputs.pull-package-deps != 'false' && inputs.pull-package-deps ) || inputs.pull-package-composer-deps }}-build:${{ inputs.build-type }}-"
         - name: 'Cache: playwright downloads'
           if: ${{ inputs.pull-playwright-cache != 'false' }}
           uses: 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9' # v6.1.0
           with:
               path: '~/.cache/ms-playwright/'
-              key: "${{ runner.os }}-playwright-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
-              restore-keys: '${{ runner.os }}-playwright-'
+              key: "${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
+              restore-keys: '${{ runner.os }}-${{ runner.arch }}-playwright-'
         - name: 'Parse Project Filters'
           id: 'project-filters'
           shell: 'bash'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,9 @@ jobs:
     name: '${{ matrix.name }}'
     # While the CI_QUEUE_OVERFLOW repository variable is '1', e2e jobs route to the
     # dedicated group. Fork PRs are excluded.
-    runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || ( vars.CI_QUEUE_OVERFLOW == '1' && matrix.testType == 'e2e' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository ) ) && fromJSON('{"group":"Woo Core Dedicated CI"}') || 'ubuntu-latest' }}
+    # Split-pool experiment: browser-heavy job types run on arm64 (faster per job), the
+    # rest stay on x64, so one PR draws from two runner pools and queues less on each.
+    runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || ( vars.CI_QUEUE_OVERFLOW == '1' && matrix.testType == 'e2e' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository ) ) && fromJSON('{"group":"Woo Core Dedicated CI"}') || ( ( matrix.testType == 'e2e' || matrix.testType == 'performance' ) && 'ubuntu-24.04-arm' ) || 'ubuntu-latest' }}
     timeout-minutes: 35
     needs: [ 'identify-jobs-to-run', 'project-jobs', 'woocommerce-plugin-build-artifact' ]
     if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) && needs.project-jobs.outputs.test-jobs != '[]' && ( needs.woocommerce-plugin-build-artifact.result == 'success' || needs.woocommerce-plugin-build-artifact.result == 'skipped' || needs.project-jobs.outputs.shared-plugin-build-has-required-consumers != 'true' ) }}

--- a/plugins/woocommerce/changelog/dev-test-split-arch-ci
+++ b/plugins/woocommerce/changelog/dev-test-split-arch-ci
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: CI experiment only — routes e2e and performance jobs to arm64 runners while the rest stay on x64, to measure queue behavior. Not intended for merge.
+

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce setup
+ * WooCommerce setup.
  *
  * @package WooCommerce
  * @since   3.2.0


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow-up experiment to #68049. That PR showed arm64 runners make individual e2e/Metrics jobs 10–15% faster, but the whole run slower (37.6 vs 33.8 min) because ~25 jobs queue on the smaller arm pool at once.

This PR tests the middle path: only `e2e` and `performance` job types run on `ubuntu-24.04-arm`; PHP unit, lint, API, and build jobs stay on `ubuntu-latest`. One PR then draws from two runner pools, so each queue sees roughly half the demand, while the per-job arm gains are kept. Cache keys are arch-scoped (same as #68049) so mixed architectures in one run stay safe.

The docblock touch in `class-woocommerce.php` triggers the full core suite for a realistic comparison. This PR is a probe, not for merge.

### How to test the changes in this Pull Request:

1. Let CI finish, then re-run all jobs (warm caches).
2. Compare total run time and per-job queue waits against the all-arm run on #68049 (attempt 2) and the x64 baseline (run 32855866006 on #68008).
3. The experiment succeeds if total PR time drops below the x64 baseline's 33.8 min.

### Testing that has already taken place:

The CI run on this PR is the test. #68049 already verified all jobs pass on arm64.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (experiment-only PR, not intended for merge).

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Drafted with Claude Code; changes reviewed by me.