### PR TITLE
Show unavailable saved country as a disabled option in checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-58084-checkout-unavailable-country-select
+++ b/plugins/woocommerce/changelog/fix-58084-checkout-unavailable-country-select
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Show a customer's saved country as a disabled option in the checkout country dropdown when the store no longer sells or ships there, so the selection reflects the actual address and choosing an available country clears the error.
+Show a returning customer's saved country as a disabled option in the checkout country dropdown when the store no longer sells or ships to that country

--- a/plugins/woocommerce/changelog/fix-58084-checkout-unavailable-country-select
+++ b/plugins/woocommerce/changelog/fix-58084-checkout-unavailable-country-select
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show a customer's saved country as a disabled option in the checkout country dropdown when the store no longer sells or ships there, so the selection reflects the actual address and choosing an available country clears the error.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -45,22 +45,13 @@ export const CountryInput = ( {
 				'countries',
 				{}
 			);
-			const unavailableLabel = decodeEntities(
-				allCountries[ selectedCountry ] || selectedCountry
-			);
-			const insertAt = countryOptions.findIndex(
-				( option ) => option.label.localeCompare( unavailableLabel ) > 0
-			);
-			const unavailableOption = {
+			countryOptions.push( {
 				value: selectedCountry,
-				label: unavailableLabel,
+				label: decodeEntities(
+					allCountries[ selectedCountry ] || selectedCountry
+				),
 				disabled: true,
-			};
-			if ( insertAt === -1 ) {
-				countryOptions.push( unavailableOption );
-			} else {
-				countryOptions.splice( insertAt, 0, unavailableOption );
-			}
+			} );
 		}
 		return countryOptions;
 	}, [ countries, value ] );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -3,6 +3,8 @@
  */
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { getSetting } from '@woocommerce/settings';
+import { objectHasProp } from '@woocommerce/types';
 import clsx from 'clsx';
 
 /**
@@ -24,13 +26,44 @@ export const CountryInput = ( {
 	required = false,
 }: CountryInputWithCountriesProps ): JSX.Element => {
 	const options = useMemo< SelectOption[] >( () => {
-		return Object.entries( countries ).map(
+		const countryOptions: SelectOption[] = Object.entries( countries ).map(
 			( [ countryCode, countryName ] ) => ( {
 				value: countryCode,
 				label: decodeEntities( countryName ),
 			} )
 		);
-	}, [ countries ] );
+		// Keep an unavailable saved country in the list as a disabled option.
+		// With no matching option the select drifts off the stored value, and
+		// re-picking the displayed country fires no change event, so the error
+		// could never be cleared.
+		const selectedCountry = typeof value === 'string' ? value : '';
+		if (
+			selectedCountry &&
+			! objectHasProp( countries, selectedCountry )
+		) {
+			const allCountries = getSetting< Record< string, string > >(
+				'countries',
+				{}
+			);
+			const unavailableLabel = decodeEntities(
+				allCountries[ selectedCountry ] || selectedCountry
+			);
+			const insertAt = countryOptions.findIndex(
+				( option ) => option.label.localeCompare( unavailableLabel ) > 0
+			);
+			const unavailableOption = {
+				value: selectedCountry,
+				label: unavailableLabel,
+				disabled: true,
+			};
+			if ( insertAt === -1 ) {
+				countryOptions.push( unavailableOption );
+			} else {
+				countryOptions.splice( insertAt, 0, unavailableOption );
+			}
+		}
+		return countryOptions;
+	}, [ countries, value ] );
 
 	return (
 		<Select

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -3,8 +3,8 @@
  */
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { getSetting } from '@woocommerce/settings';
-import { objectHasProp } from '@woocommerce/types';
+import { getSettingWithCoercion } from '@woocommerce/settings';
+import { isObject, isString, objectHasProp } from '@woocommerce/types';
 import clsx from 'clsx';
 
 /**
@@ -41,14 +41,18 @@ export const CountryInput = ( {
 			selectedCountry &&
 			! objectHasProp( countries, selectedCountry )
 		) {
-			const allCountries = getSetting< Record< string, string > >(
+			const allCountries = getSettingWithCoercion(
 				'countries',
-				{}
+				{},
+				isObject
 			);
+			const countryName = allCountries[ selectedCountry ];
 			countryOptions.push( {
 				value: selectedCountry,
 				label: decodeEntities(
-					allCountries[ selectedCountry ] || selectedCountry
+					isString( countryName ) && countryName
+						? countryName
+						: selectedCountry
 				),
 				disabled: true,
 			} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/test/index.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from '@wordpress/element';
 import { allSettings } from '@woocommerce/settings';
 
 /**
@@ -65,7 +67,7 @@ describe( 'CountryInput', () => {
 		expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
 	} );
 
-	it( 'inserts the unavailable country in alphabetical position', () => {
+	it( 'appends the unavailable country after the allowed countries', () => {
 		render( <CountryInput { ...defaultProps } value="GB" /> );
 
 		const optionLabels = screen
@@ -75,8 +77,8 @@ describe( 'CountryInput', () => {
 		expect( optionLabels ).toEqual( [
 			'Select a country/region',
 			'Austria',
-			'United Kingdom (UK)',
 			'United States (US)',
+			'United Kingdom (UK)',
 		] );
 	} );
 
@@ -103,5 +105,36 @@ describe( 'CountryInput', () => {
 			screen.queryByRole( 'option', { name: 'United Kingdom (UK)' } )
 		).not.toBeInTheDocument();
 		expect( screen.getByLabelText( 'Country/Region' ) ).toHaveValue( 'US' );
+	} );
+
+	it( 'lets the user pick the only allowed country when the saved one is unavailable', async () => {
+		const onChange = jest.fn();
+		const ControlledCountryInput = () => {
+			const [ country, setCountry ] = useState( 'GB' );
+			return (
+				<CountryInput
+					{ ...defaultProps }
+					countries={ { US: 'United States (US)' } }
+					value={ country }
+					onChange={ ( newCountry: string ) => {
+						onChange( newCountry );
+						setCountry( newCountry );
+					} }
+				/>
+			);
+		};
+		render( <ControlledCountryInput /> );
+
+		const select = screen.getByLabelText( 'Country/Region' );
+		expect( select ).toHaveValue( 'GB' );
+
+		await userEvent.selectOptions( select, 'US' );
+
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( 'US' );
+		expect( select ).toHaveValue( 'US' );
+		expect(
+			screen.queryByRole( 'option', { name: 'United Kingdom (UK)' } )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/test/index.tsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { allSettings } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import CountryInput from '../country-input';
+
+const allowedCountries = {
+	AT: 'Austria',
+	US: 'United States (US)',
+} as const;
+
+const defaultProps = {
+	id: 'shipping-country',
+	label: 'Country/Region',
+	countries: allowedCountries,
+	onChange: jest.fn(),
+};
+
+describe( 'CountryInput', () => {
+	beforeEach( () => {
+		allSettings.countries = {
+			...allowedCountries,
+			GB: 'United Kingdom (UK)',
+		};
+	} );
+
+	afterEach( () => {
+		allSettings.countries = [];
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the allowed countries as options', () => {
+		render( <CountryInput { ...defaultProps } value="US" /> );
+
+		expect(
+			screen.getByRole( 'option', { name: 'United States (US)' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'option', { name: 'Austria' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows the selected country as a disabled option when it is not in the allowed list', () => {
+		render( <CountryInput { ...defaultProps } value="GB" /> );
+
+		const unavailableOption = screen.getByRole( 'option', {
+			name: 'United Kingdom (UK)',
+		} ) as HTMLOptionElement;
+
+		expect( unavailableOption ).toBeInTheDocument();
+		expect( unavailableOption.disabled ).toBe( true );
+		expect( unavailableOption.selected ).toBe( true );
+		expect( screen.getByLabelText( 'Country/Region' ) ).toHaveValue( 'GB' );
+	} );
+
+	it( 'does not add an extra option when the selected country is allowed', () => {
+		render( <CountryInput { ...defaultProps } value="US" /> );
+
+		// Placeholder + the two allowed countries only.
+		expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'inserts the unavailable country in alphabetical position', () => {
+		render( <CountryInput { ...defaultProps } value="GB" /> );
+
+		const optionLabels = screen
+			.getAllByRole( 'option' )
+			.map( ( option ) => option.textContent );
+
+		expect( optionLabels ).toEqual( [
+			'Select a country/region',
+			'Austria',
+			'United Kingdom (UK)',
+			'United States (US)',
+		] );
+	} );
+
+	it( 'falls back to the country code when the full country list has no name for it', () => {
+		render( <CountryInput { ...defaultProps } value="XX" /> );
+
+		expect(
+			screen.getByRole( 'option', { name: 'XX' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'removes the unavailable option once an allowed country is selected', () => {
+		const { rerender } = render(
+			<CountryInput { ...defaultProps } value="GB" />
+		);
+
+		expect(
+			screen.getByRole( 'option', { name: 'United Kingdom (UK)' } )
+		).toBeInTheDocument();
+
+		rerender( <CountryInput { ...defaultProps } value="US" /> );
+
+		expect(
+			screen.queryByRole( 'option', { name: 'United Kingdom (UK)' } )
+		).not.toBeInTheDocument();
+		expect( screen.getByLabelText( 'Country/Region' ) ).toHaveValue( 'US' );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/test/index.tsx
@@ -90,6 +90,21 @@ describe( 'CountryInput', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'falls back to the country code when the countries setting is not an object', () => {
+		// A plugin can replace the setting through the shared settings filter.
+		allSettings.countries = null as unknown as typeof allSettings.countries;
+
+		render( <CountryInput { ...defaultProps } value="GB" /> );
+
+		const unavailableOption = screen.getByRole( 'option', {
+			name: 'GB',
+		} ) as HTMLOptionElement;
+
+		expect( unavailableOption ).toBeInTheDocument();
+		expect( unavailableOption.disabled ).toBe( true );
+		expect( screen.getByLabelText( 'Country/Region' ) ).toHaveValue( 'GB' );
+	} );
+
 	it( 'removes the unavailable option once an allowed country is selected', () => {
 		const { rerender } = render(
 			<CountryInput { ...defaultProps } value="GB" />

--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { getSetting, STORE_PAGES } from '@woocommerce/settings';
-import { CountryData } from '@woocommerce/types';
+import {
+	getSetting,
+	getSettingWithCoercion,
+	STORE_PAGES,
+} from '@woocommerce/settings';
+import { CountryData, isObject, isString } from '@woocommerce/types';
 import type {
 	OrderForm,
 	AddressForm,
@@ -68,7 +72,7 @@ type FieldsLocations = {
 };
 
 // Contains country names.
-const countries = getSetting< Record< string, string > >( 'countries', {} );
+const countries = getSettingWithCoercion( 'countries', {}, isObject );
 
 // Contains country settings.
 const countryData = getSetting< Record< string, CountryData > >(
@@ -82,7 +86,8 @@ export const ALLOWED_COUNTRIES = Object.fromEntries(
 			return countryData[ countryCode ].allowBilling === true;
 		} )
 		.map( ( countryCode ) => {
-			return [ countryCode, countries[ countryCode ] || '' ];
+			const countryName = countries[ countryCode ];
+			return [ countryCode, isString( countryName ) ? countryName : '' ];
 		} )
 );
 
@@ -92,7 +97,8 @@ export const SHIPPING_COUNTRIES = Object.fromEntries(
 			return countryData[ countryCode ].allowShipping === true;
 		} )
 		.map( ( countryCode ) => {
-			return [ countryCode, countries[ countryCode ] || '' ];
+			const countryName = countries[ countryCode ];
+			return [ countryCode, isString( countryName ) ? countryName : '' ];
 		} )
 );
 

--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/test/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/test/constants.ts
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import type { CountryData } from '@woocommerce/types';
+
+type Constants = typeof import('../constants');
+
+const countryData: Record< string, CountryData > = {
+	US: {
+		allowBilling: true,
+		allowShipping: true,
+		states: {},
+		locale: {} as CountryData[ 'locale' ],
+	},
+	GB: {
+		allowBilling: false,
+		allowShipping: false,
+		states: {},
+		locale: {} as CountryData[ 'locale' ],
+	},
+};
+
+// The country maps are computed when the module loads, so every case needs a
+// fresh module registry seeded with its own `countries` setting.
+const loadConstants = ( countries: unknown ): Constants => {
+	window.wcSettings = { ...window.wcSettings, countries, countryData };
+	let constants: Constants | null = null;
+	jest.isolateModules( () => {
+		constants = require( '../constants' );
+	} );
+	if ( ! constants ) {
+		throw new Error( 'Constants module did not load.' );
+	}
+	return constants;
+};
+
+describe( 'country constants', () => {
+	const originalSettings = window.wcSettings;
+
+	afterEach( () => {
+		window.wcSettings = originalSettings;
+	} );
+
+	it( 'maps allowed countries to their names', () => {
+		const { ALLOWED_COUNTRIES, SHIPPING_COUNTRIES } = loadConstants( {
+			US: 'United States (US)',
+			GB: 'United Kingdom (UK)',
+		} );
+
+		expect( ALLOWED_COUNTRIES ).toEqual( { US: 'United States (US)' } );
+		expect( SHIPPING_COUNTRIES ).toEqual( { US: 'United States (US)' } );
+	} );
+
+	it.each( [
+		[ 'null', null ],
+		[ 'an array', [] ],
+		[ 'a string', 'broken' ],
+	] )(
+		'does not throw when the countries setting is %s',
+		( _label, countries ) => {
+			const { ALLOWED_COUNTRIES, SHIPPING_COUNTRIES } =
+				loadConstants( countries );
+
+			expect( ALLOWED_COUNTRIES ).toEqual( { US: '' } );
+			expect( SHIPPING_COUNTRIES ).toEqual( { US: '' } );
+		}
+	);
+
+	it( 'falls back to an empty name when the entry is not a string', () => {
+		const { ALLOWED_COUNTRIES } = loadConstants( { US: 42 } );
+
+		expect( ALLOWED_COUNTRIES ).toEqual( { US: '' } );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a logged-in shopper has a saved address in a country the store no longer sells or ships to, the Checkout block gets stuck. The country select has no option for the saved country, so the browser coerces it onto the first available option while the cart store still holds the old one; the select shows a valid country, the error stays, and re-selecting that country fires no change event. With a single allowed country there is no way out except logging out.

This PR keeps the saved country in the dropdown as a disabled option, labeled with the localized name from the `countries` setting. The selection now reflects the actual value, the existing validation error explains it, and picking an allowed country is a real option change; the store updates and the error clears. This is the flow agreed in [this issue comment](https://github.com/woocommerce/woocommerce/issues/58084#issuecomment-3150927970).

**Guarding the `countries` setting.** Review asked to validate the setting before indexing it, since `getSetting()` returns a `null` setting unchanged. While testing that with a corrupted setting I found the checkout crashes earlier: `assets/js/settings/blocks/constants.ts` indexes the same setting at module load to build `ALLOWED_COUNTRIES` and `SHIPPING_COUNTRIES`, so a `null` value throws in every bundle that imports it and the page never renders. Both reads now go through `getSettingWithCoercion` with the `isObject` guard, and country names are checked with `isString`.

BC impact: for a well-formed setting the exported constants keep the same values and the same inferred type. For a malformed setting the checkout renders with empty country names instead of throwing; a non-string name becomes `''` instead of passing through. These constants are bundled per entry and not exposed on `window.wc`, so there is no third-party contract here. The neighbouring `countryData` read has the same shape and is deliberately left alone in this PR; it is a separate change with its own typing.

Closes #58084 
Closes WOOPLUG-4321

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|   <img width="856" height="451" alt="Screenshot 2026-08-26 at 18 29 53" src="https://github.com/user-attachments/assets/9cd83899-6bfb-4168-8e0f-584473f20b0d" />   | <img width="847" height="433" alt="Screenshot 2026-08-26 at 18 23 25" src="https://github.com/user-attachments/assets/fb30f77d-b488-41c0-acbc-cd3692f20c23" />      |

<img width="940" height="565" alt="Screenshot 2026-08-26 at 18 23 31" src="https://github.com/user-attachments/assets/22cf93ff-fc13-4f65-9418-5703ade92f65" />

### How to test the changes in this Pull Request:

1. Go to WooCommerce → Settings → General and set both "Selling location(s)" and "Shipping location(s)" to all countries. Add a shipping rate that covers the UK (or use a Rest of the World zone with Free shipping).
2. In an incognito window, create a customer account, add a product to the cart, and check out with a UK address; this saves the address on the account.
3. Back in Settings → General, set both "Selling location(s)" and "Shipping location(s)" to specific countries with only United States (US).
4. As the customer, add a product to the cart and open the Checkout page. The address sections expand and Country/Region shows "United Kingdom (UK)" greyed out, with "Sorry, we do not ship orders to the selected country" below (billing shows its own variant).
5. Open the dropdown; "United Kingdom (UK)" is visible but not selectable. Select "United States (US)"; the error clears and the UK option leaves the list. Complete the address and place the order.
6. Repeat step 4 with "Use same address for billing" checked; selecting a valid country in shipping also clears the billing error.
7. Repeat with only a virtual product in the cart; the billing-only form behaves the same way.

Optional, for the setting guard: drop this file into `wp-content/mu-plugins/` and reload the checkout. On trunk the page stays on the loading skeletons with `Cannot read properties of null (reading 'US')` in the console; with this PR it renders, and the saved country shows its code as the label.

```php
<?php
add_action( 'wp_enqueue_scripts', function () {
	wp_add_inline_script( 'wc-settings', 'wc.wcSettings.allSettings.countries = null;', 'after' );
}, 100 );
```

<!-- End testing instructions -->

### Testing that has already taken place:

- New Jest suite for `CountryInput` covering the disabled option, the fallback label, a `null` setting, and the option leaving the list after a valid selection; new suite for the settings constants covering a `null`, array, string, and non-string setting; existing form and checkout block suites pass.
- Manual testing on a local Studio site with trunk + this change, following the steps above: the shipping flow, the "Use same address for billing" sync, and a virtual-only cart. Also verified that the DOM select value, the cart store value, and the visible selection stay in sync, which is the core of the bug.
- Reproduced the module-load crash with the mu-plugin above on the pre-guard build, and confirmed the checkout renders with the guard in place.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

The fix, tests, and this PR description were written with Claude Code; I directed the approach and reviewed the changes.
