### PR TITLE
Change error status from 400 to 429 for rate limits

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-rate-limit-status
+++ b/plugins/woocommerce/changelog/fix-store-api-rate-limit-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return HTTP 429 instead of 400 when Store API requests exceed the rate limit.

--- a/plugins/woocommerce/src/StoreApi/Authentication.php
+++ b/plugins/woocommerce/src/StoreApi/Authentication.php
@@ -249,7 +249,7 @@ class Authentication {
 						'Too many requests. Please wait %d seconds before trying again.',
 						$retry
 					),
-					array( 'status' => 400 )
+					array( 'status' => 429 )
 				);
 			}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/RateLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/RateLimitsTests.php
@@ -89,7 +89,7 @@ class RateLimitsTests extends WP_Test_REST_TestCase {
 
 		$body = json_decode( $spy_rest_server->sent_body );
 		$this->assertEquals( JSON_ERROR_NONE, json_last_error() );
-		$this->assertEquals( 400, $body->data->status );
+		$this->assertEquals( 429, $body->data->status );
 
 		$this->assertEquals( $rate_limiting_options->limit, $spy_rest_server->sent_headers['RateLimit-Limit'] );
 		$this->assertIsInt( $spy_rest_server->sent_headers['RateLimit-Reset'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

HTTP/429 is the correct status code for rate limiting.

Bug introduced in https://github.com/woocommerce/woocommerce-blocks/commit/dbca0115f48847af28a690d97579167fc9f54d29
