### PR TITLE
Remove unused render_order_downloads_column_headers parameter

### DIFF
--- a/plugins/woocommerce/changelog/patch-2
+++ b/plugins/woocommerce/changelog/patch-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove unused render_order_downloads_column_headers parameter
+
+

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -50674,12 +50674,6 @@ parameters:
 			path: src/Blocks/BlockTypes/OrderConfirmation/Downloads.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\OrderConfirmation\\Downloads\:\:render_order_downloads_column_headers\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Blocks/BlockTypes/OrderConfirmation/Downloads.php
-
-		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, \(int\|false\) given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Downloads.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Downloads.php
@@ -39,7 +39,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
 				<thead>
 					<tr>
-						' . $this->render_order_downloads_column_headers( $order ) . '
+						' . $this->render_order_downloads_column_headers() . '
 					</td>
 				</thead>
 				<tbody>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`render_order_downloads_column_headers` method has no parameters.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
</details>
