### PR TITLE
Analytics: add a setting to exclude free orders from report totals

### DIFF
--- a/plugins/woocommerce/changelog/32194-analytics-exclude-free-orders
+++ b/plugins/woocommerce/changelog/32194-analytics-exclude-free-orders
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Analytics: add an "Excluded orders" setting that leaves orders with a total of zero out of report totals, with a per-report control to include or exclude them.

--- a/plugins/woocommerce/client/admin/client/analytics/report/categories/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/categories/config.js
@@ -9,6 +9,7 @@ import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import { getCategoryLabels } from '../../../lib/async-requests';
 
 const CATEGORY_REPORT_CHARTS_FILTER =
@@ -154,4 +155,5 @@ export const filters = applyFilters( CATEGORY_REPORT_FILTERS_FILTER, [
 		showFilters: () => true,
 		filters: filterValues,
 	},
+	getFreeOrdersFilter(),
 ] );

--- a/plugins/woocommerce/client/admin/client/analytics/report/coupons/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/coupons/config.js
@@ -9,6 +9,7 @@ import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import { getCouponLabels } from '../../../lib/async-requests';
 
 const COUPON_REPORT_CHARTS_FILTER = 'woocommerce_admin_coupons_report_charts';
@@ -137,4 +138,5 @@ export const filters = applyFilters( COUPON_REPORT_FILTERS_FILTER, [
 		showFilters: () => true,
 		filters: filterValues,
 	},
+	getFreeOrdersFilter( { defaultValue: 'include' } ),
 ] );

--- a/plugins/woocommerce/client/admin/client/analytics/report/customers/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/customers/config.js
@@ -10,6 +10,7 @@ import { NAMESPACE, COUNTRIES_STORE_NAME } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import {
 	getCustomerLabels,
 	getRequestByIdString,
@@ -69,9 +70,9 @@ export const filters = applyFilters( CUSTOMERS_REPORT_FILTERS_FILTER, [
 			},
 		],
 	},
+	getFreeOrdersFilter(),
 ] );
 
-/*eslint-disable max-len*/
 /**
  * Customers Report Advanced Filters.
  *
@@ -502,4 +503,3 @@ export const advancedFilters = applyFilters(
 		},
 	}
 );
-/*eslint-enable max-len*/

--- a/plugins/woocommerce/client/admin/client/analytics/report/free-orders-filter.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/free-orders-filter.js
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Popover } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { Icon, info } from '@wordpress/icons';
+import { Link } from '@woocommerce/components';
+import { getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '~/utils/admin-settings';
+
+/**
+ * Whether the store leaves free orders out of report totals.
+ *
+ * Read from an immutable snapshot rather than the settings data store, because
+ * report filter configs are evaluated at module load. A store that turns the
+ * setting on will see the control after the next full page load.
+ *
+ * @return {boolean} True when free orders are excluded by default.
+ */
+export function excludesFreeOrders() {
+	return Boolean( getAdminSetting( 'analyticsExcludesFreeOrders', false ) );
+}
+
+/**
+ * Zero, formatted in the store's own currency.
+ *
+ * @return {string} Formatted zero, e.g. "$0.00".
+ */
+function getFreeOrderAmount() {
+	return getAdminSetting( 'analyticsFreeOrderAmount', '0' );
+}
+
+/**
+ * Label for the filter, with a help affordance beside it.
+ *
+ * A click-toggled popover rather than a tooltip, because it holds a link:
+ * tooltips dismiss on pointer-out and are not reachable by keyboard.
+ *
+ * @return {Object} -
+ */
+const FreeOrdersLabel = () => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<>
+			{ __( 'Orders', 'woocommerce' ) }
+			<Button
+				className="woocommerce-free-orders-filter__help-toggle"
+				label={ __( 'About free orders', 'woocommerce' ) }
+				aria-expanded={ isOpen }
+				onClick={ () => setIsOpen( ! isOpen ) }
+			>
+				<Icon icon={ info } size={ 20 } />
+			</Button>
+			{ isOpen && (
+				<Popover
+					// Beside the icon rather than below it, so the popover does
+					// not cover the control it is describing.
+					placement="right-start"
+					offset={ 8 }
+					focusOnMount="firstElement"
+					onClose={ () => setIsOpen( false ) }
+				>
+					<div className="woocommerce-free-orders-filter__help">
+						<p>
+							{ sprintf(
+								/* translators: %s: zero formatted in the store currency, e.g. $0.00 */
+								__(
+									'Orders with a total of %s can be included in or excluded from your reports.',
+									'woocommerce'
+								),
+								getFreeOrderAmount()
+							) }
+						</p>
+						<Link
+							href={ getNewPath( {}, '/analytics/settings' ) }
+							type="wc-admin"
+						>
+							{ __(
+								'Change the default in Analytics settings',
+								'woocommerce'
+							) }
+						</Link>
+					</div>
+				</Popover>
+			) }
+		</>
+	);
+};
+
+/**
+ * Builds the "Orders" filter that includes or excludes free orders.
+ *
+ * Only rendered once the store has turned the setting on, so that a store which
+ * never issues free orders is not given a control that does nothing. Visibility
+ * follows that setting and never the contents of the date range being viewed: a
+ * control that came and went as the dates moved would read as a glitch.
+ *
+ * @param {Object} options              Options.
+ * @param {string} options.defaultValue 'include' or 'exclude'.
+ * @return {Object} A report filter config.
+ */
+export function getFreeOrdersFilter( { defaultValue = 'exclude' } = {} ) {
+	return {
+		label: <FreeOrdersLabel />,
+		staticParams: [ 'chartType', 'paged', 'per_page', 'filter' ],
+		param: 'free_orders',
+		defaultValue,
+		showFilters: () => excludesFreeOrders(),
+		filters: [
+			{
+				label: __( 'Include free orders', 'woocommerce' ),
+				value: 'include',
+			},
+			{
+				label: __( 'Exclude free orders', 'woocommerce' ),
+				value: 'exclude',
+			},
+		],
+	};
+}

--- a/plugins/woocommerce/client/admin/client/analytics/report/orders/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/orders/config.js
@@ -7,6 +7,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import {
 	getCouponLabels,
 	getProductLabels,
@@ -81,9 +82,8 @@ export const filters = applyFilters( ORDERS_REPORT_FILTERS_FILTER, [
 			},
 		],
 	},
+	getFreeOrdersFilter(),
 ] );
-
-/*eslint-disable max-len*/
 
 /**
  * Orders Report Advanced Filters.
@@ -377,4 +377,3 @@ export const advancedFilters = applyFilters(
 		},
 	}
 );
-/*eslint-enable max-len*/

--- a/plugins/woocommerce/client/admin/client/analytics/report/products/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/products/config.js
@@ -9,6 +9,7 @@ import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import {
 	getProductLabels,
 	getVariationLabels,
@@ -220,4 +221,5 @@ if ( Object.keys( advancedFilters.filters ).length ) {
 export const filters = applyFilters( PRODUCTS_REPORT_FILTERS_FILTER, [
 	filterConfig,
 	variationsConfig,
+	getFreeOrdersFilter(),
 ] );

--- a/plugins/woocommerce/client/admin/client/analytics/report/revenue/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/revenue/config.js
@@ -7,6 +7,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 const REVENUE_REPORT_CHARTS_FILTER = 'woocommerce_admin_revenue_report_charts';
@@ -152,4 +153,5 @@ export const filters = applyFilters( REVENUE_REPORT_FILTERS_FILTER, [
 		showFilters: () => filterValues.length > 0,
 		filters: filterValues,
 	},
+	getFreeOrdersFilter(),
 ] );

--- a/plugins/woocommerce/client/admin/client/analytics/report/style.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/report/style.scss
@@ -11,3 +11,25 @@
 		}
 	}
 }
+
+.woocommerce-free-orders-filter__help-toggle.components-button {
+	min-width: 0;
+	height: auto;
+	padding: 2px;
+	margin-inline-start: 2px;
+	color: var(--wp-admin-theme-color);
+	vertical-align: middle;
+}
+
+.woocommerce-free-orders-filter__help {
+	// The popover shrink-wraps its content, so this needs a width rather than
+	// only a max-width or it collapses to the longest single word.
+	width: 17rem;
+	max-width: calc(100vw - 32px);
+	padding: 12px 16px;
+
+	p {
+		margin: 0 0 12px;
+		line-height: 1.5;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/analytics/report/taxes/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/taxes/config.js
@@ -10,6 +10,7 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import { getRequestByIdString } from '../../../lib/async-requests';
 import { getTaxCode } from './utils';
 
@@ -140,4 +141,5 @@ export const filters = applyFilters( TAXES_REPORT_FILTERS_FILTER, [
 		showFilters: () => true,
 		filters: filterValues,
 	},
+	getFreeOrdersFilter(),
 ] );

--- a/plugins/woocommerce/client/admin/client/analytics/report/variations/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/variations/config.js
@@ -9,6 +9,7 @@ import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 /**
  * Internal dependencies
  */
+import { getFreeOrdersFilter } from '../free-orders-filter';
 import {
 	getCategoryLabels,
 	getProductLabels,
@@ -132,6 +133,7 @@ export const filters = applyFilters( VARIATIONS_REPORT_FILTERS_FILTER, [
 			},
 		],
 	},
+	getFreeOrdersFilter(),
 ] );
 
 /**

--- a/plugins/woocommerce/client/admin/client/analytics/settings/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/config.js
@@ -100,6 +100,28 @@ const baseConfig = {
 		} ),
 		defaultValue: [ 'pending', 'cancelled', 'failed' ],
 	},
+	woocommerce_analytics_excluded_orders: {
+		label: __( 'Excluded orders:', 'woocommerce' ),
+		inputType: 'checkbox',
+		options: [
+			{
+				value: 'zero_total',
+				label: sprintf(
+					/* translators: %s: zero formatted in the store currency, e.g. $0.00 */
+					__( 'Orders with a total of %s', 'woocommerce' ),
+					getAdminSetting( 'analyticsFreeOrderAmount', '0' )
+				),
+			},
+		],
+		helpText: __(
+			'Orders where the customer paid nothing are left out of report totals \u2014 a 100% off coupon, ' +
+				'a gift redemption, or a basket of entirely free items. An order that mixes paid and free items ' +
+				'still counts in full. Your net sales stay the same; order counts, items sold, and average order ' +
+				'value change.',
+			'woocommerce'
+		),
+		defaultValue: [],
+	},
 	woocommerce_actionable_order_statuses: {
 		label: __( 'Actionable statuses:', 'woocommerce' ),
 		inputType: 'checkboxGroup',

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -65,6 +65,8 @@ class Controller extends GenericController implements ExportableInterface {
 		$args['status_is_not']       = (array) $request['status_is_not'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -60,6 +60,8 @@ class Controller extends GenericController implements ExportableInterface {
 		$args['coupons']             = (array) $request['coupons'];
 		$args['extended_info']       = $request['extended_info'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
+		$args['free_orders']         = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -50,6 +50,8 @@ class Controller extends GenericStatsController {
 		$args['fields']              = $request['fields'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/DataStore.php
@@ -96,9 +96,15 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );
+		$free_orders_filter  = $this->get_free_orders_subquery( $query_args );
+		if ( $order_status_filter || $free_orders_filter ) {
+			$clauses['join'] .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_coupon_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
+		}
 		if ( $order_status_filter ) {
-			$clauses['join']  .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_coupon_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
 			$clauses['where'] .= " AND ( {$order_status_filter} )";
+		}
+		if ( $free_orders_filter ) {
+			$clauses['where'] .= " AND ( {$free_orders_filter} )";
 		}
 
 		$this->add_time_period_sql_params( $query_args, $order_coupon_lookup_table );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -111,6 +111,8 @@ class Controller extends GenericController implements ExportableInterface {
 
 		$args = self::consolidate_customer_id_filters( $args );
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -513,6 +513,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$this->subquery->add_sql_clause( 'left_join', "AND ( {$order_status_filter} )" );
 		}
 
+		// Rides the LEFT JOIN rather than the WHERE so that a customer whose
+		// orders were all free keeps their row instead of vanishing entirely.
+		$free_orders_filter = $this->get_free_orders_subquery( $query_args );
+		if ( $free_orders_filter ) {
+			$this->subquery->add_sql_clause( 'left_join', "AND ( {$free_orders_filter} )" );
+		}
+
 		if ( $having_clauses ) {
 			$preceding_match = empty( $this->get_sql_clause( 'having' ) ) ? ' AND ' : " {$match_operator} ";
 			$this->subquery->add_sql_clause( 'having', $preceding_match . implode( " {$match_operator} ", $having_clauses ) );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
@@ -78,6 +78,8 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$args = CustomersController::consolidate_customer_id_filters( $args );
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -848,6 +848,70 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 	}
 
 	/**
+	 * Report contexts that keep counting free orders unless asked otherwise.
+	 *
+	 * A coupon that discounts an order to nothing is the subject of the Coupons
+	 * report, not noise in it: leaving those orders out would remove the record
+	 * of the coupon that created them.
+	 *
+	 * @return array
+	 */
+	protected static function get_free_order_including_contexts() {
+		/**
+		 * Filters the report contexts that include free orders by default.
+		 *
+		 * @since 11.2.0
+		 * @param array $contexts Report context prefixes.
+		 */
+		return apply_filters( 'woocommerce_analytics_free_order_including_contexts', array( 'coupons' ) );
+	}
+
+	/**
+	 * Whether free orders are left out of the report being built.
+	 *
+	 * A report asking for a specific treatment wins; otherwise the store-wide
+	 * setting applies, except on the reports listed above.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return bool
+	 */
+	protected function should_exclude_free_orders( $query_args ) {
+		if ( isset( $query_args['free_orders'] ) && '' !== $query_args['free_orders'] ) {
+			return 'exclude' === $query_args['free_orders'];
+		}
+
+		foreach ( self::get_free_order_including_contexts() as $context ) {
+			if ( 0 === strpos( (string) $this->context, $context ) ) {
+				return false;
+			}
+		}
+
+		$excluded = \WC_Admin_Settings::get_option( 'woocommerce_analytics_excluded_orders', array() );
+
+		return is_array( $excluded ) && in_array( 'zero_total', $excluded, true );
+	}
+
+	/**
+	 * Returns the free order subquery to be used in a WHERE clause, or an empty
+	 * string when free orders are being counted.
+	 *
+	 * The order total is used rather than the net total so that an order the
+	 * customer paid anything for - postage on a free sample, say - still counts.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return string
+	 */
+	protected function get_free_orders_subquery( $query_args ) {
+		global $wpdb;
+
+		if ( ! $this->should_exclude_free_orders( $query_args ) ) {
+			return '';
+		}
+
+		return "{$wpdb->prefix}wc_order_stats.total_sales <> 0";
+	}
+
+	/**
 	 * Maps order status provided by the user to the one used in the database.
 	 *
 	 * @param string $status Order status.
@@ -1423,9 +1487,15 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 	protected function add_order_status_clause( $query_args, $table_name, &$sql_query ) {
 		global $wpdb;
 		$order_status_filter = $this->get_status_subquery( $query_args );
-		if ( $order_status_filter ) {
+		$free_orders_filter  = $this->get_free_orders_subquery( $query_args );
+		if ( $order_status_filter || $free_orders_filter ) {
 			$sql_query->add_sql_clause( 'join', "JOIN {$wpdb->prefix}wc_order_stats ON {$table_name}.order_id = {$wpdb->prefix}wc_order_stats.order_id" );
+		}
+		if ( $order_status_filter ) {
 			$sql_query->add_sql_clause( 'where', "AND ( {$order_status_filter} )" );
+		}
+		if ( $free_orders_filter ) {
+			$sql_query->add_sql_clause( 'where', "AND ( {$free_orders_filter} )" );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericController.php
@@ -133,6 +133,12 @@ abstract class GenericController extends \WC_REST_Reports_Controller {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
+		$params['free_orders']         = array(
+			'description'       => __( 'Whether orders with a total of zero are counted in this report. Defaults to the Analytics setting.', 'woocommerce' ),
+			'type'              => 'string',
+			'enum'              => array( 'include', 'exclude' ),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 		$params['after']               = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -77,6 +77,8 @@ class Controller extends GenericController implements ExportableInterface {
 		$args['attribute_is_not']    = (array) $request['attribute_is_not'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 
@@ -468,7 +470,7 @@ class Controller extends GenericController implements ExportableInterface {
 			'products'        => __( 'Product(s)', 'woocommerce' ),
 			'num_items_sold'  => __( 'Items sold', 'woocommerce' ),
 			'coupons'         => __( 'Coupon(s)', 'woocommerce' ),
-			'net_total' 	  => __( 'Net Sales', 'woocommerce' ),
+			'net_total'       => __( 'Net Sales', 'woocommerce' ),
 			'attribution'     => __( 'Attribution', 'woocommerce' ),
 		);
 
@@ -501,7 +503,7 @@ class Controller extends GenericController implements ExportableInterface {
 			'products'        => isset( $item['extended_info']['products'] ) ? $this->get_products( $item['extended_info']['products'] ) : null,
 			'num_items_sold'  => $item['num_items_sold'],
 			'coupons'         => isset( $item['extended_info']['coupons'] ) ? $this->get_coupons( $item['extended_info']['coupons'] ) : null,
-			'net_total' 	  => $item['net_total'],
+			'net_total'       => $item['net_total'],
 			'attribution'     => $item['extended_info']['attribution']['origin'],
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -155,6 +155,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			}
 		}
 
+		$free_orders_filter = $this->get_free_orders_subquery( $query_args );
+		if ( $free_orders_filter ) {
+			$this->subquery->add_sql_clause( 'where', "AND {$free_orders_filter}" );
+		}
+
 		$included_orders = $this->get_included_orders( $query_args );
 		if ( $included_orders ) {
 			$where_subquery[] = "{$order_stats_lookup_table}.order_id IN ({$included_orders})";

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -83,6 +83,8 @@ class Controller extends GenericStatsController {
 			$args['customer_type'] = $request['customer'];
 		}
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 
@@ -376,7 +378,8 @@ class Controller extends GenericStatsController {
 				'category',
 				'variation',
 				'coupon',
-				'customer_type', // new vs returning.
+				'customer_type',
+		// new vs returning.
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -289,6 +289,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$this->interval_query->add_sql_clause( 'where', "AND ( $where_subclause )" );
 			$this->interval_query->add_sql_clause( 'join', $from_clause );
 		}
+
+		// Added as its own clause rather than joining $where_subclause, which may
+		// be OR-combined when the request filters on specific statuses. Free
+		// orders are always excluded outright, never as one of several matches.
+		$free_orders_filter = $this->get_free_orders_subquery( $query_args );
+		if ( $free_orders_filter ) {
+			$this->total_query->add_sql_clause( 'where', "AND ( {$free_orders_filter} )" );
+			$this->interval_query->add_sql_clause( 'where', "AND ( {$free_orders_filter} )" );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -102,6 +102,8 @@ class Controller extends GenericController implements ExportableInterface {
 				}
 			}
 		}
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
@@ -212,9 +212,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );
-		if ( $order_status_filter ) {
+		$free_orders_filter  = $this->get_free_orders_subquery( $query_args );
+		if ( $order_status_filter || $free_orders_filter ) {
 			$this->subquery->add_sql_clause( 'join', "JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id" );
+		}
+		if ( $order_status_filter ) {
 			$this->subquery->add_sql_clause( 'where', "AND ( {$order_status_filter} )" );
+		}
+		if ( $free_orders_filter ) {
+			$this->subquery->add_sql_clause( 'where', "AND ( {$free_orders_filter} )" );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -88,6 +88,8 @@ class Controller extends GenericStatsController {
 			}
 		}
 
+		$query_args['free_orders'] = $request['free_orders'];
+
 		return $query_args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
@@ -94,9 +94,15 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );
+		$free_orders_filter  = $this->get_free_orders_subquery( $query_args );
+		if ( $order_status_filter || $free_orders_filter ) {
+			$products_from_clause .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
+		}
 		if ( $order_status_filter ) {
-			$products_from_clause  .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
 			$products_where_clause .= " AND ( {$order_status_filter} )";
+		}
+		if ( $free_orders_filter ) {
+			$products_where_clause .= " AND ( {$free_orders_filter} )";
 		}
 
 		$this->add_time_period_sql_params( $query_args, $order_product_lookup_table );

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -55,6 +55,8 @@ class Controller extends GenericStatsController implements ExportableInterface {
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 		$args['date_type']           = $request['date_type'];
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 
@@ -245,11 +247,12 @@ class Controller extends GenericStatsController implements ExportableInterface {
 				'category',
 				'variation',
 				'coupon',
-				'customer_type', // new vs returning.
+				'customer_type',
+		// new vs returning.
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['date_type']       = array(
+		$params['date_type'] = array(
 			'description'       => __( 'Override the "woocommerce_date_type" option that is used for the database date field considered for revenue reports.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -65,6 +65,8 @@ class Controller extends GenericController implements ExportableInterface {
 		$args['taxes']               = $request['taxes'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -161,6 +161,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$order_status_filter = $this->get_status_subquery( $query_args );
 		$this->add_from_sql_params( $query_args, $order_status_filter );
 
+		$free_orders_filter = $this->get_free_orders_subquery( $query_args );
+		if ( $free_orders_filter ) {
+			$this->subquery->add_sql_clause( 'where', "AND ( {$free_orders_filter} )" );
+		}
+
 		$this->subquery->add_sql_clause( 'where', "AND itemmeta_rate_id.meta_value = {$order_tax_lookup_table}.tax_rate_id" );
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
 			$allowed_taxes = self::get_filtered_ids( $query_args, 'taxes' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -80,6 +80,8 @@ class Controller extends GenericStatsController {
 		$args['fields']              = $request['fields'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -124,6 +124,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$taxes_where_clause .= " AND ( {$order_status_filter} )";
 		}
 
+		$free_orders_filter = $this->get_free_orders_subquery( $query_args );
+		if ( $free_orders_filter ) {
+			$taxes_where_clause .= " AND ( {$free_orders_filter} )";
+		}
+
 		$this->total_query->add_sql_clause( 'where', $taxes_where_clause );
 
 		$this->add_intervals_sql_params( $query_args, $order_stats_table );

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -120,6 +120,8 @@ class Controller extends GenericController implements ExportableInterface {
 				}
 			}
 		}
+		$args['free_orders'] = $request['free_orders'];
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
@@ -193,9 +193,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );
-		if ( $order_status_filter ) {
+		$free_orders_filter  = $this->get_free_orders_subquery( $query_args );
+		if ( $order_status_filter || $free_orders_filter ) {
 			$this->subquery->add_sql_clause( 'join', "JOIN {$order_stats_lookup_table} ON {$order_product_lookup_table}.order_id = {$order_stats_lookup_table}.order_id" );
+		}
+		if ( $order_status_filter ) {
 			$this->subquery->add_sql_clause( 'where', "AND ( {$order_status_filter} )" );
+		}
+		if ( $free_orders_filter ) {
+			$this->subquery->add_sql_clause( 'where', "AND ( {$free_orders_filter} )" );
 		}
 
 		$attribute_order_items_subquery = $this->get_order_item_by_attribute_subquery( $query_args );

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -92,6 +92,8 @@ class Controller extends GenericStatsController {
 			}
 		}
 
+		$query_args['free_orders'] = $request['free_orders'];
+
 		return $query_args;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
@@ -97,9 +97,15 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );
+		$free_orders_filter  = $this->get_free_orders_subquery( $query_args );
+		if ( $order_status_filter || $free_orders_filter ) {
+			$products_from_clause .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
+		}
 		if ( $order_status_filter ) {
-			$products_from_clause  .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
 			$products_where_clause .= " AND ( {$order_status_filter} )";
+		}
+		if ( $free_orders_filter ) {
+			$products_where_clause .= " AND ( {$free_orders_filter} )";
 		}
 
 		$attribute_order_items_subquery = $this->get_order_item_by_attribute_subquery( $query_args );

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -143,6 +143,13 @@ class Settings {
 			);
 		}
 
+		// An immutable snapshot of the free order exclusion, so report configs can
+		// decide whether to render their control at module load. The mutable
+		// wcAdminSettings source is not readable synchronously by design.
+		$excluded_orders                         = \WC_Admin_Settings::get_option( 'woocommerce_analytics_excluded_orders', array() );
+		$settings['analyticsExcludesFreeOrders'] = is_array( $excluded_orders ) && in_array( 'zero_total', $excluded_orders, true );
+		$settings['analyticsFreeOrderAmount']    = html_entity_decode( wp_strip_all_tags( wc_price( 0 ) ), ENT_QUOTES, 'UTF-8' );
+
 		//phpcs:ignore
 		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array() );
 
@@ -330,6 +337,21 @@ class Settings {
 			'default'     => array( 'pending', 'cancelled', 'failed' ),
 			'type'        => 'multiselect',
 			'options'     => $all_statuses,
+		);
+		$settings[] = array(
+			'id'          => 'woocommerce_analytics_excluded_orders',
+			'option_key'  => 'woocommerce_analytics_excluded_orders',
+			'label'       => __( 'Excluded orders', 'woocommerce' ),
+			'description' => __( 'Orders that should not be included when calculating report totals.', 'woocommerce' ),
+			'default'     => array(),
+			'type'        => 'multiselect',
+			'options'     => array(
+				'zero_total' => sprintf(
+					/* translators: %s: zero formatted in the store currency, e.g. $0.00 */
+					__( 'Orders with a total of %s', 'woocommerce' ),
+					html_entity_decode( wp_strip_all_tags( wc_price( 0 ) ), ENT_QUOTES, 'UTF-8' )
+				),
+			),
 		);
 		$settings[] = array(
 			'id'          => 'woocommerce_actionable_order_statuses',


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Opening as a **draft**: the design is settled and the implementation works end to end, but there are open questions below that are worth deciding before this is reviewed properly.

Orders with a total of zero — 100% off coupons, gift redemptions, reseller code redemptions — inflate order counts and items sold, and drag average order value down. Five people have asked for a way to leave them out since January 2022.

On a test store of 194 orders where roughly half are free:

| | orders | items sold | net sales | AOV |
| --- | --- | --- | --- | --- |
| free orders included | 194 | 363 | $21,725.80 | $111.99 |
| free orders excluded | 107 | 197 | **$21,725.80** | $203.04 |


**What this adds**

- An **Excluded orders** checkbox under Analytics → Settings, unchecked by default, so nothing changes for a store that does not opt in.
- When it is on, free orders are left out of report totals store-wide. That is what covers Overview and the Home screen, neither of which has a filter bar to put a control in.
- When it is on, each order-based report also gains an **Orders** control — *Include free orders* / *Exclude free orders* — to steer a single screen for the current view. Same default-plus-override shape as `Default date range`.

**Three decisions worth calling out**

*The Coupons report includes free orders by default.* A coupon that discounts an order to nothing is the subject of that report. Excluding those orders removes the record of the coupon that created them — on the test store, a 100%-off coupon with 81 orders and $20,015 discounted disappears from the report entirely. It is a default rather than a hard exception, so it is visible in the control and can be changed. Extensible via `woocommerce_analytics_free_order_including_contexts`.

*The order total is used, not the net total.* A free product with $6.50 postage has `total_sales = 6.50` and is kept; the same product with free shipping has `total_sales = 0` and is excluded. Both have `net_total = 0`, so the net definition would have dropped an order the customer actually paid for.

*Visibility follows the setting, never the data.* The control appears once the store opts in, not when the current date range happens to contain a free order. A control that appeared and vanished as the dates moved would read as a glitch, and "has this store ever had a free order" sticks on permanently over a single old test order.

**Scope**

The rule is whole orders only. A free item inside a paid order still counts — verified with mixed orders, where the free line reports identically either way. Fixing that would need a second definition of "free" (a $0-priced product and a fully discounted $129 product are both `product_net_revenue = 0`, but they are not the same thing) and would make an order mean different things on different screens. Worth a separate issue if it turns out to matter.

Downloads and Stock deliberately have no control. Stock reports current inventory and never touches orders. Downloads is keyed on `permission_id` rather than `order_id` and would need its own join — rather than ship a dropdown there that does nothing, it is left out.

Closes #32194

### Backward compatibility

No hooks removed, renamed, or reordered. Everything here is additive except one behavior change:

- **`DataStore::add_order_status_clause()`** (protected, `Admin\API\Reports\DataStore`) now also appends a free-orders `WHERE` clause and adds the `wc_order_stats` join when either filter is active. Signature is unchanged. Third-party code that *calls* it inherits the new behavior; third-party code that *overrides* it keeps working but will not pick up free-order exclusion.
- **`GenericController::get_collection_params()`** gains an optional `free_orders` param (`include`/`exclude`). Additive; absent means "use the store setting".
- New protected methods on `DataStore`: `should_exclude_free_orders()`, `get_free_orders_subquery()`, `get_free_order_including_contexts()`.
- New filter: `woocommerce_analytics_free_order_including_contexts`.
- New option `woocommerce_analytics_excluded_orders`, defaulting to an empty array, so existing stores are unaffected until someone ticks the box.

Not tested under multisite.

### Open questions

1. **`prepare_reports_query()` is an allowlist in ~18 controllers.** Registering `free_orders` in `GenericController::get_collection_params()` was not enough — each controller rebuilds `$args` by hand, so the param had to be added in every one. Any future report parameter will hit the same wall. Out of scope here, but it is a sharp edge.

### Screenshots or screen recordings:

<!-- Screenshots to be attached: Analytics → Settings with the new checkbox; Orders report with the control; Coupons report defaulting to Include; the help popover. -->

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store with some orders, create a coupon with a 100% percentage discount.
2. Place several orders using that coupon so their totals are $0, and several ordinary paid orders. Let Analytics import them (Analytics → Settings → **Update now**, or wait for the scheduled import).
3. Go to **Analytics → Orders** and note the order count and average order value. Free orders are counted, as today.
4. Go to **Analytics → Settings**. Confirm a new **Excluded orders** row sits under **Excluded statuses**, unchecked, reading *Orders with a total of $0.00*.
5. Tick it and save. Return to **Analytics → Orders**: the order count drops, average order value rises, and **net sales is unchanged**.
6. Confirm an **Orders** control now appears on the report, set to *Exclude free orders*. Switch it to *Include free orders* and confirm the totals return to step 3's numbers.
7. Go to **Analytics → Coupons**. Confirm the control defaults to *Include free orders* and the 100%-off coupon still appears with its orders. Switch it to *Exclude free orders* and confirm the coupon drops out.
8. Click the ⓘ beside the **Orders** label. Confirm the popover opens, is reachable by keyboard, closes on <kbd>Esc</kbd>, and its link goes to Analytics → Settings.
9. Untick the setting and save. Confirm the control disappears from every report and totals return to step 3's numbers.
10. Create an order containing one paid product and one free product. Confirm it is **not** excluded — the rule is whole orders only.
11. Create an order for a free product with a shipping charge. Confirm it is **not** excluded. Repeat with free shipping and confirm it **is**.

<!-- End testing instructions -->

### Testing that has already taken place:

Manually tested against WooCommerce 11.2.0-dev / WordPress 7.1 / PHP 8.3 on a SQLite store seeded with 194 orders, ~48% of them zero-total, plus mixed paid-and-free orders and free products with and without postage.

Verified: the setting persists through the Analytics settings screen; the control renders on every report it is registered for and is absent when the setting is off; Coupons defaults to including free orders while other reports default to excluding; the `free_orders` REST parameter reaches the data store and changes results; the help popover renders, is keyboard reachable, and links correctly; no console errors on a clean page load.

Because `free_orders` is a registered collection parameter it forms part of the report cache key, so switching the control does not serve another view's cached result.

Not yet covered: automated tests, multisite, MySQL (verified on SQLite only), and stores large enough to show whether the added join and `WHERE` affect query plans. **Performance review on a large store is worth doing before this leaves draft.**

`lint:changes:branch` passes clean for PHP and JS. PHPStan on the changed files reports only four pre-existing baseline count mismatches, confirmed identical on unmodified trunk versions of the same files.

One known limitation: the client reads an immutable snapshot of the setting at page load, because report filter configs evaluate at module load and the mutable `wcAdminSettings` source is deliberately not readable synchronously. Turning the setting on therefore reveals the control after the next full page load rather than instantly.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Milestone assigned manually.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry was added manually in `plugins/woocommerce/changelog/32194-analytics-exclude-free-orders` (Significance: minor, Type: add).

### Release Communication

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)

### Use of AI Tools

This pull request was authored with Claude Code (Claude Opus 5), working from a design agreed with the author. The design decisions, the copy, and the scope calls are the author's; the implementation, the measurements quoted above, and this description were drafted by the AI and reviewed by the author. The behaviour described in "Testing that has already taken place" was exercised on a real local store rather than asserted.
