### PR TITLE
Remove IE8-era build targets and CSS hacks

### DIFF
--- a/plugins/woocommerce/changelog/dev-remove-ie8-leftovers
+++ b/plugins/woocommerce/changelog/dev-remove-ie8-leftovers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove IE8-era leftovers from the classic-assets build: the ie8 uglify flag, the IE 8/9 browserslist targets, and two dead IE-only CSS hacks. Minified output changes; no behavior change on any supported browser.

--- a/plugins/woocommerce/client/legacy/Gruntfile.js
+++ b/plugins/woocommerce/client/legacy/Gruntfile.js
@@ -30,7 +30,6 @@ module.exports = function ( grunt ) {
 		// Minify .js files.
 		uglify: {
 			options: {
-				ie8: true,
 				parse: {
 					strict: false,
 				},

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -277,7 +277,6 @@ ul.woocommerce_stats {
 			left: 0;
 			position: absolute;
 			letter-spacing: 0.1em;
-			letter-spacing: 0\9; // IE8 & below hack ;-(
 		}
 
 		span {
@@ -295,7 +294,6 @@ ul.woocommerce_stats {
 			position: absolute;
 			left: 0;
 			letter-spacing: 0.1em;
-			letter-spacing: 0\9; // IE8 & below hack ;-(
 			color: $wp-admin-text-gray;
 		}
 	}

--- a/plugins/woocommerce/client/legacy/css/reports-print.scss
+++ b/plugins/woocommerce/client/legacy/css/reports-print.scss
@@ -8,7 +8,6 @@
 	color: #000 !important;
 	text-shadow: none !important;
 	filter: none !important;
-	-ms-filter: none !important;
 	font-size: 9pt !important;
 	opacity: 1;
 	transition: none !important;

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1165,9 +1165,7 @@
 		"node": "^24.15.0"
 	},
 	"browserslist": [
-		"> 0.1%",
-		"ie 8",
-		"ie 9"
+		"> 0.1%"
 	],
 	"dependencies": {
 		"@woocommerce/admin-library": "workspace:*",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

> **Stacked PR.** This targets `fix/classic-assets-stylelint-scss` (#68072), which targets `revert/classic-assets-node-build` (#68202). Merge order is #68202 → #68072 → this one. Reopened because #68202 restores the Gruntfile this PR edits; it was closed when #68085 replaced that file with a node script.
>
> This is the only PR in the stack that changes shipped bytes. #68202 changes nothing, #68072 changes cosmetic CSS equivalents, and this one re-minifies 48 files.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WordPress dropped IE 8/9/10 support in 2017 (WP 4.8), but a few IE8-era leftovers still shape our build and styles. This PR removes them:

- The `ie8: true` uglify option in the classic-assets Gruntfile. Without it, uglify applies two safe compressions it was holding back: `undefined` → `void 0` and `"undefined" == typeof obj.prop` → `void 0 === obj.prop` (bare-global `typeof` guards are kept). 48 of 91 minified files change; the total shrinks by 1,142 bytes (re-measured on the current stack). Both patterns are semantically identical on every supported browser.
- The `"ie 8", "ie 9"` browserslist targets in `plugins/woocommerce/package.json` (ie 9 goes too; it left support in the same WP release). The three client subtrees have their own `.browserslistrc`, and nothing at the plugin root resolves this config (no babel/postcss setup there), so this is dead configuration.
- Two `letter-spacing: 0\9;` hacks in `dashboard.scss` (commented "IE8 & below hack") and the `-ms-filter: none` line in `reports-print.scss`.

Deliberately untouched: vendored files (select2, photoswipe, blockUI, zoom, dompurify) keep their internal IE-era code; the generic IE detection in `checkout.js` `handleUnloadEvent` covers IE up to 11 and changes runtime behavior, so it's out of scope here; `zoom: 1` hasLayout hacks are IE6/7-era no-ops and left for a separate sweep if wanted.


<!-- End of proposed changes -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm install --filter=@woocommerce/classic-assets...` and `pnpm --filter=@woocommerce/classic-assets build`; confirm it succeeds.
2. Spot-check a changed file, e.g. `plugins/woocommerce/assets/js/admin/backbone-modal.min.js`: against a `trunk` build, the only differences are `undefined` → `void 0` style compressions.
3. Load an admin screen that uses the rebuilt JS (e.g. edit an order) and confirm no console errors.

<!-- End testing instructions -->

### Testing that has already taken place:

- Built on `trunk` and on this branch and diffed all 256 built `.js`/`.css` files: the changed set is exactly the table above; the minified-JS diffs were inspected and contain only the two compression patterns.
- Rebuilt twice on this branch to confirm the output is deterministic.
- Searched the repo for other IE8 accommodations; the remaining mentions are in vendored third-party files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

Drafted with Claude Code; I reviewed the diff and the minified-output comparison myself.
