### PR TITLE
Fix Shop-base verbose page rule detection

### DIFF
--- a/plugins/woocommerce/changelog/fix-verbose-page-rule-detection
+++ b/plugins/woocommerce/changelog/fix-verbose-page-rule-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep Shop subpage rewrite rules in sync with the product permalink base.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -318,14 +318,6 @@ class WC_Admin_Permalink_Settings {
 			// value is the same site-locale form settings() compares against.
 			$permalinks['product_base'] = $this->get_stored_product_base( $product_base, $posted_structure );
 
-			// Shop base may require verbose page rules if nesting pages.
-			$shop_page_id   = wc_get_page_id( 'shop' );
-			$shop_permalink = $this->get_shop_base_slug( $shop_page_id );
-
-			if ( $shop_page_id && stristr( trim( $permalinks['product_base'], '/' ), $shop_permalink ) ) {
-				$permalinks['use_verbose_page_rules'] = true;
-			}
-
 			update_option( 'woocommerce_permalinks', $permalinks );
 			wc_restore_locale();
 		}

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2151,6 +2151,10 @@ function wc_list_pluck( $list, $callback_or_field, $index_key = null ) {
  *
  * This is more inline with WP core behavior which does not localize slugs.
  *
+ * The `use_verbose_page_rules` key is kept for backward compatibility only. WooCommerce no longer
+ * writes or reads it - wc_fix_rewrite_rules() derives Shop subpage rules from the current product
+ * base and Shop page path instead - so its stored value is whatever the last save left behind.
+ *
  * @since  3.0.0
  * @return array
  */
@@ -2163,8 +2167,6 @@ function wc_get_permalink_structure() {
 			'category_base'          => _x( 'product-category', 'slug', 'woocommerce' ),
 			'tag_base'               => _x( 'product-tag', 'slug', 'woocommerce' ),
 			'attribute_base'         => '',
-			// Kept so the returned array shape stays stable for extensions. Nothing reads it:
-			// wc_fix_rewrite_rules() derives Shop subpage rules from the current paths instead.
 			'use_verbose_page_rules' => false,
 		)
 	);

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2163,6 +2163,8 @@ function wc_get_permalink_structure() {
 			'category_base'          => _x( 'product-category', 'slug', 'woocommerce' ),
 			'tag_base'               => _x( 'product-tag', 'slug', 'woocommerce' ),
 			'attribute_base'         => '',
+			// Kept so the returned array shape stays stable for extensions. Nothing reads it:
+			// wc_fix_rewrite_rules() derives Shop subpage rules from the current paths instead.
 			'use_verbose_page_rules' => false,
 		)
 	);

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1054,12 +1054,26 @@ function wc_fix_rewrite_rules( $rules ) {
 		}
 	}
 
-	// If the shop page is used as the base, we need to handle shop page subpages to avoid 404s.
-	if ( ! $permalinks['use_verbose_page_rules'] ) {
+	$shop_page_id      = wc_get_page_id( 'shop' );
+	$product_base      = trim( rawurldecode( $permalinks['product_base'] ), '/' );
+	$uses_shop_as_base = false;
+
+	// The product base is site-wide, while multilingual extensions can filter the Shop page for the current request.
+	$shop_page_ids = array_unique( array( absint( get_option( 'woocommerce_shop_page_id' ) ), $shop_page_id ) );
+	foreach ( $shop_page_ids as $candidate_shop_page_id ) {
+		$shop_page = $candidate_shop_page_id > 0 ? get_post( $candidate_shop_page_id ) : null;
+		$shop_base = $shop_page instanceof WP_Post && 'page' === $shop_page->post_type ? trim( rawurldecode( (string) get_page_uri( $candidate_shop_page_id ) ), '/' ) : '';
+
+		if ( '' !== $shop_base && ( $shop_base === $product_base || 0 === strpos( $product_base, $shop_base . '/' ) ) ) {
+			$uses_shop_as_base = true;
+			break;
+		}
+	}
+
+	if ( ! $uses_shop_as_base ) {
 		return $rules;
 	}
 
-	$shop_page_id = wc_get_page_id( 'shop' );
 	if ( $shop_page_id ) {
 		$page_rewrite_rules = array();
 		$subpages           = wc_get_page_children( $shop_page_id );

--- a/plugins/woocommerce/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/playwright.config.ts
@@ -179,8 +179,8 @@ const serialRunSpecs = [
 	// Mutate global WooCommerce settings (store address/currency/country, tax)
 	// that other workers' cart/checkout/storefront specs depend on.
 	'**/tests/settings/settings-general.spec.ts',
-	// Mutates the global woocommerce_permalinks option (product base and the
-	// derived use_verbose_page_rules flag) and restores it in teardown.
+	// Mutates the global woocommerce_permalinks option (the product base) and
+	// restores it in teardown.
 	'**/tests/settings/product-permalinks.spec.ts',
 	'**/tests/settings/settings-tax.spec.ts',
 	// Toggles the global `settings-ui` feature flag and resets all e2e feature flags

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -31,9 +31,9 @@ test.describe( 'Product permalink settings', () => {
 		// (the onboarding wizard installs the default set), and booting them under WP-CLI can
 		// exhaust the CLI container's memory limit before the command runs.
 		const optionCliFlags = '--skip-plugins --skip-themes';
-		// Snapshot the whole option rather than the visible form state: the journey's Shop base
-		// saves also flip the derived `use_verbose_page_rules` flag, which no form field exposes,
-		// so a UI-driven restore could never put it back.
+		// Snapshot the whole option rather than the visible form state: the saved product base is
+		// normalized on the way in, so replaying the form values would not always restore the
+		// bytes the option started with.
 		const readPermalinks = async () =>
 			(
 				await wpCLI(

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -342,7 +342,7 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	 * is normalized to the bare form in the first place.
 	 *
 	 * Nothing downstream depends on which label renders — the stored base is byte-identical, so
-	 * the product URLs and the derived `use_verbose_page_rules` flag are too.
+	 * the product URLs are too.
 	 *
 	 * @testdox Should report "Default" when the Shop slug makes both choices store the same base.
 	 */

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -74,6 +74,42 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Shop subpage rules should match a non-Latin Shop path in either encoded or decoded form.
+	 *
+	 * @testWith ["encoded"]
+	 *           ["decoded"]
+	 *
+	 * @param string $product_base_form Form the product base is stored in.
+	 */
+	public function test_wc_fix_rewrite_rules_matches_a_non_latin_shop_path( string $product_base_form ): void {
+		// WordPress stores a non-Latin page slug percent-encoded, while the product base is stored
+		// as the merchant typed it, so the two only line up once both have been decoded.
+		$shop_page_id = $this->create_shop_page_tree( 0, 'магазин' );
+		$shop_uri     = (string) get_page_uri( $shop_page_id );
+		$this->assertStringContainsString( '%d0%', $shop_uri, 'WordPress should store the non-Latin Shop slug percent-encoded.' );
+
+		$product_base = 'encoded' === $product_base_form ? $shop_uri : rawurldecode( $shop_uri );
+		update_option(
+			'woocommerce_permalinks',
+			array(
+				'product_base'           => '/' . $product_base . '/%product_cat%',
+				'use_verbose_page_rules' => false,
+			)
+		);
+
+		$rules = wc_fix_rewrite_rules( array( 'fallback/?$' => 'index.php?fallback=1' ) );
+
+		// Only the presence of the rule is asserted. WP_Rewrite::generate_rewrite_rules() reads the
+		// `%d0%` byte pairs of a percent-encoded slug as rewrite tags, so the target it builds for
+		// one is malformed. That predates deriving the match from the current paths.
+		$this->assertArrayHasKey(
+			$shop_uri . '/sale/?$',
+			$rules,
+			'A non-Latin Shop path should still add the Shop child rule.'
+		);
+	}
+
+	/**
 	 * @testdox Shop subpage rules should follow a changed Shop page path.
 	 */
 	public function test_wc_fix_rewrite_rules_follows_shop_page_reparenting(): void {

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -11,6 +11,134 @@
 class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 
 	/**
+	 * Create a Shop page with one child.
+	 *
+	 * @param int    $parent_id Shop page parent ID.
+	 * @param string $shop_slug Shop page slug.
+	 * @return int Shop page ID.
+	 */
+	private function create_shop_page_tree( int $parent_id = 0, string $shop_slug = 'shop' ): int {
+		$shop_page_id = self::factory()->post->create(
+			array(
+				'post_parent' => $parent_id,
+				'post_type'   => 'page',
+				'post_name'   => $shop_slug,
+				'post_status' => 'publish',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_parent' => $shop_page_id,
+				'post_type'   => 'page',
+				'post_name'   => 'sale',
+				'post_status' => 'publish',
+			)
+		);
+
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+
+		return $shop_page_id;
+	}
+
+	/**
+	 * @testdox Shop subpage rules should follow the current paths instead of the stored derived flag.
+	 *
+	 * @testWith ["/shop", true]
+	 *           ["/shop/%product_cat%", true]
+	 *           ["/webshop", false]
+	 *           ["/shopper", false]
+	 *           ["/catalog/shop", false]
+	 *
+	 * @param string $product_base Product permalink base.
+	 * @param bool   $expected     Whether the Shop child rule should be added.
+	 */
+	public function test_wc_fix_rewrite_rules_derives_shop_subpage_rules_from_paths( string $product_base, bool $expected ): void {
+		$this->create_shop_page_tree();
+		update_option(
+			'woocommerce_permalinks',
+			array(
+				'product_base'           => $product_base,
+				'use_verbose_page_rules' => ! $expected,
+			)
+		);
+
+		$original_rules = array( 'fallback/?$' => 'index.php?fallback=1' );
+		$rules          = wc_fix_rewrite_rules( $original_rules );
+
+		if ( $expected ) {
+			$this->assertSame( 'shop/sale/?$', array_key_first( $rules ), 'The Shop child rule should take priority over product rules.' );
+			$this->assertSame( 'index.php?pagename=shop/sale', $rules['shop/sale/?$'] );
+		} else {
+			$this->assertSame( $original_rules, $rules, 'Unrelated product paths should not add Shop child rules.' );
+		}
+	}
+
+	/**
+	 * @testdox Shop subpage rules should follow a changed Shop page path.
+	 */
+	public function test_wc_fix_rewrite_rules_follows_shop_page_reparenting(): void {
+		$catalog_page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_name'   => 'catalog',
+				'post_status' => 'publish',
+			)
+		);
+		$shop_page_id    = $this->create_shop_page_tree();
+		update_option(
+			'woocommerce_permalinks',
+			array(
+				'product_base'           => '/catalog/shop',
+				'use_verbose_page_rules' => false,
+			)
+		);
+
+		$original_rules = array( 'fallback/?$' => 'index.php?fallback=1' );
+		$this->assertSame( $original_rules, wc_fix_rewrite_rules( $original_rules ) );
+
+		wp_update_post(
+			array(
+				'ID'          => $shop_page_id,
+				'post_parent' => $catalog_page_id,
+			)
+		);
+
+		$rules = wc_fix_rewrite_rules( $original_rules );
+
+		$this->assertSame( 'catalog/shop/sale/?$', array_key_first( $rules ), 'The new Shop child path should take priority over product rules.' );
+		$this->assertSame( 'index.php?pagename=catalog/shop/sale', $rules['catalog/shop/sale/?$'] );
+	}
+
+	/**
+	 * @testdox Shop subpage rules should keep using a filtered Shop page after matching the configured Shop path.
+	 */
+	public function test_wc_fix_rewrite_rules_preserves_filtered_shop_page_rules(): void {
+		$configured_shop_page_id = $this->create_shop_page_tree();
+		$filtered_shop_page_id   = $this->create_shop_page_tree( 0, 'boutique' );
+		update_option( 'woocommerce_shop_page_id', $configured_shop_page_id );
+		update_option(
+			'woocommerce_permalinks',
+			array(
+				'product_base'           => '/shop/%product_cat%',
+				'use_verbose_page_rules' => true,
+			)
+		);
+
+		$filter_shop_page_id = static function () use ( $filtered_shop_page_id ) {
+			return $filtered_shop_page_id;
+		};
+		add_filter( 'woocommerce_get_shop_page_id', $filter_shop_page_id );
+
+		try {
+			$rules = wc_fix_rewrite_rules( array() );
+		} finally {
+			remove_filter( 'woocommerce_get_shop_page_id', $filter_shop_page_id );
+		}
+
+		$this->assertSame( 'index.php?pagename=boutique/sale', $rules['boutique/sale/?$'] );
+	}
+
+	/**
 	 * Test wc_ascii_uasort_comparison() function.
 	 */
 	public function test_wc_ascii_uasort_comparison() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Shop descendant rules were controlled by the stored `use_verbose_page_rules` flag. That flag can become stale when either permalink settings or the Shop page path changes, and its substring-based writer also matches unrelated bases such as `/webshop`.

WooCommerce now decides whether the rules are needed when rewrite rules are generated. It compares decoded Shop and product paths on complete segment boundaries and preserves filtered Shop-page handling used by multilingual integrations. The legacy option remains stored for compatibility but no longer controls core routing. Normal WooCommerce updates already regenerate rewrite rules, so no versioned migration is needed.

No public PHP signature or hook changes. Third-party code that directly writes the legacy option can no longer use it to force or suppress WooCommerce's Shop descendant rules. WooCommerce also no longer writes the key, so its stored value freezes at whatever the last permalink save left. `wc_get_permalink_structure()` still returns it and the array shape is unchanged, but third-party code reading it now gets a stale value rather than a live one. Nothing in core consumes it. The configuration remains site-scoped; multisite was not tested separately. Descendant discovery is unchanged, so #67668 remains separate.

Closes #68029.

Closes WOOPLUG-7602

Bug introduced in PR #18905.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a Shop child page at `/shop/sale/`, set the product base to `/shop/%product_cat%/`, save permalinks, and confirm the child page and product URLs resolve.
2. Change the product base to `/webshop/` or `/shopper/`, save permalinks, and confirm both the Shop child page and product URLs still resolve.
3. Set the product base to `/catalog/shop/`, move the Shop page beneath a `catalog` page, and confirm `/catalog/shop/sale/` resolves after the queued rewrite flush runs.
4. Seed `use_verbose_page_rules` with the opposite value, flush rewrite rules, and confirm routing follows the current paths rather than the stale value.

<!-- End testing instructions -->

### Testing that has already taken place:

The complete core-functions test class passes with 32 tests and 65 assertions. Regression coverage includes stale values in both directions, path boundaries, Shop reparenting, and filtered Shop pages. Front-end smoke tests confirmed both `/shop/sale/` and `/webshop/smoke-product/` return 200 with a stale true value. PHP linting, branch coding standards, static analysis, and two independent pre-merge reviews pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Use of AI Tools

Codex authored the implementation, tests, and pull request update under maintainer direction. Codex subagents performed independent pre-merge reviews; their valid finding was addressed and verified.
