### PR TITLE
Dispatch thrown plugin errors as error notices in createNoticesFromResponse

### DIFF
--- a/plugins/woocommerce/changelog/fix-68092-error-notices-from-plugin-error
+++ b/plugins/woocommerce/changelog/fix-68092-error-notices-from-plugin-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Dispatch plugin install/activate failures as error notices instead of success notices when the rejected PluginError is passed to createNoticesFromResponse().

--- a/plugins/woocommerce/client/admin/client/lib/notices/index.js
+++ b/plugins/woocommerce/client/admin/client/lib/notices/index.js
@@ -67,6 +67,12 @@ export function createNoticesFromResponse( response ) {
 		Object.keys( response.errors ).forEach( ( errorKey ) => {
 			createNotice( 'error', response.errors[ errorKey ].join( ' ' ) );
 		} );
+	} else if ( response instanceof Error ) {
+		// A thrown Error (e.g. the PluginError rejected by @woocommerce/data's
+		// plugin actions) is always a failure, even though it carries no code.
+		if ( response.message ) {
+			createNotice( 'error', response.message );
+		}
 	} else if ( response.message ) {
 		// Handle generic messages.
 		createNotice( response.code ? 'error' : 'success', response.message );

--- a/plugins/woocommerce/client/admin/client/lib/notices/test/index.js
+++ b/plugins/woocommerce/client/admin/client/lib/notices/test/index.js
@@ -81,6 +81,35 @@ describe( 'createNoticesFromResponse', () => {
 		expect( call2 ).toEqual( [ 'error', response.errors.item2[ 0 ] ] );
 	} );
 
+	test( 'should create an error notice when the response is a thrown Error', () => {
+		// Mirrors the PluginError thrown by @woocommerce/data's plugin actions: an
+		// Error subclass carrying a message and data, but no code.
+		class PluginError extends Error {
+			constructor( message, data ) {
+				super( message );
+				this.data = data;
+			}
+		}
+		const response = new PluginError( 'Could not install foo. Reason.', {
+			foo: [ 'Reason.' ],
+		} );
+
+		createNoticesFromResponse( response );
+		expect( createNotice ).toHaveBeenCalledWith(
+			'error',
+			response.message
+		);
+		expect( createNotice ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should not create an empty error notice when an Error has no message', () => {
+		// Pins the message guard inside the Error branch: an Error inherits an
+		// empty `message` from the prototype, so without the guard this would
+		// dispatch a notice with no text.
+		createNoticesFromResponse( new Error() );
+		expect( createNotice ).not.toHaveBeenCalled();
+	} );
+
 	test( 'should not call createNotice when no message or errors exist', () => {
 		const response = { data: {} };
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #68092.

`createNoticesFromResponse()` (`client/admin/client/lib/notices/index.js`) is written for REST response shapes: it loops over `errors`, and otherwise decides the notice status from the presence of `code`. The plugin actions in `@woocommerce/data` (`installPlugins`, `activatePlugins`, `installAndActivatePlugins`) reject with a `PluginError`, an `Error` subclass that carries a `message` and per-plugin `data` but no `code`. Around seventeen `client/admin` callers (listed in the issue) hand that rejection straight to the helper, which fell into the generic branch and dispatched the failure to `core/notices` with status **`success`**. The text was right, the status wrong.

**What this does and does not change:** no surface renders that difference today. wc-admin's only consumer of `core/notices` is `TransientNotices` → `SnackbarList` → `Snackbar` (`client/layout/transient-notices/`), and that `Snackbar` never reads `status` — it drops the prop and hard-codes `politeness = 'polite'`, exactly as upstream's `@wordpress/components` `Snackbar` does. So this corrects the data written to a shared store rather than anything a merchant currently sees. It stays worth fixing because `createNoticesFromResponse()` is the shared helper all of those callers trust to classify a response, and the moment any surface reads `status`, every plugin install failure reads as a success.

This PR adds an `instanceof Error` branch ahead of the generic one that always dispatches `error` (and nothing when the message is empty). It sits after the existing `TypeError`/offline check, so that copy is unchanged, and no REST response object is an `Error`, so every existing branch keeps its behaviour. Fixing the helper covers every current caller, and future ones, without touching them. #68087 fixed the Settings → Payments caller by dispatching `error` directly; this is the general fix the issue asked for.

**Backward compatibility:** no signature, hook, REST, or success-path change. The only behavioural change is the status of notices created from a thrown `Error`, which was `success` and is now `error`. Besides `PluginError`, that also covers the `Error` `apiFetch` rejects with on network or invalid-JSON failures (`hooks/use-endpoint-dismiss.ts`), which were likewise mislabelled. The helper is bundled into the admin app and not exported from any published package, so there is no external consumer.

### How to test the changes in this Pull Request:

1. Force every plugin install to fail by adding an mu-plugin, e.g. `wp-content/mu-plugins/force-install-failure.php`:
   ```php
   <?php
   add_filter( 'upgrader_pre_install', fn() => new WP_Error( 'forced', 'Forced failure for testing' ) );
   ```
2. Go to WooCommerce → Marketing, scroll to "Discover more marketing tools", and click "Install extension" on any plugin.
3. In the browser console run `wp.data.select( 'core/notices' ).getNotices()`.
- [ ] Verify the failure notice ("Could not install … plugin, …") has `status: "error"`. On trunk it has `status: "success"`.
4. Optionally repeat from another affected surface (WooCommerce → Home task list → "Set up payments" or "Set up tax"; Settings → Shipping recommendations) and verify the same.
5. Remove the mu-plugin.

### Testing that has already taken place:

- Unit: `pnpm test:js -- client/lib/notices` in `plugins/woocommerce/client/admin` — 8/8, including two new tests (an `Error` subclass shaped like `PluginError` is dispatched as `error`; an `Error` with no message creates no notice at all). The first failed before the fix and passes after it. Both are mutation-tested: deleting the `instanceof Error` branch fails only the first, and dropping the inner `response.message` guard fails only the second, so each test pins exactly one thing.
- Manual, wp-env (WordPress 7.1, PHP 8.1, WooCommerce trunk): with the forced-failure mu-plugin above, Marketing → Discover tools → "Install extension" (Google for WooCommerce) produced a `core/notices` entry with `status: "error"`; a store subscriber confirmed no `success` notice was created.
- ESLint and oxlint clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually: `plugins/woocommerce/changelog/fix-68092-error-notices-from-plugin-error`.

### Release Communication

<!-- release-communication-section -->
- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

### Use of AI Tools

Implemented with Claude Code (analysis, fix, tests, and manual verification), reviewed by the author.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

