### PR TITLE
Fix and extend the changelog, milestone, and hook docs guidance in the agent skills

### DIFF
--- a/.ai/skills/woocommerce-backend-dev/code-entities.md
+++ b/.ai/skills/woocommerce-backend-dev/code-entities.md
@@ -92,14 +92,9 @@ Add concise docblocks to all hooks and methods. One line is ideal. The descripti
 
 ### Public, Protected Methods, and Hooks
 
-Must include a `@since` annotation with the next WooCommerce version number.
+Must include a `@since` annotation with the next WooCommerce version number: the version from `includes/class-woocommerce.php` on trunk, with the `-dev` suffix removed (e.g., if trunk shows `10.4.0-dev`, use `@since 10.4.0`).
 
-Place it where [WordPress's inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) put it:
-
-- Directly after the description, separated by a blank comment line
-- Before `@param` and `@return`, separated from them by a blank comment line
-- Use the version from `includes/class-woocommerce.php` on trunk, removing the `-dev` suffix
-  (e.g., if trunk shows `10.4.0-dev`, use `@since 10.4.0`)
+Place it where [WordPress's inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) put it: directly after the description and before any `@param` and `@return` tags, with a blank comment line on either side.
 
 Some older docblocks put `@since` last instead. Leave those alone; reordering them on its own is just diff noise.
 

--- a/.ai/skills/woocommerce-backend-dev/code-entities.md
+++ b/.ai/skills/woocommerce-backend-dev/code-entities.md
@@ -94,12 +94,14 @@ Add concise docblocks to all hooks and methods. One line is ideal. The descripti
 
 Must include a `@since` annotation with the next WooCommerce version number.
 
-The `@since` annotation must be:
+Place it where [WordPress's inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) put it:
 
-- The last line in the docblock
-- Preceded by a blank comment line
+- Directly after the description, separated by a blank comment line
+- Before `@param` and `@return`, separated from them by a blank comment line
 - Use the version from `includes/class-woocommerce.php` on trunk, removing the `-dev` suffix
   (e.g., if trunk shows `10.4.0-dev`, use `@since 10.4.0`)
+
+Some older docblocks put `@since` last instead. Leave those alone; reordering them on its own is just diff noise.
 
 **Good - Concise:**
 
@@ -107,19 +109,19 @@ The `@since` annotation must be:
 /**
  * Process the order and update status.
  *
+ * @since 9.5.0
+ *
  * @param int $order_id The order ID.
  * @return bool True if successful.
- *
- * @since 9.5.0
  */
 public function process_order( int $order_id ) { }
 
 /**
  * Fires after an order is processed.
  *
- * @param int $order_id The order ID.
- *
  * @since 9.5.0
+ *
+ * @param int $order_id The order ID.
  */
 do_action( 'woocommerce_order_processed', $order_id );
 ```
@@ -132,10 +134,10 @@ do_action( 'woocommerce_order_processed', $order_id );
  * checking inventory levels, processing payment, and then updating
  * the order status to reflect the successful processing.
  *
+ * @since 9.5.0
+ *
  * @param int $order_id The unique identifier for the order that needs to be processed.
  * @return bool Returns true if the order was processed successfully, false otherwise.
- *
- * @since 9.5.0
  */
 ```
 

--- a/.ai/skills/woocommerce-backend-dev/hooks.md
+++ b/.ai/skills/woocommerce-backend-dev/hooks.md
@@ -30,11 +30,12 @@ public function handle_woocommerce_before_checkout( $checkout ) {
 
 ## Hook Docblocks
 
-If you modify a line that fires a hook without a docblock:
+All hooks must have a docblock with a description of when the hook fires, a `@since` annotation, and `@param` tags for each parameter. Formatting and `@since` placement follow the same rules as method docblocks — see `code-entities.md` in this skill.
 
-1. Add docblock with description and `@param` tags
-2. Use `git log -S "hook_name"` to find when it was introduced
-3. Add `@since` annotation with that version
+For the `@since` version:
+
+- New hooks: use the version from `includes/class-woocommerce.php` on trunk, removing the `-dev` suffix
+- Existing hooks missing a docblock: use `git log -S "hook_name"` to find the version that introduced the hook
 
 ```php
 /**
@@ -46,44 +47,6 @@ If you modify a line that fires a hook without a docblock:
  * @param array $order_data The order data.
  */
 do_action( 'woocommerce_order_processed', $order_id, $order_data );
-```
-
-## Hook Documentation Requirements
-
-All hooks must have docblocks that include, in this order:
-
-- Description of when the hook fires
-- `@since` annotation with the version number, right after the description and before the `@param` tags, with a blank comment line on either side, as in [WordPress's inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#4-hooks-actions-and-filters)
-    - For new hooks: Use the version from `includes/class-woocommerce.php` on trunk, removing `-dev` suffix
-    - For existing hooks: Use `git log -S "hook_name"` to find when it was introduced
-- `@param` tags for each parameter passed to the hook
-
-**Action hook example:**
-
-```php
-/**
- * Fires after a product is saved.
- *
- * @since 9.5.0
- *
- * @param int        $product_id The product ID.
- * @param WC_Product $product    The product object.
- */
-do_action( 'woocommerce_product_saved', $product_id, $product );
-```
-
-**Filter hook example:**
-
-```php
-/**
- * Filters the product price before display.
- *
- * @since 9.5.0
- *
- * @param string     $price   The formatted price.
- * @param WC_Product $product The product object.
- */
-$price = apply_filters( 'woocommerce_product_price', $price, $product );
 ```
 
 ## Regenerating the Published Hook Docs

--- a/.ai/skills/woocommerce-backend-dev/hooks.md
+++ b/.ai/skills/woocommerce-backend-dev/hooks.md
@@ -104,7 +104,8 @@ Nothing in CI checks these files, so a skipped run leaves the published referenc
 Points to keep in mind:
 
 - Never hand-edit `actions.md` or `filters.md`. Fix the source docblock and regenerate.
-- Only `src/Blocks` and `src/StoreApi` are scanned. Everything else in `plugins/woocommerce/src` is excluded by `extra.wp-hooks.ignore-files` in `plugins/woocommerce/client/blocks/composer.json`, so a hook elsewhere needs no regeneration.
+- Only hooks in `src/Blocks` and `src/StoreApi` reach the docs, so a hook elsewhere needs no regeneration. The generator scans all of `plugins/woocommerce/src` and subtracts the `extra.wp-hooks.ignore-files` list in `plugins/woocommerce/client/blocks/composer.json`.
+- That list names what to skip, not what to include. Add a new directory under `plugins/woocommerce/src` to it, or its hooks start showing up in the published reference.
 - The command also refreshes `docs/block-development/reference/block-references.md`, which is the one generated file CI does validate.
 - Docblock text lands in the docs as Markdown. Wrap literal angle-bracket placeholders in backticks (`` `<hook-name>` ``) so markdownlint doesn't read them as inline HTML.
 - A hook with no docblock at the call site is skipped by the generator, and `internal_`-prefixed hooks are filtered out on purpose.

--- a/.ai/skills/woocommerce-backend-dev/hooks.md
+++ b/.ai/skills/woocommerce-backend-dev/hooks.md
@@ -85,3 +85,28 @@ do_action( 'woocommerce_product_saved', $product_id, $product );
  */
 $price = apply_filters( 'woocommerce_product_price', $price, $product );
 ```
+
+## Regenerating the Published Hook Docs
+
+Hooks in `plugins/woocommerce/src/Blocks` and `plugins/woocommerce/src/StoreApi` are published as a developer reference generated from their docblocks:
+
+- `plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md`
+- `plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md`
+
+After adding, removing, or editing a hook or its docblock in either directory, regenerate them and commit the result alongside the code change:
+
+```bash
+pnpm --filter=@woocommerce/block-library build:docs
+```
+
+Nothing in CI checks these files, so a skipped run leaves the published reference silently stale.
+
+Points to keep in mind:
+
+- Never hand-edit `actions.md` or `filters.md`. Fix the source docblock and regenerate.
+- Only `src/Blocks` and `src/StoreApi` are scanned. Everything else in `plugins/woocommerce/src` is excluded by `extra.wp-hooks.ignore-files` in `plugins/woocommerce/client/blocks/composer.json`, so a hook elsewhere needs no regeneration.
+- The command also refreshes `docs/block-development/reference/block-references.md`, which is the one generated file CI does validate.
+- Docblock text lands in the docs as Markdown. Wrap literal angle-bracket placeholders in backticks (`` `<hook-name>` ``) so markdownlint doesn't read them as inline HTML.
+- A hook with no docblock at the call site is skipped by the generator, and `internal_`-prefixed hooks are filtered out on purpose.
+
+See `plugins/woocommerce/client/blocks/bin/hook-docs/README.md` for how the pipeline works and how to change its scope.

--- a/.ai/skills/woocommerce-backend-dev/hooks.md
+++ b/.ai/skills/woocommerce-backend-dev/hooks.md
@@ -40,23 +40,23 @@ If you modify a line that fires a hook without a docblock:
 /**
  * Fires after an order has been processed.
  *
+ * @since 8.2.0
+ *
  * @param int $order_id The processed order ID.
  * @param array $order_data The order data.
- *
- * @since 8.2.0
  */
 do_action( 'woocommerce_order_processed', $order_id, $order_data );
 ```
 
 ## Hook Documentation Requirements
 
-All hooks must have docblocks that include:
+All hooks must have docblocks that include, in this order:
 
 - Description of when the hook fires
-- `@param` tags for each parameter passed to the hook
-- `@since` annotation with the version number (last line, with blank line before)
+- `@since` annotation with the version number, right after the description and before the `@param` tags, with a blank comment line on either side, as in [WordPress's inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#4-hooks-actions-and-filters)
     - For new hooks: Use the version from `includes/class-woocommerce.php` on trunk, removing `-dev` suffix
     - For existing hooks: Use `git log -S "hook_name"` to find when it was introduced
+- `@param` tags for each parameter passed to the hook
 
 **Action hook example:**
 
@@ -64,10 +64,10 @@ All hooks must have docblocks that include:
 /**
  * Fires after a product is saved.
  *
+ * @since 9.5.0
+ *
  * @param int        $product_id The product ID.
  * @param WC_Product $product    The product object.
- *
- * @since 9.5.0
  */
 do_action( 'woocommerce_product_saved', $product_id, $product );
 ```
@@ -78,10 +78,10 @@ do_action( 'woocommerce_product_saved', $product_id, $product );
 /**
  * Filters the product price before display.
  *
+ * @since 9.5.0
+ *
  * @param string     $price   The formatted price.
  * @param WC_Product $product The product object.
- *
- * @since 9.5.0
  */
 $price = apply_filters( 'woocommerce_product_price', $price, $product );
 ```

--- a/.ai/skills/woocommerce-backend-dev/hooks.md
+++ b/.ai/skills/woocommerce-backend-dev/hooks.md
@@ -104,8 +104,8 @@ Nothing in CI checks these files, so a skipped run leaves the published referenc
 Points to keep in mind:
 
 - Never hand-edit `actions.md` or `filters.md`. Fix the source docblock and regenerate.
-- Only hooks in `src/Blocks` and `src/StoreApi` reach the docs, so a hook elsewhere needs no regeneration. The generator scans all of `plugins/woocommerce/src` and subtracts the `extra.wp-hooks.ignore-files` list in `plugins/woocommerce/client/blocks/composer.json`.
-- That list names what to skip, not what to include. Add a new directory under `plugins/woocommerce/src` to it, or its hooks start showing up in the published reference.
+- Only hooks in `src/Blocks` and `src/StoreApi` reach the docs, so a hook elsewhere needs no regeneration.
+- Keeping it that way takes maintenance. The generator scans all of `plugins/woocommerce/src` except the directories listed under `extra.wp-hooks.ignore-files` in `plugins/woocommerce/client/blocks/composer.json`. When you add a new top-level directory to `src/`, add it to that list as well — otherwise the next `build:docs` run stops with an error the first time it finds a documented hook there.
 - The command also refreshes `docs/block-development/reference/block-references.md`, which is the one generated file CI does validate.
 - Docblock text lands in the docs as Markdown. Wrap literal angle-bracket placeholders in backticks (`` `<hook-name>` ``) so markdownlint doesn't read them as inline HTML.
 - A hook with no docblock at the call site is skipped by the generator, and `internal_`-prefixed hooks are filtered out on purpose.

--- a/.ai/skills/woocommerce-git-commit/SKILL.md
+++ b/.ai/skills/woocommerce-git-commit/SKILL.md
@@ -81,7 +81,13 @@ After all commits, show `git log --oneline -n <number of new commits>` to confir
 
 ## Changelog Entry Files
 
-`pnpm --filter=<project> changelog add` creates a file under `<package>/changelog/`. Fill it in as follows:
+Create one entry per affected package under `<package>/changelog/`. The interactive `pnpm --filter=<project> changelog add` prompts for its answers, so either run it non-interactively with its flags (`-s` significance, `-t` type, `-e` entry, `-c` comment, `-f` filename):
+
+```sh
+pnpm --filter=<project> changelog add --no-interaction -s patch -t fix -e "One user-facing sentence."
+```
+
+or write the file directly, in this format:
 
 - `Significance:` — `patch`, `minor`, or `major`.
 - `Type:` — one of the types declared in the package's `composer.json` under `extra.changelogger.types`. For WooCommerce Core: `fix`, `add`, `update`, `dev`, `tweak`, `performance`, `enhancement`.

--- a/.ai/skills/woocommerce-git-commit/SKILL.md
+++ b/.ai/skills/woocommerce-git-commit/SKILL.md
@@ -79,6 +79,36 @@ Always stage specific files — never `git add -A` or `git add .`.
 
 After all commits, show `git log --oneline -n <number of new commits>` to confirm.
 
+## Changelog Entry Files
+
+`pnpm --filter=<project> changelog add` creates a file under `<package>/changelog/`. Fill it in as follows:
+
+- `Significance:` — `patch`, `minor`, or `major`.
+- `Type:` — one of the types declared in the package's `composer.json` under `extra.changelogger.types`. For WooCommerce Core: `fix`, `add`, `update`, `dev`, `tweak`, `performance`, `enhancement`.
+- **Body** — one user-facing sentence, after a blank line, describing what changed for merchants. This ships in the release changelog, so keep it short and leave out issue numbers, PR links, and implementation detail.
+- `Comment:` — **only** for entries that ship no body, to explain why there is no user-facing line. Almost always paired with `Type: dev`. Never use it alongside a body, and never as a place to record an issue reference.
+
+An entry with a user-facing change:
+
+```text
+Significance: patch
+Type: fix
+
+Restore the "Browse store" link on the empty cart page.
+```
+
+An entry with nothing to tell merchants:
+
+```text
+Significance: patch
+Type: dev
+Comment: Remove real sleep() calls from PHP unit tests; no production change.
+```
+
+Do not confuse `Comment:` with the pull request template's "Comment required below" field. That one belongs to the PR form and is unrelated to the changelog file.
+
+Changes that touch no package (for example `.ai/skills/` or `AGENTS.md`) need no entry at all.
+
 ## Constraints
 
 - No Co-Authored-By lines or self-attribution

--- a/.ai/skills/woocommerce-git-draft-pr/SKILL.md
+++ b/.ai/skills/woocommerce-git-draft-pr/SKILL.md
@@ -80,5 +80,5 @@ Output the PR URL. If UI changes need screenshots, remind the user.
 
 - No Co-Authored-By lines or self-attribution
 - Never commit code — pushing is fine
-- Preserve the PR template section headings and HTML comments exactly
+- Preserve the PR template section headings and HTML comments exactly; the Milestone section is required in every PR body, ticked or not — its `<!-- milestone-target-selection -->` markers drive PR automation
 - Changelog checkboxes must match CI automation format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,7 @@ Database migrations live in `WC_Install::$db_updates`; read that class for the c
 
 ## Comments and Docblocks
 
-Docblocks are expected on methods, classes, and hooks (see the `woocommerce-backend-dev` skill for exact requirements). Inline comments are the exception, not the default: add one only when the code can't explain itself, for example a non-obvious "why", a hidden constraint, or a workaround for a specific bug. Either way, don't add a comment that just restates what the identifier names already say.
+Docblocks are expected on methods, classes, and hooks (see the `woocommerce-backend-dev` skill for exact requirements). Hook docblocks in `src/Blocks` and `src/StoreApi` are published as developer documentation and have to be regenerated after a change — the `woocommerce-backend-dev` skill has the command. Inline comments are the exception, not the default: add one only when the code can't explain itself, for example a non-obvious "why", a hidden constraint, or a workaround for a specific bug. Either way, don't add a comment that just restates what the identifier names already say.
 
 When writing a comment or docblock description:
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Three updates to the agent documentation:

- **`woocommerce-git-commit`**: documents the changelog entry file format — what each field means, and that `Comment:` explains an entry that ships no user-facing line rather than holding an issue reference.
- **`woocommerce-git-draft-pr`**: restores the constraint that the Milestone section stays in every PR body. It was added in #65408 and trimmed away in #65204; its `<!-- milestone-target-selection -->` markers drive PR automation.
- **`woocommerce-backend-dev`** (plus a one-line pointer in `AGENTS.md`): hook docblocks in `src/Blocks` and `src/StoreApi` are published as `actions.md` and `filters.md`, so they need `pnpm --filter=@woocommerce/block-library build:docs` after a change. Nothing in CI checks those two files.

### How to test the changes in this Pull Request:

<!-- Please list out step by step instructions on how to test this Pull Request. -->

Documentation only — no runtime behaviour changes. Read the three changed sections and check them against their sources: `extra.changelogger.types` in `plugins/woocommerce/composer.json`, the Milestone section of `.github/PULL_REQUEST_TEMPLATE.md`, and `plugins/woocommerce/client/blocks/bin/hook-docs/README.md`.

### Testing that has already taken place:

<!-- Please describe the testing that has already taken place on the changes made in this Pull Request. -->

Each claim was verified against the repo — existing `Comment:` entries, the `git log` trail on the milestone regression, and the workflows that touch the generated docs. `markdownlint` passes on all four changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

Left unchecked — agent documentation only, nothing ships to merchants.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

Agent documentation only, not shipped to merchants — matching #65995 and #65204, which also changed `.ai/skills/` with no entry.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
