### PR TITLE
Fix product attribute lookup updates for deleted products

### DIFF
--- a/plugins/woocommerce/changelog/fix-68028-deleted-product-lookup
+++ b/plugins/woocommerce/changelog/fix-68028-deleted-product-lookup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when product attribute lookup updates run after a product is deleted.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -62683,12 +62683,6 @@ parameters:
 			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
 
 		-
-			message: '#^Call to method get_id\(\) on an unknown class Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\WC_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\LookupDataStore\:\:create_data_for\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -62815,12 +62809,6 @@ parameters:
 			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
 
 		-
-			message: '#^Parameter \#1 \$object_or_string of function is_a expects object, Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\WC_Product\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
-
-		-
 			message: '#^Parameter \#1 \$object_or_string of function is_a expects object, int\|WC_Product given\.$#'
 			identifier: argument.type
 			count: 2
@@ -62833,20 +62821,8 @@ parameters:
 			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
 
 		-
-			message: '#^Parameter \#1 \$var of function intval expects array\|bool\|float\|int\|resource\|string\|null, Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\WC_Product\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
-
-		-
 			message: '#^Parameter \#1 \$variation of method Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\LookupDataStore\:\:create_data_for_variation\(\) expects WC_Product_Variation, WC_Product given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
-
-		-
-			message: '#^Parameter \$product of method Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\LookupDataStore\:\:create_data_for_product\(\) has invalid type Automattic\\WooCommerce\\Internal\\ProductAttributesLookup\\WC_Product\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -133,6 +133,9 @@ class LookupDataStore {
 		if ( ! is_a( $product, \WC_Product::class ) ) {
 			$product = WC()->call_function( 'wc_get_product', $product );
 		}
+		if ( ! $product ) {
+			return;
+		}
 
 		$action = $this->get_update_action( $changeset );
 		if ( self::ACTION_NONE !== $action ) {
@@ -311,6 +314,10 @@ class LookupDataStore {
 		} else {
 			if ( ! is_a( $product, \WC_Product::class ) ) {
 				$product = WC()->call_function( 'wc_get_product', $product );
+			}
+			if ( ! $product ) {
+				$this->last_create_operation_failed = false;
+				return;
 			}
 
 			$this->delete_data_for( $product->get_id() );

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -307,8 +307,9 @@ class LookupDataStore {
 	 * the information is created for all of its variations.
 	 * This method is intended to be called from the data regenerator.
 	 *
-	 * If the product no longer exists, any stale lookup data for it is removed
-	 * and the operation is not considered failed (see 'get_last_create_operation_failed').
+	 * If a product id is passed and it no longer resolves to a product, any stale lookup
+	 * data for that id is removed and the operation is not considered failed
+	 * (see 'get_last_create_operation_failed'). Product objects are used as-is.
 	 *
 	 * @param int|\WC_Product $product Product object or id.
 	 * @param bool            $use_optimized_db_access Use direct database access for data retrieval if possible.

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -308,14 +308,18 @@ class LookupDataStore {
 	 * @param bool           $use_optimized_db_access Use direct database access for data retrieval if possible.
 	 */
 	public function create_data_for_product( $product, $use_optimized_db_access = false ) {
+		$product_id = intval( ( $product instanceof \WC_Product ) ? $product->get_id() : $product );
+
 		if ( $use_optimized_db_access ) {
-			$product_id = intval( ( $product instanceof \WC_Product ) ? $product->get_id() : $product );
 			$this->create_data_for_product_cpt( $product_id );
 		} else {
 			if ( ! is_a( $product, \WC_Product::class ) ) {
 				$product = WC()->call_function( 'wc_get_product', $product );
 			}
+
+			// A product can be deleted after its lookup table update has been scheduled.
 			if ( ! $product ) {
+				$this->delete_data_for( $product_id );
 				$this->last_create_operation_failed = false;
 				return;
 			}
@@ -895,6 +899,10 @@ class LookupDataStore {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$product_ids_with_stock_status = $wpdb->get_results( $sql, ARRAY_A );
+		if ( empty( $product_ids_with_stock_status ) ) {
+			$this->delete_data_for( $product_id );
+			return;
+		}
 
 		$main_product_row = array_filter( $product_ids_with_stock_status, fn( $item ) => ProductType::VARIATION !== $item['product_type'] );
 		$is_variation     = empty( $main_product_row );

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -133,6 +133,9 @@ class LookupDataStore {
 		if ( ! is_a( $product, \WC_Product::class ) ) {
 			$product = WC()->call_function( 'wc_get_product', $product );
 		}
+
+		// A deferred caller can pass the id of a product that has been deleted in the meantime.
+		// The deletion has already scheduled the removal of the lookup data, so there's nothing to do.
 		if ( ! $product ) {
 			return;
 		}
@@ -304,8 +307,11 @@ class LookupDataStore {
 	 * the information is created for all of its variations.
 	 * This method is intended to be called from the data regenerator.
 	 *
-	 * @param int|WC_Product $product Product object or id.
-	 * @param bool           $use_optimized_db_access Use direct database access for data retrieval if possible.
+	 * If the product no longer exists, any stale lookup data for it is removed
+	 * and the operation is not considered failed (see 'get_last_create_operation_failed').
+	 *
+	 * @param int|\WC_Product $product Product object or id.
+	 * @param bool            $use_optimized_db_access Use direct database access for data retrieval if possible.
 	 */
 	public function create_data_for_product( $product, $use_optimized_db_access = false ) {
 		$product_id = intval( ( $product instanceof \WC_Product ) ? $product->get_id() : $product );
@@ -313,7 +319,7 @@ class LookupDataStore {
 		if ( $use_optimized_db_access ) {
 			$this->create_data_for_product_cpt( $product_id );
 		} else {
-			if ( ! is_a( $product, \WC_Product::class ) ) {
+			if ( ! $product instanceof \WC_Product ) {
 				$product = WC()->call_function( 'wc_get_product', $product );
 			}
 
@@ -900,6 +906,8 @@ class LookupDataStore {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$product_ids_with_stock_status = $wpdb->get_results( $sql, ARRAY_A );
 		if ( empty( $product_ids_with_stock_status ) ) {
+			// The product has been deleted. The DELETE above only covers rows keyed by parent id,
+			// delete_data_for also removes the rows of a deleted variation (keyed by product_id).
 			$this->delete_data_for( $product_id );
 			return;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -188,17 +188,24 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox `create_data_for_product` skips products that no longer exist.
+	 * @testdox `create_data_for_product` removes stale data for products that no longer exist.
+	 *
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_optimized_db_access 'true' to use optimized db access for the table update.
 	 */
-	public function test_create_data_for_product_skips_deleted_product(): void {
+	public function test_create_data_for_product_removes_data_for_deleted_product( bool $use_optimized_db_access ): void {
 		$product = new \WC_Product_Simple();
 		$this->save( $product );
 		$product_id = $product->get_id();
+		$this->insert_lookup_table_data( $product_id, $product_id, self::$attributes[0]['name'], self::$attributes[0]['term_ids'][0], false, true );
 		$product->delete( true );
 
 		$this->assertFalse( wc_get_product( $product_id ) );
+		$this->assertCount( 1, $this->get_lookup_table_data() );
 
-		$this->sut->create_data_for_product( $product_id );
+		$this->sut->create_data_for_product( $product_id, $use_optimized_db_access );
 
 		$this->assertFalse( $this->sut->get_last_create_operation_failed() );
 		$this->assertEmpty( $this->get_lookup_table_data() );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -212,6 +212,37 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox `create_data_for_product` removes stale data for variations that no longer exist.
+	 *
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_optimized_db_access 'true' to use optimized db access for the table update.
+	 */
+	public function test_create_data_for_product_removes_data_for_deleted_variation( bool $use_optimized_db_access ): void {
+		$parent = new \WC_Product_Variable();
+		$this->save( $parent );
+		$parent_id = $parent->get_id();
+
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $parent_id );
+		$this->save( $variation );
+		$variation_id = $variation->get_id();
+
+		// Variation rows are keyed by the parent id in 'product_or_parent_id'.
+		$this->insert_lookup_table_data( $variation_id, $parent_id, self::$attributes[0]['name'], self::$attributes[0]['term_ids'][0], true, true );
+		$variation->delete( true );
+
+		$this->assertFalse( wc_get_product( $variation_id ) );
+		$this->assertCount( 1, $this->get_lookup_table_data() );
+
+		$this->sut->create_data_for_product( $variation_id, $use_optimized_db_access );
+
+		$this->assertFalse( $this->sut->get_last_create_operation_failed() );
+		$this->assertEmpty( $this->get_lookup_table_data() );
+	}
+
+	/**
 	 * @testdox `create_data_for_product` creates the appropriate entries for variable products.
 	 *
 	 * @testWith [false]
@@ -869,7 +900,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox `on_product_changed` skips products that no longer exist.
+	 * @testdox `on_product_changed` schedules nothing for products that no longer exist.
 	 */
 	public function test_on_product_changed_skips_deleted_product(): void {
 		$this->set_direct_update_option( false );
@@ -881,13 +912,13 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->assertFalse( wc_get_product( $product_id ) );
 
+		// Deleting the product schedules a lookup data deletion, that's not what's being tested here.
 		$queue = WC()->get_instance_of( \WC_Queue::class );
+		$queue->clear_methods_called();
 
 		$this->sut->on_product_changed( $product_id );
 
-		$queue_calls = $queue->get_methods_called();
-		$this->assertCount( 1, $queue_calls );
-		$this->assertSame( array( $product_id, LookupDataStore::ACTION_DELETE ), $queue_calls[0]['args'] );
+		$this->assertEmpty( $queue->get_methods_called(), 'No lookup table update should be scheduled for a deleted product.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -188,6 +188,23 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox `create_data_for_product` skips products that no longer exist.
+	 */
+	public function test_create_data_for_product_skips_deleted_product(): void {
+		$product = new \WC_Product_Simple();
+		$this->save( $product );
+		$product_id = $product->get_id();
+		$product->delete( true );
+
+		$this->assertFalse( wc_get_product( $product_id ) );
+
+		$this->sut->create_data_for_product( $product_id );
+
+		$this->assertFalse( $this->sut->get_last_create_operation_failed() );
+		$this->assertEmpty( $this->get_lookup_table_data() );
+	}
+
+	/**
 	 * @testdox `create_data_for_product` creates the appropriate entries for variable products.
 	 *
 	 * @testWith [false]
@@ -842,6 +859,28 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( 'no', get_option( 'woocommerce_attribute_lookup_direct_updates' ) );
+	}
+
+	/**
+	 * @testdox `on_product_changed` skips products that no longer exist.
+	 */
+	public function test_on_product_changed_skips_deleted_product(): void {
+		$this->set_direct_update_option( false );
+
+		$product = new \WC_Product_Simple();
+		$this->save( $product );
+		$product_id = $product->get_id();
+		$product->delete( true );
+
+		$this->assertFalse( wc_get_product( $product_id ) );
+
+		$queue = WC()->get_instance_of( \WC_Queue::class );
+
+		$this->sut->on_product_changed( $product_id );
+
+		$queue_calls = $queue->get_methods_called();
+		$this->assertCount( 1, $queue_calls );
+		$this->assertSame( array( $product_id, LookupDataStore::ACTION_DELETE ), $queue_calls[0]['args'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product attribute lookup updates can run after a product has been hard-deleted, causing lookup data-store methods to dereference a missing product or an empty optimized query result. Handle missing product IDs in both optimized and non-optimized creation paths, remove any stale lookup rows, and retain the delete action already scheduled by normal product deletion.

No method signatures or hooks change. For external callers, `create_data_for_product( $missing_id )` now treats the vanished product as a successful cleanup: stale lookup rows are removed and `get_last_create_operation_failed()` returns `false`, so the CLI and data regenerator do not report a failure for a product that disappeared before processing. This cleanup behavior applies when an ID is passed; `WC_Product` objects continue to be used as-is. Valid-product behavior is unchanged; multisite was not tested.

The `create_data_for_product` docblock now references `\WC_Product` correctly, which lets PHPStan resolve the parameter type; the `is_a` check it then flagged is replaced with `instanceof`, and the four baseline entries this resolves are removed.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #68028.

(For Bug Fixes) Bug introduced in PR #30041.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the PHP test environment with `pnpm --filter='@woocommerce/plugin-woocommerce' env:test:start`.
2. Run `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter LookupDataStoreTest` and confirm all 92 tests pass.
3. Run `pnpm --filter='@woocommerce/plugin-woocommerce' wp-env:test run cli wp shell`, then paste:

   ```php
   $product = new WC_Product_Simple();
   $product->save();
   $product_id = $product->get_id();
   $product->delete( true );
   $store = wc_get_container()->get( Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore::class );
   $store->on_product_changed( $product_id );
   $store->create_data_for_product( $product_id );
   $store->create_data_for_product( $product_id, true );
   var_dump( $store->get_last_create_operation_failed() );
   ```

4. Confirm no exception or warning is emitted and the final value is `bool(false)`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Reproduced the optimized-path failure before the follow-up fix: a hard-deleted product ID caused `get_last_create_operation_failed()` to return `true` under test-style warning handling.
- Passed `LookupDataStoreTest` in the single-site wp-env test environment with PHP 8.1: 92 tests, 123 assertions.
- Passed PHPStan for `LookupDataStore.php`.
- Passed changed-file PHP linting, full branch PHP linting, PHP syntax checks, and `git diff --check`.
- Passed GitHub CI, including PHP 7.4 and 8.5 unit tests, lint, PHPStan, API, end-to-end, and performance checks.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the issue, implement the fix and regression tests, and draft the pull request text. The changes were verified with the focused PHP test suite, PHP linting, and PHPStan.
