### PR TITLE
Fix Store API cart recovery after redirect payments

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-order-awaiting-payment
+++ b/plugins/woocommerce/changelog/fix-store-api-order-awaiting-payment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure Store API checkout carts clear after redirect payments.

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -88,6 +88,10 @@ trait CheckoutTrait {
 	private function process_payment( \WP_REST_Request $request, PaymentResult $payment_result ) {
 		$order = $this->get_order_or_throw();
 
+		WC()->session->set( 'order_awaiting_payment', $order->get_id() );
+		// Persist before invoking gateways because redirects or stalled requests may prevent the session from being saved on shutdown.
+		WC()->session->save_data();
+
 		try {
 			// Prepare the payment context object to pass through payment hooks.
 			$context = new PaymentContext();

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -88,9 +88,12 @@ trait CheckoutTrait {
 	private function process_payment( \WP_REST_Request $request, PaymentResult $payment_result ) {
 		$order = $this->get_order_or_throw();
 
-		WC()->session->set( 'order_awaiting_payment', $order->get_id() );
+		$session = WC()->session;
+		$session->set( 'order_awaiting_payment', $order->get_id() );
 		// Persist before invoking gateways because redirects or stalled requests may prevent the session from being saved on shutdown.
-		WC()->session->save_data();
+		if ( is_callable( array( $session, 'save_data' ) ) ) {
+			$session->save_data();
+		}
 
 		try {
 			// Prepare the payment context object to pass through payment hooks.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3102,6 +3102,9 @@ class Checkout extends \WP_Test_REST_TestCase {
 	 * @testdox Store API checkout stores the order awaiting payment before invoking the payment gateway.
 	 */
 	public function test_post_sets_order_awaiting_payment_before_processing_payment(): void {
+		WC()->session->set_customer_session_cookie( true );
+		WC()->session->save_data();
+
 		$order_id_during_payment = 0;
 		$payment_handler         = function ( $context, $payment_result ) use ( &$order_id_during_payment ) {
 			unset( $context );
@@ -3121,7 +3124,9 @@ class Checkout extends \WP_Test_REST_TestCase {
 		$order_id = (int) $response->get_data()['order_id'];
 		$this->assertGreaterThan( 0, $order_id, 'Checkout should create an order.' );
 		$this->assertSame( $order_id, $order_id_during_payment, 'The order should be linked to the session before payment processing starts.' );
-		$this->assertSame( $order_id, (int) WC()->session->get( 'order_awaiting_payment' ), 'Redirect payments should leave the order linked to the shopper session.' );
+		$persisted_session_data = WC()->session->get_session_data();
+		$this->assertArrayHasKey( 'order_awaiting_payment', $persisted_session_data, 'Redirect payments should persist the order link in the shopper session.' );
+		$this->assertSame( $order_id, (int) $persisted_session_data['order_awaiting_payment'], 'Redirect payments should leave the persisted order linked to the shopper session.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3099,6 +3099,32 @@ class Checkout extends \WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * @testdox Store API checkout stores the order awaiting payment before invoking the payment gateway.
+	 */
+	public function test_post_sets_order_awaiting_payment_before_processing_payment(): void {
+		$order_id_during_payment = 0;
+		$payment_handler         = function ( $context, $payment_result ) use ( &$order_id_during_payment ) {
+			unset( $context );
+			$order_id_during_payment = (int) WC()->session->get( 'order_awaiting_payment' );
+			$payment_result->set_status( 'success' );
+		};
+
+		add_action( 'woocommerce_rest_checkout_process_payment_with_context', $payment_handler, 1, 2 );
+
+		try {
+			$response = rest_get_server()->dispatch( $this->build_valid_post_request() );
+		} finally {
+			remove_action( 'woocommerce_rest_checkout_process_payment_with_context', $payment_handler, 1 );
+		}
+
+		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+		$order_id = (int) $response->get_data()['order_id'];
+		$this->assertGreaterThan( 0, $order_id, 'Checkout should create an order.' );
+		$this->assertSame( $order_id, $order_id_during_payment, 'The order should be linked to the session before payment processing starts.' );
+		$this->assertSame( $order_id, (int) WC()->session->get( 'order_awaiting_payment' ), 'Redirect payments should leave the order linked to the shopper session.' );
+	}
+
+	/**
 	 * Build a valid checkout POST request body for use by the sample-extension tests.
 	 *
 	 * @return \WP_REST_Request


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Store API checkout did not link redirect payments to the shopper session, so carts could remain populated when the return redirect used a different browser context. This stores and persists `order_awaiting_payment` before gateway processing so the existing cart recovery flow can clear the original cart.

Closes #68022.

Linear: [WOOPLUG-7599](https://linear.app/a8c/issue/WOOPLUG-7599/store-api-checkout-never-sets-order-awaiting-payment-so-carts-left)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable AliPay via Stripe (might need to set currency to Yen)
2. Checkout a product, select AliPay as payment method
3. Once you get redirected, don't authorise the payment. Copy URL and open in another browser
4. Complete payment in second browser
5. Go back to the store in your original browser and refresh, product should still be in cart (Because the payment is still processing)
6. Simulate a successful webhook: `wp eval '$order = wc_get_order( 204 ); $order->update_status( "processing", "Simulate successful payment webhook." );'` replacing `204` with your order ID
7. Now refresh original browser, cart should be empty. (this step shouldn't work on `trunk`)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Store API Checkout PHPUnit suite: 59 tests, 169 assertions.
- PHPStan on the changed production file.
- Changed-file and branch PHP linting.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenCode was used to analyze, implement, and test this change. The author reviewed the result.
