### PR TITLE
Add support for typography and border radius styles to the Chips block

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -1278,7 +1278,7 @@ Display filter options as chips.
 - **Name:** woocommerce/product-filter-chips
 - **Category:** woocommerce
 - **Ancestor:** woocommerce/product-filter-attribute, woocommerce/product-filter-taxonomy, woocommerce/product-filter-status, woocommerce/add-to-cart-with-options-variation-selector-attribute
-- **Supports:** interactivity, woocommerce (innerBlockDisplayStyle)
+- **Supports:** interactivity, typography (fontSize), woocommerce (innerBlockDisplayStyle)
 - **Attributes:** chipBackground, chipBorder, chipText, customChipBackground, customChipBorder, customChipText, customSelectedChipBackground, customSelectedChipBorder, customSelectedChipText, selectedChipBackground, selectedChipBorder, selectedChipText
 
 ## Clear filters - woocommerce/product-filter-clear-button

--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -1278,7 +1278,7 @@ Display filter options as chips.
 - **Name:** woocommerce/product-filter-chips
 - **Category:** woocommerce
 - **Ancestor:** woocommerce/product-filter-attribute, woocommerce/product-filter-taxonomy, woocommerce/product-filter-status, woocommerce/add-to-cart-with-options-variation-selector-attribute
-- **Supports:** interactivity, typography (fontSize), woocommerce (innerBlockDisplayStyle)
+- **Supports:** interactivity, spacing (padding), typography (fontSize), woocommerce (innerBlockDisplayStyle)
 - **Attributes:** chipBackground, chipBorder, chipText, customChipBackground, customChipBorder, customChipText, customSelectedChipBackground, customSelectedChipBorder, customSelectedChipText, selectedChipBackground, selectedChipBorder, selectedChipText
 
 ## Clear filters - woocommerce/product-filter-clear-button

--- a/plugins/woocommerce/changelog/add-filter-chips-styles
+++ b/plugins/woocommerce/changelog/add-filter-chips-styles
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add support for typography and border radius styles to the Chips block
+Add support for typography, padding, and border radius styles to the Chips block

--- a/plugins/woocommerce/changelog/add-filter-chips-styles
+++ b/plugins/woocommerce/changelog/add-filter-chips-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for typography and border radius styles to the Chips block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -17,7 +17,19 @@
 		"interactivity": true,
 		"woocommerce": {
 			"innerBlockDisplayStyle": true
+		},
+		"typography": {
+			"fontSize": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"__experimentalSkipSerialization": true
 		}
+	},
+	"selectors": {
+		"border": ".wc-block-product-filter-chips__item"
 	},
 	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -29,7 +29,7 @@
 		}
 	},
 	"selectors": {
-		"border": ".wc-block-product-filter-chips__item"
+		"border": ".wp-block-woocommerce-product-filter-chips:not(.is-style-swatch) .wc-block-product-filter-chips__item"
 	},
 	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -26,10 +26,17 @@
 		"__experimentalBorder": {
 			"radius": true,
 			"__experimentalSkipSerialization": true
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalSkipSerialization": true
 		}
 	},
 	"selectors": {
-		"border": ".wp-block-woocommerce-product-filter-chips:not(.is-style-swatch) .wc-block-product-filter-chips__item"
+		"border": ".wp-block-woocommerce-product-filter-chips:not(.is-style-swatch) .wc-block-product-filter-chips__item",
+		"spacing": {
+			"padding": ".wp-block-woocommerce-product-filter-chips:not(.is-style-swatch) .wc-block-product-filter-chips__item"
+		}
 	},
 	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -104,21 +104,26 @@ const Edit = ( props: EditProps ): JSX.Element => {
 		},
 	} );
 
-	const loadingState = useMemo( () => {
-		return [ ...Array( 10 ) ].map( ( _, i ) => (
-			<div
-				className={ chipItemClassName }
-				key={ i }
-				style={ {
-					...chipItemStyle,
-					/* stylelint-disable */
-					width: Math.floor( Math.random() * ( 100 - 25 ) ) + '%',
-				} }
-			>
-				&nbsp;
-			</div>
-		) );
-	}, [ chipItemStyle, chipItemClassName ] );
+	const loadingWidths = useMemo(
+		() =>
+			[ ...Array( 10 ) ].map(
+				() => Math.floor( Math.random() * ( 100 - 25 ) ) + '%'
+			),
+		[]
+	);
+	const loadingState = loadingWidths.map( ( width, i ) => (
+		<div
+			className={ chipItemClassName }
+			key={ i }
+			style={ {
+				...chipItemStyle,
+				/* stylelint-disable */
+				width,
+			} }
+		>
+			&nbsp;
+		</div>
+	) );
 
 	if ( ! items ) {
 		return <></>;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -74,8 +74,9 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	const borderProps = useBorderProps( attributes );
 	const chipItemClassName = clsx(
 		'wc-block-product-filter-chips__item',
-		borderProps.className
+		! hasVisualSwatches && borderProps.className
 	);
+	const chipItemStyle = hasVisualSwatches ? undefined : borderProps.style;
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filter-chips', {
@@ -102,7 +103,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 				className={ chipItemClassName }
 				key={ i }
 				style={ {
-					...borderProps.style,
+					...chipItemStyle,
 					/* stylelint-disable */
 					width: Math.floor( Math.random() * ( 100 - 25 ) ) + '%',
 				} }
@@ -110,7 +111,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 				&nbsp;
 			</div>
 		) );
-	}, [ borderProps.style, chipItemClassName ] );
+	}, [ chipItemStyle, chipItemClassName ] );
 
 	if ( ! items ) {
 		return <></>;
@@ -133,7 +134,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 								<div
 									key={ index }
 									className={ chipItemClassName }
-									style={ borderProps.style }
+									style={ chipItemStyle }
 									aria-checked={ !! item.selected }
 								>
 									<span className="wc-block-product-filter-chips__label">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -17,6 +17,9 @@ import {
 	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+	// @ts-expect-error - no types.
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseBorderProps as useBorderProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -68,6 +71,11 @@ const Edit = ( props: EditProps ): JSX.Element => {
 		{}
 	);
 	const colorVars = getColorVars( attributes );
+	const borderProps = useBorderProps( attributes );
+	const chipItemClassName = clsx(
+		'wc-block-product-filter-chips__item',
+		borderProps.className
+	);
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filter-chips', {
@@ -91,9 +99,10 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	const loadingState = useMemo( () => {
 		return [ ...Array( 10 ) ].map( ( _, i ) => (
 			<div
-				className="wc-block-product-filter-chips__item"
+				className={ chipItemClassName }
 				key={ i }
 				style={ {
+					...borderProps.style,
 					/* stylelint-disable */
 					width: Math.floor( Math.random() * ( 100 - 25 ) ) + '%',
 				} }
@@ -101,7 +110,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 				&nbsp;
 			</div>
 		) );
-	}, [] );
+	}, [ borderProps.style, chipItemClassName ] );
 
 	if ( ! items ) {
 		return <></>;
@@ -123,7 +132,8 @@ const Edit = ( props: EditProps ): JSX.Element => {
 							).map( ( item, index ) => (
 								<div
 									key={ index }
-									className="wc-block-product-filter-chips__item"
+									className={ chipItemClassName }
+									style={ borderProps.style }
 									aria-checked={ !! item.selected }
 								>
 									<span className="wc-block-product-filter-chips__label">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -20,6 +20,9 @@ import {
 	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUseBorderProps as useBorderProps,
+	// @ts-expect-error - no types.
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -72,11 +75,15 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	);
 	const colorVars = getColorVars( attributes );
 	const borderProps = useBorderProps( attributes );
+	const spacingProps = useSpacingProps( attributes );
 	const chipItemClassName = clsx(
 		'wc-block-product-filter-chips__item',
-		! hasVisualSwatches && borderProps.className
+		! hasVisualSwatches && borderProps.className,
+		! hasVisualSwatches && spacingProps.className
 	);
-	const chipItemStyle = hasVisualSwatches ? undefined : borderProps.style;
+	const chipItemStyle = hasVisualSwatches
+		? undefined
+		: { ...borderProps.style, ...spacingProps.style };
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filter-chips', {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 import clsx from 'clsx';
 import { decodeHtmlEntities } from '@woocommerce/utils';
@@ -35,6 +34,17 @@ import {
 	getVisualAttributeTermStyle,
 	isVisualAttributeTermEmpty,
 } from '../../../../base/utils/visual-attribute-terms';
+
+const LOADING_WIDTHS = [
+	'42%',
+	'67%',
+	'31%',
+	'55%',
+	'73%',
+	'28%',
+	'48%',
+	'61%',
+];
 
 const Edit = ( props: EditProps ): JSX.Element => {
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
@@ -76,14 +86,6 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	const colorVars = getColorVars( attributes );
 	const borderProps = useBorderProps( attributes );
 	const spacingProps = useSpacingProps( attributes );
-	const chipItemClassName = clsx(
-		'wc-block-product-filter-chips__item',
-		! hasVisualSwatches && borderProps.className,
-		! hasVisualSwatches && spacingProps.className
-	);
-	const chipItemStyle = hasVisualSwatches
-		? undefined
-		: { ...borderProps.style, ...spacingProps.style };
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filter-chips', {
@@ -104,14 +106,22 @@ const Edit = ( props: EditProps ): JSX.Element => {
 		},
 	} );
 
-	const loadingWidths = useMemo(
-		() =>
-			[ ...Array( 10 ) ].map(
-				() => Math.floor( Math.random() * ( 100 - 25 ) ) + '%'
-			),
-		[]
+	if ( ! items ) {
+		return <></>;
+	}
+
+	const threshold = 15;
+	const isLongList = items.length > threshold;
+
+	const chipItemClassName = clsx(
+		'wc-block-product-filter-chips__item',
+		! hasVisualSwatches && borderProps.className,
+		! hasVisualSwatches && spacingProps.className
 	);
-	const loadingState = loadingWidths.map( ( width, i ) => (
+	const chipItemStyle = hasVisualSwatches
+		? undefined
+		: { ...borderProps.style, ...spacingProps.style };
+	const loadingState = LOADING_WIDTHS.map( ( width, i ) => (
 		<div
 			className={ chipItemClassName }
 			key={ i }
@@ -124,13 +134,6 @@ const Edit = ( props: EditProps ): JSX.Element => {
 			&nbsp;
 		</div>
 	) );
-
-	if ( ! items ) {
-		return <></>;
-	}
-
-	const threshold = 15;
-	const isLongList = items.length > threshold;
 
 	return (
 		<>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -83,24 +83,15 @@
 	display: inline-flex;
 	align-items: center;
 	gap: $gap-smallest;
-	font-size: inherit;
-	letter-spacing: inherit;
-	text-transform: inherit;
 	vertical-align: bottom;
 }
 
 .wc-block-product-filter-chips__text {
 	display: contents;
-	font-size: inherit;
-	letter-spacing: inherit;
-	text-transform: inherit;
 }
 
 .wc-block-product-filter-chips__count {
 	white-space: nowrap;
-	font-size: inherit;
-	letter-spacing: inherit;
-	text-transform: inherit;
 }
 
 .wc-block-product-filter-chips__show-more {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -12,7 +12,7 @@
 	gap: $gap-smallest;
 }
 
-:where(.wc-block-product-filter-chips__item) {
+.wc-block-product-filter-chips__item {
 	border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
 	padding: 0.4em 0.75em;
 	appearance: none;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -1,3 +1,7 @@
+:where(.wp-block-woocommerce-product-filter-chips) {
+	font-size: 0.8em;
+}
+
 :where(.wc-block-product-filter-chips__fieldset) {
 	display: contents;
 }
@@ -8,14 +12,16 @@
 	gap: $gap-smallest;
 }
 
-.wc-block-product-filter-chips__item {
+:where(.wc-block-product-filter-chips__item) {
 	border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
 	padding: 0.4em 0.75em;
 	appearance: none;
 	background: transparent;
 	border-radius: 2px;
-	font-size: 0.8em;
 	font-family: inherit;
+	font-size: inherit;
+	letter-spacing: inherit;
+	text-transform: inherit;
 	cursor: pointer;
 	color: inherit;
 
@@ -77,15 +83,24 @@
 	display: inline-flex;
 	align-items: center;
 	gap: $gap-smallest;
+	font-size: inherit;
+	letter-spacing: inherit;
+	text-transform: inherit;
 	vertical-align: bottom;
 }
 
 .wc-block-product-filter-chips__text {
 	display: contents;
+	font-size: inherit;
+	letter-spacing: inherit;
+	text-transform: inherit;
 }
 
 .wc-block-product-filter-chips__count {
 	white-space: nowrap;
+	font-size: inherit;
+	letter-spacing: inherit;
+	text-transform: inherit;
 }
 
 .wc-block-product-filter-chips__show-more {
@@ -94,7 +109,6 @@
 	border: 0;
 	padding: 0;
 	font: inherit;
-	font-size: 0.875em;
 	color: inherit;
 	text-decoration: underline;
 	cursor: pointer;

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -51310,18 +51310,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductFilterChips.php
 
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, string\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/ProductFilterChips.php
-
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, string\|true\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/ProductFilterChips.php
-
-		-
 			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\WP_Block\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 
 /**
@@ -52,14 +53,22 @@ final class ProductFilterChips extends AbstractBlock {
 		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
 		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
 		$display_limit   = 'woocommerce/product-filters' === $store_namespace ? 15 : 30;
-		$classes         = '';
-		$style           = '';
 
-		$tags = new \WP_HTML_Tag_Processor( $content );
+		$classes = '';
+		$style   = '';
+		$tags    = new \WP_HTML_Tag_Processor( $content );
 		if ( $tags->next_tag( array( 'class_name' => 'wc-block-product-filter-chips' ) ) ) {
-			$classes = $tags->get_attribute( 'class' );
-			$style   = $tags->get_attribute( 'style' );
+			$saved_classes = $tags->get_attribute( 'class' );
+			$saved_style   = $tags->get_attribute( 'style' );
+			$classes       = is_string( $saved_classes ) ? $saved_classes : '';
+			$style         = is_string( $saved_style ) ? $saved_style : '';
 		}
+
+		if ( ! str_contains( $classes, 'wc-block-product-filter-chips' ) ) {
+			$classes = trim( $classes . ' wc-block-product-filter-chips' );
+		}
+
+		$chip_item_attributes = self::get_chip_item_attributes( is_array( $attributes ) ? $attributes : array() );
 
 		$wrapper_attributes = array(
 			'data-wp-interactive'  => 'woocommerce/product-filter-chips',
@@ -99,7 +108,7 @@ final class ProductFilterChips extends AbstractBlock {
 		$has_visual_swatches = self::has_visual_swatches( $items );
 		$button_role         = 'single' === $block_context['selectionMode'] ? 'radio' : 'checkbox';
 
-		if ( $has_visual_swatches && is_string( $classes ) && ! str_contains( $classes, 'is-style-swatch' ) ) {
+		if ( $has_visual_swatches && ! str_contains( $classes, 'is-style-swatch' ) ) {
 			$classes                    .= ' is-style-swatch';
 			$wrapper_attributes['class'] = esc_attr( $classes );
 		}
@@ -116,7 +125,10 @@ final class ProductFilterChips extends AbstractBlock {
 					foreach ( $visible_items as $item ) :
 						?>
 						<button
-							class="wc-block-product-filter-chips__item"
+							class="<?php echo esc_attr( $chip_item_attributes['class'] ); ?>"
+							<?php if ( '' !== $chip_item_attributes['style'] ) : ?>
+								style="<?php echo esc_attr( $chip_item_attributes['style'] ); ?>"
+							<?php endif; ?>
 							type="button"
 							role="<?php echo esc_attr( $button_role ); ?>"
 							id="<?php echo esc_attr( $item['id'] ); ?>"
@@ -166,7 +178,10 @@ final class ProductFilterChips extends AbstractBlock {
 						data-wp-each-key="context.item.id"
 					>
 						<button
-							class="wc-block-product-filter-chips__item"
+							class="<?php echo esc_attr( $chip_item_attributes['class'] ); ?>"
+							<?php if ( '' !== $chip_item_attributes['style'] ) : ?>
+								style="<?php echo esc_attr( $chip_item_attributes['style'] ); ?>"
+							<?php endif; ?>
 							type="button"
 							role="<?php echo esc_attr( $button_role ); ?>"
 							data-wp-bind--id="context.item.id"
@@ -219,6 +234,24 @@ final class ProductFilterChips extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Get class and style attributes for individual chip items.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return array{class: string, style: string}
+	 */
+	private static function get_chip_item_attributes( array $attributes ): array {
+		$border_classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
+			$attributes,
+			array( 'border_radius' )
+		);
+
+		return array(
+			'class' => trim( 'wc-block-product-filter-chips__item ' . $border_classes_and_styles['classes'] ),
+			'style' => $border_classes_and_styles['styles'],
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -64,10 +64,6 @@ final class ProductFilterChips extends AbstractBlock {
 			$style         = is_string( $saved_style ) ? $saved_style : '';
 		}
 
-		if ( ! str_contains( $classes, 'wc-block-product-filter-chips' ) ) {
-			$classes = trim( $classes . ' wc-block-product-filter-chips' );
-		}
-
 		$has_visual_swatches  = self::has_visual_swatches( $items );
 		$chip_item_attributes = self::get_chip_item_attributes(
 			is_array( $attributes ) ? $attributes : array(),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -68,7 +68,11 @@ final class ProductFilterChips extends AbstractBlock {
 			$classes = trim( $classes . ' wc-block-product-filter-chips' );
 		}
 
-		$chip_item_attributes = self::get_chip_item_attributes( is_array( $attributes ) ? $attributes : array() );
+		$has_visual_swatches  = self::has_visual_swatches( $items );
+		$chip_item_attributes = self::get_chip_item_attributes(
+			is_array( $attributes ) ? $attributes : array(),
+			$has_visual_swatches
+		);
 
 		$wrapper_attributes = array(
 			'data-wp-interactive'  => 'woocommerce/product-filter-chips',
@@ -103,10 +107,9 @@ final class ProductFilterChips extends AbstractBlock {
 		$visible_items           = array_merge( $first_items, $overflow_selected_items );
 		$hidden_count            = count( $items ) - count( $visible_items );
 
-		$first_item          = reset( $items );
-		$show_counts         = is_array( $first_item ) && array_key_exists( 'count', $first_item );
-		$has_visual_swatches = self::has_visual_swatches( $items );
-		$button_role         = 'single' === $block_context['selectionMode'] ? 'radio' : 'checkbox';
+		$first_item  = reset( $items );
+		$show_counts = is_array( $first_item ) && array_key_exists( 'count', $first_item );
+		$button_role = 'single' === $block_context['selectionMode'] ? 'radio' : 'checkbox';
 
 		if ( $has_visual_swatches && ! str_contains( $classes, 'is-style-swatch' ) ) {
 			$classes                    .= ' is-style-swatch';
@@ -239,10 +242,20 @@ final class ProductFilterChips extends AbstractBlock {
 	/**
 	 * Get class and style attributes for individual chip items.
 	 *
-	 * @param array $attributes Block attributes.
+	 * Visual swatches stay circular, so border radius is not applied to them.
+	 *
+	 * @param array $attributes          Block attributes.
+	 * @param bool  $has_visual_swatches Whether items use the swatch style.
 	 * @return array{class: string, style: string}
 	 */
-	private static function get_chip_item_attributes( array $attributes ): array {
+	private static function get_chip_item_attributes( array $attributes, bool $has_visual_swatches ): array {
+		if ( $has_visual_swatches ) {
+			return array(
+				'class' => 'wc-block-product-filter-chips__item',
+				'style' => '',
+			);
+		}
+
 		$border_classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
 			$attributes,
 			array( 'border_radius' )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -242,7 +242,7 @@ final class ProductFilterChips extends AbstractBlock {
 	/**
 	 * Get class and style attributes for individual chip items.
 	 *
-	 * Visual swatches stay circular, so border radius is not applied to them.
+	 * Visual swatches stay circular, so padding and border radius are not applied to them.
 	 *
 	 * @param array $attributes          Block attributes.
 	 * @param bool  $has_visual_swatches Whether items use the swatch style.
@@ -256,14 +256,14 @@ final class ProductFilterChips extends AbstractBlock {
 			);
 		}
 
-		$border_classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
+		$item_classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
 			$attributes,
-			array( 'border_radius' )
+			array( 'border_radius', 'padding' )
 		);
 
 		return array(
-			'class' => trim( 'wc-block-product-filter-chips__item ' . $border_classes_and_styles['classes'] ),
-			'style' => $border_classes_and_styles['styles'],
+			'class' => trim( 'wc-block-product-filter-chips__item ' . $item_classes_and_styles['classes'] ),
+			'style' => $item_classes_and_styles['styles'],
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -65,7 +65,7 @@ final class ProductFilterChips extends AbstractBlock {
 
 		$has_visual_swatches     = self::has_visual_swatches( $items );
 		$item_classes_and_styles = wp_parse_args(
-			wp_style_engine_get_styles(
+			$has_visual_swatches ? array() : wp_style_engine_get_styles(
 				array(
 					'border'  => array(
 						'radius' => $attributes['style']['border']['radius'] ?? null,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -3,7 +3,6 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 
 /**
@@ -64,10 +63,22 @@ final class ProductFilterChips extends AbstractBlock {
 			$style         = is_string( $saved_style ) ? $saved_style : '';
 		}
 
-		$has_visual_swatches  = self::has_visual_swatches( $items );
-		$chip_item_attributes = self::get_chip_item_attributes(
-			is_array( $attributes ) ? $attributes : array(),
-			$has_visual_swatches
+		$has_visual_swatches     = self::has_visual_swatches( $items );
+		$item_classes_and_styles = wp_parse_args(
+			wp_style_engine_get_styles(
+				array(
+					'border'  => array(
+						'radius' => $attributes['style']['border']['radius'] ?? null,
+					),
+					'spacing' => array(
+						'padding' => $attributes['style']['spacing']['padding'] ?? null,
+					),
+				)
+			),
+			array(
+				'css'        => '',
+				'classnames' => '',
+			)
 		);
 
 		$wrapper_attributes = array(
@@ -124,9 +135,9 @@ final class ProductFilterChips extends AbstractBlock {
 					foreach ( $visible_items as $item ) :
 						?>
 						<button
-							class="<?php echo esc_attr( $chip_item_attributes['class'] ); ?>"
-							<?php if ( '' !== $chip_item_attributes['style'] ) : ?>
-								style="<?php echo esc_attr( $chip_item_attributes['style'] ); ?>"
+							class="wc-block-product-filter-chips__item <?php echo esc_attr( $item_classes_and_styles['classnames'] ); ?>"
+							<?php if ( $item_classes_and_styles['css'] ) : ?>
+								style="<?php echo esc_attr( $item_classes_and_styles['css'] ); ?>"
 							<?php endif; ?>
 							type="button"
 							role="<?php echo esc_attr( $button_role ); ?>"
@@ -177,9 +188,9 @@ final class ProductFilterChips extends AbstractBlock {
 						data-wp-each-key="context.item.id"
 					>
 						<button
-							class="<?php echo esc_attr( $chip_item_attributes['class'] ); ?>"
-							<?php if ( '' !== $chip_item_attributes['style'] ) : ?>
-								style="<?php echo esc_attr( $chip_item_attributes['style'] ); ?>"
+							class="wc-block-product-filter-chips__item <?php echo esc_attr( $item_classes_and_styles['classnames'] ); ?>"
+							<?php if ( $item_classes_and_styles['css'] ) : ?>
+								style="<?php echo esc_attr( $item_classes_and_styles['css'] ); ?>"
 							<?php endif; ?>
 							type="button"
 							role="<?php echo esc_attr( $button_role ); ?>"
@@ -233,34 +244,6 @@ final class ProductFilterChips extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
-	}
-
-	/**
-	 * Get class and style attributes for individual chip items.
-	 *
-	 * Visual swatches stay circular, so padding and border radius are not applied to them.
-	 *
-	 * @param array $attributes          Block attributes.
-	 * @param bool  $has_visual_swatches Whether items use the swatch style.
-	 * @return array{class: string, style: string}
-	 */
-	private static function get_chip_item_attributes( array $attributes, bool $has_visual_swatches ): array {
-		if ( $has_visual_swatches ) {
-			return array(
-				'class' => 'wc-block-product-filter-chips__item',
-				'style' => '',
-			);
-		}
-
-		$item_classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
-			$attributes,
-			array( 'border_radius', 'padding' )
-		);
-
-		return array(
-			'class' => trim( 'wc-block-product-filter-chips__item ' . $item_classes_and_styles['classes'] ),
-			'style' => $item_classes_and_styles['styles'],
-		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
@@ -1,0 +1,86 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Product Filter Chips block type.
+ */
+class ProductFilterChipsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Typography is applied to the wrapper and border radius to chip items.
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\ProductFilterChips::render
+	 */
+	public function test_renders_typography_on_wrapper_and_border_radius_on_items(): void {
+		$markup = $this->render_chips(
+			array(
+				'style' => array(
+					'border'     => array(
+						'radius' => '12px',
+					),
+					'typography' => array(
+						'textTransform' => 'uppercase',
+					),
+				),
+			)
+		);
+
+		$wrapper_style = $this->get_style( $markup, 'wc-block-product-filter-chips' );
+		$item_style    = $this->get_style( $markup, 'wc-block-product-filter-chips__item' );
+
+		$this->assertStringContainsString( 'text-transform:uppercase', $wrapper_style );
+		$this->assertStringContainsString( 'border-radius:12px', $item_style );
+		$this->assertStringNotContainsString( 'border-radius', $wrapper_style );
+	}
+
+	/**
+	 * Render the Chips block with the given attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render_chips( array $attributes ): string {
+		$block = new \WP_Block(
+			array(
+				'blockName'    => 'woocommerce/product-filter-chips',
+				'attrs'        => $attributes,
+				'innerContent' => array(),
+			),
+			array(
+				'woocommerce/selectableItems' => array(
+					'items'          => array(
+						array(
+							'id'       => 'item-red',
+							'label'    => 'Red',
+							'value'    => 'red',
+							'selected' => false,
+						),
+					),
+					'selectionMode'  => 'multiple',
+					'storeNamespace' => 'woocommerce/product-filters',
+				),
+			)
+		);
+
+		return $block->render();
+	}
+
+	/**
+	 * Get the style attribute of the first element with the given class.
+	 *
+	 * @param string $markup     Rendered markup.
+	 * @param string $class_name Class name to find.
+	 * @return string
+	 */
+	private function get_style( string $markup, string $class_name ): string {
+		$processor = new \WP_HTML_Tag_Processor( $markup );
+		$this->assertTrue( $processor->next_tag( array( 'class_name' => $class_name ) ) );
+
+		$style = $processor->get_attribute( 'style' );
+
+		return is_string( $style ) ? $style : '';
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
@@ -39,9 +39,9 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 		$wrapper_style = $this->get_style( $markup, 'wc-block-product-filter-chips' );
 		$item_style    = $this->get_style( $markup, 'wc-block-product-filter-chips__item' );
 
-		$this->assertStringContainsString( 'text-transform:uppercase', $wrapper_style );
-		$this->assertStringContainsString( 'border-radius:12px', $item_style );
-		$this->assertStringNotContainsString( 'border-radius', $wrapper_style );
+		$this->assertStringContainsString( 'text-transform:uppercase', $wrapper_style, 'Wrapper should have text-transform: uppercase.' );
+		$this->assertStringContainsString( 'border-radius:12px', $item_style, 'Item should have border-radius: 12px.' );
+		$this->assertStringNotContainsString( 'border-radius', $wrapper_style, 'Wrapper should not have border-radius.' );
 	}
 
 	/**
@@ -97,7 +97,7 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 		$block = new \WP_Block(
 			array(
 				'blockName'    => 'woocommerce/product-filter-chips',
-				'attrs'        => $attributes,
+				'attrs'        => array_merge( $attributes, array( 'className' => 'wc-block-product-filter-chips' ) ),
 				'innerContent' => array(),
 			),
 			array(
@@ -121,7 +121,7 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 	 */
 	private function get_style( string $markup, string $class_name ): string {
 		$processor = new \WP_HTML_Tag_Processor( $markup );
-		$this->assertTrue( $processor->next_tag( array( 'class_name' => $class_name ) ) );
+		$this->assertTrue( $processor->next_tag( array( 'class_name' => $class_name ) ), 'Should find the first element with the given class name.' );
 
 		$style = $processor->get_attribute( 'style' );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
@@ -45,15 +45,23 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Border radius is not applied to visual swatch chip items.
+	 * @testdox Padding and border radius are not applied to visual swatch chip items.
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\ProductFilterChips::render
 	 */
-	public function test_does_not_apply_border_radius_to_swatch_items(): void {
+	public function test_does_not_apply_padding_or_border_radius_to_swatch_items(): void {
 		$markup = $this->render_chips(
 			array(
 				'style' => array(
-					'border' => array(
+					'border'  => array(
 						'radius' => '0px',
+					),
+					'spacing' => array(
+						'padding' => array(
+							'top'    => '8px',
+							'right'  => '16px',
+							'bottom' => '8px',
+							'left'   => '16px',
+						),
 					),
 				),
 			),
@@ -75,6 +83,7 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'is-style-swatch', $markup, 'Visual items should use the swatch style.' );
 		$this->assertStringNotContainsString( 'border-radius', $item_style, 'Swatch items should not get an inline border radius.' );
+		$this->assertStringNotContainsString( 'padding-top', $item_style, 'Swatch items should not get inline padding.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterChipsTest.php
@@ -25,6 +25,14 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 						'textTransform' => 'uppercase',
 					),
 				),
+			),
+			array(
+				array(
+					'id'       => 'item-red',
+					'label'    => 'Red',
+					'value'    => 'red',
+					'selected' => false,
+				),
 			)
 		);
 
@@ -37,12 +45,46 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Border radius is not applied to visual swatch chip items.
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\ProductFilterChips::render
+	 */
+	public function test_does_not_apply_border_radius_to_swatch_items(): void {
+		$markup = $this->render_chips(
+			array(
+				'style' => array(
+					'border' => array(
+						'radius' => '0px',
+					),
+				),
+			),
+			array(
+				array(
+					'id'       => 'item-red',
+					'label'    => 'Red',
+					'value'    => 'red',
+					'selected' => false,
+					'visual'   => array(
+						'type'  => 'color',
+						'color' => '#ff0000',
+					),
+				),
+			)
+		);
+
+		$item_style = $this->get_style( $markup, 'wc-block-product-filter-chips__item' );
+
+		$this->assertStringContainsString( 'is-style-swatch', $markup, 'Visual items should use the swatch style.' );
+		$this->assertStringNotContainsString( 'border-radius', $item_style, 'Swatch items should not get an inline border radius.' );
+	}
+
+	/**
 	 * Render the Chips block with the given attributes.
 	 *
 	 * @param array $attributes Block attributes.
+	 * @param array $items      Selectable items.
 	 * @return string Rendered markup.
 	 */
-	private function render_chips( array $attributes ): string {
+	private function render_chips( array $attributes, array $items ): string {
 		$block = new \WP_Block(
 			array(
 				'blockName'    => 'woocommerce/product-filter-chips',
@@ -51,14 +93,7 @@ class ProductFilterChipsTest extends WC_Unit_Test_Case {
 			),
 			array(
 				'woocommerce/selectableItems' => array(
-					'items'          => array(
-						array(
-							'id'       => 'item-red',
-							'label'    => 'Red',
-							'value'    => 'red',
-							'selected' => false,
-						),
-					),
+					'items'          => $items,
 					'selectionMode'  => 'multiple',
 					'storeNamespace' => 'woocommerce/product-filters',
 				),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds several style options to the _Chips_ block, used by _Product Filters_ and _Add to Cart + Options_:

* text transform
* letter spacing
* font size
* border radius
* padding

See also: https://github.com/woocommerce/woo-themes/pull/427

### How to test the changes in this Pull Request:

1. Edit the _Chips_ block style either in Appearance > Editor > Styles or editing the block directly.
2. Verify the styles are visible in the editor and the frontend.
3. Verify you can still change the colors of selected and unselected chips.
4. Optionally, verify that [color swatches](https://developer.woocommerce.com/2026/06/03/introducing-color-swatches-in-woocommerce-core/) still look correct (ie: setting the border radius to 0 doesn't transform them into squares).

Custom style | No styling
--- | ---
<img width="934" height="688" alt="imatge" src="https://github.com/user-attachments/assets/7293ff08-07b0-40b3-b9b1-a943ba7e26a4" /> | <img width="934" height="688" alt="imatge" src="https://github.com/user-attachments/assets/17de676f-c4e5-4131-a84f-0ba7c85873ac" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->