### PR TITLE
Fix missing currency symbol in new-order push notification total

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7621-new-order-push-notification-currency-symbol
+++ b/plugins/woocommerce/changelog/wooplug-7621-new-order-push-notification-currency-symbol
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the new-order push notification so the order total keeps its currency symbol (e.g. $71.94) instead of showing a bare amount.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
@@ -67,7 +67,9 @@ class NewOrderNotification extends Notification {
 				 */
 				'format' => 'New order for %1$s on %2$s',
 				'args'   => array(
-					wp_strip_all_tags( $order->get_formatted_order_total() ),
+					// Decode entities first (the currency symbol is an HTML entity such as &#36;), then strip
+					// tags last so no markup can survive in the plain-text payload.
+					wp_strip_all_tags( html_entity_decode( $order->get_formatted_order_total(), ENT_QUOTES, 'UTF-8' ) ),
 					wp_strip_all_tags( get_bloginfo( 'name' ) ),
 				),
 			),

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewOrderNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewOrderNotificationTest.php
@@ -77,9 +77,29 @@ class NewOrderNotificationTest extends WC_Unit_Test_Case {
 		$this->assertSame( get_bloginfo( 'name' ), $payload['message']['args'][1] );
 
 		$this->assertSame(
-			wp_strip_all_tags( $order->get_formatted_order_total() ),
+			wp_strip_all_tags( html_entity_decode( $order->get_formatted_order_total(), ENT_QUOTES, 'UTF-8' ) ),
 			$payload['message']['args'][0]
 		);
+	}
+
+	/**
+	 * @testdox Should include the decoded currency symbol in the order total, not an HTML entity.
+	 */
+	public function test_to_payload_message_order_total_contains_decoded_currency_symbol(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'USD' );
+		$order->set_total( '71.94' );
+		$order->save();
+
+		$notification = new NewOrderNotification( $order->get_id() );
+
+		$payload = $notification->to_payload();
+		$total   = $payload['message']['args'][0];
+
+		$this->assertStringContainsString( '$', $total, 'The order total should contain the decoded currency symbol.' );
+		$this->assertStringContainsString( '71.94', $total, 'The order total should contain the amount.' );
+		$this->assertStringNotContainsString( '&#', $total, 'The order total should not contain an undecoded HTML entity.' );
+		$this->assertStringNotContainsString( '<', $total, 'The order total should not contain HTML tags.' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The new-order push notification (`store_order`) rendered the order total without its currency symbol — e.g. "New order for 71.94 on …". `get_formatted_order_total()` wraps the symbol in an HTML entity (`&#36;`), and `wp_strip_all_tags()` left the raw entity, which got dropped downstream.

Fix: decode entities first, then strip tags, so the total keeps its symbol (`$71.94`).

Closes #68104.

(For Bug Fixes) Bug introduced in PR #63380.

### How to test the changes in this Pull Request:

1. Trigger a new-order push notification and confirm the total shows its currency symbol (e.g. `$71.94`).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added manually in this PR.
