### PR TITLE
Preserve custom order item deletion behavior

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-item-delete-overrides
+++ b/plugins/woocommerce/changelog/fix-order-item-delete-overrides
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve custom data store cleanup when removing order items.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1110,7 +1110,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * without also overriding `delete_items_by_ids()` retain the historical synchronous behavior.
 	 *
 	 * @param string|null $type Order item type. Default null (remove every type).
-	 * @throws Exception If persisted item IDs cannot be read.
+	 * @throws Exception If persisted item IDs cannot be read or synchronous item deletion fails.
 	 * @return void
 	 */
 	public function remove_order_items( $type = null ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -382,11 +382,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Determine whether the data store provides custom ID-based item deletion behavior.
+	 * Determine whether the data store supports optional ID-based item deletion.
 	 *
 	 * @return bool
 	 */
-	private function data_store_overrides_delete_items_by_ids(): bool {
+	private function data_store_supports_delete_items_by_ids(): bool {
 		/**
 		 * Data store wrapper.
 		 *
@@ -400,6 +400,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$data_store_class = $data_store->get_current_class_name();
 		if ( ! is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true ) ) {
+			// Standalone data stores opt in to deferred deletion by providing this optional method.
 			return true;
 		}
 
@@ -1140,7 +1141,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Unsaved orders (id 0) have no persisted items — there's nothing to defer for deletion.
 		$has_persisted_items  = $this->get_id() > 0;
-		$delete_synchronously = $this->data_store_overrides_delete_items() && ! $this->data_store_overrides_delete_items_by_ids();
+		$delete_synchronously = $this->data_store_overrides_delete_items() && ! $this->data_store_supports_delete_items_by_ids();
 
 		if ( $delete_synchronously && $has_persisted_items ) {
 			// @phpstan-ignore-next-line -- Required order data store method forwarded by WC_Data_Store::__call().

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -369,7 +369,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		 *
 		 * @var WC_Data_Store $data_store
 		 */
-		$data_store       = $this->data_store;
+		$data_store = $this->data_store;
+
+		if ( ! $data_store->has_callable( 'delete_items' ) ) {
+			return false;
+		}
+
 		$data_store_class = $data_store->get_current_class_name();
 
 		if ( ! is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true ) ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -331,23 +331,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Deletes items in bulk if the data store supports it, otherwise deletes them one by one.
 	 *
-	 * @param array<int>  $item_ids IDs of the items to delete.
-	 * @param string|null $type     Item type, or null for every type.
+	 * @param array<int> $item_ids IDs of the items to delete.
 	 * @return void
 	 */
-	private function delete_items_by_ids( array $item_ids, $type = null ): void {
+	private function delete_items_by_ids( array $item_ids ): void {
 		/**
 		 * Data store wrapper.
 		 *
 		 * @var WC_Data_Store $data_store
 		 */
 		$data_store = $this->data_store;
-
-		if ( $this->data_store_overrides_delete_items() ) {
-			// @phpstan-ignore-next-line -- Required order data store method forwarded by WC_Data_Store::__call().
-			$data_store->delete_items( $this, $type );
-			return;
-		}
 
 		if ( $data_store->has_callable( 'delete_items_by_ids' ) ) {
 			// @phpstan-ignore-next-line -- Optional data store method checked above.
@@ -384,6 +377,33 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$method = new ReflectionMethod( $data_store_class, 'delete_items' );
+
+		return Abstract_WC_Order_Data_Store_CPT::class !== $method->getDeclaringClass()->getName();
+	}
+
+	/**
+	 * Determine whether the data store provides custom ID-based item deletion behavior.
+	 *
+	 * @return bool
+	 */
+	private function data_store_overrides_delete_items_by_ids(): bool {
+		/**
+		 * Data store wrapper.
+		 *
+		 * @var WC_Data_Store $data_store
+		 */
+		$data_store = $this->data_store;
+
+		if ( ! $data_store->has_callable( 'delete_items_by_ids' ) ) {
+			return false;
+		}
+
+		$data_store_class = $data_store->get_current_class_name();
+		if ( ! is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true ) ) {
+			return true;
+		}
+
+		$method = new ReflectionMethod( $data_store_class, 'delete_items_by_ids' );
 
 		return Abstract_WC_Order_Data_Store_CPT::class !== $method->getDeclaringClass()->getName();
 	}
@@ -474,7 +494,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			// yet been processed remain queued for the next save() rather than being silently lost.
 			foreach ( array_values( array_unique( $this->item_types_to_bulk_delete ) ) as $type ) {
 				$item_ids = $this->item_ids_to_bulk_delete_by_type[ $type ] ?? array();
-				$this->delete_items_by_ids( $item_ids, $type );
+				$this->delete_items_by_ids( $item_ids );
 				unset( $this->item_ids_to_bulk_delete_by_type[ $type ] );
 				$items_changed                   = true;
 				$this->item_types_to_bulk_delete = array_values(
@@ -1085,15 +1105,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Remove all line items (products, coupons, shipping, taxes) from the order.
 	 *
-	 * The items are cleared from the in-memory order immediately, but the database
-	 * deletion is deferred until the next call to save(). This keeps the checkout
-	 * "resume order" flow atomic: if anything between here and save() throws, the
-	 * previously persisted items remain intact in the database. As a consequence,
-	 * the `woocommerce_removed_order_items` action now fires from save_items()
-	 * (after the actual DB delete completes) rather than synchronously from this
-	 * method — listeners that observe the persisted state continue to see it as
-	 * before, but listeners pairing pre/post on the same call stack will see
-	 * the post-hook fire at save() time.
+	 * The items are cleared from the in-memory order immediately, but core data stores defer
+	 * database deletion until the next call to save(). Custom stores overriding `delete_items()`
+	 * without also overriding `delete_items_by_ids()` retain the historical synchronous behavior.
 	 *
 	 * @param string|null $type Order item type. Default null (remove every type).
 	 * @throws Exception If persisted item IDs cannot be read.
@@ -1125,10 +1139,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		do_action( 'woocommerce_remove_order_items', $this, $type );
 
 		// Unsaved orders (id 0) have no persisted items — there's nothing to defer for deletion.
-		$has_persisted_items = $this->get_id() > 0;
+		$has_persisted_items  = $this->get_id() > 0;
+		$delete_synchronously = $this->data_store_overrides_delete_items() && ! $this->data_store_overrides_delete_items_by_ids();
+
+		if ( $delete_synchronously && $has_persisted_items ) {
+			// @phpstan-ignore-next-line -- Required order data store method forwarded by WC_Data_Store::__call().
+			$this->data_store->delete_items( $this, $type );
+		}
 
 		if ( ! empty( $type ) ) {
-			if ( $has_persisted_items ) {
+			if ( $has_persisted_items && ! $delete_synchronously ) {
 				$item_ids = $this->get_persisted_item_ids( $type );
 
 				if ( $this->bulk_delete_all_items_pending ) {
@@ -1159,7 +1179,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$this->items[ $group ] = array();
 			}
 		} else {
-			if ( $has_persisted_items ) {
+			if ( $has_persisted_items && ! $delete_synchronously ) {
 				$item_ids = $this->get_persisted_item_ids();
 
 				foreach ( $this->item_ids_to_bulk_delete_by_type as $typed_item_ids ) {
@@ -1186,6 +1206,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			foreach ( $groups as $group ) {
 				$this->items[ $group ] = array();
 			}
+		}
+
+		if ( $delete_synchronously ) {
+			/**
+			 * This action is documented in save_items().
+			 *
+			 * @since 7.8.0
+			 */
+			do_action( 'woocommerce_removed_order_items', $this, $type );
 		}
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -331,16 +331,23 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Deletes items in bulk if the data store supports it, otherwise deletes them one by one.
 	 *
-	 * @param array<int> $item_ids IDs of the items to delete.
+	 * @param array<int>  $item_ids IDs of the items to delete.
+	 * @param string|null $type     Item type, or null for every type.
 	 * @return void
 	 */
-	private function delete_items_by_ids( array $item_ids ): void {
+	private function delete_items_by_ids( array $item_ids, $type = null ): void {
 		/**
 		 * Data store wrapper.
 		 *
 		 * @var WC_Data_Store $data_store
 		 */
 		$data_store = $this->data_store;
+
+		if ( $this->data_store_overrides_delete_items() ) {
+			// @phpstan-ignore-next-line -- Required order data store method forwarded by WC_Data_Store::__call().
+			$data_store->delete_items( $this, $type );
+			return;
+		}
 
 		if ( $data_store->has_callable( 'delete_items_by_ids' ) ) {
 			// @phpstan-ignore-next-line -- Optional data store method checked above.
@@ -356,6 +363,29 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Determine whether the data store provides custom item deletion behavior.
+	 *
+	 * @return bool
+	 */
+	private function data_store_overrides_delete_items(): bool {
+		/**
+		 * Data store wrapper.
+		 *
+		 * @var WC_Data_Store $data_store
+		 */
+		$data_store       = $this->data_store;
+		$data_store_class = $data_store->get_current_class_name();
+
+		if ( ! is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true ) ) {
+			return true;
+		}
+
+		$method = new ReflectionMethod( $data_store_class, 'delete_items' );
+
+		return Abstract_WC_Order_Data_Store_CPT::class !== $method->getDeclaringClass()->getName();
 	}
 
 	/**
@@ -444,7 +474,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			// yet been processed remain queued for the next save() rather than being silently lost.
 			foreach ( array_values( array_unique( $this->item_types_to_bulk_delete ) ) as $type ) {
 				$item_ids = $this->item_ids_to_bulk_delete_by_type[ $type ] ?? array();
-				$this->delete_items_by_ids( $item_ids );
+				$this->delete_items_by_ids( $item_ids, $type );
 				unset( $this->item_ids_to_bulk_delete_by_type[ $type ] );
 				$items_changed                   = true;
 				$this->item_types_to_bulk_delete = array_values(

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -106,6 +106,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected $temp_item_id_counter = 0;
 
 	/**
+	 * Whether the data store supports deferred item deletion.
+	 *
+	 * @var bool|null Null until first checked.
+	 */
+	private $data_store_supports_deferred_item_deletion = null;
+
+	/**
 	 * Bulk order item types scheduled for deletion on save().
 	 *
 	 * Populated by remove_order_items() with a specific item type and processed by
@@ -359,11 +366,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Determine whether the data store provides custom item deletion behavior.
+	 * Determine whether the data store supports deferred item deletion.
 	 *
 	 * @return bool
 	 */
-	private function data_store_overrides_delete_items(): bool {
+	private function data_store_supports_deferred_item_deletion(): bool {
+		if ( null !== $this->data_store_supports_deferred_item_deletion ) {
+			return $this->data_store_supports_deferred_item_deletion;
+		}
+
 		/**
 		 * Data store wrapper.
 		 *
@@ -372,46 +383,34 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$data_store = $this->data_store;
 
 		if ( ! $data_store->has_callable( 'delete_items' ) ) {
-			return false;
-		}
-
-		$data_store_class = $data_store->get_current_class_name();
-
-		if ( ! is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true ) ) {
+			$this->data_store_supports_deferred_item_deletion = true;
 			return true;
 		}
 
-		$method = new ReflectionMethod( $data_store_class, 'delete_items' );
+		$data_store_class = $data_store->get_current_class_name();
+		$is_cpt_store     = is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true );
 
-		return Abstract_WC_Order_Data_Store_CPT::class !== $method->getDeclaringClass()->getName();
-	}
+		if ( ! $is_cpt_store ) {
+			// Standalone data stores opt in to deferred deletion by providing this optional method.
+			$this->data_store_supports_deferred_item_deletion = $data_store->has_callable( 'delete_items_by_ids' );
+			return $this->data_store_supports_deferred_item_deletion;
+		}
 
-	/**
-	 * Determine whether the data store opts in to deferred item deletion.
-	 *
-	 * @return bool
-	 */
-	private function data_store_opts_in_to_deferred_item_deletion(): bool {
-		/**
-		 * Data store wrapper.
-		 *
-		 * @var WC_Data_Store $data_store
-		 */
-		$data_store = $this->data_store;
+		$delete_items_method = new ReflectionMethod( $data_store_class, 'delete_items' );
+		if ( Abstract_WC_Order_Data_Store_CPT::class === $delete_items_method->getDeclaringClass()->getName() ) {
+			$this->data_store_supports_deferred_item_deletion = true;
+			return true;
+		}
 
 		if ( ! $data_store->has_callable( 'delete_items_by_ids' ) ) {
+			$this->data_store_supports_deferred_item_deletion = false;
 			return false;
 		}
 
-		$data_store_class = $data_store->get_current_class_name();
-		if ( ! is_a( $data_store_class, Abstract_WC_Order_Data_Store_CPT::class, true ) ) {
-			// Standalone data stores opt in to deferred deletion by providing this optional method.
-			return true;
-		}
+		$delete_items_by_ids_method = new ReflectionMethod( $data_store_class, 'delete_items_by_ids' );
 
-		$method = new ReflectionMethod( $data_store_class, 'delete_items_by_ids' );
-
-		return Abstract_WC_Order_Data_Store_CPT::class !== $method->getDeclaringClass()->getName();
+		$this->data_store_supports_deferred_item_deletion = Abstract_WC_Order_Data_Store_CPT::class !== $delete_items_by_ids_method->getDeclaringClass()->getName();
+		return $this->data_store_supports_deferred_item_deletion;
 	}
 
 	/**
@@ -1146,7 +1145,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Unsaved orders (id 0) have no persisted items — there's nothing to defer for deletion.
 		$has_persisted_items  = $this->get_id() > 0;
-		$delete_synchronously = $this->data_store_overrides_delete_items() && ! $this->data_store_opts_in_to_deferred_item_deletion();
+		$delete_synchronously = ! $this->data_store_supports_deferred_item_deletion();
 
 		if ( $delete_synchronously && $has_persisted_items ) {
 			// @phpstan-ignore-next-line -- Required order data store method forwarded by WC_Data_Store::__call().

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -382,11 +382,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Determine whether the data store supports optional ID-based item deletion.
+	 * Determine whether the data store opts in to deferred item deletion.
 	 *
 	 * @return bool
 	 */
-	private function data_store_supports_delete_items_by_ids(): bool {
+	private function data_store_opts_in_to_deferred_item_deletion(): bool {
 		/**
 		 * Data store wrapper.
 		 *
@@ -1141,7 +1141,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Unsaved orders (id 0) have no persisted items — there's nothing to defer for deletion.
 		$has_persisted_items  = $this->get_id() > 0;
-		$delete_synchronously = $this->data_store_overrides_delete_items() && ! $this->data_store_supports_delete_items_by_ids();
+		$delete_synchronously = $this->data_store_overrides_delete_items() && ! $this->data_store_opts_in_to_deferred_item_deletion();
 
 		if ( $delete_synchronously && $has_persisted_items ) {
 			// @phpstan-ignore-next-line -- Required order data store method forwarded by WC_Data_Store::__call().

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -832,6 +832,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	/**
 	 * Delete selected order items by ID.
 	 *
+	 * Custom order data stores that override this method opt in to deferred item deletion. The IDs are captured when items are removed and deleted during order save.
+	 *
 	 * @since 11.1.0
 	 *
 	 * @param WC_Order $order Order object.

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1615,8 +1615,10 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_remove_order_items_defers_custom_data_store_id_deletion() {
 		$order               = WC_Helper_Order::create_order();
+		$original_items      = $order->get_items();
+		$product             = current( $original_items )->get_product();
 		$original_data_store = $order->get_data_store();
-		$original_item_ids   = array_merge( array_keys( $order->get_items() ), array_keys( $order->get_items( 'shipping' ) ) );
+		$original_item_ids   = array_merge( array_keys( $original_items ), array_keys( $order->get_items( 'shipping' ) ) );
 
 		// phpcs:disable Squiz.Commenting -- Anonymous test double methods are self-explanatory.
 		$custom_data_store = new class( $original_data_store ) extends WC_Order_Data_Store_CPT {
@@ -1664,6 +1666,12 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 				$this->assertInstanceOf( WC_Order_Item::class, WC_Order_Factory::get_order_item( $item_id ), 'Items should remain persisted until save().' );
 			}
 
+			$replacement_item = $this->create_deferred_deletion_test_item( $product, 'Early-saved replacement' );
+			$replacement_item->add_meta_data( '_custom_id_deletion_test', 'preserved', true );
+			$order->add_item( $replacement_item );
+			$replacement_item->set_order_id( $order->get_id() );
+			$replacement_item_id = $replacement_item->save();
+
 			$order->save();
 		} finally {
 			remove_filter( 'woocommerce_order_data_store', $data_store_filter, PHP_INT_MAX );
@@ -1675,6 +1683,9 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		foreach ( $original_item_ids as $item_id ) {
 			$this->assertFalse( WC_Order_Factory::get_order_item( $item_id ), 'Snapshotted items should be deleted during save().' );
 		}
+		$persisted_replacement = WC_Order_Factory::get_order_item( $replacement_item_id );
+		$this->assertInstanceOf( WC_Order_Item::class, $persisted_replacement, 'An item saved after removal should not be deleted during save().' );
+		$this->assertSame( 'preserved', $persisted_replacement->get_meta( '_custom_id_deletion_test' ), 'The replacement item metadata should be preserved.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1546,56 +1546,57 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 * @param string|null $type Item type, or null for every type.
 	 */
 	public function test_remove_order_items_invokes_custom_data_store_delete_items( $type ) {
-		$order               = WC_Helper_Order::create_order();
-		$original_data_store = $order->get_data_store();
+		$order                 = WC_Helper_Order::create_order();
+		$original_data_store   = $order->get_data_store();
+		$line_item_ids         = array_keys( $order->get_items() );
+		$shipping_item_ids     = array_keys( $order->get_items( 'shipping' ) );
+		$expected_deleted_ids  = null === $type ? array_merge( $line_item_ids, $shipping_item_ids ) : $line_item_ids;
+		$expected_retained_ids = null === $type ? array() : $shipping_item_ids;
 
 		// phpcs:disable Squiz.Commenting -- Anonymous test double methods are self-explanatory.
-		$overriding_data_store_class = get_class(
-			new class() extends WC_Order_Data_Store_CPT {
-				public $delete_items_call_count = 0;
-
-				public function delete_items( $order, $type = null ) {
-					++$this->delete_items_call_count;
-					parent::delete_items( $order, $type );
-				}
-			}
-		);
-		$custom_data_store           = new class( $original_data_store, $overriding_data_store_class ) extends WC_Data_Store {
+		$custom_data_store = new class( $original_data_store ) extends WC_Order_Data_Store_CPT {
 			public $deleted_item_types = array();
 
 			private $delegate;
 
-			private $overriding_data_store_class;
-
-			public function __construct( $delegate, $overriding_data_store_class ) {
-				parent::__construct( 'order' );
-				$this->delegate                    = $delegate;
-				$this->overriding_data_store_class = $overriding_data_store_class;
+			public function __construct( $delegate ) {
+				$this->delegate = $delegate;
 			}
 
-			public function get_current_class_name() {
-				return $this->overriding_data_store_class;
+			public function update( &$order ) {
+				return $this->delegate->update( $order );
 			}
 
 			public function delete_items( $order, $type = null ) {
 				$this->deleted_item_types[] = $type;
 				return $this->delegate->delete_items( $order, $type );
 			}
-
-			public function __call( $method, $parameters ) {
-				return $this->delegate->{$method}( ...$parameters );
-			}
 		};
 		// phpcs:enable Squiz.Commenting
 
-		$reflection = new ReflectionProperty( WC_Data::class, 'data_store' );
-		$reflection->setAccessible( true );
-		$reflection->setValue( $order, $custom_data_store );
+		$data_store_filter = static function () use ( $custom_data_store ) {
+			return $custom_data_store;
+		};
+		add_filter( 'woocommerce_order_data_store', $data_store_filter, PHP_INT_MAX );
 
-		$order->remove_order_items( $type );
-		$order->save();
+		try {
+			$reflection = new ReflectionProperty( WC_Data::class, 'data_store' );
+			$reflection->setAccessible( true );
+			$reflection->setValue( $order, new WC_Data_Store( 'order' ) );
+
+			$order->remove_order_items( $type );
+			$order->save();
+		} finally {
+			remove_filter( 'woocommerce_order_data_store', $data_store_filter, PHP_INT_MAX );
+		}
 
 		$this->assertSame( array( $type ), $custom_data_store->deleted_item_types, 'The custom delete_items() implementation should be invoked once with the requested type.' );
+		foreach ( $expected_deleted_ids as $item_id ) {
+			$this->assertFalse( WC_Order_Factory::get_order_item( $item_id ), 'Items selected for removal should be deleted.' );
+		}
+		foreach ( $expected_retained_ids as $item_id ) {
+			$this->assertInstanceOf( WC_Order_Item::class, WC_Order_Factory::get_order_item( $item_id ), 'Items of other types should be retained.' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1539,6 +1539,66 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should invoke custom data store item deletion behavior.
+	 * @testWith [null]
+	 *           ["line_item"]
+	 *
+	 * @param string|null $type Item type, or null for every type.
+	 */
+	public function test_remove_order_items_invokes_custom_data_store_delete_items( $type ) {
+		$order               = WC_Helper_Order::create_order();
+		$original_data_store = $order->get_data_store();
+
+		// phpcs:disable Squiz.Commenting -- Anonymous test double methods are self-explanatory.
+		$overriding_data_store_class = get_class(
+			new class() extends WC_Order_Data_Store_CPT {
+				public $delete_items_call_count = 0;
+
+				public function delete_items( $order, $type = null ) {
+					++$this->delete_items_call_count;
+					parent::delete_items( $order, $type );
+				}
+			}
+		);
+		$custom_data_store           = new class( $original_data_store, $overriding_data_store_class ) extends WC_Data_Store {
+			public $deleted_item_types = array();
+
+			private $delegate;
+
+			private $overriding_data_store_class;
+
+			public function __construct( $delegate, $overriding_data_store_class ) {
+				parent::__construct( 'order' );
+				$this->delegate                    = $delegate;
+				$this->overriding_data_store_class = $overriding_data_store_class;
+			}
+
+			public function get_current_class_name() {
+				return $this->overriding_data_store_class;
+			}
+
+			public function delete_items( $order, $type = null ) {
+				$this->deleted_item_types[] = $type;
+				return $this->delegate->delete_items( $order, $type );
+			}
+
+			public function __call( $method, $parameters ) {
+				return $this->delegate->{$method}( ...$parameters );
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
+		$reflection = new ReflectionProperty( WC_Data::class, 'data_store' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $order, $custom_data_store );
+
+		$order->remove_order_items( $type );
+		$order->save();
+
+		$this->assertSame( array( $type ), $custom_data_store->deleted_item_types, 'The custom delete_items() implementation should be invoked once with the requested type.' );
+	}
+
+	/**
 	 * @testdox Should preserve replacement items with a legacy custom data store lacking ID snapshot and deletion methods.
 	 */
 	public function test_remove_order_items_preserves_replacements_with_custom_data_store_fallback() {

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1611,7 +1611,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should defer deletion when a custom data store overrides ID-based deletion.
+	 * @testdox Should defer deletion when a custom data store opts in to ID-based deletion.
 	 */
 	public function test_remove_order_items_defers_custom_data_store_id_deletion() {
 		$order               = WC_Helper_Order::create_order();

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1539,7 +1539,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should invoke custom data store item deletion behavior.
+	 * @testdox Should synchronously invoke custom data store item deletion behavior.
 	 * @testWith [null]
 	 *           ["line_item"]
 	 *
@@ -1574,6 +1574,78 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		};
 		// phpcs:enable Squiz.Commenting
 
+		$data_store_filter  = static function () use ( $custom_data_store ) {
+			return $custom_data_store;
+		};
+		$removed_item_types = array();
+		$removed_hook       = static function ( $hook_order, $hook_type ) use ( &$removed_item_types ) {
+			$removed_item_types[] = $hook_type;
+		};
+		add_filter( 'woocommerce_order_data_store', $data_store_filter, PHP_INT_MAX );
+		add_action( 'woocommerce_removed_order_items', $removed_hook, 10, 2 );
+
+		try {
+			$reflection = new ReflectionProperty( WC_Data::class, 'data_store' );
+			$reflection->setAccessible( true );
+			$reflection->setValue( $order, new WC_Data_Store( 'order' ) );
+
+			$order->remove_order_items( $type );
+
+			$this->assertSame( array( $type ), $custom_data_store->deleted_item_types, 'The custom delete_items() implementation should run synchronously with the requested type.' );
+			$this->assertSame( array( $type ), $removed_item_types, 'The post-removal hook should run synchronously with the requested type.' );
+			foreach ( $expected_deleted_ids as $item_id ) {
+				$this->assertFalse( WC_Order_Factory::get_order_item( $item_id ), 'Items selected for removal should be deleted synchronously.' );
+			}
+			foreach ( $expected_retained_ids as $item_id ) {
+				$this->assertInstanceOf( WC_Order_Item::class, WC_Order_Factory::get_order_item( $item_id ), 'Items of other types should be retained.' );
+			}
+
+			$order->save();
+
+			$this->assertSame( array( $type ), $custom_data_store->deleted_item_types, 'Saving should not invoke the custom delete_items() implementation again.' );
+			$this->assertSame( array( $type ), $removed_item_types, 'Saving should not fire the post-removal hook again.' );
+		} finally {
+			remove_filter( 'woocommerce_order_data_store', $data_store_filter, PHP_INT_MAX );
+			remove_action( 'woocommerce_removed_order_items', $removed_hook, 10 );
+		}
+	}
+
+	/**
+	 * @testdox Should defer deletion when a custom data store overrides ID-based deletion.
+	 */
+	public function test_remove_order_items_defers_custom_data_store_id_deletion() {
+		$order               = WC_Helper_Order::create_order();
+		$original_data_store = $order->get_data_store();
+		$original_item_ids   = array_merge( array_keys( $order->get_items() ), array_keys( $order->get_items( 'shipping' ) ) );
+
+		// phpcs:disable Squiz.Commenting -- Anonymous test double methods are self-explanatory.
+		$custom_data_store = new class( $original_data_store ) extends WC_Order_Data_Store_CPT {
+			public $delete_items_call_count = 0;
+
+			public $deleted_item_id_batches = array();
+
+			private $delegate;
+
+			public function __construct( $delegate ) {
+				$this->delegate = $delegate;
+			}
+
+			public function update( &$order ) {
+				return $this->delegate->update( $order );
+			}
+
+			public function delete_items( $order, $type = null ) {
+				++$this->delete_items_call_count;
+				return $this->delegate->delete_items( $order, $type );
+			}
+
+			public function delete_items_by_ids( $order, $ids ) {
+				$this->deleted_item_id_batches[] = $ids;
+				return $this->delegate->delete_items_by_ids( $order, $ids );
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
 		$data_store_filter = static function () use ( $custom_data_store ) {
 			return $custom_data_store;
 		};
@@ -1584,18 +1656,24 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 			$reflection->setAccessible( true );
 			$reflection->setValue( $order, new WC_Data_Store( 'order' ) );
 
-			$order->remove_order_items( $type );
+			$order->remove_order_items();
+
+			$this->assertSame( 0, $custom_data_store->delete_items_call_count, 'The legacy deletion override should not run when custom ID-based deletion is available.' );
+			$this->assertSame( array(), $custom_data_store->deleted_item_id_batches, 'ID-based deletion should remain deferred until save().' );
+			foreach ( $original_item_ids as $item_id ) {
+				$this->assertInstanceOf( WC_Order_Item::class, WC_Order_Factory::get_order_item( $item_id ), 'Items should remain persisted until save().' );
+			}
+
 			$order->save();
 		} finally {
 			remove_filter( 'woocommerce_order_data_store', $data_store_filter, PHP_INT_MAX );
 		}
 
-		$this->assertSame( array( $type ), $custom_data_store->deleted_item_types, 'The custom delete_items() implementation should be invoked once with the requested type.' );
-		foreach ( $expected_deleted_ids as $item_id ) {
-			$this->assertFalse( WC_Order_Factory::get_order_item( $item_id ), 'Items selected for removal should be deleted.' );
-		}
-		foreach ( $expected_retained_ids as $item_id ) {
-			$this->assertInstanceOf( WC_Order_Item::class, WC_Order_Factory::get_order_item( $item_id ), 'Items of other types should be retained.' );
+		$this->assertSame( 0, $custom_data_store->delete_items_call_count, 'The legacy deletion override should not run during save().' );
+		$this->assertCount( 1, $custom_data_store->deleted_item_id_batches, 'The custom ID-based deletion override should run once during save().' );
+		$this->assertEqualsCanonicalizing( $original_item_ids, $custom_data_store->deleted_item_id_batches[0], 'The custom ID-based deletion override should receive the snapshotted item IDs.' );
+		foreach ( $original_item_ids as $item_id ) {
+			$this->assertFalse( WC_Order_Factory::get_order_item( $item_id ), 'Snapshotted items should be deleted during save().' );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1692,9 +1692,10 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 * @testdox Should preserve replacement items with a legacy custom data store lacking ID snapshot and deletion methods.
 	 */
 	public function test_remove_order_items_preserves_replacements_with_custom_data_store_fallback() {
-		$order          = WC_Helper_Order::create_order();
-		$original_items = $order->get_items();
-		$product        = current( $original_items )->get_product();
+		$order             = WC_Helper_Order::create_order();
+		$original_items    = $order->get_items();
+		$original_item_ids = array_merge( array_keys( $original_items ), array_keys( $order->get_items( 'shipping' ) ) );
+		$product           = current( $original_items )->get_product();
 
 		$original_data_store = $order->get_data_store();
 		// phpcs:disable Squiz.Commenting -- Anonymous test double methods are self-explanatory.
@@ -1707,7 +1708,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 			}
 
 			public function has_callable( string $method ): bool {
-				return in_array( $method, array( 'get_item_ids', 'delete_items_by_ids' ), true ) ? false : $this->delegate->has_callable( $method );
+				return in_array( $method, array( 'delete_items', 'get_item_ids', 'delete_items_by_ids' ), true ) ? false : $this->delegate->has_callable( $method );
 			}
 
 			public function update( &$data ) {
@@ -1715,7 +1716,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 			}
 
 			public function get_current_class_name() {
-				return $this->delegate->get_current_class_name();
+				return get_class( $this );
 			}
 
 			public function __call( $method, $parameters ) {
@@ -1729,6 +1730,10 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$reflection->setValue( $order, $custom_data_store );
 
 		$order->remove_order_items();
+
+		foreach ( $original_item_ids as $item_id ) {
+			$this->assertInstanceOf( WC_Order_Item::class, WC_Order_Factory::get_order_item( $item_id ), 'Items should remain persisted until save().' );
+		}
 
 		$early_saved_item = $this->create_deferred_deletion_test_item( $product, 'Early-saved replacement' );
 		$early_saved_item->add_meta_data( '_fallback_test', 'preserved', true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The ID-based order item deletion path added in #67975 bypassed custom data stores overriding the existing `delete_items()` method. This PR preserves deferred snapshot-based deletion for core CPT and HPOS stores. Custom stores overriding `delete_items()` retain the historical synchronous behavior unless they also override `delete_items_by_ids()`, which explicitly opts them into deferred deletion. Standalone stores without a callable `delete_items()` method use the deferred fallback instead of silently skipping persisted-item deletion.

This restores the released extension contract without changing any public method signatures or hook names and arguments. For affected custom stores, `woocommerce_removed_order_items` timing is restored to synchronous. It also avoids exposing custom stores to a hybrid deferred flow with the known replacement-item bug.

Bug introduced in PR #67975.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Register a custom order data store that overrides `delete_items()` but not `delete_items_by_ids()`.
2. Remove all order items, or one item type, and confirm before saving that `delete_items()` and `woocommerce_removed_order_items` ran once, with the requested items deleted.
3. Save the order and confirm deletion and the hook do not run again.
4. Override both deletion methods, save a replacement item after removal, and confirm ID-based deletion remains deferred until save while preserving the replacement.
5. Register a standalone store without `delete_items()`, save replacement items after removal, and confirm the original items remain until save and are then deleted without removing the replacements.
6. Repeat with HPOS enabled and disabled.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused regression tests with HPOS enabled: 4 tests, 28 assertions.
- Focused regression tests with HPOS disabled: 4 tests, 28 assertions.
- `WC_Abstract_Order_Test` with HPOS enabled: 62 tests, 237 assertions.
- `lint:php:changes`
- `lint:php:changes:branch`
- PHPStan on `includes/abstracts/abstract-wc-order.php`
- Scanned 8,136 latest WordPress.org plugins tagged `woocommerce`; no order data store `delete_items()` overrides were found and no archive errors occurred.
- Scanned all 1,802 current plugin ZIPs in `woocommerce/all-plugins`; no order data store `delete_items()` overrides were found and no archive errors occurred. CartPulse contained unrelated REST-controller methods with the same name.

These scans cover current published/package snapshots, not older releases, private bespoke extensions, or other unindexed code. Multisite was not tested; this change does not introduce or alter site-scoped storage.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI GPT-5.6 via pi was used to analyze the regression and draft the implementation and tests.







