### PR TITLE
Add an opt-in migration from Back In Stock Notifications to Core stock notifications

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5001-add-stock-notifications-migration
+++ b/plugins/woocommerce/changelog/wooplug-5001-add-stock-notifications-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an opt-in migration that carries subscribers, settings and product signup flags from the Back In Stock Notifications extension into the customer stock notifications feature, run from WooCommerce > Status > Tools or wp wc bis-migrate, so unsubscribe links in already-delivered emails keep working after the move.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -433,6 +433,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\POS\POSController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\StockNotifications\StockNotifications::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ScheduledSalePriceReconciler::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalController::class )->register();
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -197,10 +197,7 @@ class EmailActionController {
 	 */
 	private function process_unsubscribe_action( Notification $notification, string $action_key ): void {
 		if ( $notification->check_unsubscribe_key( $action_key ) ) {
-			$notification->set_status( NotificationStatus::CANCELLED );
-			$notification->set_cancellation_source( NotificationCancellationSource::USER );
-			$notification->set_date_cancelled( time() );
-			$notification->save();
+			$this->unsubscribe( $notification );
 
 			// We need a cookie-based session for notices to work on frontend pages.
 			if ( WC()->session instanceof \WC_Session_Handler && ! WC()->session->has_session() ) {
@@ -224,6 +221,30 @@ class EmailActionController {
 			wp_safe_redirect( $url );
 			exit;
 		}
+	}
+
+	/**
+	 * Cancel a notification, if it is still eligible to be cancelled.
+	 *
+	 * Acts only on a `pending` or `active` notification, so calling this again on an
+	 * already-cancelled or already-sent row is a no-op.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param Notification $notification The notification to cancel.
+	 * @return bool True if the notification was cancelled, false if it was left unchanged.
+	 */
+	public function unsubscribe( Notification $notification ): bool {
+		if ( ! in_array( $notification->get_status(), array( NotificationStatus::PENDING, NotificationStatus::ACTIVE ), true ) ) {
+			return false;
+		}
+
+		$notification->set_status( NotificationStatus::CANCELLED );
+		$notification->set_cancellation_source( NotificationCancellationSource::USER );
+		$notification->set_date_cancelled( time() );
+		$notification->save();
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShim.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShim.php
@@ -359,7 +359,8 @@ class LegacyUnsubscribeShim {
 	 */
 	private function respond_generic_stale_link(): void {
 		$this->start_session();
-		wc_add_notice( esc_html__( 'This unsubscribe link is invalid or has expired.', 'woocommerce' ) );
+		// Notice, not the default success type: an expired link is not something that worked.
+		wc_add_notice( esc_html__( 'This unsubscribe link is invalid or has expired.', 'woocommerce' ), 'notice' );
 		$this->redirect();
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShim.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShim.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * LegacyUnsubscribeShim class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Compat;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailActionController;
+use Automattic\WooCommerce\Internal\StockNotifications\Factory;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\LegacyHash;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Internal\StockNotifications\NotificationQuery;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Keeps the legacy Back In Stock Notifications extension's `bis_unsub` email links working
+ * against migrated Core notifications.
+ *
+ * Registered on `template_redirect` only while `wc_bis_migration_has_legacy_links` is set.
+ * `MigrationController` owns that registration decision; this class only handles the request
+ * once it is hooked up.
+ *
+ * Removal is a release decision, not a runtime one: a later release drops this class, along
+ * with the `_wc_bis_legacy_unsub_hash` meta key and the `wc_bis_migration_has_legacy_links`
+ * flag, and replaces it with a minimal permanent responder that keeps giving old links the
+ * same generic notice without doing any resolution or sweeping.
+ */
+class LegacyUnsubscribeShim {
+
+	/**
+	 * Meta key holding the legacy notification id a Core row was migrated from.
+	 */
+	private const META_KEY_LEGACY_ID = '_wc_bis_legacy_id';
+
+	/**
+	 * Meta key holding the precomputed legacy unsubscribe token digest.
+	 */
+	private const META_KEY_LEGACY_UNSUB_HASH = '_wc_bis_legacy_unsub_hash';
+
+	/**
+	 * `bis_unsub_ref` value used by the legacy "back in stock" confirmation email.
+	 */
+	private const REF_CONFIRMATION = 'confirmation';
+
+	/**
+	 * Email action controller. Owns the actual cancellation once a row is resolved.
+	 *
+	 * @var EmailActionController
+	 */
+	private EmailActionController $email_action_controller;
+
+	/**
+	 * Constructor. Hooks the shim into the request lifecycle.
+	 */
+	public function __construct() {
+		add_action( 'template_redirect', array( $this, 'maybe_process_legacy_unsubscribe' ) );
+	}
+
+	/**
+	 * Init the service.
+	 *
+	 * @internal
+	 *
+	 * @param EmailActionController $email_action_controller The email action controller.
+	 */
+	final public function init( EmailActionController $email_action_controller ): void {
+		$this->email_action_controller = $email_action_controller;
+	}
+
+	/**
+	 * Handle an incoming legacy unsubscribe request, if there is one.
+	 *
+	 * Every terminal outcome sets the session cookie, adds a notice and redirects, so a
+	 * customer clicking a stale link never lands on an ordinary page wondering whether it
+	 * worked.
+	 */
+	public function maybe_process_legacy_unsubscribe(): void {
+		// No nonce here: these are links delivered by email, not a form submitted by a
+		// logged-in visitor.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( empty( $_GET['bis_unsub'] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$token_raw = sanitize_text_field( wp_unslash( $_GET['bis_unsub'] ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$legacy_id = isset( $_GET['bis_unsub_id'] ) ? absint( wp_unslash( $_GET['bis_unsub_id'] ) ) : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$ref = isset( $_GET['bis_unsub_ref'] ) ? sanitize_key( wp_unslash( $_GET['bis_unsub_ref'] ) ) : '';
+
+		// Pre-1.2.0 links have no `bis_unsub_id` and used a hash Core never reproduces
+		// (see Mapping\LegacyHash and the migration plan). Out of scope: same generic
+		// notice as every other unresolvable link.
+		if ( ! $legacy_id ) {
+			$this->respond_generic_stale_link();
+			return;
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- decoding legacy's own token encoding, not obfuscating output.
+		$token = urldecode( base64_decode( $token_raw ) );
+
+		try {
+			$notification = $this->resolve_notification( $legacy_id, $token );
+		} catch ( \Throwable $exception ) {
+			// The notification data store is unregistered when the stock notifications
+			// feature toggle is off. The shim's own flag can outlive that toggle.
+			$notification = null;
+		}
+
+		if ( ! $notification ) {
+			$this->respond_generic_stale_link();
+			return;
+		}
+
+		$this->start_session();
+		$this->cancel_and_respond( $notification, $ref );
+	}
+
+	/**
+	 * Resolve the Core notification a legacy unsubscribe link points at, and verify its token.
+	 *
+	 * @param int    $legacy_id Legacy notification id from `bis_unsub_id`.
+	 * @param string $token     Decoded token from `bis_unsub`.
+	 * @return Notification|null Null when nothing resolved or the token did not verify.
+	 */
+	private function resolve_notification( int $legacy_id, string $token ): ?Notification {
+		global $wpdb;
+
+		$meta_table = $wpdb->prefix . 'wc_stock_notificationmeta';
+
+		$notification_id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name built from $wpdb->prefix, not from user input.
+				"SELECT notification_id FROM {$meta_table} WHERE meta_key = %s AND CAST( meta_value AS UNSIGNED ) = %d LIMIT 1",
+				self::META_KEY_LEGACY_ID,
+				$legacy_id
+			)
+		);
+
+		if ( ! $notification_id ) {
+			wc_get_logger()->warning(
+				sprintf( 'Legacy BIS unsubscribe: no notification found for legacy id %d.', $legacy_id ),
+				array( 'source' => 'stock-notifications' )
+			);
+			return null;
+		}
+
+		$hash_values = $wpdb->get_col(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name built from $wpdb->prefix, not from user input.
+				"SELECT meta_value FROM {$meta_table} WHERE notification_id = %d AND meta_key = %s",
+				$notification_id,
+				self::META_KEY_LEGACY_UNSUB_HASH
+			)
+		);
+
+		$matched_meta_value = null;
+		foreach ( $hash_values as $hash_value ) {
+			$parsed = LegacyHash::parse( (string) $hash_value );
+			if ( $parsed && $legacy_id === $parsed[0] ) {
+				$matched_meta_value = (string) $hash_value;
+				break;
+			}
+		}
+
+		if ( null === $matched_meta_value || ! LegacyHash::verify( $matched_meta_value, $token ) ) {
+			wc_get_logger()->warning(
+				sprintf( 'Legacy BIS unsubscribe: token did not verify for legacy id %d.', $legacy_id ),
+				array( 'source' => 'stock-notifications' )
+			);
+			return null;
+		}
+
+		$notification = Factory::get_notification( $notification_id );
+
+		return $notification instanceof Notification ? $notification : null;
+	}
+
+	/**
+	 * Cancel the rows a verified token authorises, and respond with a notice and redirect.
+	 *
+	 * Reproduces legacy scope branching: `confirmation` cancels every row for the same
+	 * product and email, a registered recipient of any other link cancels only this one
+	 * row (legacy sent them to a My Account endpoint Core does not register), and a guest
+	 * cancels every row for that email.
+	 *
+	 * @param Notification $notification The resolved, token-verified notification.
+	 * @param string       $ref          Sanitized `bis_unsub_ref` value.
+	 */
+	private function cancel_and_respond( Notification $notification, string $ref ): void {
+		if ( self::REF_CONFIRMATION === $ref ) {
+			$cancelled = $this->cancel_legacy_rows(
+				NotificationQuery::get_notifications(
+					array(
+						'product_id' => $notification->get_product_id(),
+						'user_email' => $notification->get_user_email(),
+						'return'     => 'objects',
+					)
+				)
+			);
+			$this->respond_product_scoped( $notification, $cancelled );
+			return;
+		}
+
+		$user = get_user_by( 'email', $notification->get_user_email() );
+
+		if ( $user instanceof \WP_User ) {
+			$cancelled = $this->email_action_controller->unsubscribe( $notification ) ? 1 : 0;
+			$this->respond_single_row( $notification, $cancelled );
+			return;
+		}
+
+		$cancelled = $this->cancel_legacy_rows(
+			NotificationQuery::get_notifications(
+				array(
+					'user_email' => $notification->get_user_email(),
+					'return'     => 'objects',
+				)
+			)
+		);
+		$this->respond_email_scoped( $notification->get_user_email(), $cancelled );
+	}
+
+	/**
+	 * Cancel every candidate that still carries the legacy migration marker.
+	 *
+	 * Scoping to `_wc_bis_legacy_id` keeps an old link's authority bounded to the data it
+	 * was issued against: notifications signed up natively in Core after the migration
+	 * carry their own working unsubscribe link and must not be swept in here. Delegates
+	 * the actual cancellation to `EmailActionController::unsubscribe()`, which is a no-op
+	 * for a row that is not `pending` or `active`.
+	 *
+	 * @param Notification[] $notifications Candidate notifications.
+	 * @return int Number of rows actually cancelled.
+	 */
+	private function cancel_legacy_rows( array $notifications ): int {
+		$cancelled = 0;
+
+		foreach ( $notifications as $notification ) {
+			if ( ! $notification instanceof Notification ) {
+				continue;
+			}
+
+			if ( '' === (string) $notification->get_meta( self::META_KEY_LEGACY_ID ) ) {
+				continue;
+			}
+
+			if ( $this->email_action_controller->unsubscribe( $notification ) ) {
+				++$cancelled;
+			}
+		}
+
+		return $cancelled;
+	}
+
+	/**
+	 * Respond to a `confirmation`-scoped, or a registered-user single-row, cancellation.
+	 *
+	 * @param Notification $notification    The notification the link was issued for.
+	 * @param int          $cancelled_count Rows actually cancelled by this request.
+	 */
+	private function respond_product_scoped( Notification $notification, int $cancelled_count ): void {
+		if ( $cancelled_count > 0 ) {
+			$product = wc_get_product( $notification->get_product_id() );
+
+			if ( $product instanceof \WC_Product ) {
+				$notice_text = sprintf(
+					/* translators: %1$s user email, %2$s product name */
+					esc_html__( 'Successfully unsubscribed %1$s. You will not receive a notification when "%2$s" becomes available.', 'woocommerce' ),
+					$notification->get_user_email(),
+					$product->get_name()
+				);
+			} else {
+				$notice_text = sprintf(
+					/* translators: %s user email */
+					esc_html__( 'Successfully unsubscribed %s.', 'woocommerce' ),
+					$notification->get_user_email()
+				);
+			}
+			wc_add_notice( $notice_text );
+		} else {
+			wc_add_notice( esc_html__( 'You are already unsubscribed.', 'woocommerce' ) );
+		}
+
+		$this->redirect();
+	}
+
+	/**
+	 * Respond to a registered-user request that is limited to the single resolved row.
+	 *
+	 * @param Notification $notification    The notification the link was issued for.
+	 * @param int          $cancelled_count 1 if the row was cancelled, 0 otherwise.
+	 */
+	private function respond_single_row( Notification $notification, int $cancelled_count ): void {
+		if ( $cancelled_count > 0 ) {
+			$product = wc_get_product( $notification->get_product_id() );
+
+			if ( $product instanceof \WC_Product ) {
+				$notice_text = sprintf(
+					/* translators: %1$s user email, %2$s product name */
+					esc_html__( 'Successfully unsubscribed %1$s. You will not receive a notification when "%2$s" becomes available. Manage the rest of your stock notifications from your account.', 'woocommerce' ),
+					$notification->get_user_email(),
+					$product->get_name()
+				);
+			} else {
+				$notice_text = sprintf(
+					/* translators: %s user email */
+					esc_html__( 'Successfully unsubscribed %s.', 'woocommerce' ),
+					$notification->get_user_email()
+				);
+			}
+			wc_add_notice( $notice_text );
+		} else {
+			wc_add_notice( esc_html__( 'You are already unsubscribed.', 'woocommerce' ) );
+		}
+
+		$this->redirect();
+	}
+
+	/**
+	 * Respond to a guest request cancelling every legacy row for one email address.
+	 *
+	 * @param string $user_email      The email address the link was issued for.
+	 * @param int    $cancelled_count Number of rows cancelled by this request.
+	 */
+	private function respond_email_scoped( string $user_email, int $cancelled_count ): void {
+		if ( $cancelled_count > 0 ) {
+			$notice_text = sprintf(
+				/* translators: %1$d number of cancelled stock notifications, %2$s user email */
+				_n(
+					'Successfully unsubscribed %2$s from %1$d stock notification.',
+					'Successfully unsubscribed %2$s from %1$d stock notifications.',
+					$cancelled_count,
+					'woocommerce'
+				),
+				$cancelled_count,
+				$user_email
+			);
+			wc_add_notice( $notice_text );
+		} else {
+			wc_add_notice( esc_html__( 'You are already unsubscribed.', 'woocommerce' ) );
+		}
+
+		$this->redirect();
+	}
+
+	/**
+	 * Respond with the uniform notice for every outcome where the token did not verify or
+	 * nothing resolved.
+	 *
+	 * Deliberately identical wording and redirect target for every cause: `bis_unsub_id` is
+	 * a sequential integer on a public, unauthenticated endpoint, so distinguishing the
+	 * causes would let the endpoint be used to enumerate how many signups the store had.
+	 * The specific cause is logged separately in resolve_notification().
+	 */
+	private function respond_generic_stale_link(): void {
+		$this->start_session();
+		wc_add_notice( esc_html__( 'This unsubscribe link is invalid or has expired.', 'woocommerce' ) );
+		$this->redirect();
+	}
+
+	/**
+	 * Start a cookie-based session, if there is not one already, so notices work on the
+	 * frontend page the customer is redirected to.
+	 *
+	 * Must run before any notice is added, or the notice has nowhere to persist to.
+	 */
+	private function start_session(): void {
+		if ( WC()->session instanceof \WC_Session_Handler && ! WC()->session->has_session() ) {
+			WC()->session->set_customer_session_cookie( true );
+		}
+	}
+
+	/**
+	 * Redirect to the same destination Core's own unsubscribe controller uses, and stop
+	 * execution.
+	 */
+	private function redirect(): void {
+		/**
+		 * `woocommerce_customer_stock_notification_unsubscribe_redirect_url` filter.
+		 *
+		 * @since 10.2.0
+		 *
+		 * @param  string  $url
+		 * @return string
+		 */
+		$url = apply_filters( 'woocommerce_customer_stock_notification_unsubscribe_redirect_url', (string) get_permalink( wc_get_page_id( 'shop' ) ) );
+		wp_safe_redirect( $url );
+		exit;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/CancellationSourceMiner.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/CancellationSourceMiner.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * CancellationSourceMiner class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Mines `woocommerce_bis_activity` for the cancellation source of a batch of legacy
+ * Back In Stock Notifications rows.
+ *
+ * One query per batch, never per row: `mine()` takes every legacy row in the batch and
+ * resolves the whole set with a single `notification_id IN (...)` lookup.
+ */
+class CancellationSourceMiner {
+
+	/**
+	 * Legacy activity types that can end a notification.
+	 *
+	 * @var string[]
+	 */
+	private const CANCELLING_TYPES = array( 'unsubscribed', 'deactivated' );
+
+	/**
+	 * Mine the cancellation source and date for a batch of legacy rows.
+	 *
+	 * For each row, takes the latest `unsubscribed`/`deactivated` activity event:
+	 *
+	 * - `unsubscribed` always resolves to `USER` — both legacy call sites are customer
+	 *   initiated.
+	 * - `deactivated` with an activity `user_id` other than `0` and other than the row's
+	 *   own `user_id` resolves to `ADMIN`: someone else deactivated the subscription.
+	 * - `deactivated` with activity `user_id = 0` resolves to `SYSTEM` — this is
+	 *   `deactivate( 0 )` from the delivery path.
+	 * - `deactivated` with activity `user_id` equal to the row's own `user_id` resolves
+	 *   to `USER` — this is `deactivate()` called with no arguments, which uses the
+	 *   customer's own id.
+	 * - No matching activity row resolves to `SYSTEM`. Legacy's `add_event()` writes
+	 *   nothing when the user id is set but the email is empty, so coverage of every
+	 *   cancelled row is not guaranteed.
+	 *
+	 * @param array $legacy_rows List of rows from `woocommerce_bis_notifications`, each
+	 *                           with at least `id` and `user_id` keys.
+	 * @return array<int,array{source:string,date:?int}> Lookup keyed by legacy
+	 *                                                    notification id.
+	 */
+	public function mine( array $legacy_rows ): array {
+		$notification_user_ids = array();
+
+		foreach ( $legacy_rows as $legacy_row ) {
+			$notification_id = (int) ( $legacy_row['id'] ?? 0 );
+
+			if ( $notification_id > 0 ) {
+				$notification_user_ids[ $notification_id ] = (int) ( $legacy_row['user_id'] ?? 0 );
+			}
+		}
+
+		if ( empty( $notification_user_ids ) ) {
+			return array();
+		}
+
+		$result = array();
+
+		foreach ( $notification_user_ids as $notification_id => $notification_user_id ) {
+			$result[ $notification_id ] = array(
+				'source' => NotificationCancellationSource::SYSTEM,
+				'date'   => null,
+			);
+		}
+
+		foreach ( $this->fetch_latest_events( array_keys( $notification_user_ids ) ) as $notification_id => $event ) {
+			$result[ $notification_id ] = array(
+				'source' => $this->resolve_source( $event, $notification_user_ids[ $notification_id ] ),
+				'date'   => (int) $event['date'],
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Fetch the latest `unsubscribed`/`deactivated` activity row per notification id.
+	 *
+	 * @param int[] $notification_ids Legacy notification ids to look up.
+	 * @return array<int,array{type:string,user_id:int,date:int}> Latest event per id.
+	 */
+	private function fetch_latest_events( array $notification_ids ): array {
+		global $wpdb;
+
+		$table             = $wpdb->prefix . 'woocommerce_bis_activity';
+		$id_placeholders   = implode( ', ', array_fill( 0, count( $notification_ids ), '%d' ) );
+		$type_placeholders = implode( ', ', array_fill( 0, count( self::CANCELLING_TYPES ), '%s' ) );
+
+		// $table is built from $wpdb->prefix, not user input; $id_placeholders/$type_placeholders are
+		// locally built %d/%s placeholder lists, bound via $wpdb->prepare() below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$sql = $wpdb->prepare(
+			"SELECT notification_id, type, user_id, date FROM {$table}
+			WHERE notification_id IN ( $id_placeholders )
+			AND type IN ( $type_placeholders )
+			ORDER BY notification_id ASC, date DESC, id DESC",
+			array_merge( $notification_ids, self::CANCELLING_TYPES )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+
+		$latest = array();
+
+		foreach ( (array) $rows as $row ) {
+			$notification_id = (int) $row['notification_id'];
+
+			// The ORDER BY puts the latest event first for each notification id, so
+			// only the first row seen per id needs to be kept.
+			if ( isset( $latest[ $notification_id ] ) ) {
+				continue;
+			}
+
+			$latest[ $notification_id ] = array(
+				'type'    => (string) $row['type'],
+				'user_id' => (int) $row['user_id'],
+				'date'    => (int) $row['date'],
+			);
+		}
+
+		return $latest;
+	}
+
+	/**
+	 * Resolve a single event to a `NotificationCancellationSource` value.
+	 *
+	 * @param array{type:string,user_id:int,date:int} $event                 Latest cancelling event for the row.
+	 * @param int                                     $notification_user_id The row's own `user_id`.
+	 * @return string One of the `NotificationCancellationSource` constants.
+	 */
+	private function resolve_source( array $event, int $notification_user_id ): string {
+		if ( 'unsubscribed' === $event['type'] ) {
+			return NotificationCancellationSource::USER;
+		}
+
+		if ( 0 === $event['user_id'] ) {
+			return NotificationCancellationSource::SYSTEM;
+		}
+
+		if ( $event['user_id'] !== $notification_user_id ) {
+			return NotificationCancellationSource::ADMIN;
+		}
+
+		return NotificationCancellationSource::USER;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/DateMapper.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/DateMapper.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * DateMapper class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Maps legacy Back In Stock Notifications epoch columns to Core GMT datetime strings.
+ *
+ * Pure and side-effect free: no `$wpdb`, no options, no hooks. Legacy INT columns are
+ * already UTC `time()` values, so every conversion here uses `gmdate()` unconditionally.
+ * The migration timestamp is injected at construction rather than read from `time()`,
+ * so a whole batch shares one stable "now" and the class stays testable without it.
+ */
+class DateMapper {
+
+	/**
+	 * Datetime format used for every Core GMT column.
+	 *
+	 * @var string
+	 */
+	private const FORMAT = 'Y-m-d H:i:s';
+
+	/**
+	 * Earliest `create_date` accepted as plausible; anything before this is corrupt.
+	 * 1420070400 is 2015-01-01 00:00:00 UTC.
+	 *
+	 * @var int
+	 */
+	private const MIN_CREATE_DATE = 1420070400;
+
+	/**
+	 * Seconds in a day, used for the `create_date` upper bound. A local literal, not the
+	 * WordPress `DAY_IN_SECONDS` constant, so this class stays testable without WP loaded.
+	 *
+	 * @var int
+	 */
+	private const DAY_IN_SECONDS = 86400;
+
+	/**
+	 * Migration run timestamp, shared by every row in the batch.
+	 *
+	 * @var int
+	 */
+	private int $migration_timestamp;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int $migration_timestamp Epoch seconds to use as "now" for this run.
+	 */
+	public function __construct( int $migration_timestamp ) {
+		$this->migration_timestamp = $migration_timestamp;
+	}
+
+	/**
+	 * Map `date_created_gmt`.
+	 *
+	 * Prefers `create_date`, rejecting it as corrupt when it falls outside
+	 * 2015..now+1day, then falls back to `subscribe_date`, then the migration time.
+	 *
+	 * @param array $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @return string GMT datetime string.
+	 */
+	public function date_created_gmt( array $legacy_row ): string {
+		$create_date = (int) ( $legacy_row['create_date'] ?? 0 );
+
+		if ( $this->is_plausible_create_date( $create_date ) ) {
+			return gmdate( self::FORMAT, $create_date );
+		}
+
+		$subscribe_date = (int) ( $legacy_row['subscribe_date'] ?? 0 );
+
+		if ( $subscribe_date > 0 ) {
+			return gmdate( self::FORMAT, $subscribe_date );
+		}
+
+		return gmdate( self::FORMAT, $this->migration_timestamp );
+	}
+
+	/**
+	 * Map `date_modified_gmt`.
+	 *
+	 * Always the migration timestamp: legacy has no per-row "last modified" column.
+	 *
+	 * @return string GMT datetime string.
+	 */
+	public function date_modified_gmt(): string {
+		return gmdate( self::FORMAT, $this->migration_timestamp );
+	}
+
+	/**
+	 * Map `date_confirmed_gmt`.
+	 *
+	 * `subscribe_date` is legacy's activation date. `subscribe_date = 0` is normal —
+	 * legacy leaves it unset when the signup happened while the product was in stock —
+	 * so it falls back to `create_date` in that case.
+	 *
+	 * @param array $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @return string GMT datetime string.
+	 */
+	public function date_confirmed_gmt( array $legacy_row ): string {
+		$subscribe_date = (int) ( $legacy_row['subscribe_date'] ?? 0 );
+
+		if ( $subscribe_date > 0 ) {
+			return gmdate( self::FORMAT, $subscribe_date );
+		}
+
+		$create_date = (int) ( $legacy_row['create_date'] ?? 0 );
+
+		return gmdate( self::FORMAT, $create_date );
+	}
+
+	/**
+	 * Map `date_last_attempt_gmt`.
+	 *
+	 * @param array $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @return string|null GMT datetime string, or null when `last_notified_date` is 0.
+	 */
+	public function date_last_attempt_gmt( array $legacy_row ): ?string {
+		$last_notified_date = (int) ( $legacy_row['last_notified_date'] ?? 0 );
+
+		if ( $last_notified_date <= 0 ) {
+			return null;
+		}
+
+		return gmdate( self::FORMAT, $last_notified_date );
+	}
+
+	/**
+	 * Map `date_notified_gmt`.
+	 *
+	 * Only populated when the row's mapped status is `sent`; every other status leaves
+	 * this null even when `last_notified_date` is set.
+	 *
+	 * @param array  $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @param string $status     Status already resolved by `StatusMapper::map()`.
+	 * @return string|null GMT datetime string, or null.
+	 */
+	public function date_notified_gmt( array $legacy_row, string $status ): ?string {
+		if ( NotificationStatus::SENT !== $status ) {
+			return null;
+		}
+
+		$last_notified_date = (int) ( $legacy_row['last_notified_date'] ?? 0 );
+
+		if ( $last_notified_date <= 0 ) {
+			return null;
+		}
+
+		return gmdate( self::FORMAT, $last_notified_date );
+	}
+
+	/**
+	 * Map `date_cancelled_gmt`.
+	 *
+	 * Only populated when the row's mapped status is `cancelled`. Prefers the latest
+	 * `unsubscribed`/`deactivated` activity date mined from `woocommerce_bis_activity`,
+	 * then falls back to `last_notified_date`, then `create_date`.
+	 *
+	 * @param array    $legacy_row            Row from `woocommerce_bis_notifications`.
+	 * @param string   $status                Status already resolved by `StatusMapper::map()`.
+	 * @param int|null $latest_activity_date  Latest cancelling activity epoch, if any.
+	 * @return string|null GMT datetime string, or null.
+	 */
+	public function date_cancelled_gmt( array $legacy_row, string $status, ?int $latest_activity_date = null ): ?string {
+		if ( NotificationStatus::CANCELLED !== $status ) {
+			return null;
+		}
+
+		if ( null !== $latest_activity_date && $latest_activity_date > 0 ) {
+			return gmdate( self::FORMAT, $latest_activity_date );
+		}
+
+		$last_notified_date = (int) ( $legacy_row['last_notified_date'] ?? 0 );
+
+		if ( $last_notified_date > 0 ) {
+			return gmdate( self::FORMAT, $last_notified_date );
+		}
+
+		$create_date = (int) ( $legacy_row['create_date'] ?? 0 );
+
+		return gmdate( self::FORMAT, $create_date );
+	}
+
+	/**
+	 * Whether a `create_date` value is plausible rather than corrupt.
+	 *
+	 * @param int $create_date Candidate epoch value.
+	 * @return bool
+	 */
+	private function is_plausible_create_date( int $create_date ): bool {
+		$max = $this->migration_timestamp + self::DAY_IN_SECONDS;
+
+		return $create_date >= self::MIN_CREATE_DATE && $create_date <= $max;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/LegacyHash.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/LegacyHash.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * LegacyHash class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reproduces the legacy Back In Stock Notifications unsubscribe token, and shapes the
+ * value the migration stores for it.
+ *
+ * Pure: no database or WordPress hook access, only the WordPress hashing functions.
+ */
+final class LegacyHash {
+
+	/**
+	 * Reproduce `WC_BIS_Notification_Data::get_hash()` for one legacy notification.
+	 *
+	 * Returns null when either secret is missing or `openssl_encrypt()` fails, so the
+	 * caller can count the row separately rather than treat it as a lost link.
+	 *
+	 * @param int    $legacy_id           Legacy notification id.
+	 * @param int    $product_id          Product id.
+	 * @param int    $legacy_create_date  Legacy `create_date`, as an integer timestamp.
+	 * @param string $hash_key            Legacy per-notification `_hash_key` meta value.
+	 * @param string $hash_iv             Legacy per-notification `_hash_iv` meta value.
+	 * @return string|null
+	 */
+	public static function compute( int $legacy_id, int $product_id, int $legacy_create_date, string $hash_key, string $hash_iv ): ?string {
+		if ( '' === $hash_key || '' === $hash_iv ) {
+			return null;
+		}
+
+		$input     = "{$legacy_id}-{$product_id}-{$legacy_create_date}";
+		$encrypted = openssl_encrypt( $input, 'AES-256-CBC', $hash_key, 0, $hash_iv );
+
+		if ( false === $encrypted ) {
+			return null;
+		}
+
+		return hash( 'sha256', $encrypted );
+	}
+
+	/**
+	 * Build the `_wc_bis_legacy_unsub_hash` meta value stored for one legacy id.
+	 *
+	 * The raw token is never stored: only its `wp_fast_hash()` digest, prefixed with the
+	 * legacy id so several legacy rows can adopt the same Core notification.
+	 *
+	 * @param int    $legacy_id Legacy notification id.
+	 * @param string $token     Token produced by self::compute().
+	 * @return string
+	 */
+	public static function to_meta_value( int $legacy_id, string $token ): string {
+		return "{$legacy_id}:" . wp_fast_hash( $token );
+	}
+
+	/**
+	 * Split a stored `_wc_bis_legacy_unsub_hash` value into its legacy id and digest.
+	 *
+	 * Splits on the first colon only, so the boundary never depends on the hash
+	 * format's alphabet.
+	 *
+	 * @param string $meta_value Stored meta value.
+	 * @return array{0:int,1:string}|null Null when the value is not in `id:hash` shape.
+	 */
+	public static function parse( string $meta_value ): ?array {
+		$parts = explode( ':', $meta_value, 2 );
+
+		if ( 2 !== count( $parts ) || '' === $parts[0] || '' === $parts[1] || ! ctype_digit( $parts[0] ) ) {
+			return null;
+		}
+
+		return array( (int) $parts[0], $parts[1] );
+	}
+
+	/**
+	 * Verify a token presented by an incoming unsubscribe link against a stored meta value.
+	 *
+	 * @param string $meta_value Stored `_wc_bis_legacy_unsub_hash` value.
+	 * @param string $token      Token recomputed from the link's request parameters.
+	 * @return bool
+	 */
+	public static function verify( string $meta_value, string $token ): bool {
+		$parsed = self::parse( $meta_value );
+
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		return wp_verify_fast_hash( $token, $parsed[1] );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/MetaMapper.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/MetaMapper.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * MetaMapper class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Maps one legacy notification's meta bag to the Core meta rows to write.
+ *
+ * Pure: no database access. Implements the Meta table in the migration plan. Migration
+ * markers (`_wc_bis_legacy_id`, `_wc_bis_legacy_unsub_hash`) are owned by the migrator,
+ * not this class.
+ */
+final class MetaMapper {
+
+	/**
+	 * Legacy meta keys carried across to Core unchanged.
+	 *
+	 * @var string[]
+	 */
+	private const CARRIED_KEYS = array( '_customer_locale', '_customer_location_data' );
+
+	/**
+	 * Map a legacy meta bag to the Core meta rows to write.
+	 *
+	 * Carries `_customer_locale`, `_customer_location_data` and `posted_attributes`
+	 * across unchanged (unserialized), and drops `_hash_key`, `_hash_iv`,
+	 * `awaiting_verification` and `_verification_*` along with any other legacy key
+	 * not named here. The writer is the sole owner of `maybe_serialize()`; serializing
+	 * here too would double-serialize the value once it reaches the writer.
+	 *
+	 * @param array<string,mixed> $legacy_meta Legacy meta bag, keyed by meta key.
+	 * @return array<int,array{0:string,1:mixed}> Meta rows in WriterInterface shape.
+	 */
+	public static function map( array $legacy_meta ): array {
+		$rows = array();
+
+		foreach ( self::CARRIED_KEYS as $key ) {
+			if ( array_key_exists( $key, $legacy_meta ) ) {
+				$rows[] = array( $key, $legacy_meta[ $key ] );
+			}
+		}
+
+		if ( array_key_exists( 'posted_attributes', $legacy_meta ) ) {
+			$rows[] = array( 'posted_attributes', $legacy_meta['posted_attributes'] );
+		}
+
+		return $rows;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/StatusMapper.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Mapping/StatusMapper.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * StatusMapper class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Maps a legacy Back In Stock Notifications row to a Core notification status.
+ *
+ * Pure and side-effect free: no `$wpdb`, no WordPress functions beyond the status
+ * enum. `rollback` and `verify` re-derive expected status through this same mapper,
+ * so its rules must match the ones the migrator applies at write time exactly.
+ */
+class StatusMapper {
+
+	/**
+	 * Map a legacy row to a Core `status` value.
+	 *
+	 * Rules are evaluated top-down; the first match wins. Rule 1 is listed for
+	 * completeness only: the candidate predicate excludes unverified rows entirely, so
+	 * no row reaching this method ever satisfies it. Rule 2 is load-bearing and keys on
+	 * the delivery clocks rather than on `is_active`, since legacy will not re-send to a
+	 * row that has already been delivered for its current cycle until the product goes
+	 * out of stock and re-arms `subscribe_date`.
+	 *
+	 * @param array $legacy_row  Row from `woocommerce_bis_notifications`.
+	 * @param array $legacy_meta Meta for this row, keyed by meta_key.
+	 * @return string One of the `NotificationStatus` constants.
+	 */
+	public static function map( array $legacy_row, array $legacy_meta ): string {
+		$is_verified           = (string) ( $legacy_row['is_verified'] ?? '' );
+		$awaiting_verification = (string) ( $legacy_meta['awaiting_verification'] ?? '' );
+
+		if ( 'no' === $is_verified || 'yes' === $awaiting_verification ) {
+			return NotificationStatus::PENDING;
+		}
+
+		$last_notified_date = (int) ( $legacy_row['last_notified_date'] ?? 0 );
+		$subscribe_date     = (int) ( $legacy_row['subscribe_date'] ?? 0 );
+
+		if ( $last_notified_date > 0 && $last_notified_date >= $subscribe_date ) {
+			return NotificationStatus::SENT;
+		}
+
+		$is_active = (string) ( $legacy_row['is_active'] ?? '' );
+
+		if ( 'on' === $is_active ) {
+			return NotificationStatus::ACTIVE;
+		}
+
+		return NotificationStatus::CANCELLED;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationController.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * MigrationController class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Compat\LegacyUnsubscribeShim;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\Cli;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\ToolsRegistrar;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Gates registration of the BIS-to-Core stock notifications migration and wires it up.
+ *
+ * This is the only class in `Migration\` autoloaded on a normal request. Every decision below
+ * reads an option that is already autoloaded and in memory, so registration itself never runs a
+ * query. Everything else - the Tools entry, the CLI commands, the unsubscribe shim - is resolved
+ * from the container lazily, inside the callback that actually needs it, so nothing beyond this
+ * class is autoloaded until one of those callbacks fires.
+ */
+class MigrationController implements RegisterHooksInterface {
+
+	/**
+	 * Option the legacy extension writes on install, with no autoload argument (so it is
+	 * autoloaded) and never deletes. Its presence is the answer to "was the extension ever
+	 * installed" - the extension ships no uninstall.php, so the option and its tables survive
+	 * plugin deletion together.
+	 */
+	private const OPTION_LEGACY_DB_VERSION = 'wc_bis_db_version';
+
+	/**
+	 * Autoloaded flag the notifications migrator sets the first time it writes a row carrying a
+	 * legacy unsubscribe token. Answers "are there live legacy links", and gates only the
+	 * unsubscribe shim's registration - it is not a general "migrated rows exist" signal, since a
+	 * store whose legacy rows all lack `_hash_key`/`_hash_iv` never sets it. See
+	 * OPTION_HAS_MIGRATED_ROWS for that broader question.
+	 */
+	private const OPTION_HAS_LEGACY_LINKS = 'wc_bis_migration_has_legacy_links';
+
+	/**
+	 * Autoloaded flag the notifications migrator sets the first time it migrates any row,
+	 * inserted or adopted, regardless of whether it carries a legacy unsubscribe token. Answers
+	 * "have any rows been migrated" for the double-send admin notice below.
+	 */
+	private const OPTION_HAS_MIGRATED_ROWS = 'wc_bis_migration_has_migrated_rows';
+
+	/**
+	 * Basename of the legacy Back In Stock Notifications extension, as WordPress lists it in
+	 * the active plugins option.
+	 */
+	private const LEGACY_PLUGIN_BASENAME = 'woocommerce-back-in-stock-notifications/woocommerce-back-in-stock-notifications.php';
+
+	/**
+	 * Register the migration's hooks, gated per the rules above.
+	 *
+	 * @internal
+	 */
+	public function register(): void {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			// Unconditional: gating this on the option below would make `--force-discover`
+			// unreachable in exactly the situation it exists for - legacy tables present but
+			// the option deleted by hand.
+			wc_get_container()->get( Cli::class )->register();
+		}
+
+		if ( ! $this->extension_was_ever_installed() ) {
+			return;
+		}
+
+		add_filter( 'woocommerce_debug_tools', array( $this, 'handle_woocommerce_debug_tools' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_render_double_send_notice' ) );
+
+		if ( get_option( self::OPTION_HAS_LEGACY_LINKS ) ) {
+			// The shim hooks itself in its constructor; resolving it from the container is
+			// the registration.
+			wc_get_container()->get( LegacyUnsubscribeShim::class );
+		}
+	}
+
+	/**
+	 * Add or remove the `woocommerce_debug_tools` entry for the migration.
+	 *
+	 * Delegates to `Runners\ToolsRegistrar`, resolved lazily so nothing beyond this class is
+	 * autoloaded until the Tools page actually filters its list.
+	 *
+	 * @internal
+	 *
+	 * @param array $tools Existing tools list.
+	 * @return array
+	 */
+	public function handle_woocommerce_debug_tools( array $tools ): array {
+		return wc_get_container()->get( ToolsRegistrar::class )->handle_woocommerce_debug_tools( $tools );
+	}
+
+	/**
+	 * Warn while the legacy extension is still active and rows have already been migrated: a
+	 * restock in that state emails from both the legacy queue and Core.
+	 *
+	 * Reads `wc_bis_migration_has_migrated_rows`, set the first time any row is migrated
+	 * regardless of whether it carries a legacy unsubscribe token. `wc_bis_migration_has_legacy_links`
+	 * would under-report this: a store whose legacy rows all lack `_hash_key`/`_hash_iv` never
+	 * sets it, even with migrated rows present. Never auto-deactivates the extension; this is a
+	 * notice only.
+	 *
+	 * @internal
+	 */
+	public function maybe_render_double_send_notice(): void {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		if ( ! get_option( self::OPTION_HAS_MIGRATED_ROWS ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) || ! is_plugin_active( self::LEGACY_PLUGIN_BASENAME ) ) {
+			return;
+		}
+
+		wp_admin_notice(
+			__( 'WooCommerce Back In Stock Notifications is still active and some of its subscribers have already been migrated to the built-in Customer stock notifications feature. While both are active, a restock can send duplicate emails to the same customer. Finish the migration, then deactivate the legacy plugin.', 'woocommerce' ),
+			array(
+				'id'          => 'wc-bis-migration-double-send',
+				'type'        => 'warning',
+				'dismissible' => false,
+			)
+		);
+	}
+
+	/**
+	 * Whether the legacy extension was ever installed on this site.
+	 *
+	 * @return bool
+	 */
+	private function extension_was_ever_installed(): bool {
+		return false !== get_option( self::OPTION_LEGACY_DB_VERSION, false );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationState.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationState.php
@@ -291,13 +291,19 @@ class MigrationState {
 	 *                            derived from, used later to detect a changed source.
 	 * @param string $target_hash Fingerprint of the value actually written, used later
 	 *                            to detect a merchant edit.
+	 * @param bool   $skipped     Whether this records a merchant-modified option that was
+	 *                            reported and left alone, rather than one that was written.
+	 *                            Recording it is what drains the section: an option that
+	 *                            keeps deciding `skipped_user_modified` is otherwise
+	 *                            outstanding forever and the run never terminates.
 	 * @return void
 	 */
-	public function record_option_fingerprint( string $option_key, string $source_hash, string $target_hash ): void {
+	public function record_option_fingerprint( string $option_key, string $source_hash, string $target_hash, bool $skipped = false ): void {
 		$state                           = $this->get_state();
 		$state['options'][ $option_key ] = array(
 			'written' => $source_hash,
 			'hash'    => $target_hash,
+			'skipped' => $skipped,
 			'at'      => time(),
 		);
 		$this->save_state( $state );
@@ -306,11 +312,16 @@ class MigrationState {
 	/**
 	 * Fingerprint a value for comparison, stable across arrays and scalars.
 	 *
+	 * Serializes unconditionally rather than through maybe_serialize(): that returns
+	 * scalars untouched, so an integer option value reaches hash() as an int and
+	 * fatals on PHP 8. Serializing everything also keeps `false`, `null` and `''`
+	 * distinct, which a string cast would collapse into one fingerprint.
+	 *
 	 * @param mixed $value The value to fingerprint.
 	 * @return string
 	 */
 	public function fingerprint_value( $value ): string {
-		return hash( 'sha256', maybe_serialize( $value ) );
+		return hash( 'sha256', serialize( $value ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Hashed for comparison only, never stored or unserialized.
 	}
 
 	/**
@@ -321,6 +332,10 @@ class MigrationState {
 	 * | Absent                     | Write                                            |
 	 * | Present, hash matches      | We wrote it; rewrite only if the source changed  |
 	 * | Present, hash differs      | Merchant edited it; skip, unless $force          |
+	 *
+	 * A recorded skip keeps its own entry, so a merchant-modified option reports once and
+	 * then stops being outstanding. `$force` still overrides it: without that, an option
+	 * skipped by an earlier run could never be forced again.
 	 *
 	 * @param string $option_key         The option name.
 	 * @param string $source_hash        Fingerprint of the current legacy source data.
@@ -334,6 +349,10 @@ class MigrationState {
 		$fingerprint = $this->get_option_fingerprint( $option_key );
 
 		if ( null === $fingerprint ) {
+			return self::OPTION_ACTION_WRITE;
+		}
+
+		if ( $force && ! empty( $fingerprint['skipped'] ) ) {
 			return self::OPTION_ACTION_WRITE;
 		}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationState.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationState.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * MigrationState class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reads and writes `wc_bis_migration_state`, the run state for the BIS migration.
+ *
+ * The option is written with autoload off: it changes on every batch, and nothing
+ * outside a migration run needs it in memory. It holds four top-level keys: the CLI
+ * run `lock`, the per-section `cursor`, cached display-only `counts`, and per-option
+ * migration `fingerprints`.
+ *
+ * State here is an optimization, never authority. What has actually been migrated is
+ * recorded by the markers the migrators write onto legacy and Core rows
+ * (`_wc_bis_legacy_id`, `_wc_bis_migration_failed`), not by anything in this option.
+ * Deleting `wc_bis_migration_state` mid-run and re-running the migration must produce
+ * an identical result: cursors and counts are cheaply re-derivable from the markers,
+ * so losing them costs a re-scan, never correctness.
+ */
+class MigrationState {
+
+	/**
+	 * The option name this class reads and writes.
+	 */
+	private const OPTION_NAME = 'wc_bis_migration_state';
+
+	/**
+	 * A CLI lock older than this is treated as abandoned and reclaimed.
+	 *
+	 * An hour, not minutes: too short a threshold reclaims the lock out from under a
+	 * still-running worker and reintroduces the concurrent-run problem the lock exists
+	 * to prevent.
+	 */
+	private const STALE_LOCK_SECONDS = HOUR_IN_SECONDS;
+
+	/**
+	 * Decision: no fingerprint is on record for this option, write it.
+	 */
+	public const OPTION_ACTION_WRITE = 'write';
+
+	/**
+	 * Decision: the option matches what we last wrote and its source has not changed
+	 * since, nothing to do.
+	 */
+	public const OPTION_ACTION_SKIP_UNCHANGED = 'skip_unchanged';
+
+	/**
+	 * Decision: the option no longer matches what we last wrote, a merchant edited it.
+	 * Leave it alone unless the caller forces the write.
+	 */
+	public const OPTION_ACTION_SKIP_USER_MODIFIED = 'skipped_user_modified';
+
+	/**
+	 * The empty state shape, used when the option does not exist yet.
+	 *
+	 * @var array
+	 */
+	private const DEFAULT_STATE = array(
+		'lock'    => null,
+		'cursor'  => array(),
+		'counts'  => array(),
+		'options' => array(),
+		'losses'  => null,
+	);
+
+	/**
+	 * Read the full state, filled out to the default shape.
+	 *
+	 * Shape: `lock` (array|null), `cursor` (section slug => int), `counts` and `options`
+	 * (keyed arrays). Typed loosely because the option is merchant-writable data.
+	 *
+	 * @return array
+	 */
+	public function get_state(): array {
+		$stored = get_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $stored ) ) {
+			$stored = array();
+		}
+
+		return array_merge( self::DEFAULT_STATE, $stored );
+	}
+
+	/**
+	 * Persist the full state, with autoload off.
+	 *
+	 * @param array $state The full state, as returned by get_state().
+	 * @return void
+	 */
+	private function save_state( array $state ): void {
+		update_option( self::OPTION_NAME, $state, false );
+	}
+
+	/**
+	 * Attempt to acquire the CLI run lock.
+	 *
+	 * @param string $owner Identifier for the process acquiring the lock, used only for
+	 *                      reporting who holds it.
+	 * @return bool True when the lock was acquired, false when another run already holds
+	 *              a lock that is not yet stale.
+	 */
+	public function acquire_lock( string $owner ): bool {
+		$state = $this->get_state();
+
+		if ( $this->is_lock_fresh( $state['lock'] ) ) {
+			return false;
+		}
+
+		$state['lock'] = array(
+			'owner'       => $owner,
+			'acquired_at' => time(),
+		);
+
+		$this->save_state( $state );
+
+		return true;
+	}
+
+	/**
+	 * Release the CLI run lock, whoever holds it.
+	 *
+	 * @return void
+	 */
+	public function release_lock(): void {
+		$state         = $this->get_state();
+		$state['lock'] = null;
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Whether a CLI run lock is currently held and not stale.
+	 *
+	 * @return bool
+	 */
+	public function is_lock_held(): bool {
+		return $this->is_lock_fresh( $this->get_state()['lock'] );
+	}
+
+	/**
+	 * The current lock's details, for building a "run in progress" message.
+	 *
+	 * Returns the lock even when stale; callers that need "is it actually held" should
+	 * use is_lock_held() instead.
+	 *
+	 * @return array|null `owner` and `acquired_at` when a lock entry is present.
+	 */
+	public function get_lock(): ?array {
+		return $this->get_state()['lock'];
+	}
+
+	/**
+	 * Whether a lock entry is present and within the stale threshold.
+	 *
+	 * @param array|null $lock The lock entry from state.
+	 * @return bool
+	 */
+	private function is_lock_fresh( ?array $lock ): bool {
+		if ( null === $lock || ! isset( $lock['acquired_at'] ) ) {
+			return false;
+		}
+
+		return ( time() - (int) $lock['acquired_at'] ) < self::STALE_LOCK_SECONDS;
+	}
+
+	/**
+	 * Get a section's keyset cursor.
+	 *
+	 * @param string $section Migrator section slug.
+	 * @return int Last identifier handled in the current pass, or 0 to start a pass.
+	 */
+	public function get_cursor( string $section ): int {
+		$state = $this->get_state();
+
+		return (int) ( $state['cursor'][ $section ] ?? 0 );
+	}
+
+	/**
+	 * Set a section's keyset cursor.
+	 *
+	 * @param string $section Migrator section slug.
+	 * @param int    $cursor  Last identifier handled in the current pass.
+	 * @return void
+	 */
+	public function set_cursor( string $section, int $cursor ): void {
+		$state                       = $this->get_state();
+		$state['cursor'][ $section ] = $cursor;
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Reset a single section's cursor to the start of a pass.
+	 *
+	 * @param string $section Migrator section slug.
+	 * @return void
+	 */
+	public function reset_cursor( string $section ): void {
+		$this->set_cursor( $section, 0 );
+	}
+
+	/**
+	 * Clear every section's cursor.
+	 *
+	 * Called at the start of a run: a run always starts from zero, so nothing a
+	 * previous run left behind can strand rows below a stale cursor.
+	 *
+	 * @return void
+	 */
+	public function reset_all_cursors(): void {
+		$state           = $this->get_state();
+		$state['cursor'] = array();
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Get a section's cached remaining-count, for display only.
+	 *
+	 * @param string $section Migrator section slug.
+	 * @return array|null `count` and `at`, or null when nothing has been cached yet.
+	 */
+	public function get_count( string $section ): ?array {
+		$state = $this->get_state();
+
+		return $state['counts'][ $section ] ?? null;
+	}
+
+	/**
+	 * Cache a section's remaining-count, timestamped now.
+	 *
+	 * @param string $section Migrator section slug.
+	 * @param int    $count   Remaining candidate rows for the section.
+	 * @return void
+	 */
+	public function set_count( string $section, int $count ): void {
+		$state                       = $this->get_state();
+		$state['counts'][ $section ] = array(
+			'count' => $count,
+			'at'    => time(),
+		);
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Get the cached known-losses counts, for display only.
+	 *
+	 * @return array|null `values` (the known-losses counts, keyed by name) and `at`, or
+	 *                     null when nothing has been cached yet.
+	 */
+	public function get_losses(): ?array {
+		return $this->get_state()['losses'];
+	}
+
+	/**
+	 * Cache the known-losses counts, timestamped now.
+	 *
+	 * @param array<string,int> $values Known-losses counts, keyed by name.
+	 * @return void
+	 */
+	public function set_losses( array $values ): void {
+		$state           = $this->get_state();
+		$state['losses'] = array(
+			'values' => $values,
+			'at'     => time(),
+		);
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Get the recorded fingerprint for a migrated option key.
+	 *
+	 * @param string $option_key The option name.
+	 * @return array|null `written`, `hash` and `at`, or null when this option has never been migrated.
+	 */
+	public function get_option_fingerprint( string $option_key ): ?array {
+		$state = $this->get_state();
+
+		return $state['options'][ $option_key ] ?? null;
+	}
+
+	/**
+	 * Record that an option was written by the migration.
+	 *
+	 * @param string $option_key  The option name.
+	 * @param string $source_hash Fingerprint of the legacy source data the value was
+	 *                            derived from, used later to detect a changed source.
+	 * @param string $target_hash Fingerprint of the value actually written, used later
+	 *                            to detect a merchant edit.
+	 * @return void
+	 */
+	public function record_option_fingerprint( string $option_key, string $source_hash, string $target_hash ): void {
+		$state                           = $this->get_state();
+		$state['options'][ $option_key ] = array(
+			'written' => $source_hash,
+			'hash'    => $target_hash,
+			'at'      => time(),
+		);
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Fingerprint a value for comparison, stable across arrays and scalars.
+	 *
+	 * @param mixed $value The value to fingerprint.
+	 * @return string
+	 */
+	public function fingerprint_value( $value ): string {
+		return hash( 'sha256', maybe_serialize( $value ) );
+	}
+
+	/**
+	 * Decide what to do with a migrated option, per the fingerprint table:
+	 *
+	 * | Target state              | Action                                          |
+	 * |----------------------------|-------------------------------------------------|
+	 * | Absent                     | Write                                            |
+	 * | Present, hash matches      | We wrote it; rewrite only if the source changed  |
+	 * | Present, hash differs      | Merchant edited it; skip, unless $force          |
+	 *
+	 * @param string $option_key         The option name.
+	 * @param string $source_hash        Fingerprint of the current legacy source data.
+	 * @param string $current_target_hash Fingerprint of the option's current stored value.
+	 * @param bool   $force              Whether to write anyway when the merchant edited it.
+	 *                                   Overrides only the "hash differs" case; a changed
+	 *                                   source already writes without it.
+	 * @return string One of the OPTION_ACTION_* constants.
+	 */
+	public function decide_option_action( string $option_key, string $source_hash, string $current_target_hash, bool $force = false ): string {
+		$fingerprint = $this->get_option_fingerprint( $option_key );
+
+		if ( null === $fingerprint ) {
+			return self::OPTION_ACTION_WRITE;
+		}
+
+		if ( $fingerprint['hash'] !== $current_target_hash ) {
+			return $force ? self::OPTION_ACTION_WRITE : self::OPTION_ACTION_SKIP_USER_MODIFIED;
+		}
+
+		if ( $fingerprint['written'] !== $source_hash ) {
+			return self::OPTION_ACTION_WRITE;
+		}
+
+		return self::OPTION_ACTION_SKIP_UNCHANGED;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationState.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/MigrationState.php
@@ -312,16 +312,16 @@ class MigrationState {
 	/**
 	 * Fingerprint a value for comparison, stable across arrays and scalars.
 	 *
-	 * Serializes unconditionally rather than through maybe_serialize(): that returns
-	 * scalars untouched, so an integer option value reaches hash() as an int and
-	 * fatals on PHP 8. Serializing everything also keeps `false`, `null` and `''`
-	 * distinct, which a string cast would collapse into one fingerprint.
+	 * The string cast is required: maybe_serialize() returns scalars untouched, so an
+	 * integer value reaches hash() as an int and fatals on PHP 8. Casting also matches
+	 * how the value reads back out of the database, where everything is a string, and
+	 * keeps this in step with ProductMetaMigrator's SQL-side `SHA2()` comparison.
 	 *
 	 * @param mixed $value The value to fingerprint.
 	 * @return string
 	 */
 	public function fingerprint_value( $value ): string {
-		return hash( 'sha256', serialize( $value ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Hashed for comparison only, never stored or unserialized.
+		return hash( 'sha256', (string) maybe_serialize( $value ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigrator.php
@@ -102,6 +102,15 @@ class EmailSettingsMigrator implements MigratorInterface {
 	private bool $force;
 
 	/**
+	 * Identifiers already visited by this instance, so they leave the outstanding list
+	 * even when nothing was persisted - a dry run records no state at all, and without
+	 * this its section would never drain.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $handled = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param MigrationState $state    Migration run state.
@@ -156,6 +165,10 @@ class EmailSettingsMigrator implements MigratorInterface {
 		$outstanding = array();
 
 		foreach ( $this->all_ids() as $id ) {
+			if ( isset( $this->handled[ $id ] ) ) {
+				continue;
+			}
+
 			if ( MigrationState::OPTION_ACTION_SKIP_UNCHANGED !== $this->decide( $id ) ) {
 				$outstanding[] = $id;
 			}
@@ -191,9 +204,28 @@ class EmailSettingsMigrator implements MigratorInterface {
 
 			$action = $this->decide( $id );
 
+			$this->handled[ $id ] = true;
+
 			if ( MigrationState::OPTION_ACTION_SKIP_USER_MODIFIED === $action ) {
 				$this->reporter->record( self::SLUG, Reporter::OUTCOME_SKIPPED_USER_MODIFIED, $row_id );
 				$counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] = ( $counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 ) + 1;
+
+				if ( ! $writer->is_dry_run() ) {
+					// Record what the merchant's value is now, so it reports once rather than
+					// staying outstanding on every later run.
+					$core_settings       = (array) get_option( $core_key, array() );
+					$current_target_hash = $this->state->fingerprint_value( $core_settings[ $sub_key ] ?? '' );
+					$source_settings     = (array) get_option( $legacy_key, array() );
+					$source_hash         = $this->state->fingerprint_value( $source_settings[ $sub_key ] ?? '' );
+
+					$this->state->record_option_fingerprint(
+						$this->fingerprint_key( $core_key, $sub_key ),
+						$source_hash,
+						$current_target_hash,
+						true
+					);
+				}
+
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigrator.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * EmailSettingsMigrator class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrates the legacy Back In Stock Notifications email settings to their Core
+ * `WC_Email` equivalents.
+ *
+ * Legacy `confirm` (the post-signup confirmation email) maps to Core `verified`, NOT
+ * `verify` — reversing the two swaps their copy, since `verify` is the double opt-in
+ * email and `verified` is the confirmation sent after it. Pinned by a unit test.
+ *
+ * Each settings option is a `WC_Email::$settings` array. Migration merges per sub-key
+ * (`subject`, `heading`, ...) rather than replacing the array, so migrating one field
+ * never clobbers a hand-edited sibling.
+ */
+class EmailSettingsMigrator implements MigratorInterface {
+
+	/**
+	 * Section slug, used in state keys and CLI `--section` values.
+	 */
+	private const SLUG = 'emails';
+
+	/**
+	 * Legacy email settings option name to its Core equivalent.
+	 *
+	 * @var array<string, string>
+	 */
+	private const OPTION_MAP = array(
+		'woocommerce_bis_notification_received_settings' => 'woocommerce_customer_stock_notification_settings',
+		'woocommerce_bis_notification_verify_settings'   => 'woocommerce_customer_stock_notification_verify_settings',
+		'woocommerce_bis_notification_confirm_settings'  => 'woocommerce_customer_stock_notification_verified_settings',
+	);
+
+	/**
+	 * Sub-keys migrated within each settings array. Shared by legacy and Core: both are
+	 * `WC_Email` subclasses with the same base form fields plus an injected `intro_content`.
+	 *
+	 * @var string[]
+	 */
+	private const SUB_KEYS = array( 'enabled', 'subject', 'heading', 'intro_content', 'additional_content' );
+
+	/**
+	 * Sub-keys that carry free text and are checked for placeholder tokens outside the
+	 * known set. `enabled` is a toggle, not text.
+	 *
+	 * @var string[]
+	 */
+	private const TEXT_SUB_KEYS = array( 'subject', 'heading', 'intro_content', 'additional_content' );
+
+	/**
+	 * Placeholders every Core stock notification email declares. Both sides ship this
+	 * same default set; the legacy `woocommerce_bis_*_email_placeholders` filters are the
+	 * only way a stored value could contain anything outside it.
+	 *
+	 * @var string[]
+	 */
+	private const KNOWN_PLACEHOLDERS = array( '{site_title}', '{product_name}' );
+
+	/**
+	 * Delimiter joining a core option name and sub-key into one batch identifier.
+	 */
+	private const ID_DELIMITER = '::';
+
+	/**
+	 * Outcome code for a value containing a placeholder token outside the known set.
+	 *
+	 * @var string
+	 */
+	private const OUTCOME_UNKNOWN_PLACEHOLDER = 'unknown_placeholder';
+
+	/**
+	 * Migration run state, used for fingerprint bookkeeping.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Outcome reporter.
+	 *
+	 * @var Reporter
+	 */
+	private Reporter $reporter;
+
+	/**
+	 * Whether to overwrite a sub-key the merchant has already edited.
+	 *
+	 * @var bool
+	 */
+	private bool $force;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param MigrationState $state    Migration run state.
+	 * @param Reporter       $reporter Outcome reporter.
+	 * @param bool           $force    Whether to overwrite merchant-edited sub-keys. CLI only.
+	 */
+	public function __construct( MigrationState $state, Reporter $reporter, bool $force = false ) {
+		$this->state    = $state;
+		$this->reporter = $reporter;
+		$this->force    = $force;
+	}
+
+	/**
+	 * Section slug, used in state keys and CLI `--section` values.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return self::SLUG;
+	}
+
+	/**
+	 * Count the sub-keys that still need a write. Display only.
+	 *
+	 * @return int
+	 */
+	public function count_remaining(): int {
+		$count = 0;
+
+		foreach ( $this->all_ids() as $id ) {
+			if ( MigrationState::OPTION_ACTION_WRITE === $this->decide( $id ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Fetch the outstanding `core_option::sub_key` identifiers, capped at $size.
+	 *
+	 * Includes sub-keys that need a write and sub-keys the merchant has edited, since the
+	 * latter still need to be visited so migrate_batch() can report them. This section is
+	 * small and finite, so $cursor is not used as a keyset: the same outstanding list is
+	 * returned every call.
+	 *
+	 * @param int $cursor Unused; this section never needs more than one pass.
+	 * @param int $size   Maximum number of identifiers to return.
+	 * @return array List of `core_option::sub_key` identifiers.
+	 */
+	public function get_batch( int $cursor, int $size ): array {
+		$outstanding = array();
+
+		foreach ( $this->all_ids() as $id ) {
+			if ( MigrationState::OPTION_ACTION_SKIP_UNCHANGED !== $this->decide( $id ) ) {
+				$outstanding[] = $id;
+			}
+		}
+
+		return array_slice( $outstanding, 0, max( 0, $size ) );
+	}
+
+	/**
+	 * Migrate the given `core_option::sub_key` identifiers.
+	 *
+	 * Sub-key writes are grouped by option so each option is written once per batch, with
+	 * every other sub-key it already holds left untouched.
+	 *
+	 * @param array           $ids    Identifiers returned by get_batch().
+	 * @param WriterInterface $writer Writer to route all persistence through.
+	 * @return array Outcome counts keyed by outcome code.
+	 */
+	public function migrate_batch( array $ids, WriterInterface $writer ): array {
+		$counts = array();
+		$row_id = 0;
+
+		$writes_by_option = array();
+
+		foreach ( $ids as $id ) {
+			$parsed = $this->parse_id( $id );
+			if ( null === $parsed ) {
+				continue;
+			}
+
+			++$row_id;
+			list( $legacy_key, $core_key, $sub_key ) = $parsed;
+
+			$action = $this->decide( $id );
+
+			if ( MigrationState::OPTION_ACTION_SKIP_USER_MODIFIED === $action ) {
+				$this->reporter->record( self::SLUG, Reporter::OUTCOME_SKIPPED_USER_MODIFIED, $row_id );
+				$counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] = ( $counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 ) + 1;
+				continue;
+			}
+
+			if ( MigrationState::OPTION_ACTION_WRITE !== $action ) {
+				continue;
+			}
+
+			$legacy_settings = (array) get_option( $legacy_key, array() );
+			$value           = $legacy_settings[ $sub_key ] ?? '';
+
+			if ( in_array( $sub_key, self::TEXT_SUB_KEYS, true ) && is_string( $value ) ) {
+				foreach ( $this->find_unknown_placeholders( $value ) as $placeholder ) {
+					$this->reporter->record( self::SLUG, self::OUTCOME_UNKNOWN_PLACEHOLDER, $row_id );
+					$counts[ self::OUTCOME_UNKNOWN_PLACEHOLDER ] = ( $counts[ self::OUTCOME_UNKNOWN_PLACEHOLDER ] ?? 0 ) + 1;
+					break;
+				}
+			}
+
+			$writes_by_option[ $core_key ][ $sub_key ] = array(
+				'value'       => $value,
+				'source_hash' => $this->state->fingerprint_value( $value ),
+			);
+
+			$counts[ Reporter::OUTCOME_MIGRATED ] = ( $counts[ Reporter::OUTCOME_MIGRATED ] ?? 0 ) + 1;
+		}
+
+		foreach ( $writes_by_option as $core_key => $sub_key_writes ) {
+			$core_settings = (array) get_option( $core_key, array() );
+
+			foreach ( $sub_key_writes as $sub_key => $write ) {
+				$core_settings[ $sub_key ] = $write['value'];
+			}
+
+			$writer->write_option( $core_key, $core_settings );
+
+			if ( $writer->is_dry_run() ) {
+				continue;
+			}
+
+			foreach ( $sub_key_writes as $sub_key => $write ) {
+				$this->state->record_option_fingerprint(
+					$this->fingerprint_key( $core_key, $sub_key ),
+					$write['source_hash'],
+					$write['source_hash']
+				);
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Every `core_option::sub_key` identifier this migrator is responsible for.
+	 *
+	 * @return string[]
+	 */
+	private function all_ids(): array {
+		$ids = array();
+
+		foreach ( self::OPTION_MAP as $legacy_key => $core_key ) {
+			foreach ( self::SUB_KEYS as $sub_key ) {
+				$ids[] = $legacy_key . self::ID_DELIMITER . $core_key . self::ID_DELIMITER . $sub_key;
+			}
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Split a batch identifier into its legacy option, Core option and sub-key.
+	 *
+	 * @param string $id Identifier produced by all_ids().
+	 * @return array{0: string, 1: string, 2: string}|null Null when the identifier does not parse.
+	 */
+	private function parse_id( string $id ): ?array {
+		$parts = explode( self::ID_DELIMITER, $id );
+
+		if ( 3 !== count( $parts ) || ! isset( self::OPTION_MAP[ $parts[0] ] ) ) {
+			return null;
+		}
+
+		return array( $parts[0], $parts[1], $parts[2] );
+	}
+
+	/**
+	 * The fingerprint key used to track one sub-key of one Core option independently.
+	 *
+	 * @param string $core_key Core option name.
+	 * @param string $sub_key  Settings sub-key.
+	 * @return string
+	 */
+	private function fingerprint_key( string $core_key, string $sub_key ): string {
+		return $core_key . self::ID_DELIMITER . $sub_key;
+	}
+
+	/**
+	 * Decide what to do with one `core_option::sub_key` identifier.
+	 *
+	 * @param string $id Identifier produced by all_ids().
+	 * @return string One of the MigrationState::OPTION_ACTION_* constants.
+	 */
+	private function decide( string $id ): string {
+		$parsed = $this->parse_id( $id );
+
+		if ( null === $parsed ) {
+			return MigrationState::OPTION_ACTION_SKIP_UNCHANGED;
+		}
+
+		list( $legacy_key, $core_key, $sub_key ) = $parsed;
+
+		$legacy_settings = (array) get_option( $legacy_key, array() );
+		$source_value    = $legacy_settings[ $sub_key ] ?? '';
+		$source_hash     = $this->state->fingerprint_value( $source_value );
+
+		$core_settings        = (array) get_option( $core_key, array() );
+		$current_target_value = $core_settings[ $sub_key ] ?? '';
+		$current_target_hash  = $this->state->fingerprint_value( $current_target_value );
+
+		return $this->state->decide_option_action(
+			$this->fingerprint_key( $core_key, $sub_key ),
+			$source_hash,
+			$current_target_hash,
+			$this->force
+		);
+	}
+
+	/**
+	 * Find `{...}` placeholder tokens in a value that fall outside the known set.
+	 *
+	 * A token outside the known set indicates a custom placeholder added through the
+	 * legacy `woocommerce_bis_*_email_placeholders` filters, which Core does not fill in.
+	 *
+	 * @param string $value Text to scan.
+	 * @return string[] Unknown placeholder tokens found, e.g. `{custom_field}`.
+	 */
+	private function find_unknown_placeholders( string $value ): array {
+		if ( ! preg_match_all( '/\{[a-zA-Z0-9_]+\}/', $value, $matches ) ) {
+			return array();
+		}
+
+		return array_values( array_diff( $matches[0], self::KNOWN_PLACEHOLDERS ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/MigratorInterface.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/MigratorInterface.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * MigratorInterface class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Contract for a single section of the legacy Back In Stock Notifications migration.
+ *
+ * Each migrator owns one slice of the legacy data set and is fully responsible for
+ * deciding which of its rows are still outstanding.
+ */
+interface MigratorInterface {
+
+	/**
+	 * Section slug, used in batch item prefixes, state keys and CLI `--section` values.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string;
+
+	/**
+	 * Count the rows this section still has to migrate.
+	 *
+	 * This is the section's candidate predicate expressed as a COUNT(*). It is display
+	 * only and never drives the batch loop.
+	 *
+	 * @return int
+	 */
+	public function count_remaining(): int;
+
+	/**
+	 * Fetch the next batch of candidate identifiers after the given keyset cursor.
+	 *
+	 * Must be side-effect free: calling it twice with the same cursor returns the same
+	 * batch and changes no stored state.
+	 *
+	 * @param int $cursor Last identifier handled in the current pass, or 0 to start a pass.
+	 * @param int $size   Maximum number of identifiers to return.
+	 * @return array List of identifiers, ascending.
+	 */
+	public function get_batch( int $cursor, int $size ): array;
+
+	/**
+	 * Migrate the given identifiers.
+	 *
+	 * Per-row failures are recorded and reported rather than thrown. Throw only for
+	 * transient conditions that failed the whole batch and where a retry is correct.
+	 *
+	 * @param array           $ids    Identifiers returned by get_batch().
+	 * @param WriterInterface $writer Writer to route all persistence through.
+	 * @return array Outcome counts keyed by outcome code.
+	 */
+	public function migrate_batch( array $ids, WriterInterface $writer ): array;
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigrator.php
@@ -1,0 +1,750 @@
+<?php
+/**
+ * NotificationsMigrator class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\CancellationSourceMiner;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\DateMapper;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\LegacyHash;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\MetaMapper;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\StatusMapper;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrates `woocommerce_bis_notifications` rows to Core `wc_stock_notifications` rows.
+ *
+ * The candidate predicate in `predicate_sql()` is authoritative: `get_batch()` and
+ * `count_remaining()` both express it, and nothing downstream may skip a row it admits
+ * without writing `_wc_bis_migration_failed`. `get_batch()` returns identifiers only and
+ * is side-effect free; `migrate_batch()` re-fetches the full rows for those identifiers
+ * and does the actual work. Legacy meta and cancellation sources are fetched once per
+ * batch, never per row.
+ */
+class NotificationsMigrator implements MigratorInterface {
+
+	/**
+	 * Section slug.
+	 *
+	 * @var string
+	 */
+	private const SLUG = 'notifications';
+
+	/**
+	 * Legacy meta keys read for a batch in one query.
+	 *
+	 * @var string[]
+	 */
+	private const LEGACY_META_KEYS = array(
+		'posted_attributes',
+		'_customer_locale',
+		'_customer_location_data',
+		'_hash_key',
+		'_hash_iv',
+	);
+
+	/**
+	 * Migration marker recording a successful migration onto a Core notification.
+	 * Inserted, never updated; a Core row can carry several.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_ID_META_KEY = '_wc_bis_legacy_id';
+
+	/**
+	 * Meta key holding the precomputed legacy unsubscribe token digest, one row per
+	 * legacy id.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_UNSUB_HASH_META_KEY = '_wc_bis_legacy_unsub_hash';
+
+	/**
+	 * Marker meta carrying the legacy id, written only when a legacy row adopts a
+	 * pre-existing Core notification instead of being inserted. Inserted alongside
+	 * `_wc_bis_legacy_id`, never updated; a Core row adopted by several legacy rows
+	 * carries one pair per legacy id. This is what lets `rollback` tell an adopted row
+	 * — never deleted — apart from one this migration inserted.
+	 *
+	 * @var string
+	 */
+	private const ADOPTED_MARKER_META_KEY = '_wc_bis_legacy_adopted';
+
+	/**
+	 * Legacy meta key recording a permanent per-row failure. The migration's only write
+	 * into the legacy schema.
+	 *
+	 * @var string
+	 */
+	private const FAILED_META_KEY = '_wc_bis_migration_failed';
+
+	/**
+	 * Autoloaded option that gates registration of the legacy unsubscribe link shim.
+	 * Set only when a migrated row carries a legacy unsubscribe token — narrower than,
+	 * and not a substitute for, HAS_MIGRATED_ROWS_OPTION below.
+	 *
+	 * @var string
+	 */
+	private const HAS_LEGACY_LINKS_OPTION = 'wc_bis_migration_has_legacy_links';
+
+	/**
+	 * Autoloaded option set the first time any row is migrated, inserted or adopted,
+	 * regardless of whether it carries a legacy unsubscribe token. Answers "have any
+	 * rows been migrated" for the double-send admin notice, which HAS_LEGACY_LINKS_OPTION
+	 * cannot: a store whose legacy rows all lack `_hash_key`/`_hash_iv` never sets that flag.
+	 *
+	 * @var string
+	 */
+	private const HAS_MIGRATED_ROWS_OPTION = 'wc_bis_migration_has_migrated_rows';
+
+	/**
+	 * Failure reason recorded when a row throws while being mapped or written.
+	 *
+	 * @var string
+	 */
+	private const FAILURE_REASON_EXCEPTION = 'exception';
+
+	/**
+	 * Mines `woocommerce_bis_activity` for cancellation source and date, once per batch.
+	 *
+	 * @var CancellationSourceMiner
+	 */
+	private CancellationSourceMiner $cancellation_source_miner;
+
+	/**
+	 * Collects and logs outcome counts.
+	 *
+	 * @var Reporter
+	 */
+	private Reporter $reporter;
+
+	/**
+	 * Running count of migrated rows mapped to `sent`, which lose their eventual
+	 * legacy re-fire under Core's terminal `sent` status. See Known losses.
+	 *
+	 * @var int
+	 */
+	private int $recurring_lost_count = 0;
+
+	/**
+	 * Running count of migrated or adopted rows with no `_hash_key`/`_hash_iv`, so no
+	 * legacy unsubscribe token could be computed. Not a lost link: legacy mints these
+	 * lazily, so a row without them never had one.
+	 *
+	 * @var int
+	 */
+	private int $rows_without_hash_count = 0;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Reporter                     $reporter                   Outcome collector.
+	 * @param CancellationSourceMiner|null $cancellation_source_miner Cancellation source miner.
+	 *                                                                 Defaults to a new instance.
+	 */
+	public function __construct( Reporter $reporter, ?CancellationSourceMiner $cancellation_source_miner = null ) {
+		$this->reporter                  = $reporter;
+		$this->cancellation_source_miner = $cancellation_source_miner ?? new CancellationSourceMiner();
+	}
+
+	/**
+	 * Section slug.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return self::SLUG;
+	}
+
+	/**
+	 * Count candidate rows still outstanding. Same predicate as get_batch(), as COUNT(*).
+	 *
+	 * @return int
+	 */
+	public function count_remaining(): int {
+		global $wpdb;
+
+		// predicate_sql() returns a fixed literal built by this class, never user input.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$sql = $wpdb->prepare( 'SELECT COUNT(*) ' . $this->predicate_sql() );
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Fetch the next batch of candidate legacy ids after the given keyset cursor.
+	 *
+	 * Side-effect free: calling this twice with the same cursor returns the same ids.
+	 * The cursor itself is owned and advanced by the caller, on successful migrate_batch().
+	 *
+	 * @param int $cursor Last legacy id handled in the current pass, or 0 to start a pass.
+	 * @param int $size   Maximum number of ids to return.
+	 * @return array List of legacy ids, ascending.
+	 */
+	public function get_batch( int $cursor, int $size ): array {
+		global $wpdb;
+
+		// predicate_sql() returns a fixed literal built by this class, never user input;
+		// $cursor and $size are bound via $wpdb->prepare() below.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$sql = $wpdb->prepare(
+			'SELECT n.id ' . $this->predicate_sql() . ' AND n.id > %d ORDER BY n.id ASC LIMIT %d',
+			$cursor,
+			$size
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return array_map( 'intval', (array) $wpdb->get_col( $sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Migrate the given legacy ids.
+	 *
+	 * Fetches full rows and batched meta for the given ids, resolves natural-key
+	 * adoption per row, and bulk-inserts everything that did not adopt. Per-row failures
+	 * are caught, marked with `_wc_bis_migration_failed`, and reported rather than
+	 * thrown; only a whole-batch write failure (from the writer) propagates, since that
+	 * is the one condition a retry can fix.
+	 *
+	 * @param array           $ids    Legacy ids returned by get_batch().
+	 * @param WriterInterface $writer Writer to route all persistence through.
+	 * @return array Outcome counts keyed by Reporter::OUTCOME_* code.
+	 */
+	public function migrate_batch( array $ids, WriterInterface $writer ): array {
+		$outcomes = array();
+
+		if ( empty( $ids ) ) {
+			return $outcomes;
+		}
+
+		$legacy_rows          = $this->fetch_legacy_rows( $ids );
+		$legacy_meta          = $this->fetch_legacy_meta( $ids );
+		$cancellation_sources = $this->cancellation_source_miner->mine( $legacy_rows );
+		$date_mapper          = new DateMapper( time() );
+
+		$insert_rows       = array();
+		$insert_legacy_ids = array();
+
+		foreach ( $legacy_rows as $legacy_row ) {
+			$legacy_id = (int) $legacy_row['id'];
+
+			try {
+				$row_meta = $legacy_meta[ $legacy_id ] ?? array();
+				$status   = StatusMapper::map( $legacy_row, $row_meta );
+
+				// Must match the stored value byte-for-byte: MetaMapper hands posted_attributes
+				// to the writer unserialized, and the writer is the sole maybe_serialize() owner,
+				// so this local serialize (for comparison only) has to mirror that exactly.
+				$posted_attributes_value = array_key_exists( 'posted_attributes', $row_meta )
+					? maybe_serialize( $row_meta['posted_attributes'] )
+					: '';
+
+				$adoption_target_id = $this->find_adoption_target( $legacy_row, (string) $posted_attributes_value );
+
+				if ( null !== $adoption_target_id ) {
+					$this->adopt( $adoption_target_id, $legacy_row, $row_meta, $writer );
+					$this->record_outcome( $outcomes, Reporter::OUTCOME_ADOPTED, $legacy_id );
+					continue;
+				}
+
+				$cancellation = $cancellation_sources[ $legacy_id ] ?? null;
+
+				$insert_rows[]       = array(
+					'columns' => $this->build_columns( $legacy_row, $status, $date_mapper, $cancellation ),
+					'meta'    => $this->build_meta( $legacy_id, $legacy_row, $row_meta, $writer ),
+				);
+				$insert_legacy_ids[] = $legacy_id;
+
+				if ( NotificationStatus::SENT === $status ) {
+					++$this->recurring_lost_count;
+				}
+			} catch ( \Throwable $e ) {
+				$this->fail_row( $legacy_id, $writer );
+				$this->record_outcome( $outcomes, Reporter::OUTCOME_FAILED, $legacy_id );
+			}
+		}
+
+		if ( ! empty( $insert_rows ) ) {
+			// A failure here is a whole-batch condition (DB error, lost connection); let it
+			// propagate so the controller retries. Rows that already adopted or failed above
+			// have already left the candidate set via their own markers, so a retry re-queries
+			// rather than replaying them.
+			$writer->insert_notifications( $insert_rows );
+			$this->maybe_set_has_migrated_rows_option( $writer );
+
+			foreach ( $insert_legacy_ids as $legacy_id ) {
+				$this->record_outcome( $outcomes, Reporter::OUTCOME_MIGRATED, $legacy_id );
+			}
+		}
+
+		$this->reporter->report_batch( self::SLUG, count( $ids ) );
+
+		return $outcomes;
+	}
+
+	/**
+	 * Rows with no `_hash_key`/`_hash_iv`, accumulated across every migrate_batch() call
+	 * on this instance. See Known losses.
+	 *
+	 * @return int
+	 */
+	public function get_rows_without_hash_count(): int {
+		return $this->rows_without_hash_count;
+	}
+
+	/**
+	 * Rows mapped to `sent` that lose their eventual legacy re-fire, accumulated across
+	 * every migrate_batch() call on this instance. See Known losses.
+	 *
+	 * @return int
+	 */
+	public function get_recurring_lost_count(): int {
+		return $this->recurring_lost_count;
+	}
+
+	/**
+	 * Count legacy rows excluded because they are unverified. Not a candidate population,
+	 * so invisible to count_remaining(); counted separately for the Known losses report.
+	 *
+	 * @return int
+	 */
+	public function count_unverified_excluded(): int {
+		global $wpdb;
+
+		// base_sql() returns a fixed literal built by this class, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$sql = $wpdb->prepare(
+			'SELECT COUNT(*) ' . $this->base_sql() . " AND ( n.is_verified = 'no' OR ( av.meta_value IS NOT NULL AND av.meta_value = 'yes' ) )"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Count legacy rows skipped because their email is longer than Core's column allows.
+	 *
+	 * @return int
+	 */
+	public function count_email_too_long(): int {
+		global $wpdb;
+
+		// base_sql()/verified_clause() return fixed literals built by this class, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$sql = $wpdb->prepare(
+			'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause() . ' AND CHAR_LENGTH( n.user_email ) > 100'
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Count legacy rows skipped because their email does not validate.
+	 *
+	 * @return int
+	 */
+	public function count_invalid_email(): int {
+		global $wpdb;
+
+		// Every fragment here is a fixed literal built by this class, never user input;
+		// the LIKE wildcards are part of that literal, not a bound value.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+		$sql = $wpdb->prepare(
+			'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause()
+			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND ( n.user_email = '' OR n.user_email NOT LIKE '%%_@_%%' )"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Count legacy rows skipped because their product is missing, trashed, or not a product.
+	 *
+	 * @return int
+	 */
+	public function count_product_missing(): int {
+		global $wpdb;
+
+		$posts_table = $wpdb->prefix . 'posts';
+
+		// $posts_table is $wpdb->prefix-based, never user input; every other fragment is a
+		// fixed literal built by this class, including the LIKE wildcards.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+		$sql = $wpdb->prepare(
+			'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause()
+			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND n.user_email <> '' AND n.user_email LIKE '%%_@_%%'"
+			. " AND NOT EXISTS ( SELECT 1 FROM {$posts_table} p"
+			. " WHERE p.ID = n.product_id AND p.post_type IN ( 'product', 'product_variation' ) AND p.post_status <> 'trash' )"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * The candidate predicate: FROM/JOIN/WHERE, matching the migration plan's SQL
+	 * verbatim in shape. Reused by count_remaining() and get_batch(), which append
+	 * only a cursor bound and a LIMIT.
+	 *
+	 * Literal `%` characters are doubled, since this fragment is always passed through
+	 * $wpdb->prepare() by its callers.
+	 *
+	 * @return string
+	 */
+	private function predicate_sql(): string {
+		global $wpdb;
+
+		$posts_table = $wpdb->prefix . 'posts';
+
+		return $this->base_sql() . $this->verified_clause()
+			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND n.user_email <> '' AND n.user_email LIKE '%%_@_%%'"
+			. " AND EXISTS ( SELECT 1 FROM {$posts_table} p" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $posts_table is $wpdb->prefix-based, never user input.
+			. " WHERE p.ID = n.product_id AND p.post_type IN ( 'product', 'product_variation' ) AND p.post_status <> 'trash' )";
+	}
+
+	/**
+	 * The shared FROM/JOIN/WHERE base every predicate variant starts from: the two
+	 * anti-joins against the migrated set and the permanently-failed set. Callers append
+	 * their own conditions.
+	 *
+	 * @return string
+	 */
+	private function base_sql(): string {
+		global $wpdb;
+
+		$notifications_table = $wpdb->prefix . 'woocommerce_bis_notifications';
+		$core_meta_table     = $wpdb->prefix . 'wc_stock_notificationmeta';
+		$legacy_meta_table   = $wpdb->prefix . 'woocommerce_bis_notificationsmeta';
+
+		// Table names are $wpdb->prefix-based, never user input; every caller runs the
+		// resulting fragment through $wpdb->prepare().
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return "
+			FROM {$notifications_table} n
+			LEFT JOIN {$core_meta_table} mm
+			       ON mm.meta_key = '_wc_bis_legacy_id'
+			      AND CAST( mm.meta_value AS UNSIGNED ) = n.id
+			LEFT JOIN {$legacy_meta_table} av
+			       ON av.bis_notifications_id = n.id AND av.meta_key = 'awaiting_verification'
+			LEFT JOIN {$legacy_meta_table} fm
+			       ON fm.bis_notifications_id = n.id AND fm.meta_key = '_wc_bis_migration_failed'
+			WHERE mm.notification_id IS NULL
+			  AND fm.bis_notifications_id IS NULL
+		";
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * The verified test shared by every predicate variant except count_unverified_excluded().
+	 *
+	 * @return string
+	 */
+	private function verified_clause(): string {
+		return " AND n.is_verified <> 'no' AND ( av.meta_value IS NULL OR av.meta_value <> 'yes' )";
+	}
+
+	/**
+	 * Fetch full legacy rows for a batch of ids.
+	 *
+	 * @param int[] $ids Legacy ids.
+	 * @return array<int,array<string,mixed>> Rows, keyed sequentially, each an associative array.
+	 */
+	private function fetch_legacy_rows( array $ids ): array {
+		global $wpdb;
+
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$table        = $wpdb->prefix . 'woocommerce_bis_notifications';
+		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+
+		// $table is $wpdb->prefix-based, never user input; $placeholders is a locally built
+		// %d placeholder list, bound via $wpdb->prepare() below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE id IN ( $placeholders )", $ids );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		return (array) $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Fetch legacy meta for a batch of ids in one query, indexed by id then meta key.
+	 *
+	 * Only the keys the migration reads are fetched: posted_attributes, _customer_locale,
+	 * _customer_location_data, _hash_key, _hash_iv.
+	 *
+	 * @param int[] $ids Legacy ids.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function fetch_legacy_meta( array $ids ): array {
+		global $wpdb;
+
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$table            = $wpdb->prefix . 'woocommerce_bis_notificationsmeta';
+		$id_placeholders  = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+		$key_placeholders = implode( ', ', array_fill( 0, count( self::LEGACY_META_KEYS ), '%s' ) );
+
+		// $table is $wpdb->prefix-based, never user input; $id_placeholders/$key_placeholders
+		// are locally built %d/%s placeholder lists, bound via $wpdb->prepare() below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$sql = $wpdb->prepare(
+			"SELECT bis_notifications_id, meta_key, meta_value FROM {$table}
+			WHERE bis_notifications_id IN ( $id_placeholders ) AND meta_key IN ( $key_placeholders )",
+			array_merge( $ids, self::LEGACY_META_KEYS )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$rows = (array) $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+
+		$indexed = array();
+
+		foreach ( $rows as $row ) {
+			$legacy_id                                 = (int) $row['bis_notifications_id'];
+			$indexed[ $legacy_id ][ $row['meta_key'] ] = maybe_unserialize( $row['meta_value'] );
+		}
+
+		return $indexed;
+	}
+
+	/**
+	 * Find an existing Core notification carrying this legacy row's natural key, if any.
+	 *
+	 * Natural key: product_id, plus user_id when non-zero and user_email (lowercased,
+	 * trimmed) otherwise, plus posted_attributes in maybe_serialize() form. Restricted to
+	 * `active` and `pending` targets, ordered active before pending then by ascending id,
+	 * so the same legacy row adopts the same target on every run.
+	 *
+	 * @param array<string,mixed> $legacy_row               Row from `woocommerce_bis_notifications`.
+	 * @param string              $posted_attributes_value Normalised posted_attributes value for this row.
+	 * @return int|null Target notification id, or null when no target matches.
+	 */
+	private function find_adoption_target( array $legacy_row, string $posted_attributes_value ): ?int {
+		global $wpdb;
+
+		$table      = $wpdb->prefix . 'wc_stock_notifications';
+		$meta_table = $wpdb->prefix . 'wc_stock_notificationmeta';
+		$user_id    = (int) ( $legacy_row['user_id'] ?? 0 );
+
+		$conditions = array( 'n.product_id = %d' );
+		$params     = array( (int) ( $legacy_row['product_id'] ?? 0 ) );
+
+		if ( $user_id > 0 ) {
+			$conditions[] = 'n.user_id = %d';
+			$params[]     = $user_id;
+		} else {
+			$conditions[] = 'LOWER( TRIM( n.user_email ) ) = %s';
+			$params[]     = strtolower( trim( (string) ( $legacy_row['user_email'] ?? '' ) ) );
+		}
+
+		$conditions[] = "COALESCE( pm.meta_value, '' ) = %s";
+		$params[]     = $posted_attributes_value;
+
+		// $table/$meta_table are $wpdb->prefix-based, never user input; $conditions is a
+		// locally built list of %d/%s placeholder fragments, bound via $wpdb->prepare() below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$sql = $wpdb->prepare(
+			"SELECT n.id FROM {$table} n
+			LEFT JOIN {$meta_table} pm ON pm.notification_id = n.id AND pm.meta_key = 'posted_attributes'
+			WHERE n.status IN ( 'active', 'pending' )
+			  AND " . implode( ' AND ', $conditions ) . '
+			ORDER BY FIELD( n.status, \'active\', \'pending\' ), n.id ASC
+			LIMIT 1',
+			$params
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$target_id = $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+
+		return null === $target_id ? null : (int) $target_id;
+	}
+
+	/**
+	 * Adopt an existing Core notification: write only the legacy id marker, the adoption
+	 * marker that records this was adoption rather than an insert, and, when both hash
+	 * secrets are present, the legacy unsubscribe token. Never reconciles status, dates,
+	 * or any other meta onto the target — the Core row is the merchant's.
+	 *
+	 * The adoption marker is what lets `rollback` remove only this legacy id's markers
+	 * from the target row instead of deleting a row the migration did not create.
+	 *
+	 * @param int                 $target_id  Core notification id being adopted.
+	 * @param array<string,mixed> $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @param array<string,mixed> $row_meta   This row's legacy meta bag.
+	 * @param WriterInterface     $writer     Writer to route the marker writes through.
+	 * @return void
+	 */
+	private function adopt( int $target_id, array $legacy_row, array $row_meta, WriterInterface $writer ): void {
+		$legacy_id = (int) $legacy_row['id'];
+		$meta      = array(
+			array( self::LEGACY_ID_META_KEY, $legacy_id ),
+			array( self::ADOPTED_MARKER_META_KEY, $legacy_id ),
+		);
+		$token     = $this->compute_token( $legacy_id, $legacy_row, $row_meta );
+
+		if ( null !== $token ) {
+			$meta[] = array( self::LEGACY_UNSUB_HASH_META_KEY, LegacyHash::to_meta_value( $legacy_id, $token ) );
+		} else {
+			++$this->rows_without_hash_count;
+		}
+
+		$writer->insert_notification_meta( $target_id, $meta );
+		$this->maybe_set_has_migrated_rows_option( $writer );
+
+		if ( null !== $token ) {
+			$this->maybe_set_has_legacy_links_option( $writer );
+		}
+	}
+
+	/**
+	 * Build the Core column values for a new notification row.
+	 *
+	 * @param array<string,mixed>                 $legacy_row   Row from `woocommerce_bis_notifications`.
+	 * @param string                              $status       Status already resolved by StatusMapper.
+	 * @param DateMapper                          $date_mapper  Date mapper shared by the whole batch.
+	 * @param array{source:string,date:?int}|null $cancellation Cancellation source/date mined for this row.
+	 * @return array<string,mixed>
+	 */
+	private function build_columns( array $legacy_row, string $status, DateMapper $date_mapper, ?array $cancellation ): array {
+		$latest_activity_date = null !== $cancellation ? $cancellation['date'] : null;
+		$cancellation_source  = null;
+
+		if ( NotificationStatus::CANCELLED === $status ) {
+			$cancellation_source = null !== $cancellation ? $cancellation['source'] : NotificationCancellationSource::SYSTEM;
+		}
+
+		return array(
+			'product_id'            => (int) $legacy_row['product_id'],
+			'user_id'               => (int) $legacy_row['user_id'],
+			'user_email'            => strtolower( trim( (string) $legacy_row['user_email'] ) ),
+			'status'                => $status,
+			'date_created_gmt'      => $date_mapper->date_created_gmt( $legacy_row ),
+			'date_modified_gmt'     => $date_mapper->date_modified_gmt(),
+			'date_confirmed_gmt'    => $date_mapper->date_confirmed_gmt( $legacy_row ),
+			'date_last_attempt_gmt' => $date_mapper->date_last_attempt_gmt( $legacy_row ),
+			'date_notified_gmt'     => $date_mapper->date_notified_gmt( $legacy_row, $status ),
+			'date_cancelled_gmt'    => $date_mapper->date_cancelled_gmt( $legacy_row, $status, $latest_activity_date ),
+			'cancellation_source'   => $cancellation_source,
+		);
+	}
+
+	/**
+	 * Build the Core meta rows for a new notification row: the mapped legacy meta bag,
+	 * the legacy id marker, and the legacy unsubscribe token when both hash secrets exist.
+	 *
+	 * @param int                 $legacy_id  Legacy notification id.
+	 * @param array<string,mixed> $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @param array<string,mixed> $row_meta   This row's legacy meta bag.
+	 * @param WriterInterface     $writer     Writer, used only to set the legacy-links option.
+	 * @return array<int,array{0:string,1:mixed}>
+	 */
+	private function build_meta( int $legacy_id, array $legacy_row, array $row_meta, WriterInterface $writer ): array {
+		$meta   = MetaMapper::map( $row_meta );
+		$meta[] = array( self::LEGACY_ID_META_KEY, $legacy_id );
+
+		$token = $this->compute_token( $legacy_id, $legacy_row, $row_meta );
+
+		if ( null !== $token ) {
+			$meta[] = array( self::LEGACY_UNSUB_HASH_META_KEY, LegacyHash::to_meta_value( $legacy_id, $token ) );
+			$this->maybe_set_has_legacy_links_option( $writer );
+		} else {
+			++$this->rows_without_hash_count;
+		}
+
+		return $meta;
+	}
+
+	/**
+	 * Reproduce the legacy unsubscribe token for one row, when both hash secrets exist.
+	 *
+	 * @param int                 $legacy_id  Legacy notification id.
+	 * @param array<string,mixed> $legacy_row Row from `woocommerce_bis_notifications`.
+	 * @param array<string,mixed> $row_meta   This row's legacy meta bag.
+	 * @return string|null
+	 */
+	private function compute_token( int $legacy_id, array $legacy_row, array $row_meta ): ?string {
+		$hash_key = (string) ( $row_meta['_hash_key'] ?? '' );
+		$hash_iv  = (string) ( $row_meta['_hash_iv'] ?? '' );
+
+		return LegacyHash::compute(
+			$legacy_id,
+			(int) $legacy_row['product_id'],
+			(int) $legacy_row['create_date'],
+			$hash_key,
+			$hash_iv
+		);
+	}
+
+	/**
+	 * Set the autoloaded `wc_bis_migration_has_legacy_links` flag the first time a row
+	 * carrying a legacy unsubscribe token is written. Reads the option first so an
+	 * already-set flag costs nothing beyond the cached autoloaded read.
+	 *
+	 * @param WriterInterface $writer Writer to route the option write through.
+	 * @return void
+	 */
+	private function maybe_set_has_legacy_links_option( WriterInterface $writer ): void {
+		if ( 'yes' !== get_option( self::HAS_LEGACY_LINKS_OPTION ) ) {
+			$writer->write_option( self::HAS_LEGACY_LINKS_OPTION, 'yes' );
+		}
+	}
+
+	/**
+	 * Set the autoloaded `wc_bis_migration_has_migrated_rows` flag the first time any row
+	 * is migrated, inserted or adopted. Reads the option first so an already-set flag
+	 * costs nothing beyond the cached autoloaded read.
+	 *
+	 * @param WriterInterface $writer Writer to route the option write through.
+	 * @return void
+	 */
+	private function maybe_set_has_migrated_rows_option( WriterInterface $writer ): void {
+		if ( 'yes' !== get_option( self::HAS_MIGRATED_ROWS_OPTION ) ) {
+			$writer->write_option( self::HAS_MIGRATED_ROWS_OPTION, 'yes' );
+		}
+	}
+
+	/**
+	 * Mark a legacy row as permanently failed and leave it out of the candidate set.
+	 *
+	 * @param int             $legacy_id Legacy notification id.
+	 * @param WriterInterface $writer    Writer to route the marker write through.
+	 * @return void
+	 */
+	private function fail_row( int $legacy_id, WriterInterface $writer ): void {
+		$writer->write_legacy_meta(
+			$legacy_id,
+			self::FAILED_META_KEY,
+			array(
+				'reason' => self::FAILURE_REASON_EXCEPTION,
+				'at'     => time(),
+			)
+		);
+	}
+
+	/**
+	 * Record one outcome for one row against both the returned outcome-count array and
+	 * the shared Reporter.
+	 *
+	 * @param array  $outcomes  Outcome counts accumulated so far, by reference.
+	 * @param string $outcome   One of the Reporter::OUTCOME_* constants.
+	 * @param int    $legacy_id Legacy row identifier.
+	 * @return void
+	 */
+	private function record_outcome( array &$outcomes, string $outcome, int $legacy_id ): void {
+		$outcomes[ $outcome ] = ( $outcomes[ $outcome ] ?? 0 ) + 1;
+		$this->reporter->record( self::SLUG, $outcome, $legacy_id );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigrator.php
@@ -172,11 +172,9 @@ class NotificationsMigrator implements MigratorInterface {
 	public function count_remaining(): int {
 		global $wpdb;
 
-		// predicate_sql() returns a fixed literal built by this class, never user input.
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$sql = $wpdb->prepare( 'SELECT COUNT(*) ' . $this->predicate_sql() );
+		$sql = 'SELECT COUNT(*) ' . $this->predicate_sql();
 
-		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a fixed literal built by this class, never user input.
 	}
 
 	/**
@@ -192,17 +190,11 @@ class NotificationsMigrator implements MigratorInterface {
 	public function get_batch( int $cursor, int $size ): array {
 		global $wpdb;
 
-		// predicate_sql() returns a fixed literal built by this class, never user input;
-		// $cursor and $size are bound via $wpdb->prepare() below.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$sql = $wpdb->prepare(
-			'SELECT n.id ' . $this->predicate_sql() . ' AND n.id > %d ORDER BY n.id ASC LIMIT %d',
-			$cursor,
-			$size
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// predicate_sql() returns a fixed literal built by this class, never user input; only
+		// the cursor and size are bound, so only that tail goes through $wpdb->prepare().
+		$sql = 'SELECT n.id ' . $this->predicate_sql() . $wpdb->prepare( ' AND n.id > %d ORDER BY n.id ASC LIMIT %d', $cursor, $size );
 
-		return array_map( 'intval', (array) $wpdb->get_col( $sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+		return array_map( 'intval', (array) $wpdb->get_col( $sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- see above.
 	}
 
 	/**
@@ -319,14 +311,9 @@ class NotificationsMigrator implements MigratorInterface {
 	public function count_unverified_excluded(): int {
 		global $wpdb;
 
-		// base_sql() returns a fixed literal built by this class, never user input.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$sql = $wpdb->prepare(
-			'SELECT COUNT(*) ' . $this->base_sql() . " AND ( n.is_verified = 'no' OR ( av.meta_value IS NOT NULL AND av.meta_value = 'yes' ) )"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		$sql = 'SELECT COUNT(*) ' . $this->base_sql() . " AND ( n.is_verified = 'no' OR ( av.meta_value IS NOT NULL AND av.meta_value = 'yes' ) )";
 
-		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a fixed literal built by this class, never user input.
 	}
 
 	/**
@@ -337,14 +324,9 @@ class NotificationsMigrator implements MigratorInterface {
 	public function count_email_too_long(): int {
 		global $wpdb;
 
-		// base_sql()/verified_clause() return fixed literals built by this class, never user input.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$sql = $wpdb->prepare(
-			'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause() . ' AND CHAR_LENGTH( n.user_email ) > 100'
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		$sql = 'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause() . ' AND CHAR_LENGTH( n.user_email ) > 100';
 
-		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a fixed literal built by this class, never user input.
 	}
 
 	/**
@@ -355,16 +337,11 @@ class NotificationsMigrator implements MigratorInterface {
 	public function count_invalid_email(): int {
 		global $wpdb;
 
-		// Every fragment here is a fixed literal built by this class, never user input;
-		// the LIKE wildcards are part of that literal, not a bound value.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
-		$sql = $wpdb->prepare(
-			'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause()
-			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND ( n.user_email = '' OR n.user_email NOT LIKE '%%_@_%%' )"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+		// The LIKE wildcards are part of this class's own literal, not a bound value.
+		$sql = 'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause()
+			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND ( n.user_email = '' OR n.user_email NOT LIKE '%_@_%' )";
 
-		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a fixed literal built by this class, never user input.
 	}
 
 	/**
@@ -379,16 +356,14 @@ class NotificationsMigrator implements MigratorInterface {
 
 		// $posts_table is $wpdb->prefix-based, never user input; every other fragment is a
 		// fixed literal built by this class, including the LIKE wildcards.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
-		$sql = $wpdb->prepare(
-			'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause()
-			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND n.user_email <> '' AND n.user_email LIKE '%%_@_%%'"
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = 'SELECT COUNT(*) ' . $this->base_sql() . $this->verified_clause()
+			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND n.user_email <> '' AND n.user_email LIKE '%_@_%'"
 			. " AND NOT EXISTS ( SELECT 1 FROM {$posts_table} p"
-			. " WHERE p.ID = n.product_id AND p.post_type IN ( 'product', 'product_variation' ) AND p.post_status <> 'trash' )"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+			. " WHERE p.ID = n.product_id AND p.post_type IN ( 'product', 'product_variation' ) AND p.post_status <> 'trash' )";
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a fixed literal built by this class, never user input.
 	}
 
 	/**
@@ -396,8 +371,9 @@ class NotificationsMigrator implements MigratorInterface {
 	 * verbatim in shape. Reused by count_remaining() and get_batch(), which append
 	 * only a cursor bound and a LIMIT.
 	 *
-	 * Literal `%` characters are doubled, since this fragment is always passed through
-	 * $wpdb->prepare() by its callers.
+	 * Never passed through $wpdb->prepare(): it binds no values, and prepare() on a
+	 * placeholder-free query is a `_doing_it_wrong()` notice. Callers that do bind
+	 * values prepare only their own tail and concatenate it onto this fragment.
 	 *
 	 * @return string
 	 */
@@ -407,7 +383,7 @@ class NotificationsMigrator implements MigratorInterface {
 		$posts_table = $wpdb->prefix . 'posts';
 
 		return $this->base_sql() . $this->verified_clause()
-			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND n.user_email <> '' AND n.user_email LIKE '%%_@_%%'"
+			. " AND CHAR_LENGTH( n.user_email ) <= 100 AND n.user_email <> '' AND n.user_email LIKE '%_@_%'"
 			. " AND EXISTS ( SELECT 1 FROM {$posts_table} p" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $posts_table is $wpdb->prefix-based, never user input.
 			. " WHERE p.ID = n.product_id AND p.post_type IN ( 'product', 'product_variation' ) AND p.post_status <> 'trash' )";
 	}
@@ -415,7 +391,8 @@ class NotificationsMigrator implements MigratorInterface {
 	/**
 	 * The shared FROM/JOIN/WHERE base every predicate variant starts from: the two
 	 * anti-joins against the migrated set and the permanently-failed set. Callers append
-	 * their own conditions.
+	 * their own conditions. Binds no values; see predicate_sql() on why it is never
+	 * passed through $wpdb->prepare().
 	 *
 	 * @return string
 	 */
@@ -426,8 +403,7 @@ class NotificationsMigrator implements MigratorInterface {
 		$core_meta_table     = $wpdb->prefix . 'wc_stock_notificationmeta';
 		$legacy_meta_table   = $wpdb->prefix . 'woocommerce_bis_notificationsmeta';
 
-		// Table names are $wpdb->prefix-based, never user input; every caller runs the
-		// resulting fragment through $wpdb->prepare().
+		// Table names are $wpdb->prefix-based, never user input.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return "
 			FROM {$notifications_table} n
@@ -523,8 +499,10 @@ class NotificationsMigrator implements MigratorInterface {
 	/**
 	 * Find an existing Core notification carrying this legacy row's natural key, if any.
 	 *
-	 * Natural key: product_id, plus user_id when non-zero and user_email (lowercased,
-	 * trimmed) otherwise, plus posted_attributes in maybe_serialize() form. Restricted to
+	 * Natural key: product_id, plus user_id when non-zero and, for a guest row, a zero
+	 * user_id with a matching user_email (lowercased, trimmed), plus posted_attributes in
+	 * maybe_serialize() form. A guest row and a registered row never adopt each other, in
+	 * either direction. Restricted to
 	 * `active` and `pending` targets, ordered active before pending then by ascending id,
 	 * so the same legacy row adopts the same target on every run.
 	 *
@@ -546,6 +524,10 @@ class NotificationsMigrator implements MigratorInterface {
 			$conditions[] = 'n.user_id = %d';
 			$params[]     = $user_id;
 		} else {
+			// A guest legacy row only ever adopts a guest Core row. Matching a registered
+			// Core row on the address alone would hand one person's subscription to a row
+			// that belongs to their account, which is a different subscription.
+			$conditions[] = 'n.user_id = 0';
 			$conditions[] = 'LOWER( TRIM( n.user_email ) ) = %s';
 			$params[]     = strtolower( trim( (string) ( $legacy_row['user_email'] ?? '' ) ) );
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/ProductMetaMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/ProductMetaMigrator.php
@@ -1,0 +1,411 @@
+<?php
+/**
+ * ProductMetaMigrator class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Config;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrates the legacy per-product "disable sign-ups" flag onto the Core product meta key.
+ *
+ * Legacy stores `_wc_bis_disabled = 'yes'` in `wp_postmeta`. Core stores the opposite
+ * polarity, `customer_stock_notifications_enable_signups = 'no'`, via
+ * `Config::get_product_signups_meta_key()`. Absent means enabled on both sides, so only
+ * the `'yes'` rows are candidates; a row that is absent or any other value needs no write
+ * and is never selected.
+ *
+ * No variation fan-out: `EligibilityService::product_allows_signups()` resolves a
+ * variation to its parent and tests only the parent's flag (it never reads a variation's
+ * own meta), matching legacy's own parent lookup in `WC_BIS_Product::is_disabled()`. This
+ * migrator therefore only considers `product` posts; a flag set directly on a
+ * `product_variation` post has nowhere to go on the Core side and is not migrated.
+ */
+class ProductMetaMigrator implements MigratorInterface {
+
+	/**
+	 * Section slug.
+	 */
+	private const SLUG = 'product-meta';
+
+	/**
+	 * Legacy post meta key holding the "sign-ups disabled" flag.
+	 */
+	private const LEGACY_META_KEY = '_wc_bis_disabled';
+
+	/**
+	 * The only legacy value this migrator acts on. Anything else means "enabled", which is
+	 * also Core's default, so there is nothing to write.
+	 */
+	private const LEGACY_DISABLED_VALUE = 'yes';
+
+	/**
+	 * Product meta key holding this migrator's per-product fingerprint.
+	 *
+	 * Stored as `{source hash}:{target hash}:{timestamp}` rather than as an array, so the
+	 * candidate query can compare both hashes in SQL. A row is a candidate again once the
+	 * live target value's hash no longer matches the target hash recorded here, even
+	 * though a fingerprint already exists — that is how a merchant edit made after this
+	 * migrator last ran gets picked up on the next pass.
+	 */
+	private const FINGERPRINT_META_KEY = '_wc_bis_migration_signups_written';
+
+	/**
+	 * Separator between the two hashes and the timestamp in a stored fingerprint.
+	 */
+	private const FINGERPRINT_SEPARATOR = ':';
+
+	/**
+	 * Reporter every outcome is recorded through.
+	 *
+	 * @var Reporter
+	 */
+	private Reporter $reporter;
+
+	/**
+	 * Used for its fingerprint hashing helper and its OPTION_ACTION_* vocabulary, kept
+	 * consistent with the option fingerprints even though per-product fingerprints live
+	 * in product meta rather than in `wc_bis_migration_state`.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $migration_state;
+
+	/**
+	 * Whether to overwrite a product a merchant already edited since this migrator wrote it.
+	 *
+	 * @var bool
+	 */
+	private bool $force;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Reporter       $reporter        Reporter to record outcomes through.
+	 * @param MigrationState $migration_state State helper, used here only for fingerprint hashing.
+	 * @param bool           $force           Whether `--force` was passed on the CLI.
+	 */
+	public function __construct( Reporter $reporter, MigrationState $migration_state, bool $force = false ) {
+		$this->reporter        = $reporter;
+		$this->migration_state = $migration_state;
+		$this->force           = $force;
+	}
+
+	/**
+	 * Section slug, used in batch item prefixes, state keys and CLI `--section` values.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return self::SLUG;
+	}
+
+	/**
+	 * Count the rows this section still has to migrate.
+	 *
+	 * Same predicate as get_batch(), without the cursor, expressed as a COUNT(*).
+	 *
+	 * @return int
+	 */
+	public function count_remaining(): int {
+		global $wpdb;
+
+		$sql = $this->candidate_sql( 'COUNT( DISTINCT p.ID )', '', array() );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was prepared by candidate_sql(); table names are fixed internal names, never user input.
+		return (int) $wpdb->get_var( $sql );
+	}
+
+	/**
+	 * Fetch the next batch of candidate product ids after the given keyset cursor.
+	 *
+	 * Side-effect free: reads only. A product leaves the candidate set once its recorded
+	 * fingerprint matches both the legacy source value and the live target meta value,
+	 * whatever the fingerprint decision was, so a settled row is never selected again.
+	 *
+	 * @param int $cursor Last product id handled in the current pass, or 0 to start a pass.
+	 * @param int $size   Maximum number of ids to return.
+	 * @return array List of product ids, ascending.
+	 */
+	public function get_batch( int $cursor, int $size ): array {
+		global $wpdb;
+
+		$sql = $this->candidate_sql(
+			'DISTINCT p.ID',
+			'AND p.ID > %d
+			ORDER BY p.ID ASC
+			LIMIT %d',
+			array( $cursor, $size )
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was prepared by candidate_sql(); table names are fixed internal names, never user input.
+		$ids = $wpdb->get_col( $sql );
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Build the candidate query shared by get_batch() and count_remaining().
+	 *
+	 * A product is a candidate while `decide_action()` would return anything other than
+	 * "already handled, unchanged": no fingerprint yet, a fingerprint whose recorded
+	 * source hash no longer matches the legacy value, or one whose recorded target hash
+	 * no longer matches what is stored under the Core meta key today. Expressing all
+	 * three in SQL keeps merchant edits visible on later runs while still letting the
+	 * section drain — a row settled by migrate_one() matches on both hashes and drops out.
+	 *
+	 * `SHA2( ..., 256 )` mirrors `MigrationState::fingerprint_value()`: WordPress stores
+	 * meta already serialized, and `maybe_serialize()` on the value read back reproduces
+	 * that same string, so both sides hash identical bytes. An absent target meta row
+	 * hashes as the empty string on both sides too. The two hashes are compared as binary
+	 * so a connection collation that differs from the column's cannot make the comparison
+	 * fail.
+	 *
+	 * @param string $select      Select list. A fixed internal string, never user input.
+	 * @param string $suffix      Extra conditions and clauses. A fixed internal string, never user input.
+	 * @param array  $suffix_args Values for the placeholders `$suffix` adds, in order.
+	 * @return string Prepared SQL.
+	 */
+	private function candidate_sql( string $select, string $suffix, array $suffix_args ): string {
+		global $wpdb;
+
+		$separator = self::FINGERPRINT_SEPARATOR;
+
+		$sql = "SELECT {$select}
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->postmeta} legacy_meta
+				ON legacy_meta.post_id = p.ID
+				AND legacy_meta.meta_key = %s
+				AND legacy_meta.meta_value = '" . self::LEGACY_DISABLED_VALUE . "'
+			LEFT JOIN {$wpdb->postmeta} target_meta
+				ON target_meta.post_id = p.ID
+				AND target_meta.meta_key = %s
+			LEFT JOIN {$wpdb->postmeta} fingerprint_meta
+				ON fingerprint_meta.post_id = p.ID
+				AND fingerprint_meta.meta_key = %s
+			WHERE p.post_type = 'product'
+				AND p.post_status <> 'trash'
+				AND (
+					fingerprint_meta.meta_id IS NULL
+					OR SUBSTRING_INDEX( fingerprint_meta.meta_value, '{$separator}', 1 ) <> %s
+					OR CAST( SUBSTRING_INDEX( SUBSTRING_INDEX( fingerprint_meta.meta_value, '{$separator}', 2 ), '{$separator}', -1 ) AS BINARY )
+						<> CAST( SHA2( COALESCE( target_meta.meta_value, '' ), 256 ) AS BINARY )
+				)
+				{$suffix}";
+
+		$args = array_merge(
+			array(
+				self::LEGACY_META_KEY,
+				Config::get_product_signups_meta_key(),
+				self::FINGERPRINT_META_KEY,
+				$this->get_source_hash(),
+			),
+			$suffix_args
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- the only values interpolated into $sql are fixed internal strings; every caller-supplied value is passed as a placeholder argument here.
+		return (string) $wpdb->prepare( $sql, $args );
+	}
+
+	/**
+	 * Migrate the given product ids.
+	 *
+	 * Per-row failures are recorded and reported rather than thrown.
+	 *
+	 * @param array           $ids    Product ids returned by get_batch().
+	 * @param WriterInterface $writer Writer to route all persistence through.
+	 * @return array Outcome counts keyed by outcome code.
+	 */
+	public function migrate_batch( array $ids, WriterInterface $writer ): array {
+		$outcomes = array();
+
+		foreach ( $ids as $product_id ) {
+			$product_id = (int) $product_id;
+			$outcome    = $this->migrate_one( $product_id, $writer );
+
+			$outcomes[ $outcome ] = ( $outcomes[ $outcome ] ?? 0 ) + 1;
+			$this->reporter->record( self::SLUG, $outcome, $product_id );
+		}
+
+		$this->reporter->report_batch( self::SLUG, count( $ids ) );
+
+		return $outcomes;
+	}
+
+	/**
+	 * Migrate a single product.
+	 *
+	 * @param int             $product_id Product id.
+	 * @param WriterInterface $writer     Writer to route all persistence through.
+	 * @return string One of the Reporter::OUTCOME_* constants.
+	 */
+	private function migrate_one( int $product_id, WriterInterface $writer ): string {
+		$product = wc_get_product( $product_id );
+
+		if ( ! $product instanceof WC_Product ) {
+			// Record the visit so the row leaves the candidate set. A row that keeps failing
+			// without a marker is never drained, and the section would stall the whole run.
+			$this->mark_terminal_failure( $product_id, $writer );
+
+			return Reporter::OUTCOME_PRODUCT_MISSING;
+		}
+
+		$target_meta_key = Config::get_product_signups_meta_key();
+
+		// Read the raw stored value rather than WC_Product::get_meta(), and let an absent
+		// row read as '', which is what the candidate query hashes it as too.
+		$current_value = get_post_meta( $product_id, $target_meta_key, true );
+
+		$current_target_hash = $this->migration_state->fingerprint_value( $current_value );
+		$source_hash         = $this->get_source_hash();
+
+		$fingerprint = $this->parse_fingerprint( get_post_meta( $product_id, self::FINGERPRINT_META_KEY, true ) );
+
+		$action = $this->decide_action( $fingerprint, $source_hash, $current_target_hash );
+
+		if ( MigrationState::OPTION_ACTION_SKIP_USER_MODIFIED === $action ) {
+			// Do not touch the value the merchant set; record what it is now, so the row
+			// only comes back as user-modified again after a further edit.
+			$writer->write_product_meta(
+				$product_id,
+				self::FINGERPRINT_META_KEY,
+				$this->format_fingerprint( $source_hash, $current_target_hash )
+			);
+
+			return Reporter::OUTCOME_SKIPPED_USER_MODIFIED;
+		}
+
+		if ( MigrationState::OPTION_ACTION_SKIP_UNCHANGED === $action ) {
+			return MigrationState::OPTION_ACTION_SKIP_UNCHANGED;
+		}
+
+		if ( ! $writer->write_product_meta( $product_id, $target_meta_key, 'no' ) ) {
+			$this->mark_terminal_failure( $product_id, $writer );
+
+			return Reporter::OUTCOME_FAILED;
+		}
+
+		$new_target_hash = $this->migration_state->fingerprint_value( 'no' );
+
+		$writer->write_product_meta(
+			$product_id,
+			self::FINGERPRINT_META_KEY,
+			$this->format_fingerprint( $source_hash, $new_target_hash )
+		);
+
+		return Reporter::OUTCOME_MIGRATED;
+	}
+
+	/**
+	 * Fingerprint of the legacy source value.
+	 *
+	 * Both the candidate query and migrate_one() only ever deal with `'yes'` rows, so the
+	 * source side of a fingerprint is the same for every product.
+	 *
+	 * @return string
+	 */
+	private function get_source_hash(): string {
+		return $this->migration_state->fingerprint_value( self::LEGACY_DISABLED_VALUE );
+	}
+
+	/**
+	 * Build the fingerprint meta value for a product.
+	 *
+	 * @param string $source_hash Fingerprint of the legacy source value.
+	 * @param string $target_hash Fingerprint of the value now stored under the Core meta key.
+	 * @return string
+	 */
+	private function format_fingerprint( string $source_hash, string $target_hash ): string {
+		return implode( self::FINGERPRINT_SEPARATOR, array( $source_hash, $target_hash, (string) time() ) );
+	}
+
+	/**
+	 * Read a stored fingerprint back into the shape decide_action() expects.
+	 *
+	 * Anything that is not a well-formed fingerprint reads as absent, so a garbled value
+	 * is rewritten rather than trusted. The candidate query treats it the same way.
+	 *
+	 * @param mixed $stored Raw fingerprint meta value.
+	 * @return array{written: string, hash: string}|null
+	 */
+	private function parse_fingerprint( $stored ): ?array {
+		if ( ! is_string( $stored ) ) {
+			return null;
+		}
+
+		$parts = explode( self::FINGERPRINT_SEPARATOR, $stored );
+
+		if ( count( $parts ) < 2 || '' === $parts[0] || '' === $parts[1] ) {
+			return null;
+		}
+
+		return array(
+			'written' => $parts[0],
+			'hash'    => $parts[1],
+		);
+	}
+
+	/**
+	 * Decide what to do with a product's target meta, mirroring
+	 * `MigrationState::decide_option_action()` for a fingerprint stored in product meta
+	 * instead of `wc_bis_migration_state`.
+	 *
+	 * | Fingerprint  | Action                                                  |
+	 * | ------------ | -------------------------------------------------------- |
+	 * | Absent       | Write                                                     |
+	 * | Hash matches | We wrote it; rewrite only if the source changed           |
+	 * | Hash differs | Merchant edited it; skip, unless `--force`                |
+	 *
+	 * @param array<string,string>|null $fingerprint        Fingerprint on record, if any, as
+	 *                                                       returned by parse_fingerprint().
+	 * @param string                    $source_hash         Fingerprint of the current legacy source value.
+	 * @param string                    $current_target_hash Fingerprint of the product's current stored value.
+	 * @return string One of MigrationState::OPTION_ACTION_* constants.
+	 */
+	private function decide_action( ?array $fingerprint, string $source_hash, string $current_target_hash ): string {
+		if ( null === $fingerprint || ! isset( $fingerprint['hash'], $fingerprint['written'] ) ) {
+			return MigrationState::OPTION_ACTION_WRITE;
+		}
+
+		if ( $fingerprint['hash'] !== $current_target_hash ) {
+			return $this->force ? MigrationState::OPTION_ACTION_WRITE : MigrationState::OPTION_ACTION_SKIP_USER_MODIFIED;
+		}
+
+		if ( $fingerprint['written'] !== $source_hash ) {
+			return MigrationState::OPTION_ACTION_WRITE;
+		}
+
+		return MigrationState::OPTION_ACTION_SKIP_UNCHANGED;
+	}
+
+	/**
+	 * Write a fingerprint for a row that can never be migrated, so it stops being a candidate.
+	 *
+	 * The fingerprint records the state actually observed rather than a successful write, so
+	 * a later run re-admits the row only if something about it genuinely changes.
+	 *
+	 * @param int             $product_id Product id.
+	 * @param WriterInterface $writer     Writer to persist through.
+	 * @return void
+	 */
+	private function mark_terminal_failure( int $product_id, WriterInterface $writer ): void {
+		$target_hash = $this->migration_state->fingerprint_value(
+			(string) get_post_meta( $product_id, Config::get_product_signups_meta_key(), true )
+		);
+
+		$writer->write_product_meta(
+			$product_id,
+			self::FINGERPRINT_META_KEY,
+			$this->format_fingerprint( $this->get_source_hash(), $target_hash )
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/ProductMetaMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/ProductMetaMigrator.php
@@ -49,6 +49,12 @@ class ProductMetaMigrator implements MigratorInterface {
 	private const LEGACY_DISABLED_VALUE = 'yes';
 
 	/**
+	 * The value written to the Core meta key for a legacy-disabled product. Polarity is
+	 * inverted: legacy `_wc_bis_disabled = 'yes'` means Core signups are off.
+	 */
+	private const TARGET_DISABLED_VALUE = 'no';
+
+	/**
 	 * Product meta key holding this migrator's per-product fingerprint.
 	 *
 	 * Stored as `{source hash}:{target hash}:{timestamp}` rather than as an array, so the
@@ -180,6 +186,13 @@ class ProductMetaMigrator implements MigratorInterface {
 
 		$separator = self::FINGERPRINT_SEPARATOR;
 
+		// With --force, a row a previous run recorded as merchant-edited is settled as far as
+		// the fingerprint is concerned, so it is re-admitted on the value itself instead. The
+		// test still terminates: once the row holds the migrated value it stops matching.
+		$force_clause = $this->force
+			? "OR COALESCE( target_meta.meta_value, '' ) <> '" . self::TARGET_DISABLED_VALUE . "'"
+			: '';
+
 		$sql = "SELECT {$select}
 			FROM {$wpdb->posts} p
 			INNER JOIN {$wpdb->postmeta} legacy_meta
@@ -199,6 +212,7 @@ class ProductMetaMigrator implements MigratorInterface {
 					OR SUBSTRING_INDEX( fingerprint_meta.meta_value, '{$separator}', 1 ) <> %s
 					OR CAST( SUBSTRING_INDEX( SUBSTRING_INDEX( fingerprint_meta.meta_value, '{$separator}', 2 ), '{$separator}', -1 ) AS BINARY )
 						<> CAST( SHA2( COALESCE( target_meta.meta_value, '' ), 256 ) AS BINARY )
+					{$force_clause}
 				)
 				{$suffix}";
 
@@ -288,13 +302,13 @@ class ProductMetaMigrator implements MigratorInterface {
 			return MigrationState::OPTION_ACTION_SKIP_UNCHANGED;
 		}
 
-		if ( ! $writer->write_product_meta( $product_id, $target_meta_key, 'no' ) ) {
+		if ( ! $writer->write_product_meta( $product_id, $target_meta_key, self::TARGET_DISABLED_VALUE ) ) {
 			$this->mark_terminal_failure( $product_id, $writer );
 
 			return Reporter::OUTCOME_FAILED;
 		}
 
-		$new_target_hash = $this->migration_state->fingerprint_value( 'no' );
+		$new_target_hash = $this->get_target_hash();
 
 		$writer->write_product_meta(
 			$product_id,
@@ -315,6 +329,15 @@ class ProductMetaMigrator implements MigratorInterface {
 	 */
 	private function get_source_hash(): string {
 		return $this->migration_state->fingerprint_value( self::LEGACY_DISABLED_VALUE );
+	}
+
+	/**
+	 * Fingerprint of the value this section writes.
+	 *
+	 * @return string
+	 */
+	private function get_target_hash(): string {
+		return $this->migration_state->fingerprint_value( self::TARGET_DISABLED_VALUE );
 	}
 
 	/**
@@ -373,6 +396,13 @@ class ProductMetaMigrator implements MigratorInterface {
 	 */
 	private function decide_action( ?array $fingerprint, string $source_hash, string $current_target_hash ): string {
 		if ( null === $fingerprint || ! isset( $fingerprint['hash'], $fingerprint['written'] ) ) {
+			return MigrationState::OPTION_ACTION_WRITE;
+		}
+
+		// A skip recorded by an earlier run makes the fingerprint match the merchant's own
+		// value, so the "hash differs" case below can no longer see it. `--force` therefore
+		// asks the plainer question: is the stored value already the one this section writes?
+		if ( $this->force && $current_target_hash !== $this->get_target_hash() ) {
 			return MigrationState::OPTION_ACTION_WRITE;
 		}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/SettingsMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/SettingsMigrator.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * SettingsMigrator class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrates the legacy Back In Stock Notifications general settings to their Core
+ * `Config` equivalents.
+ *
+ * `wc_bis_allow_signups` migrating to `woocommerce_customer_stock_notifications_allow_signups`
+ * is the option that actually turns signups on for a migrated store:
+ * `WC_Install::enable_customer_stock_notifications_signups()` writes
+ * `woocommerce_back_in_stock_allow_signups`, a key `Config::allows_signups()` never reads,
+ * so without this migrator new installs never really got signups enabled by default.
+ */
+class SettingsMigrator implements MigratorInterface {
+
+	/**
+	 * Section slug, used in state keys and CLI `--section` values.
+	 */
+	private const SLUG = 'settings';
+
+	/**
+	 * Legacy option name to `array{ core: string, default: mixed }`.
+	 *
+	 * Defaults mirror the legacy admin settings screen so a store that never wrote the
+	 * option row still migrates the value the merchant actually saw.
+	 *
+	 * @var array<string, array{core: string, default: mixed}>
+	 */
+	private const OPTION_MAP = array(
+		'wc_bis_allow_signups'                      => array(
+			'core'    => 'woocommerce_customer_stock_notifications_allow_signups',
+			'default' => 'yes',
+		),
+		'wc_bis_double_opt_in_required'             => array(
+			'core'    => 'woocommerce_customer_stock_notifications_require_double_opt_in',
+			'default' => 'no',
+		),
+		'wc_bis_delete_unverified_days_threshold'   => array(
+			'core'    => 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold',
+			'default' => 0,
+		),
+		'wc_bis_account_required'                   => array(
+			'core'    => 'woocommerce_customer_stock_notifications_require_account',
+			'default' => 'no',
+		),
+		'wc_bis_create_new_account_on_registration' => array(
+			'core'    => 'woocommerce_customer_stock_notifications_create_account_on_signup',
+			'default' => 'no',
+		),
+	);
+
+	/**
+	 * Legacy options with no Core `Config` equivalent, counted and reported but never
+	 * written. See the plan's "Known losses" section.
+	 *
+	 * @var string[]
+	 */
+	private const KNOWN_LOSS_OPTIONS = array(
+		'wc_bis_stock_threshold',
+		'wc_bis_opt_in_required',
+		'wc_bis_show_product_registrations_count',
+		'wc_bis_loop_signup_prompt_status',
+		'wc_bis_create_new_account_optin_text',
+		'wc_bis_product_registrations_text',
+		'wc_bis_product_registrations_plural_text',
+		'wc_bis_form_header_text',
+		'wc_bis_form_header_signed_up_text',
+		'wc_bis_form_header_signed_up_link_text',
+		'wc_bis_form_button_text',
+		'wc_bis_loop_signup_prompt_text',
+		'wc_bis_loop_signup_prompt_link_text',
+		'wc_bis_loop_signup_prompt_signed_up_text',
+		'wc_bis_loop_signup_prompt_signed_up_link_text',
+	);
+
+	/**
+	 * Outcome code for an option with no Core home, counted but never written.
+	 *
+	 * @var string
+	 */
+	private const OUTCOME_NO_CORE_HOME = 'no_core_home';
+
+	/**
+	 * Migration run state, used for fingerprint bookkeeping.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Outcome reporter.
+	 *
+	 * @var Reporter
+	 */
+	private Reporter $reporter;
+
+	/**
+	 * Whether to overwrite an option the merchant has already edited.
+	 *
+	 * @var bool
+	 */
+	private bool $force;
+
+	/**
+	 * Whether the known-losses count has already been reported this run.
+	 *
+	 * @var bool
+	 */
+	private bool $known_losses_reported = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param MigrationState $state    Migration run state.
+	 * @param Reporter       $reporter Outcome reporter.
+	 * @param bool           $force    Whether to overwrite merchant-edited options. CLI only.
+	 */
+	public function __construct( MigrationState $state, Reporter $reporter, bool $force = false ) {
+		$this->state    = $state;
+		$this->reporter = $reporter;
+		$this->force    = $force;
+	}
+
+	/**
+	 * Section slug, used in state keys and CLI `--section` values.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return self::SLUG;
+	}
+
+	/**
+	 * Count the options that still need a write. Display only.
+	 *
+	 * @return int
+	 */
+	public function count_remaining(): int {
+		$count = 0;
+
+		foreach ( array_keys( self::OPTION_MAP ) as $legacy_key ) {
+			if ( MigrationState::OPTION_ACTION_WRITE === $this->decide( $legacy_key ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Fetch the outstanding legacy option keys, capped at $size.
+	 *
+	 * Includes options that need a write and options the merchant has edited, since the
+	 * latter still need to be visited so migrate_batch() can report them. Excludes
+	 * options already migrated and unchanged since. This section is small and finite, so
+	 * $cursor is not used as a keyset: the same outstanding list is returned every call.
+	 *
+	 * @param int $cursor Unused; this section never needs more than one pass.
+	 * @param int $size   Maximum number of option keys to return.
+	 * @return array List of legacy option keys.
+	 */
+	public function get_batch( int $cursor, int $size ): array {
+		$outstanding = array();
+
+		foreach ( array_keys( self::OPTION_MAP ) as $legacy_key ) {
+			$action = $this->decide( $legacy_key );
+
+			if ( MigrationState::OPTION_ACTION_SKIP_UNCHANGED !== $action ) {
+				$outstanding[] = $legacy_key;
+			}
+		}
+
+		return array_slice( $outstanding, 0, max( 0, $size ) );
+	}
+
+	/**
+	 * Migrate the given legacy option keys.
+	 *
+	 * @param array           $ids    Legacy option keys returned by get_batch().
+	 * @param WriterInterface $writer Writer to route all persistence through.
+	 * @return array Outcome counts keyed by outcome code.
+	 */
+	public function migrate_batch( array $ids, WriterInterface $writer ): array {
+		$counts = array();
+		$row_id = 0;
+
+		foreach ( $ids as $legacy_key ) {
+			if ( ! isset( self::OPTION_MAP[ $legacy_key ] ) ) {
+				continue;
+			}
+
+			++$row_id;
+
+			$mapping     = self::OPTION_MAP[ $legacy_key ];
+			$core_key    = $mapping['core'];
+			$value       = get_option( $legacy_key, $mapping['default'] );
+			$source_hash = $this->state->fingerprint_value( $value );
+			$action      = $this->decide( $legacy_key );
+
+			if ( MigrationState::OPTION_ACTION_SKIP_USER_MODIFIED === $action ) {
+				$this->reporter->record( self::SLUG, Reporter::OUTCOME_SKIPPED_USER_MODIFIED, $row_id );
+				$counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] = ( $counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 ) + 1;
+				continue;
+			}
+
+			if ( MigrationState::OPTION_ACTION_WRITE !== $action ) {
+				continue;
+			}
+
+			$writer->write_option( $core_key, $value );
+
+			if ( ! $writer->is_dry_run() ) {
+				$this->state->record_option_fingerprint( $core_key, $source_hash, $source_hash );
+			}
+
+			$counts[ Reporter::OUTCOME_MIGRATED ] = ( $counts[ Reporter::OUTCOME_MIGRATED ] ?? 0 ) + 1;
+		}
+
+		$this->report_known_losses();
+
+		return $counts;
+	}
+
+	/**
+	 * Decide what to do with one mapped legacy option.
+	 *
+	 * @param string $legacy_key Legacy option name, a key of OPTION_MAP.
+	 * @return string One of the MigrationState::OPTION_ACTION_* constants.
+	 */
+	private function decide( string $legacy_key ): string {
+		$mapping     = self::OPTION_MAP[ $legacy_key ];
+		$core_key    = $mapping['core'];
+		$value       = get_option( $legacy_key, $mapping['default'] );
+		$source_hash = $this->state->fingerprint_value( $value );
+
+		$current_target_value = get_option( $core_key, $mapping['default'] );
+		$current_target_hash  = $this->state->fingerprint_value( $current_target_value );
+
+		return $this->state->decide_option_action( $core_key, $source_hash, $current_target_hash, $this->force );
+	}
+
+	/**
+	 * Count and report the legacy options that have no Core home, once per run.
+	 *
+	 * These options are never written; they are reported so the merchant sees them as a
+	 * stated decision rather than an unexplained gap.
+	 *
+	 * @return void
+	 */
+	private function report_known_losses(): void {
+		if ( $this->known_losses_reported ) {
+			return;
+		}
+
+		$this->known_losses_reported = true;
+		$row_id                      = 0;
+
+		foreach ( self::KNOWN_LOSS_OPTIONS as $legacy_key ) {
+			if ( null === get_option( $legacy_key, null ) ) {
+				continue;
+			}
+
+			++$row_id;
+			$this->reporter->record( self::SLUG, self::OUTCOME_NO_CORE_HOME, $row_id );
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/SettingsMigrator.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Migrators/SettingsMigrator.php
@@ -121,6 +121,15 @@ class SettingsMigrator implements MigratorInterface {
 	private bool $known_losses_reported = false;
 
 	/**
+	 * Legacy option keys already visited by this instance, so they leave the outstanding
+	 * list even when nothing was persisted - a dry run records no state at all, and
+	 * without this its section would never drain.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $handled = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param MigrationState $state    Migration run state.
@@ -175,6 +184,10 @@ class SettingsMigrator implements MigratorInterface {
 		$outstanding = array();
 
 		foreach ( array_keys( self::OPTION_MAP ) as $legacy_key ) {
+			if ( isset( $this->handled[ $legacy_key ] ) ) {
+				continue;
+			}
+
 			$action = $this->decide( $legacy_key );
 
 			if ( MigrationState::OPTION_ACTION_SKIP_UNCHANGED !== $action ) {
@@ -209,9 +222,19 @@ class SettingsMigrator implements MigratorInterface {
 			$source_hash = $this->state->fingerprint_value( $value );
 			$action      = $this->decide( $legacy_key );
 
+			$this->handled[ $legacy_key ] = true;
+
 			if ( MigrationState::OPTION_ACTION_SKIP_USER_MODIFIED === $action ) {
 				$this->reporter->record( self::SLUG, Reporter::OUTCOME_SKIPPED_USER_MODIFIED, $row_id );
 				$counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] = ( $counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 ) + 1;
+
+				if ( ! $writer->is_dry_run() ) {
+					// Record what the merchant's value is now, so it reports once rather than
+					// staying outstanding on every later run.
+					$current_target_hash = $this->state->fingerprint_value( get_option( $core_key, $mapping['default'] ) );
+					$this->state->record_option_fingerprint( $core_key, $source_hash, $current_target_hash, true );
+				}
+
 				continue;
 			}
 
@@ -222,7 +245,11 @@ class SettingsMigrator implements MigratorInterface {
 			$writer->write_option( $core_key, $value );
 
 			if ( ! $writer->is_dry_run() ) {
-				$this->state->record_option_fingerprint( $core_key, $source_hash, $source_hash );
+				// Fingerprint the value as it reads back, not as it was handed over: options
+				// round-trip through the database as strings, so an int written here would
+				// never match its own stored form and would report as merchant-edited.
+				$stored_hash = $this->state->fingerprint_value( get_option( $core_key, $mapping['default'] ) );
+				$this->state->record_option_fingerprint( $core_key, $source_hash, $stored_hash );
 			}
 
 			$counts[ Reporter::OUTCOME_MIGRATED ] = ( $counts[ Reporter::OUTCOME_MIGRATED ] ?? 0 ) + 1;

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Report/Reporter.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Report/Reporter.php
@@ -1,0 +1,442 @@
+<?php
+/**
+ * Reporter class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Report;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Collects and shapes the migration's outcome counts and logs its progress.
+ *
+ * Every migrator and runner reports through this class rather than logging directly, so the
+ * CLI's final table and the Tools description render from the same accumulated structure. Only
+ * ids and outcome codes are ever logged or displayed; full rows are never touched, since they
+ * carry customer PII (email addresses).
+ */
+class Reporter {
+
+	/**
+	 * Outcome code for a row that was migrated to a new Core notification.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_MIGRATED = 'migrated';
+
+	/**
+	 * Outcome code for a row that resolved to an existing Core row via natural-key adoption.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_ADOPTED = 'adopted';
+
+	/**
+	 * Outcome code for a row that failed permanently and was marked with `_wc_bis_migration_failed`.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_FAILED = 'failed';
+
+	/**
+	 * Outcome code for a legacy row excluded because it was never verified.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_UNVERIFIED = 'unverified';
+
+	/**
+	 * Outcome code for a row skipped because its email address is too long for Core's column.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_EMAIL_TOO_LONG = 'email_too_long';
+
+	/**
+	 * Outcome code for a row skipped because its email address does not validate.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_INVALID_EMAIL = 'invalid_email';
+
+	/**
+	 * Outcome code for a row skipped because its product is missing, trashed or not a product.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_PRODUCT_MISSING = 'product_missing';
+
+	/**
+	 * Outcome code for an option or row left untouched because the merchant had already edited it.
+	 *
+	 * @var string
+	 */
+	public const OUTCOME_SKIPPED_USER_MODIFIED = 'skipped_user_modified';
+
+	/**
+	 * Cached known-losses key: unverified legacy rows excluded from the migration entirely.
+	 *
+	 * @var string
+	 */
+	private const LOSS_UNVERIFIED_EXCLUDED = 'unverified_excluded';
+
+	/**
+	 * Cached known-losses key: rows skipped because their email is too long for Core's column.
+	 *
+	 * @var string
+	 */
+	private const LOSS_EMAIL_TOO_LONG = 'email_too_long';
+
+	/**
+	 * Cached known-losses key: rows skipped because their email does not validate.
+	 *
+	 * @var string
+	 */
+	private const LOSS_INVALID_EMAIL = 'invalid_email';
+
+	/**
+	 * Cached known-losses key: rows skipped because their product is missing, trashed or not a product.
+	 *
+	 * @var string
+	 */
+	private const LOSS_PRODUCT_MISSING = 'product_missing';
+
+	/**
+	 * Cached known-losses key: migrated rows that lose their eventual legacy re-fire.
+	 *
+	 * @var string
+	 */
+	private const LOSS_RECURRING = 'recurring_lost';
+
+	/**
+	 * Cached known-losses key: migrated rows with no legacy unsubscribe secret to preserve.
+	 *
+	 * @var string
+	 */
+	private const LOSS_ROWS_WITHOUT_HASH = 'rows_without_hash';
+
+	/**
+	 * The four skip counts that together make up the lost-unsubscribe-link population.
+	 *
+	 * @var string[]
+	 */
+	private const SKIP_LOSS_KEYS = array(
+		self::LOSS_UNVERIFIED_EXCLUDED,
+		self::LOSS_EMAIL_TOO_LONG,
+		self::LOSS_INVALID_EMAIL,
+		self::LOSS_PRODUCT_MISSING,
+	);
+
+	/**
+	 * Logger source used for every log entry this class writes.
+	 *
+	 * @var string
+	 */
+	private const LOG_SOURCE = 'bis-migration';
+
+	/**
+	 * Outcome counts, keyed by section slug then outcome code.
+	 *
+	 * @var array<string, array<string, int>>
+	 */
+	private array $counts = array();
+
+	/**
+	 * Whether any error-severity outcome has been logged.
+	 *
+	 * @var bool
+	 */
+	private bool $has_errors = false;
+
+	/**
+	 * Record one outcome for one row and log it at the appropriate severity.
+	 *
+	 * `migrated` and `adopted` log nothing here; per-batch totals are logged by report_batch().
+	 * Every other outcome is a skip (`warning`) except `failed`, which is an `error` since it
+	 * represents an exception the row could not recover from.
+	 *
+	 * @param string $section Section slug, e.g. `notifications`.
+	 * @param string $outcome One of the OUTCOME_* constants.
+	 * @param int    $id      Legacy row identifier. Never a full row.
+	 * @return void
+	 */
+	public function record( string $section, string $outcome, int $id ): void {
+		$this->counts[ $section ][ $outcome ] = ( $this->counts[ $section ][ $outcome ] ?? 0 ) + 1;
+
+		if ( self::OUTCOME_MIGRATED === $outcome || self::OUTCOME_ADOPTED === $outcome ) {
+			return;
+		}
+
+		if ( self::OUTCOME_FAILED === $outcome ) {
+			$this->has_errors = true;
+			wc_get_logger()->error(
+				sprintf( 'section=%s id=%d outcome=%s', $section, $id, $outcome ),
+				array( 'source' => self::LOG_SOURCE )
+			);
+			return;
+		}
+
+		wc_get_logger()->warning(
+			sprintf( 'section=%s id=%d outcome=%s', $section, $id, $outcome ),
+			array( 'source' => self::LOG_SOURCE )
+		);
+	}
+
+	/**
+	 * Log one `info` entry summarising a completed batch.
+	 *
+	 * @param string $section Section slug.
+	 * @param int    $count   Number of ids the batch attempted.
+	 * @return void
+	 */
+	public function report_batch( string $section, int $count ): void {
+		wc_get_logger()->info(
+			sprintf( 'section=%s batch complete, %d row(s) processed', $section, $count ),
+			array( 'source' => self::LOG_SOURCE )
+		);
+	}
+
+	/**
+	 * Log one `error` entry for an exception that failed a whole batch.
+	 *
+	 * Used for transient conditions - a DB error, a lost connection - that the controller
+	 * should retry, as distinct from a per-row failure recorded via record().
+	 *
+	 * @param string     $section Section slug.
+	 * @param \Throwable $error   The exception that failed the batch.
+	 * @return void
+	 */
+	public function report_exception( string $section, \Throwable $error ): void {
+		$this->has_errors = true;
+		wc_get_logger()->error(
+			sprintf( 'section=%s batch failed: %s', $section, $error->getMessage() ),
+			array( 'source' => self::LOG_SOURCE )
+		);
+	}
+
+	/**
+	 * Whether any error-severity outcome has occurred so far.
+	 *
+	 * Used by the CLI to decide its exit code.
+	 *
+	 * @return bool
+	 */
+	public function has_errors(): bool {
+		return $this->has_errors;
+	}
+
+	/**
+	 * All accumulated outcome counts, keyed by section then outcome code.
+	 *
+	 * @return array<string, array<string, int>>
+	 */
+	public function get_counts(): array {
+		return $this->counts;
+	}
+
+	/**
+	 * Outcome counts for one section.
+	 *
+	 * @param string $section Section slug.
+	 * @return array<string, int>
+	 */
+	public function get_section_counts( string $section ): array {
+		return $this->counts[ $section ] ?? array();
+	}
+
+	/**
+	 * Render the section x outcome x count structure as a flat table.
+	 *
+	 * Used by both the CLI's final table and the Tools description, so the two surfaces never
+	 * drift out of sync with each other.
+	 *
+	 * @return array<int, array{section: string, outcome: string, count: int}>
+	 */
+	public function get_table(): array {
+		$table = array();
+
+		foreach ( $this->counts as $section => $outcomes ) {
+			foreach ( $outcomes as $outcome => $count ) {
+				$table[] = array(
+					'section' => $section,
+					'outcome' => $outcome,
+					'count'   => $count,
+				);
+			}
+		}
+
+		return $table;
+	}
+
+	/**
+	 * Merchant-facing "known losses" summary lines for the given counts.
+	 *
+	 * Each line is translated and carries its own count, so a zero-count loss can be omitted by
+	 * the caller rather than presented as if it happened. Counts are supplied by the caller
+	 * rather than read from $this->counts, since some of these populations - recurring
+	 * notifications, rows missing a hash - are not outcome codes but sub-counts a migrator
+	 * derives while producing OUTCOME_MIGRATED rows.
+	 *
+	 * @param int $recurring_lost      Rows mapped to `sent` that would have re-fired on a future restock under legacy.
+	 * @param int $unverified_excluded Unverified legacy rows excluded from migration entirely.
+	 * @param int $links_lost_on_skip  Predicate skips (unverified, email_too_long, invalid_email, product_missing) whose legacy unsubscribe link stops working.
+	 * @param int $rows_without_hash   Migrated rows with no `_hash_key`/`_hash_iv`, so no Core token - not a lost link, counted separately to distinguish pre-1.2.0 data from a bug.
+	 * @return array<int, string> Translated summary lines, one per non-empty population.
+	 */
+	public function get_known_losses_summary( int $recurring_lost, int $unverified_excluded, int $links_lost_on_skip, int $rows_without_hash ): array {
+		$lines = array();
+
+		if ( $recurring_lost > 0 ) {
+			$lines[] = sprintf(
+				/* translators: %d: number of notifications */
+				_n(
+					'%d notification that would have re-fired on a future restock will not re-fire under Core.',
+					'%d notifications that would have re-fired on a future restock will not re-fire under Core.',
+					$recurring_lost,
+					'woocommerce'
+				),
+				$recurring_lost
+			);
+		}
+
+		if ( $unverified_excluded > 0 ) {
+			$lines[] = sprintf(
+				/* translators: %d: number of unverified signups */
+				_n(
+					'%d unverified signup was not migrated; its verification link had already expired and Core would have deleted it under the data-retention setting.',
+					'%d unverified signups were not migrated; their verification links had already expired and Core would have deleted them under the data-retention setting.',
+					$unverified_excluded,
+					'woocommerce'
+				),
+				$unverified_excluded
+			);
+		}
+
+		if ( $links_lost_on_skip > 0 ) {
+			$lines[] = sprintf(
+				/* translators: %d: number of unsubscribe links */
+				_n(
+					'%d customer\'s legacy unsubscribe link will stop working, because the row it pointed to was skipped and has no Core notification.',
+					'%d customers\' legacy unsubscribe links will stop working, because the rows they pointed to were skipped and have no Core notification.',
+					$links_lost_on_skip,
+					'woocommerce'
+				),
+				$links_lost_on_skip
+			);
+		}
+
+		if ( $rows_without_hash > 0 ) {
+			$lines[] = sprintf(
+				/* translators: %d: number of migrated rows without a legacy unsubscribe hash */
+				_n(
+					'%d migrated row had no legacy unsubscribe secret to preserve; it never had a link in a delivered email.',
+					'%d migrated rows had no legacy unsubscribe secret to preserve; they never had a link in a delivered email.',
+					$rows_without_hash,
+					'woocommerce'
+				),
+				$rows_without_hash
+			);
+		}
+
+		return $lines;
+	}
+
+	/**
+	 * Count the skipped populations a run start caches, ready to hand to MigrationState.
+	 *
+	 * The four counts are one `COUNT(*)` each and are computed only here, at run start, never
+	 * on a page load. The two accumulator keys start at zero: they are totals a run adds up as
+	 * it migrates, and are filled in afterwards by with_run_losses().
+	 *
+	 * @param NotificationsMigrator $migrator The notifications migrator these counts come from.
+	 * @return array<string, int> Known-losses counts, keyed by name.
+	 */
+	public function collect_known_losses( NotificationsMigrator $migrator ): array {
+		return array(
+			self::LOSS_UNVERIFIED_EXCLUDED => $migrator->count_unverified_excluded(),
+			self::LOSS_EMAIL_TOO_LONG      => $migrator->count_email_too_long(),
+			self::LOSS_INVALID_EMAIL       => $migrator->count_invalid_email(),
+			self::LOSS_PRODUCT_MISSING     => $migrator->count_product_missing(),
+			self::LOSS_RECURRING           => 0,
+			self::LOSS_ROWS_WITHOUT_HASH   => 0,
+		);
+	}
+
+	/**
+	 * Fill in the two totals a finished run accumulated, leaving the cached skip counts alone.
+	 *
+	 * @param array<string, int>    $values   Known-losses counts cached at run start.
+	 * @param NotificationsMigrator $migrator The notifications migrator that just ran.
+	 * @return array<string, int> The counts, with the run's accumulated totals merged in.
+	 */
+	public function with_run_losses( array $values, NotificationsMigrator $migrator ): array {
+		$values[ self::LOSS_RECURRING ]         = $migrator->get_recurring_lost_count();
+		$values[ self::LOSS_ROWS_WITHOUT_HASH ] = $migrator->get_rows_without_hash_count();
+
+		return $values;
+	}
+
+	/**
+	 * Merchant-facing known-losses lines built from cached counts.
+	 *
+	 * Derives the lost-unsubscribe-link total from the four skip counts here, so the CLI and
+	 * the Tools description cannot disagree about which skips cost a customer their link.
+	 *
+	 * @param array<string, int> $values Known-losses counts, as cached by MigrationState.
+	 * @return array<int, string> Translated summary lines, one per non-empty population.
+	 */
+	public function summarize_cached_losses( array $values ): array {
+		$links_lost_on_skip = 0;
+
+		foreach ( self::SKIP_LOSS_KEYS as $key ) {
+			$links_lost_on_skip += (int) ( $values[ $key ] ?? 0 );
+		}
+
+		return $this->get_known_losses_summary(
+			(int) ( $values[ self::LOSS_RECURRING ] ?? 0 ),
+			(int) ( $values[ self::LOSS_UNVERIFIED_EXCLUDED ] ?? 0 ),
+			$links_lost_on_skip,
+			(int) ( $values[ self::LOSS_ROWS_WITHOUT_HASH ] ?? 0 )
+		);
+	}
+
+	/**
+	 * Format a cached count with the timestamp it was computed at.
+	 *
+	 * Counts are computed at run start and on section drain, then cached - never a live query on
+	 * a normal page load - so they must always be presented as of that timestamp, not as a
+	 * current remaining count. The timestamp is rendered in site-local time via wp_date(), since
+	 * merchants have been reading localised values in the legacy admin.
+	 *
+	 * @param int $count     Cached count.
+	 * @param int $timestamp Unix timestamp (UTC) the count was computed at.
+	 * @return string Merchant-facing string, e.g. "42 (as of 27 Aug 2026, 14:03)".
+	 */
+	public function format_cached_count( int $count, int $timestamp ): string {
+		return sprintf(
+			/* translators: 1: cached count, 2: site-local date/time the count was computed at */
+			__( '%1$d (as of %2$s)', 'woocommerce' ),
+			$count,
+			$this->format_site_time( $timestamp )
+		);
+	}
+
+	/**
+	 * Format a UTC timestamp in site-local time.
+	 *
+	 * Merchants have been reading localised values in the legacy admin, so a raw UTC value
+	 * here would read as the migration having shifted their dates.
+	 *
+	 * @param int $timestamp Unix timestamp (UTC).
+	 * @return string
+	 */
+	public function format_site_time( int $timestamp ): string {
+		$formatted = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+
+		return false === $formatted ? '' : $formatted;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Requirements.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Requirements.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Requirements class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration;
+
+use Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificationsDataStore;
+use Automattic\WooCommerce\Internal\StockNotifications\StockNotifications;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Verifies that a migration run is allowed to start or continue.
+ *
+ * `check()` is called once at the start of a run and again on every batch, since a
+ * merchant can toggle the feature off, or drop the legacy tables, mid-run and a
+ * background worker must stop cleanly rather than fatal.
+ *
+ * `SHOW TABLES LIKE` lives here, and only here, in the whole migration. It is a
+ * correctness guard inside a migration run, not a discovery mechanism: whether the
+ * migration *registers* at all is decided elsewhere, from an already-autoloaded
+ * option, at zero query cost. Do not call `SHOW TABLES LIKE` from any other class.
+ */
+class Requirements {
+
+	/**
+	 * Legacy Back In Stock Notifications tables the migration reads from.
+	 *
+	 * @var string[]
+	 */
+	private const LEGACY_TABLES = array(
+		'woocommerce_bis_notifications',
+		'woocommerce_bis_notificationsmeta',
+		'woocommerce_bis_activity',
+	);
+
+	/**
+	 * Legacy notifications table, unprefixed. Kept as its own constant rather than
+	 * indexed out of LEGACY_TABLES, so count_legacy_queued_rows() reads independently of
+	 * that list's order.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_NOTIFICATIONS_TABLE = 'woocommerce_bis_notifications';
+
+	/**
+	 * Class defined by the legacy extension when it is active. Used only to decide whether
+	 * the `is_queued='on'` flag can mean anything - no other queue will ever drain it.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_EXTENSION_CLASS = 'WC_Back_In_Stock';
+
+	/**
+	 * The Core stock notifications data store, used to resolve the target table names.
+	 *
+	 * @var StockNotificationsDataStore
+	 */
+	private StockNotificationsDataStore $data_store;
+
+	/**
+	 * Init the service.
+	 *
+	 * @internal
+	 *
+	 * @param StockNotificationsDataStore $data_store The Core stock notifications data store.
+	 */
+	final public function init( StockNotificationsDataStore $data_store ): void {
+		$this->data_store = $data_store;
+	}
+
+	/**
+	 * Check whether a migration run may start or continue.
+	 *
+	 * @return true|WP_Error True when every requirement is met, otherwise a `WP_Error`
+	 *                       carrying a translated, merchant-facing reason.
+	 */
+	public function check() {
+		if ( ! FeaturesUtil::feature_is_enabled( StockNotifications::FEATURE_NAME ) ) {
+			return new WP_Error(
+				'feature_disabled',
+				__( 'The "Customer stock notifications" feature is off. Turn it on under WooCommerce → Settings → Advanced → Features, then run the migration again.', 'woocommerce' )
+			);
+		}
+
+		$missing_legacy_table = $this->find_missing_table( self::LEGACY_TABLES );
+		if ( null !== $missing_legacy_table ) {
+			return new WP_Error(
+				'legacy_tables_missing',
+				sprintf(
+					/* translators: %s: database table name */
+					__( 'The legacy Back In Stock Notifications table "%s" was not found. There is nothing to migrate.', 'woocommerce' ),
+					$missing_legacy_table
+				)
+			);
+		}
+
+		$missing_target_table = $this->find_missing_table(
+			array(
+				$this->data_store->get_table_name(),
+				$this->data_store->get_meta_table_name(),
+			),
+			false
+		);
+		if ( null !== $missing_target_table ) {
+			return new WP_Error(
+				'target_tables_missing',
+				sprintf(
+					/* translators: %s: database table name */
+					__( 'The Stock Notifications table "%s" does not exist yet. Update WooCommerce to the latest version, then run the migration again.', 'woocommerce' ),
+					$missing_target_table
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Count legacy rows still queued by the legacy extension's own send processor.
+	 *
+	 * The `is_queued='on'` flag can only mean something while the extension that writes and
+	 * drains it is active; with it inactive, nothing will ever drain that queue, so the flag
+	 * is ignored entirely and this returns 0 without a query.
+	 *
+	 * Shared by the CLI `run` pre-flight and the Tools `start` pre-flight: both refuse to
+	 * start a migration while legacy rows are still queued, since starting anyway risks the
+	 * legacy extension and Core both sending the same notification.
+	 *
+	 * @return int
+	 */
+	public function count_legacy_queued_rows(): int {
+		if ( ! class_exists( self::LEGACY_EXTENSION_CLASS ) ) {
+			return 0;
+		}
+
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::LEGACY_NOTIFICATIONS_TABLE;
+
+		// $table is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE is_queued = %s", 'on' );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Find the first table, from a list of table names, that does not exist.
+	 *
+	 * @param string[] $tables      Table names to check.
+	 * @param bool     $needs_prefix Whether the names still need `$wpdb->prefix` applied.
+	 * @return string|null The first missing table name, or null when all exist.
+	 */
+	private function find_missing_table( array $tables, bool $needs_prefix = true ): ?string {
+		global $wpdb;
+
+		foreach ( $tables as $table ) {
+			$table_name = $needs_prefix ? $wpdb->prefix . $table : $table;
+
+			$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+
+			if ( $found !== $table_name ) {
+				return $table_name;
+			}
+		}
+
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/Cli.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/Cli.php
@@ -1,0 +1,1186 @@
+<?php
+/**
+ * Cli class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners;
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\StatusMapper;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\EmailSettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\MigratorInterface;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\ProductMetaMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\SettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\NullWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * `wp wc bis-migrate` — the CLI entry point for the Back In Stock Notifications migration.
+ *
+ * Registers unconditionally under `WP_CLI`, never gated on `wc_bis_db_version`: gating it on
+ * that option would make `--force-discover` unreachable in exactly the situation it exists for.
+ * On a store with nothing to migrate every subcommand still runs, reports "nothing to migrate",
+ * and exits `0`.
+ *
+ * `run` drives the four migrators directly, in the fixed section order, rather than going
+ * through `MigrationBatchProcessor`: that class is the Action Scheduler entry point and its
+ * `BatchProcessorInterface::process_batch()` contract has no room for the CLI-only knobs
+ * (`--dry-run`, `--force`, `--retry-failed`, `--section`). Both entry points share the same
+ * state — `MigrationState` cursors/counts and the markers the migrators write — so a run
+ * started from either one is resumed correctly by the other.
+ *
+ * This class only reads whether a background run is enqueued, via
+ * `BatchProcessingController::is_enqueued()`; it never enqueues or dequeues the processor
+ * itself, since only the Tools screen and this CLI are meant to trigger a run.
+ */
+class Cli {
+
+	/**
+	 * Section slugs in the fixed, load-bearing migration order. Matches every migrator's
+	 * `get_slug()` and the CLI `--section` values.
+	 *
+	 * @var string[]
+	 */
+	private const SECTION_ORDER = array( 'notifications', 'product-meta', 'emails', 'settings' );
+
+	/**
+	 * Option recording that Back In Stock Notifications was ever installed. Absent means
+	 * there is nothing to migrate; `--force-discover` is the only way past this gate.
+	 *
+	 * @var string
+	 */
+	private const DB_VERSION_OPTION = 'wc_bis_db_version';
+
+	/**
+	 * Autoloaded flag gating the legacy unsubscribe shim's registration. Narrower than
+	 * HAS_MIGRATED_ROWS_OPTION below: only set when a migrated row carries a legacy
+	 * unsubscribe token.
+	 *
+	 * @var string
+	 */
+	private const HAS_LEGACY_LINKS_OPTION = 'wc_bis_migration_has_legacy_links';
+
+	/**
+	 * Autoloaded flag set the first time any row is migrated, inserted or adopted. Backs
+	 * the double-send admin notice in MigrationController.
+	 *
+	 * @var string
+	 */
+	private const HAS_MIGRATED_ROWS_OPTION = 'wc_bis_migration_has_migrated_rows';
+
+	/**
+	 * Legacy meta key recording a permanent per-row failure. Cleared by `--retry-failed`
+	 * and by `rollback`.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_FAILED_META_KEY = '_wc_bis_migration_failed';
+
+	/**
+	 * Migration marker recording a successful migration onto a Core notification.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_ID_META_KEY = '_wc_bis_legacy_id';
+
+	/**
+	 * Meta key holding the precomputed legacy unsubscribe token digest.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_UNSUB_HASH_META_KEY = '_wc_bis_legacy_unsub_hash';
+
+	/**
+	 * Marker meta written only when a legacy row adopted a pre-existing Core notification
+	 * instead of being inserted. Distinguishes the two so `rollback` never deletes an
+	 * adopted row - only inserted rows are deleted.
+	 *
+	 * @var string
+	 */
+	private const ADOPTED_MARKER_META_KEY = '_wc_bis_legacy_adopted';
+
+	/**
+	 * Legacy notifications table, unprefixed.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_NOTIFICATIONS_TABLE = 'woocommerce_bis_notifications';
+
+	/**
+	 * Legacy notifications meta table, unprefixed.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_META_TABLE = 'woocommerce_bis_notificationsmeta';
+
+	/**
+	 * Core notifications table, unprefixed.
+	 *
+	 * @var string
+	 */
+	private const CORE_NOTIFICATIONS_TABLE = 'wc_stock_notifications';
+
+	/**
+	 * Core notifications meta table, unprefixed.
+	 *
+	 * @var string
+	 */
+	private const CORE_META_TABLE = 'wc_stock_notificationmeta';
+
+	/**
+	 * Default batch size for a CLI run. Raised by `--batch-size`; scheduled runs use their
+	 * own, smaller default from `get_default_batch_size()`.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_BATCH_SIZE = 500;
+
+	/**
+	 * Row count used to page through Core notifications in `verify` and `rollback`.
+	 *
+	 * @var int
+	 */
+	private const ORACLE_BATCH_SIZE = 500;
+
+	/**
+	 * Verifies whether a run may start or continue.
+	 *
+	 * @var Requirements
+	 */
+	private Requirements $requirements;
+
+	/**
+	 * Used only to read whether the background processor is currently enqueued.
+	 *
+	 * @var BatchProcessingController
+	 */
+	private BatchProcessingController $batch_processing_controller;
+
+	/**
+	 * Migration run state: the CLI lock, per-section cursors and cached counts.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Constructor. Resolves its dependencies from the container directly rather than via
+	 * autowired parameters, matching `ProductAttributesLookup\CLIRunner`: whatever registers
+	 * this class with `WP_CLI::add_command()` may pass either a bare `new self()` or a
+	 * container-resolved instance, and both must work.
+	 */
+	public function __construct() {
+		$container = wc_get_container();
+
+		$this->requirements                = $container->get( Requirements::class );
+		$this->batch_processing_controller = $container->get( BatchProcessingController::class );
+		$this->state                       = new MigrationState();
+	}
+
+	/**
+	 * Register the `wp wc bis-migrate` command and its subcommands.
+	 *
+	 * Registration is unconditional under WP_CLI, so `--force-discover` stays reachable on a
+	 * store whose `wc_bis_db_version` option was deleted by hand.
+	 */
+	public function register(): void {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		// @phpstan-ignore-next-line -- WP_CLI is only defined in a CLI context.
+		WP_CLI::add_command( 'wc bis-migrate', $this );
+	}
+
+	/**
+	 * Report migration status.
+	 *
+	 * There is no run-status field to report: a run is either holding the CLI lock or it is
+	 * not, and what has migrated is recorded by markers rather than by a status. This reports
+	 * the facts that replace it: per-section cached counts with their timestamp, whether a
+	 * background run is enqueued, whether the CLI lock is held, and how many rows carry the
+	 * permanent-failure marker.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc bis-migrate status
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments (unused).
+	 */
+	public function status( $args, $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- standard WP-CLI command signature.
+		$check = $this->requirements->check();
+
+		if ( is_wp_error( $check ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( sprintf( 'Nothing to migrate: %s', $check->get_error_message() ) );
+		}
+
+		$reporter = new Reporter();
+
+		foreach ( self::SECTION_ORDER as $slug ) {
+			$cached = $this->state->get_count( $slug );
+
+			if ( null === $cached ) {
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::log( sprintf( '%-14s not yet computed', $slug ) );
+				continue;
+			}
+
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log(
+				sprintf( '%-14s %s', $slug, $reporter->format_cached_count( $cached['count'], $cached['at'] ) )
+			);
+		}
+
+		$this->print_known_losses( $reporter );
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::log( sprintf( 'Background run enqueued: %s', $this->is_processor_enqueued() ? 'yes' : 'no' ) );
+
+		$lock = $this->state->get_lock();
+
+		if ( $this->state->is_lock_held() && null !== $lock ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log(
+				sprintf(
+					'CLI lock held: yes (owner: %s, since %s)',
+					$lock['owner'],
+					$this->format_site_time( (int) $lock['acquired_at'] )
+				)
+			);
+		} else {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( 'CLI lock held: no' );
+		}
+
+		$failed = is_wp_error( $check ) && 'legacy_tables_missing' === $check->get_error_code()
+			? 0
+			: $this->count_failed_rows();
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::log( sprintf( 'Rows marked permanently failed: %d', $failed ) );
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::success( 'Status reported.' );
+	}
+
+	/**
+	 * Run the migration.
+	 *
+	 * Drives the requested sections, in the fixed order (notifications, product-meta, emails,
+	 * settings — load-bearing, never reordered by `--section`), each with its own cursor
+	 * reset pass: when a section's query comes back empty, its cursor resets and the query
+	 * runs again, and the section is only considered drained when a query immediately after a
+	 * reset also comes back empty.
+	 *
+	 * `--max-batches` bounds this CLI loop only. It is a debugging aid, not a throughput
+	 * mode: a run always re-walks the whole candidate range from the start of each section
+	 * (cursors are reset at the top of every run), so repeated small invocations pay that
+	 * re-scan every time.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--section=<sections>]
+	 * : Comma-separated sections to run. Defaults to all four: notifications, product-meta,
+	 * emails, settings.
+	 *
+	 * [--batch-size=<size>]
+	 * : Maximum rows fetched per batch. Default 500.
+	 *
+	 * [--dry-run]
+	 * : Compute and report everything without writing anything.
+	 *
+	 * [--force]
+	 * : CLI only, requires --yes. Overwrites an option or product-meta value a merchant
+	 * edited after a previous migration, and overrides the is_queued='on' pre-flight refusal.
+	 * Does not skip Requirements::check() and does not change any status mapping.
+	 *
+	 * [--retry-failed]
+	 * : Clear the permanent-failure marker on legacy rows so they are retried. Ignored under
+	 * --dry-run.
+	 *
+	 * [--max-batches=<n>]
+	 * : Stop after this many batches, across all sections. Debugging aid only.
+	 *
+	 * [--force-discover]
+	 * : Skip the wc_bis_db_version option gate and go straight to Requirements::check(). The
+	 * one path that reaches a store whose option was deleted by hand.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc bis-migrate run
+	 *     wp wc bis-migrate run --section=notifications --dry-run
+	 *     wp wc bis-migrate run --force --yes
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments (options).
+	 */
+	public function run( $args, $assoc_args ): void {
+		$force = isset( $assoc_args['force'] );
+
+		if ( $force && ! isset( $assoc_args['yes'] ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error( '--force requires --yes.' );
+			return;
+		}
+
+		$force_discover = isset( $assoc_args['force-discover'] );
+
+		if ( ! $force_discover && ! get_option( self::DB_VERSION_OPTION ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success( 'Nothing to migrate: Back In Stock Notifications was never installed on this store.' );
+			return;
+		}
+
+		$check = $this->requirements->check();
+
+		if ( is_wp_error( $check ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success( sprintf( 'Nothing to migrate: %s', $check->get_error_message() ) );
+			return;
+		}
+
+		if ( $this->is_processor_enqueued() ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error(
+				'A migration run is already in progress in the background (WooCommerce → Status → Tools). ' .
+				'Stop it there before starting a CLI run — --force does not override this.'
+			);
+			return;
+		}
+
+		$sections     = $this->resolve_sections( $assoc_args );
+		$dry_run      = isset( $assoc_args['dry-run'] );
+		$retry_failed = isset( $assoc_args['retry-failed'] );
+		$batch_size   = isset( $assoc_args['batch-size'] ) ? max( 1, (int) $assoc_args['batch-size'] ) : self::DEFAULT_BATCH_SIZE;
+		$max_batches  = isset( $assoc_args['max-batches'] ) ? max( 1, (int) $assoc_args['max-batches'] ) : null;
+
+		if ( in_array( 'notifications', $sections, true ) ) {
+			$queued = $this->requirements->count_legacy_queued_rows();
+
+			if ( $queued > 0 && ! $force ) {
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::error(
+					sprintf(
+						'Refusing to start: %d legacy row(s) are still queued (is_queued=\'on\') by the active ' .
+						'Back In Stock Notifications extension. Let the legacy queue drain, or pass --force --yes to override.',
+						$queued
+					)
+				);
+				return;
+			}
+		}
+
+		if ( ! $dry_run ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::confirm( 'This will write to the database. Continue?' );
+		}
+
+		if ( ! $this->acquire_lock( 'run' ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error( 'Could not acquire the migration CLI lock. Another CLI run may already be in progress.' );
+			return;
+		}
+
+		try {
+			if ( $retry_failed && ! $dry_run && in_array( 'notifications', $sections, true ) ) {
+				$cleared = $this->clear_failed_markers();
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::log( sprintf( 'Cleared the failed marker on %d row(s); they will be retried.', $cleared ) );
+			}
+
+			// A run always starts from zero: cursors left behind by a previous run cannot be
+			// trusted (a row deleted in Core mid-run re-enters the candidate set below them).
+			// `MigrationBatchProcessor` only ever advances cursors, never resets them, so this
+			// invariant is enforced only at run-start entry points — this one and the Tools
+			// start callback — not inside the processor itself.
+			$this->state->reset_all_cursors();
+
+			$reporter               = new Reporter();
+			$notifications_migrator = new NotificationsMigrator( $reporter );
+			$migrators              = $this->build_migrators( $reporter, $force, $notifications_migrator );
+			$writer                 = $dry_run ? new NullWriter() : new DbWriter();
+
+			// Counts are cached, display-only, and refreshed at run start and on section
+			// drain — never computed live outside a run.
+			$total_estimate = 0;
+			foreach ( $sections as $slug ) {
+				$remaining = $migrators[ $slug ]->count_remaining();
+				$this->state->set_count( $slug, $remaining );
+				$total_estimate += $remaining;
+			}
+
+			if ( in_array( 'notifications', $sections, true ) ) {
+				// One COUNT(*) per skipped population, run once here and cached: `status` and
+				// the Tools description report these from the cache and never compute them.
+				$this->state->set_losses( $reporter->collect_known_losses( $notifications_migrator ) );
+			}
+
+			// @phpstan-ignore-next-line function.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			$progress    = WP_CLI\Utils\make_progress_bar( 'BIS migration', max( 1, $total_estimate ) );
+			$batches_run = 0;
+
+			foreach ( $sections as $slug ) {
+				$migrator = $migrators[ $slug ];
+
+				while ( null === $max_batches || $batches_run < $max_batches ) {
+					$check = $this->requirements->check();
+
+					if ( is_wp_error( $check ) ) {
+						// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+						WP_CLI::warning( sprintf( 'Stopping: %s', $check->get_error_message() ) );
+						break 2;
+					}
+
+					$cursor = $this->state->get_cursor( $slug );
+					$ids    = $migrator->get_batch( $cursor, $batch_size );
+
+					if ( empty( $ids ) ) {
+						if ( 0 === $cursor ) {
+							break;
+							// Query right after a reset came back empty: this section is drained.
+						}
+
+						$this->state->reset_cursor( $slug );
+						continue;
+					}
+
+					$migrator->migrate_batch( $ids, $writer );
+					$this->state->set_cursor( $slug, max( $ids ) );
+					$progress->tick( count( $ids ) );
+					++$batches_run;
+				}
+
+				$this->state->set_count( $slug, $migrator->count_remaining() );
+			}
+
+			$progress->finish();
+
+			if ( in_array( 'notifications', $sections, true ) ) {
+				$cached = $this->state->get_losses();
+				$values = is_array( $cached['values'] ?? null ) ? $cached['values'] : array();
+				$this->state->set_losses( $reporter->with_run_losses( $values, $notifications_migrator ) );
+			}
+
+			$this->print_report( $reporter );
+			$this->print_known_losses( $reporter );
+
+			if ( $reporter->has_errors() ) {
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::warning( 'Run finished with error-severity outcomes. See the table above.' );
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::halt( 1 );
+			}
+
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success( $dry_run ? 'Dry run complete.' : 'Run complete.' );
+		} finally {
+			$this->release_lock();
+		}
+	}
+
+	/**
+	 * Read-only verification: re-derive expected state via the mappers and diff it against
+	 * what is actually stored. Never writes anything.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc bis-migrate verify
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments (unused).
+	 */
+	public function verify( $args, $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- standard WP-CLI command signature.
+		$check = $this->requirements->check();
+
+		if ( is_wp_error( $check ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success( sprintf( 'Nothing to migrate: %s', $check->get_error_message() ) );
+			return;
+		}
+
+		$reporter  = new Reporter();
+		$migrators = $this->build_migrators( $reporter, false );
+
+		foreach ( self::SECTION_ORDER as $slug ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( sprintf( '%-14s %d row(s) still outstanding.', $slug, $migrators[ $slug ]->count_remaining() ) );
+		}
+
+		list( $verified, $mismatched ) = $this->verify_notification_statuses();
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::log(
+			sprintf(
+				'%-14s %d migrated row(s) checked against their legacy source; %d status mismatch(es).',
+				'notifications',
+				$verified,
+				$mismatched
+			)
+		);
+
+		if ( $mismatched > 0 ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error( 'Verification found status mismatches. See above.' );
+			return;
+		}
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::success( 'Verified: current state matches what the mappers derive from the legacy source.' );
+	}
+
+	/**
+	 * Undo the migration's writes for rows a merchant has not touched since.
+	 *
+	 * Splits by how a row entered Core. A row this migration *inserted* is deleted outright,
+	 * gated on the "untouched" test below. A row it only *adopted* - a pre-existing Core row
+	 * that already belonged to the merchant - is never deleted: only the markers this
+	 * migration added for that legacy id (`_wc_bis_legacy_id`, `_wc_bis_legacy_adopted`, and
+	 * the matching `_wc_bis_legacy_unsub_hash` row) are removed, leaving status, dates and
+	 * every other meta untouched.
+	 *
+	 * "Untouched" (for an inserted row) is tested by status equality against what
+	 * `StatusMapper` re-derives from the row's legacy source, never by `date_modified_gmt`:
+	 * any meta write bumps that column, which would refuse every row. Requires the legacy
+	 * tables to still exist, since they are the oracle that test reads from; refuses up front
+	 * with that reason rather than silently reporting zero rows, which would look identical
+	 * to success.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * [--dry-run]
+	 * : Report what would be rolled back without deleting anything.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc bis-migrate rollback --dry-run
+	 *     wp wc bis-migrate rollback --yes
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments (options).
+	 */
+	public function rollback( $args, $assoc_args ): void {
+		$check = $this->requirements->check();
+
+		if ( is_wp_error( $check ) ) {
+			if ( 'legacy_tables_missing' === $check->get_error_code() ) {
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::error( sprintf( 'Refusing to roll back: %s', $check->get_error_message() ) );
+				return;
+			}
+
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success( sprintf( 'Nothing to migrate: %s', $check->get_error_message() ) );
+			return;
+		}
+
+		if ( $this->is_processor_enqueued() ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error(
+				'A migration run is in progress in the background (WooCommerce → Status → Tools). Stop it before rolling back.'
+			);
+			return;
+		}
+
+		$dry_run = isset( $assoc_args['dry-run'] );
+
+		if ( ! $dry_run ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::confirm( 'This will permanently delete migrated Stock Notifications rows. Continue?' );
+		}
+
+		if ( ! $this->acquire_lock( 'rollback' ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error( 'Could not acquire the migration CLI lock. Another CLI run may already be in progress.' );
+			return;
+		}
+
+		try {
+			list( $deleted, $markers_cleared, $skipped ) = $this->rollback_notifications( $dry_run );
+
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log(
+				sprintf(
+					'%d inserted row(s) %s, %d adopted row(s) %s, %d row(s) left untouched (status changed since migration).',
+					$deleted,
+					$dry_run ? 'would be deleted' : 'deleted',
+					$markers_cleared,
+					$dry_run ? 'would have their migration markers cleared' : 'had their migration markers cleared',
+					$skipped
+				)
+			);
+
+			if ( ! $dry_run ) {
+				$cleared = $this->clear_failed_markers();
+				delete_option( self::HAS_LEGACY_LINKS_OPTION );
+				delete_option( self::HAS_MIGRATED_ROWS_OPTION );
+				// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+				WP_CLI::log( sprintf( 'Cleared the failed marker on %d row(s) and the legacy-links/migrated-rows flags.', $cleared ) );
+			}
+
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success( $dry_run ? 'Dry run complete.' : 'Rollback complete.' );
+		} finally {
+			$this->release_lock();
+		}
+	}
+
+	/**
+	 * Remove the legacy unsubscribe shim's remaining footprint: the per-notification token
+	 * hash and the flag that gates the shim's registration. `_wc_bis_legacy_id` survives —
+	 * it is the idempotency marker, not shim-specific.
+	 *
+	 * Writes by direct SQL, like `BulkNotificationWriter`: going through the CRUD layer
+	 * would bump `date_modified_gmt` on every migrated row and break `rollback`'s status
+	 * equality test.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc bis-migrate disable-legacy-links --yes
+	 *
+	 * @subcommand disable-legacy-links
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments (options).
+	 */
+	public function disable_legacy_links( $args, $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- standard WP-CLI command signature.
+		if ( $this->is_processor_enqueued() ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error(
+				'A migration run is in progress in the background (WooCommerce → Status → Tools). Stop it before continuing.'
+			);
+			return;
+		}
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::confirm( 'This will permanently remove legacy unsubscribe links. Continue?' );
+
+		if ( ! $this->acquire_lock( 'disable-legacy-links' ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error( 'Could not acquire the migration CLI lock. Another CLI run may already be in progress.' );
+			return;
+		}
+
+		try {
+			global $wpdb;
+
+			$core_meta_table = $wpdb->prefix . self::CORE_META_TABLE;
+
+			// $core_meta_table is $wpdb->prefix-based, never user input.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$sql = $wpdb->prepare( "DELETE FROM {$core_meta_table} WHERE meta_key = %s", self::LEGACY_UNSUB_HASH_META_KEY );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$deleted = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+
+			delete_option( self::HAS_LEGACY_LINKS_OPTION );
+
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::success(
+				sprintf(
+					'Removed %d legacy unsubscribe token(s) and cleared the legacy-links flag.',
+					false === $deleted ? 0 : (int) $deleted
+				)
+			);
+		} finally {
+			$this->release_lock();
+		}
+	}
+
+	/**
+	 * Build the four migrators, sharing one Reporter and this instance's MigrationState.
+	 *
+	 * @param Reporter                   $reporter      Outcome collector shared across every section.
+	 * @param bool                       $force         Whether `--force` was passed. Ignored by NotificationsMigrator,
+	 *                                                  which has no merchant-editable fingerprint to overwrite.
+	 * @param NotificationsMigrator|null $notifications The notifications migrator to use. Passed in by `run`, which
+	 *                                                  also reads the known-losses totals off that same instance.
+	 * @return array<string, MigratorInterface> Migrators keyed by section slug, in section order.
+	 */
+	private function build_migrators( Reporter $reporter, bool $force, ?NotificationsMigrator $notifications = null ): array {
+		return array(
+			'notifications' => $notifications ?? new NotificationsMigrator( $reporter ),
+			'product-meta'  => new ProductMetaMigrator( $reporter, $this->state, $force ),
+			'emails'        => new EmailSettingsMigrator( $this->state, $reporter, $force ),
+			'settings'      => new SettingsMigrator( $this->state, $reporter, $force ),
+		);
+	}
+
+	/**
+	 * Resolve and validate the `--section` option, preserving the canonical section order
+	 * regardless of the order requested.
+	 *
+	 * @param array $assoc_args Associative arguments.
+	 * @return string[] Section slugs, in canonical order.
+	 */
+	private function resolve_sections( array $assoc_args ): array {
+		if ( empty( $assoc_args['section'] ) ) {
+			return self::SECTION_ORDER;
+		}
+
+		$requested = array_map( 'trim', explode( ',', (string) $assoc_args['section'] ) );
+		$invalid   = array_diff( $requested, self::SECTION_ORDER );
+
+		if ( ! empty( $invalid ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::error(
+				sprintf(
+					'Unknown section(s): %1$s. Valid sections: %2$s.',
+					implode( ', ', $invalid ),
+					implode( ', ', self::SECTION_ORDER )
+				)
+			);
+		}
+
+		return array_values( array_intersect( self::SECTION_ORDER, $requested ) );
+	}
+
+	/**
+	 * Whether the background batch processor is currently enqueued.
+	 *
+	 * @return bool
+	 */
+	private function is_processor_enqueued(): bool {
+		return $this->batch_processing_controller->is_enqueued( MigrationBatchProcessor::class );
+	}
+
+	/**
+	 * Acquire the CLI run lock for the duration of a command.
+	 *
+	 * @param string $context Short label for the command taking the lock, used only for
+	 *                        reporting who holds it.
+	 * @return bool True when acquired.
+	 */
+	private function acquire_lock( string $context ): bool {
+		return $this->state->acquire_lock( sprintf( '%s (pid %d)', $context, getmypid() ) );
+	}
+
+	/**
+	 * Release the CLI run lock, whoever holds it. Always called from a `finally` block so a
+	 * fatal or uncaught exception mid-command cannot wedge it — the stale-lock reclaim in
+	 * `MigrationState` is the backstop for the cases even that misses.
+	 *
+	 * @return void
+	 */
+	private function release_lock(): void {
+		$this->state->release_lock();
+	}
+
+	/**
+	 * Count legacy rows currently carrying the permanent-failure marker.
+	 *
+	 * @return int
+	 */
+	private function count_failed_rows(): int {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::LEGACY_META_TABLE;
+
+		// $table is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE meta_key = %s", self::LEGACY_FAILED_META_KEY );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Clear the permanent-failure marker from every legacy row that carries it, re-admitting
+	 * those rows to the candidate set. Used by `--retry-failed` and by `rollback`.
+	 *
+	 * @return int Number of marker rows removed.
+	 */
+	private function clear_failed_markers(): int {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::LEGACY_META_TABLE;
+
+		// $table is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare( "DELETE FROM {$table} WHERE meta_key = %s", self::LEGACY_FAILED_META_KEY );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$result = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+
+		return false === $result ? 0 : (int) $result;
+	}
+
+	/**
+	 * Re-derive the expected status of every migrated Core notification from its legacy
+	 * source and diff it against the status actually stored, paging through by notification
+	 * id. Read-only.
+	 *
+	 * @return array{0: int, 1: int} Tuple of [rows checked, mismatches found].
+	 */
+	private function verify_notification_statuses(): array {
+		$verified   = 0;
+		$mismatched = 0;
+
+		foreach ( $this->each_migrated_notification() as $row ) {
+			list( $legacy_row, $legacy_meta ) = $this->fetch_legacy_source( (int) $row['legacy_id'] );
+
+			if ( null === $legacy_row ) {
+				continue;
+				// Legacy row is gone; nothing to re-derive against.
+			}
+
+			++$verified;
+
+			if ( StatusMapper::map( $legacy_row, $legacy_meta ) !== $row['status'] ) {
+				++$mismatched;
+			}
+		}
+
+		return array( $verified, $mismatched );
+	}
+
+	/**
+	 * Roll back the migration's writes, one legacy-id marker at a time.
+	 *
+	 * An inserted row (no `_wc_bis_legacy_adopted` counterpart for that legacy id) is
+	 * deleted outright when its status still equals what `StatusMapper` re-derives from its
+	 * legacy source, paging through by marker id. An adopted row is never deleted: only that
+	 * legacy id's markers are removed via `remove_adoption_markers()`. A row inserted by this
+	 * migration and later also adopted by a duplicate legacy row carries both kinds of
+	 * marker; once its insert marker triggers deletion, its other markers are skipped since
+	 * the row itself is already gone.
+	 *
+	 * @param bool $dry_run When true, count what would happen without writing anything.
+	 * @return array{0: int, 1: int, 2: int} Tuple of [rows deleted, rows with markers cleared, rows left untouched].
+	 */
+	private function rollback_notifications( bool $dry_run ): array {
+		global $wpdb;
+
+		$core_table      = $wpdb->prefix . self::CORE_NOTIFICATIONS_TABLE;
+		$core_meta_table = $wpdb->prefix . self::CORE_META_TABLE;
+
+		$deleted                  = 0;
+		$markers_cleared          = 0;
+		$skipped                  = 0;
+		$deleted_notification_ids = array();
+
+		foreach ( $this->each_legacy_id_marker() as $marker ) {
+			$notification_id = (int) $marker['notification_id'];
+
+			if ( isset( $deleted_notification_ids[ $notification_id ] ) ) {
+				// Already deleted for its insert marker this run; its other markers went with it.
+				continue;
+			}
+
+			list( $legacy_row, $legacy_meta ) = $this->fetch_legacy_source( (int) $marker['legacy_id'] );
+
+			if ( null === $legacy_row ) {
+				++$skipped;
+				continue;
+			}
+
+			if ( ! empty( $marker['is_adopted'] ) ) {
+				++$markers_cleared;
+
+				if ( ! $dry_run ) {
+					$this->remove_adoption_markers( $notification_id, (int) $marker['legacy_id'] );
+				}
+
+				continue;
+			}
+
+			if ( StatusMapper::map( $legacy_row, $legacy_meta ) !== $marker['status'] ) {
+				++$skipped;
+				continue;
+			}
+
+			++$deleted;
+			$deleted_notification_ids[ $notification_id ] = true;
+
+			if ( $dry_run ) {
+				continue;
+			}
+
+			// Deletes meta first, matching Core's own delete() cascade order, so a failure
+			// between the two statements never leaves an orphaned notification row without
+			// its meta already gone.
+			$wpdb->delete( $core_meta_table, array( 'notification_id' => $notification_id ), array( '%d' ) );
+			$wpdb->delete( $core_table, array( 'id' => $notification_id ), array( '%d' ) );
+		}
+
+		return array( $deleted, $markers_cleared, $skipped );
+	}
+
+	/**
+	 * Remove only the markers this migration added for one adopted legacy id, leaving the
+	 * Core notification itself, and every marker belonging to any other legacy id, untouched.
+	 *
+	 * @param int $notification_id Core notification id the marker was written onto.
+	 * @param int $legacy_id       Legacy notification id whose markers are being removed.
+	 * @return void
+	 */
+	private function remove_adoption_markers( int $notification_id, int $legacy_id ): void {
+		global $wpdb;
+
+		$core_meta_table = $wpdb->prefix . self::CORE_META_TABLE;
+
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$wpdb->delete(
+			$core_meta_table,
+			array(
+				'notification_id' => $notification_id,
+				'meta_key'        => self::LEGACY_ID_META_KEY,
+				'meta_value'      => (string) $legacy_id,
+			),
+			array( '%d', '%s', '%s' )
+		);
+
+		$wpdb->delete(
+			$core_meta_table,
+			array(
+				'notification_id' => $notification_id,
+				'meta_key'        => self::ADOPTED_MARKER_META_KEY,
+				'meta_value'      => (string) $legacy_id,
+			),
+			array( '%d', '%s', '%s' )
+		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+		// $core_meta_table is $wpdb->prefix-based, never user input; the LIKE prefix is built
+		// with $wpdb->esc_like() and bound via $wpdb->prepare() below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare(
+			"DELETE FROM {$core_meta_table} WHERE notification_id = %d AND meta_key = %s AND meta_value LIKE %s",
+			$notification_id,
+			self::LEGACY_UNSUB_HASH_META_KEY,
+			$wpdb->esc_like( $legacy_id . ':' ) . '%'
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+	}
+
+	/**
+	 * Yield every Core notification carrying a `_wc_bis_legacy_id` marker, one row per
+	 * notification id with its lowest associated legacy id, paging by keyset on id.
+	 *
+	 * The lowest legacy id is used as "the" legacy source for a row that was inserted by the
+	 * migration; a row later adopted by additional legacy rows accumulates further markers
+	 * that this deliberately ignores, since adoption never reconciled status onto the target
+	 * in the first place.
+	 *
+	 * @return \Generator<array{id: string, status: string, legacy_id: string}>
+	 */
+	private function each_migrated_notification(): \Generator {
+		global $wpdb;
+
+		$core_table      = $wpdb->prefix . self::CORE_NOTIFICATIONS_TABLE;
+		$core_meta_table = $wpdb->prefix . self::CORE_META_TABLE;
+
+		$cursor = 0;
+
+		do {
+			// Table names are $wpdb->prefix-based, never user input; the meta key and the
+			// cursor/limit bounds are passed through $wpdb->prepare() below.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+			$sql = $wpdb->prepare(
+				"SELECT n.id, n.status, MIN( CAST( m.meta_value AS UNSIGNED ) ) AS legacy_id
+				FROM {$core_table} n
+				INNER JOIN {$core_meta_table} m ON m.notification_id = n.id AND m.meta_key = %s
+				WHERE n.id > %d
+				GROUP BY n.id, n.status
+				ORDER BY n.id ASC
+				LIMIT %d",
+				self::LEGACY_ID_META_KEY,
+				$cursor,
+				self::ORACLE_BATCH_SIZE
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+
+			$rows       = (array) $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+			$rows_count = count( $rows );
+
+			foreach ( $rows as $row ) {
+				$cursor = max( $cursor, (int) $row['id'] );
+				yield $row;
+			}
+		} while ( self::ORACLE_BATCH_SIZE === $rows_count );
+	}
+
+	/**
+	 * Yield every `_wc_bis_legacy_id` marker on a Core notification, one row per legacy id,
+	 * paging by keyset on the marker's own meta id. Used only by `rollback`, which needs
+	 * every legacy id a row carries - unlike `each_migrated_notification()`, which collapses
+	 * a row to a single representative legacy id for `verify`.
+	 *
+	 * `is_adopted` is true when a `_wc_bis_legacy_adopted` marker with the same legacy id
+	 * exists on the same notification: that legacy id adopted a pre-existing row rather than
+	 * having been inserted by this migration.
+	 *
+	 * @return \Generator<array{notification_id: string, status: string, legacy_id: string, is_adopted: string|int}>
+	 */
+	private function each_legacy_id_marker(): \Generator {
+		global $wpdb;
+
+		$core_table      = $wpdb->prefix . self::CORE_NOTIFICATIONS_TABLE;
+		$core_meta_table = $wpdb->prefix . self::CORE_META_TABLE;
+
+		$cursor = 0;
+
+		do {
+			// Table names are $wpdb->prefix-based, never user input; the meta keys and the
+			// cursor/limit bounds are passed through $wpdb->prepare() below.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+			$sql = $wpdb->prepare(
+				"SELECT lm.id AS marker_id, n.id AS notification_id, n.status,
+					CAST( lm.meta_value AS UNSIGNED ) AS legacy_id,
+					( am.id IS NOT NULL ) AS is_adopted
+				FROM {$core_meta_table} lm
+				INNER JOIN {$core_table} n ON n.id = lm.notification_id
+				LEFT JOIN {$core_meta_table} am
+				       ON am.notification_id = lm.notification_id
+				      AND am.meta_key = %s
+				      AND am.meta_value = lm.meta_value
+				WHERE lm.meta_key = %s AND lm.id > %d
+				ORDER BY lm.id ASC
+				LIMIT %d",
+				self::ADOPTED_MARKER_META_KEY,
+				self::LEGACY_ID_META_KEY,
+				$cursor,
+				self::ORACLE_BATCH_SIZE
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+
+			$rows       = (array) $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+			$rows_count = count( $rows );
+
+			foreach ( $rows as $row ) {
+				$cursor = max( $cursor, (int) $row['marker_id'] );
+				yield $row;
+			}
+		} while ( self::ORACLE_BATCH_SIZE === $rows_count );
+	}
+
+	/**
+	 * Fetch one legacy row and its meta bag, in the shape `StatusMapper::map()` expects.
+	 *
+	 * @param int $legacy_id Legacy notification id.
+	 * @return array{0: array<string,mixed>|null, 1: array<string,mixed>} Tuple of
+	 *                                                                    [legacy row or null, legacy meta bag].
+	 */
+	private function fetch_legacy_source( int $legacy_id ): array {
+		global $wpdb;
+
+		$table      = $wpdb->prefix . self::LEGACY_NOTIFICATIONS_TABLE;
+		$meta_table = $wpdb->prefix . self::LEGACY_META_TABLE;
+
+		// $table is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$legacy_row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $legacy_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( ! $legacy_row ) {
+			return array( null, array() );
+		}
+
+		// $meta_table is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare( "SELECT meta_key, meta_value FROM {$meta_table} WHERE bis_notifications_id = %d", $legacy_id );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$meta_rows = (array) $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql was built with $wpdb->prepare() above.
+
+		$legacy_meta = array();
+		foreach ( $meta_rows as $meta_row ) {
+			$legacy_meta[ $meta_row['meta_key'] ] = maybe_unserialize( $meta_row['meta_value'] );
+		}
+
+		return array( $legacy_row, $legacy_meta );
+	}
+
+	/**
+	 * Print the final section × outcome × count table.
+	 *
+	 * @param Reporter $reporter Outcome collector for the command that just ran.
+	 * @return void
+	 */
+	private function print_report( Reporter $reporter ): void {
+		$table = $reporter->get_table();
+
+		if ( empty( $table ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( 'Nothing to migrate.' );
+			return;
+		}
+
+		// @phpstan-ignore-next-line function.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI\Utils\format_items( 'table', $table, array( 'section', 'outcome', 'count' ) );
+	}
+
+	/**
+	 * Print the known-losses summary from the counts cached at run start.
+	 *
+	 * Reads the cache rather than counting, so `status` stays cheap; a run that has not
+	 * happened yet says so instead of reporting zeroes as if they were measured.
+	 *
+	 * @param Reporter $reporter Used to turn the cached counts into merchant-facing lines.
+	 * @return void
+	 */
+	private function print_known_losses( Reporter $reporter ): void {
+		$cached = $this->state->get_losses();
+
+		if ( null === $cached ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( 'Skipped and lost populations: not yet counted; they are counted when a run starts.' );
+			return;
+		}
+
+		$lines = $reporter->summarize_cached_losses( is_array( $cached['values'] ?? null ) ? $cached['values'] : array() );
+
+		if ( empty( $lines ) ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( sprintf( 'Skipped and lost populations: none (as of %s).', $this->format_site_time( (int) $cached['at'] ) ) );
+			return;
+		}
+
+		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+		WP_CLI::log( sprintf( 'Skipped and lost populations (as of %s):', $this->format_site_time( (int) $cached['at'] ) ) );
+
+		foreach ( $lines as $line ) {
+			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
+			WP_CLI::log( sprintf( '  %s', $line ) );
+		}
+	}
+
+	/**
+	 * Format a UTC timestamp in site-local time, matching what merchants read in the legacy
+	 * admin — a plain UTC value here would read as the migration having shifted their dates.
+	 *
+	 * @param int $timestamp Unix timestamp (UTC).
+	 * @return string
+	 */
+	private function format_site_time( int $timestamp ): string {
+		if ( 0 === $timestamp ) {
+			return '';
+		}
+
+		$formatted = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+
+		return false === $formatted ? '' : $formatted;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/Cli.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/Cli.php
@@ -387,7 +387,7 @@ class Cli {
 
 		if ( ! $dry_run ) {
 			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
-			WP_CLI::confirm( 'This will write to the database. Continue?' );
+			WP_CLI::confirm( 'This will write to the database. Continue?', $assoc_args );
 		}
 
 		if ( ! $this->acquire_lock( 'run' ) ) {
@@ -607,7 +607,7 @@ class Cli {
 
 		if ( ! $dry_run ) {
 			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
-			WP_CLI::confirm( 'This will permanently delete migrated Stock Notifications rows. Continue?' );
+			WP_CLI::confirm( 'This will permanently delete migrated Stock Notifications rows. Continue?', $assoc_args );
 		}
 
 		if ( ! $this->acquire_lock( 'rollback' ) ) {
@@ -679,7 +679,7 @@ class Cli {
 		}
 
 		// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.
-		WP_CLI::confirm( 'This will permanently remove legacy unsubscribe links. Continue?' );
+		WP_CLI::confirm( 'This will permanently remove legacy unsubscribe links. Continue?', $assoc_args );
 
 		if ( ! $this->acquire_lock( 'disable-legacy-links' ) ) {
 			// @phpstan-ignore-next-line class.notFound -- WP_CLI is not resolvable to PHPStan outside a wp-cli runtime; see other CLI command classes in this codebase.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/Cli.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/Cli.php
@@ -450,9 +450,12 @@ class Cli {
 					$ids    = $migrator->get_batch( $cursor, $batch_size );
 
 					if ( empty( $ids ) ) {
-						if ( 0 === $cursor ) {
+						if ( 0 === $cursor || $writer->is_dry_run() ) {
+							// Under a dry run nothing is written, so no row ever leaves the
+							// candidate set; a reset-and-retry pass would just fetch the same
+							// rows forever. Only a real run needs the reset pass, to pick up
+							// rows that re-entered the candidate set below an advancing cursor.
 							break;
-							// Query right after a reset came back empty: this section is drained.
 						}
 
 						$this->state->reset_cursor( $slug );
@@ -460,7 +463,8 @@ class Cli {
 					}
 
 					$migrator->migrate_batch( $ids, $writer );
-					$this->state->set_cursor( $slug, max( $ids ) );
+					// get_batch() returns ids as strings, as $wpdb hands them over.
+					$this->state->set_cursor( $slug, (int) max( $ids ) );
 					$progress->tick( count( $ids ) );
 					++$batches_run;
 				}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/MigrationBatchProcessor.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/MigrationBatchProcessor.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * MigrationBatchProcessor class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners;
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\EmailSettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\MigratorInterface;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\ProductMetaMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\SettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\WriterInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Drives the whole legacy Back In Stock Notifications migration as a single
+ * `BatchProcessorInterface`, across four sections: notifications, product-meta, emails,
+ * settings, in that fixed order.
+ *
+ * The order is load-bearing (settings must land last, see the plan's Idempotency
+ * section), so this is one processor rather than four independently-enqueued ones.
+ * `get_next_batch_to_process()` serves the first section with pending work and only
+ * moves on once that section is drained; a returned batch never spans two sections.
+ * Batch items are `{section}::{id}` strings, so a batch is self-describing in logs.
+ *
+ * There is no abort state. Every way a run can end - the feature toggled off, the
+ * legacy tables gone, a CLI lock held, a killed worker - is expressed as an empty
+ * batch. `BatchProcessingController` dequeues on an empty batch, and that is never a
+ * terminal outcome: what has actually migrated is recorded by the markers the
+ * migrators write, not by anything here, so the next run picks up exactly where the
+ * markers say the previous one left off.
+ */
+class MigrationBatchProcessor implements BatchProcessorInterface {
+
+	/**
+	 * Delimiter joining a section slug and a raw identifier into one batch item.
+	 */
+	private const SECTION_DELIMITER = '::';
+
+	/**
+	 * Default batch size for scheduled (Action Scheduler) runs. The CLI raises this for
+	 * its own runs via `--batch-size`.
+	 */
+	private const DEFAULT_BATCH_SIZE = 50;
+
+	/**
+	 * Requirement checks re-run on every batch, not just at run start.
+	 *
+	 * @var Requirements
+	 */
+	private Requirements $requirements;
+
+	/**
+	 * Run state: the CLI lock, per-section cursors, and cached pending counts.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Writer every migrator routes its persistence through. Always the live `DbWriter`
+	 * here; `NullWriter` is a CLI `--dry-run` concern only.
+	 *
+	 * @var WriterInterface
+	 */
+	private WriterInterface $writer;
+
+	/**
+	 * The four section migrators, keyed by `get_slug()` and, since PHP preserves
+	 * insertion order on associative arrays, ordered notifications, product-meta,
+	 * emails, settings. That order is the section order the whole class runs on.
+	 *
+	 * @var array<string, MigratorInterface>
+	 */
+	private array $migrators = array();
+
+	/**
+	 * Init the service.
+	 *
+	 * Only `Requirements` is injected. Everything else is built here rather than resolved
+	 * from the container: `WriterInterface` is an interface, and the migrators take
+	 * constructor arguments, neither of which `RuntimeContainer` can reflect over.
+	 *
+	 * @internal
+	 *
+	 * @param Requirements $requirements Requirement checks, re-run on every batch.
+	 */
+	final public function init( Requirements $requirements ): void {
+		$this->requirements = $requirements;
+		$this->state        = new MigrationState();
+		$this->writer       = new DbWriter();
+
+		$reporter = new Reporter();
+
+		foreach (
+			array(
+				new NotificationsMigrator( $reporter ),
+				new ProductMetaMigrator( $reporter, $this->state ),
+				new EmailSettingsMigrator( $this->state, $reporter ),
+				new SettingsMigrator( $this->state, $reporter ),
+			) as $migrator
+		) {
+			$this->migrators[ $migrator->get_slug() ] = $migrator;
+		}
+	}
+
+	/**
+	 * Get a user-friendly name for this processor.
+	 *
+	 * @return string Name of the processor.
+	 */
+	public function get_name(): string {
+		return __( 'Back In Stock Notifications migration', 'woocommerce' );
+	}
+
+	/**
+	 * Get a user-friendly description for this processor.
+	 *
+	 * @return string Description of what this processor does.
+	 */
+	public function get_description(): string {
+		return __( 'Migrates legacy Back In Stock Notifications data - signups, product settings, email settings and general settings - to Core customer stock notifications.', 'woocommerce' );
+	}
+
+	/**
+	 * Sum of every section's cached remaining count.
+	 *
+	 * Display only; it never drives the batch loop. The counts are computed at run start
+	 * and after each migrated batch, cached in `wc_bis_migration_state`, and only read
+	 * here - never a live query, so a Tools page load never triggers one. A section
+	 * whose count has never been cached contributes zero.
+	 *
+	 * @return int Number of items pending processing.
+	 */
+	public function get_total_pending_count(): int {
+		$total = 0;
+
+		foreach ( array_keys( $this->migrators ) as $slug ) {
+			$cached = $this->state->get_count( $slug );
+			$total += null !== $cached ? (int) $cached['count'] : 0;
+		}
+
+		return $total;
+	}
+
+	/**
+	 * Returns the next batch of items that need to be processed.
+	 *
+	 * Side-effect free: it only reads state, never writes it, so calling it twice in a
+	 * row leaves the cursors and counts untouched and returns the same batch. Serves the
+	 * first section, in fixed order, that still has work; only moves past a section once
+	 * a query run from the start of a new pass also comes back empty.
+	 *
+	 * @param int $size Maximum size of the batch to be returned.
+	 * @return array Batch of `{section}::{id}` items, containing $size or fewer items.
+	 */
+	public function get_next_batch_to_process( int $size ): array {
+		if ( $this->state->is_lock_held() ) {
+			return array();
+		}
+
+		if ( ! $this->requirements_met() ) {
+			return array();
+		}
+
+		foreach ( $this->migrators as $slug => $migrator ) {
+			$batch = $this->get_section_batch( $slug, $migrator, $size );
+
+			if ( ! empty( $batch ) ) {
+				return $this->prefix_ids( $slug, $batch );
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Process data for the supplied batch.
+	 *
+	 * The batch is expected to hold identifiers for a single section, as produced by
+	 * `get_next_batch_to_process()`. Each section's `migrate_batch()` already catches
+	 * and marks per-row failures; only a whole-batch transient failure (a DB error, a
+	 * lost connection) is allowed to propagate here, so the controller can retry it -
+	 * safely, since rows that already succeeded wrote their own markers and left the
+	 * candidate set. A section's cursor and cached count are written only after its
+	 * migrate_batch() call returns without throwing - this is the only method in the
+	 * class that persists them.
+	 *
+	 * @param array $batch Batch to process, as returned by 'get_next_batch_to_process'.
+	 */
+	public function process_batch( array $batch ): void {
+		if ( empty( $batch ) ) {
+			return;
+		}
+
+		if ( $this->state->is_lock_held() ) {
+			return;
+		}
+
+		if ( ! $this->requirements_met() ) {
+			return;
+		}
+
+		foreach ( $this->group_by_section( $batch ) as $slug => $raw_ids ) {
+			$migrator = $this->migrators[ $slug ];
+
+			$migrator->migrate_batch( $raw_ids, $this->writer );
+			$this->store_cursor( $slug, $raw_ids );
+
+			// count_remaining() is the migration's most expensive query, so it is refreshed at
+			// run start and as a section drains, never on every batch. A batch shorter than the
+			// requested size is the last one this pass, which is the cheapest point to notice.
+			if ( count( $raw_ids ) < $this->get_default_batch_size() ) {
+				$this->state->set_count( $slug, $migrator->count_remaining() );
+			}
+		}
+	}
+
+	/**
+	 * Default (preferred) batch size to pass to 'get_next_batch_to_process'.
+	 *
+	 * @return int Default batch size.
+	 */
+	public function get_default_batch_size(): int {
+		return self::DEFAULT_BATCH_SIZE;
+	}
+
+	/**
+	 * Fetch one section's next batch, taking its cursor-pass reset into account.
+	 *
+	 * An empty query at the stored cursor does not by itself prove the section is
+	 * drained: a row deleted mid-run can re-enter the candidate set at an id the cursor
+	 * already passed. Query once more from the start of a pass; the section is drained
+	 * only when that query is also empty. The reset is only computed here, never
+	 * persisted - `process_batch()` writes the cursor once the batch has migrated, so
+	 * this method performs no writes and repeated calls return the same batch.
+	 *
+	 * @param string            $slug     Section slug.
+	 * @param MigratorInterface $migrator Section migrator.
+	 * @param int               $size     Maximum number of ids to return.
+	 * @return array List of raw identifiers, ascending, or empty when drained.
+	 */
+	private function get_section_batch( string $slug, MigratorInterface $migrator, int $size ): array {
+		$cursor = $this->state->get_cursor( $slug );
+		$batch  = $migrator->get_batch( $cursor, $size );
+
+		if ( ! empty( $batch ) || 0 === $cursor ) {
+			return $batch;
+		}
+
+		return $migrator->get_batch( 0, $size );
+	}
+
+	/**
+	 * Store a section's cursor at the highest identifier in a successfully migrated
+	 * batch, when that section uses a keyset cursor at all.
+	 *
+	 * The new value can be lower than the stored one: that is a batch the probe fetched
+	 * from the start of a new pass, and writing it here is what persists that pass
+	 * reset.
+	 *
+	 * The emails and settings sections identify their outstanding items by option key,
+	 * not by a sequential id, and never read the cursor; their raw ids are never
+	 * numeric, so this is a no-op for them.
+	 *
+	 * @param string $slug     Section slug.
+	 * @param array  $raw_ids Raw identifiers migrate_batch() was just called with.
+	 * @return void
+	 */
+	private function store_cursor( string $slug, array $raw_ids ): void {
+		$numeric_ids = array_filter( $raw_ids, 'is_numeric' );
+
+		if ( empty( $numeric_ids ) ) {
+			return;
+		}
+
+		$this->state->set_cursor( $slug, (int) max( $numeric_ids ) );
+	}
+
+	/**
+	 * Re-run `Requirements::check()` and log why a run cannot continue.
+	 *
+	 * Called on every batch, not just at run start, since a merchant can toggle the
+	 * feature off or drop the legacy tables while a background run is in progress.
+	 *
+	 * @return bool True when every requirement is met.
+	 */
+	private function requirements_met(): bool {
+		$result = $this->requirements->check();
+
+		if ( true === $result ) {
+			return true;
+		}
+
+		// Shares Reporter::LOG_SOURCE's value; this check is not a per-row outcome, so
+		// it does not go through Reporter's per-row logging methods.
+		wc_get_logger()->warning(
+			sprintf( 'run stopped: %s', $result->get_error_message() ),
+			array( 'source' => 'bis-migration' )
+		);
+
+		return false;
+	}
+
+	/**
+	 * Prefix a section's raw identifiers with its slug, into `{section}::{id}` items.
+	 *
+	 * @param string $slug     Section slug.
+	 * @param array  $raw_ids Raw identifiers from the section migrator.
+	 * @return string[] Section-prefixed batch items.
+	 */
+	private function prefix_ids( string $slug, array $raw_ids ): array {
+		return array_map(
+			static function ( $raw_id ) use ( $slug ) {
+				return $slug . self::SECTION_DELIMITER . $raw_id;
+			},
+			$raw_ids
+		);
+	}
+
+	/**
+	 * Split a batch of `{section}::{id}` items back into raw identifiers, grouped by
+	 * section. An item naming an unknown section is dropped rather than passed to a
+	 * migrator that cannot handle it.
+	 *
+	 * @param array $batch Section-prefixed batch items.
+	 * @return array<string, array> Raw identifiers, keyed by section slug.
+	 */
+	private function group_by_section( array $batch ): array {
+		$grouped = array();
+
+		foreach ( $batch as $item ) {
+			$parts = explode( self::SECTION_DELIMITER, (string) $item, 2 );
+
+			if ( 2 !== count( $parts ) || ! isset( $this->migrators[ $parts[0] ] ) ) {
+				continue;
+			}
+
+			list( $slug, $raw_id ) = $parts;
+
+			$grouped[ $slug ][] = is_numeric( $raw_id ) ? (int) $raw_id : $raw_id;
+		}
+
+		return $grouped;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/ToolsRegistrar.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/ToolsRegistrar.php
@@ -134,8 +134,11 @@ class ToolsRegistrar {
 		// possibly killed, run left behind - otherwise it resumes behind a stale cursor
 		// and strands every row below it.
 		$migration_state->reset_all_cursors();
-		$this->refresh_cached_counts( $migration_state );
-		$this->cache_known_losses( $migration_state );
+
+		$notifications_migrator = new NotificationsMigrator( new Reporter() );
+
+		$this->refresh_cached_counts( $migration_state, $notifications_migrator );
+		$this->cache_known_losses( $migration_state, $notifications_migrator );
 
 		$batch_processor->enqueue_processor( MigrationBatchProcessor::class );
 
@@ -149,11 +152,13 @@ class ToolsRegistrar {
 	 * "computed at run start" half of that contract has to happen here, in the callback
 	 * that actually starts a run.
 	 *
-	 * @param MigrationState $migration_state Run state to write the refreshed counts into.
+	 * @param MigrationState        $migration_state        Run state to write the refreshed counts into.
+	 * @param NotificationsMigrator $notifications_migrator The notifications section, shared with
+	 *                                                       cache_known_losses().
 	 * @return void
 	 */
-	private function refresh_cached_counts( MigrationState $migration_state ): void {
-		foreach ( $this->get_migrators() as $migrator ) {
+	private function refresh_cached_counts( MigrationState $migration_state, NotificationsMigrator $notifications_migrator ): void {
+		foreach ( $this->build_migrators( $migration_state, $notifications_migrator ) as $migrator ) {
 			$migration_state->set_count( $migrator->get_slug(), $migrator->count_remaining() );
 		}
 	}
@@ -164,30 +169,35 @@ class ToolsRegistrar {
 	 * These are one `COUNT(*)` each, so they are computed here, where a merchant has just
 	 * asked for a run, and never while rendering the Tools list.
 	 *
-	 * @param MigrationState $migration_state Run state to write the counts into.
+	 * @param MigrationState        $migration_state        Run state to write the counts into.
+	 * @param NotificationsMigrator $notifications_migrator The notifications section, already built.
 	 * @return void
 	 */
-	private function cache_known_losses( MigrationState $migration_state ): void {
-		$container = wc_get_container();
-
+	private function cache_known_losses( MigrationState $migration_state, NotificationsMigrator $notifications_migrator ): void {
 		$migration_state->set_losses(
-			$container->get( Reporter::class )->collect_known_losses( $container->get( NotificationsMigrator::class ) )
+			wc_get_container()->get( Reporter::class )->collect_known_losses( $notifications_migrator )
 		);
 	}
 
 	/**
-	 * Resolve the four section migrators from the container.
+	 * Build the four section migrators.
 	 *
+	 * Built here rather than resolved from the container, which cannot reflect over their
+	 * constructor arguments - the same reason `MigrationBatchProcessor` builds its own.
+	 *
+	 * @param MigrationState        $migration_state        Run state the option-backed sections read.
+	 * @param NotificationsMigrator $notifications_migrator The notifications section, built by the caller
+	 *                                                       so its run-level counters are shared.
 	 * @return MigratorInterface[]
 	 */
-	private function get_migrators(): array {
-		$container = wc_get_container();
+	private function build_migrators( MigrationState $migration_state, NotificationsMigrator $notifications_migrator ): array {
+		$reporter = new Reporter();
 
 		return array(
-			$container->get( NotificationsMigrator::class ),
-			$container->get( ProductMetaMigrator::class ),
-			$container->get( EmailSettingsMigrator::class ),
-			$container->get( SettingsMigrator::class ),
+			$notifications_migrator,
+			new ProductMetaMigrator( $reporter, $migration_state ),
+			new EmailSettingsMigrator( $migration_state, $reporter ),
+			new SettingsMigrator( $migration_state, $reporter ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/ToolsRegistrar.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Runners/ToolsRegistrar.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * ToolsRegistrar class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners;
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\EmailSettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\MigratorInterface;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\ProductMetaMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\SettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds the `woocommerce_debug_tools` entry that starts and stops the BIS migration.
+ *
+ * Modelled on `OrderCouponDataMigrator`'s start/stop split: a start button when
+ * `MigrationBatchProcessor` is not enqueued, a stop button that dequeues it when it is. The
+ * capability check lives in the callback itself rather than being inherited from the surrounding
+ * Tools screen, because the callback is what actually starts or stops a run that rewrites
+ * subscriber data.
+ */
+class ToolsRegistrar {
+
+	/**
+	 * Section slugs, in the order `MigrationState` and the migrators use them. Not sourced from
+	 * the migrators themselves: instantiating all four just to read a slug would defeat the
+	 * point of the cached counts this class only ever reads.
+	 *
+	 * @var string[]
+	 */
+	private const SECTIONS = array( 'notifications', 'product-meta', 'emails', 'settings' );
+
+	/**
+	 * Add the migration's start/stop entry to the Tools list.
+	 *
+	 * @internal
+	 *
+	 * @param array $tools Existing `woocommerce_debug_tools` entries.
+	 * @return array
+	 */
+	public function handle_woocommerce_debug_tools( array $tools ): array {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return $tools;
+		}
+
+		$description     = $this->get_description();
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+
+		if ( $batch_processor->is_enqueued( MigrationBatchProcessor::class ) ) {
+			$tools['stop_bis_migration'] = array(
+				'name'     => __( 'Stop migrating Back In Stock Notifications subscribers', 'woocommerce' ),
+				'button'   => __( 'Stop migration', 'woocommerce' ),
+				'desc'     => $description,
+				'callback' => array( $this, 'stop' ),
+			);
+
+			return $tools;
+		}
+
+		$tools['start_bis_migration'] = array(
+			'name'     => __( 'Migrate Back In Stock Notifications subscribers', 'woocommerce' ),
+			'button'   => __( 'Start migration', 'woocommerce' ),
+			'desc'     => $description,
+			'callback' => array( $this, 'start' ),
+		);
+
+		return $tools;
+	}
+
+	/**
+	 * Start the migration's background run.
+	 *
+	 * Refuses while a CLI run holds the lock, since the migration is not safe to run twice
+	 * concurrently: natural-key adoption is check-then-insert, and two concurrent workers can
+	 * each create a Core notification for the same legacy row.
+	 *
+	 * Also refuses while the legacy extension still has rows queued for its own sender, since
+	 * migrating those rows lets the extension and Core both send the same notification. There
+	 * is no override on this screen: the CLI's `--force` is the only way past it.
+	 *
+	 * @internal
+	 *
+	 * @return string Message shown after the tool runs.
+	 */
+	public function start(): string {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return __( 'You do not have permission to do this.', 'woocommerce' );
+		}
+
+		$migration_state = wc_get_container()->get( MigrationState::class );
+
+		if ( $migration_state->is_lock_held() ) {
+			$lock = $migration_state->get_lock();
+
+			return sprintf(
+				/* translators: %s: identifier of the process holding the CLI lock */
+				__( 'A migration run is already in progress via WP-CLI (%s). Stop it there before starting a run here — starting one here does not override it.', 'woocommerce' ),
+				$lock['owner'] ?? __( 'unknown', 'woocommerce' )
+			);
+		}
+
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+
+		if ( $batch_processor->is_enqueued( MigrationBatchProcessor::class ) ) {
+			return __( 'Migration already in progress, nothing done.', 'woocommerce' );
+		}
+
+		$queued = wc_get_container()->get( Requirements::class )->count_legacy_queued_rows();
+
+		if ( $queued > 0 ) {
+			return sprintf(
+				/* translators: %d: number of legacy rows still queued by the Back In Stock Notifications extension */
+				_n(
+					'Cannot start: %d legacy row is still queued for sending by the active Back In Stock Notifications extension, so migrating now risks sending the same notification twice. Let the legacy queue drain, then start again. This cannot be overridden here; run `wp wc bis-migrate run --force --yes` if you have to override it.',
+					'Cannot start: %d legacy rows are still queued for sending by the active Back In Stock Notifications extension, so migrating now risks sending the same notification twice. Let the legacy queue drain, then start again. This cannot be overridden here; run `wp wc bis-migrate run --force --yes` if you have to override it.',
+					$queued,
+					'woocommerce'
+				),
+				$queued
+			);
+		}
+
+		// A run always starts from zero: MigrationBatchProcessor only ever advances a
+		// cursor, never resets one, so a fresh run has to clear whatever a previous,
+		// possibly killed, run left behind - otherwise it resumes behind a stale cursor
+		// and strands every row below it.
+		$migration_state->reset_all_cursors();
+		$this->refresh_cached_counts( $migration_state );
+		$this->cache_known_losses( $migration_state );
+
+		$batch_processor->enqueue_processor( MigrationBatchProcessor::class );
+
+		return __( 'Migration started. Subscribers will be migrated in the background over the next few minutes.', 'woocommerce' );
+	}
+
+	/**
+	 * Recompute and cache every section's remaining count at run start.
+	 *
+	 * The processor itself only refreshes a section's cached count on drain, so the
+	 * "computed at run start" half of that contract has to happen here, in the callback
+	 * that actually starts a run.
+	 *
+	 * @param MigrationState $migration_state Run state to write the refreshed counts into.
+	 * @return void
+	 */
+	private function refresh_cached_counts( MigrationState $migration_state ): void {
+		foreach ( $this->get_migrators() as $migrator ) {
+			$migration_state->set_count( $migrator->get_slug(), $migrator->count_remaining() );
+		}
+	}
+
+	/**
+	 * Count and cache the skipped populations at run start.
+	 *
+	 * These are one `COUNT(*)` each, so they are computed here, where a merchant has just
+	 * asked for a run, and never while rendering the Tools list.
+	 *
+	 * @param MigrationState $migration_state Run state to write the counts into.
+	 * @return void
+	 */
+	private function cache_known_losses( MigrationState $migration_state ): void {
+		$container = wc_get_container();
+
+		$migration_state->set_losses(
+			$container->get( Reporter::class )->collect_known_losses( $container->get( NotificationsMigrator::class ) )
+		);
+	}
+
+	/**
+	 * Resolve the four section migrators from the container.
+	 *
+	 * @return MigratorInterface[]
+	 */
+	private function get_migrators(): array {
+		$container = wc_get_container();
+
+		return array(
+			$container->get( NotificationsMigrator::class ),
+			$container->get( ProductMetaMigrator::class ),
+			$container->get( EmailSettingsMigrator::class ),
+			$container->get( SettingsMigrator::class ),
+		);
+	}
+
+	/**
+	 * Stop the migration's background run.
+	 *
+	 * Stopping is never a terminal outcome: nothing migrated so far is undone, and the
+	 * outstanding count above continues to reflect what is left to do.
+	 *
+	 * @internal
+	 *
+	 * @return string Message shown after the tool runs.
+	 */
+	public function stop(): string {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return __( 'You do not have permission to do this.', 'woocommerce' );
+		}
+
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+
+		if ( ! $batch_processor->is_enqueued( MigrationBatchProcessor::class ) ) {
+			return __( 'Migration not in progress, nothing done.', 'woocommerce' );
+		}
+
+		$batch_processor->remove_processor( MigrationBatchProcessor::class );
+
+		return __( 'Migration stopped. Rows already migrated are untouched; the outstanding count above will still be there next time you start it.', 'woocommerce' );
+	}
+
+	/**
+	 * Build the tool's description from the cached, per-section counts.
+	 *
+	 * Reads only `MigrationState`'s cached counts - computed at run start and on section drain,
+	 * never here - so this never runs the live candidate-selection query. Rendered whether or not
+	 * a run is in progress, so a half-finished migration reads as outstanding work rather than as
+	 * an idle screen, and each number carries the timestamp it was computed at rather than being
+	 * presented as current.
+	 *
+	 * @return string
+	 */
+	private function get_description(): string {
+		$migration_state = wc_get_container()->get( MigrationState::class );
+		$reporter        = wc_get_container()->get( Reporter::class );
+
+		$lines = array(
+			__( 'Migrates subscribers, product settings and email settings from the legacy Back In Stock Notifications extension into the built-in Customer stock notifications feature. Runs in the background over several requests via Action Scheduler.', 'woocommerce' ),
+		);
+
+		$section_lines = array();
+		$known_total   = 0;
+		$has_unknown   = false;
+
+		foreach ( self::SECTIONS as $section ) {
+			$cached = $migration_state->get_count( $section );
+
+			if ( null === $cached ) {
+				$has_unknown     = true;
+				$section_lines[] = sprintf(
+					/* translators: %s: migration section slug */
+					__( '%s: not yet counted.', 'woocommerce' ),
+					$section
+				);
+				continue;
+			}
+
+			$known_total    += $cached['count'];
+			$section_lines[] = sprintf(
+				/* translators: 1: migration section slug, 2: cached remaining count with its timestamp */
+				__( '%1$s: %2$s remaining.', 'woocommerce' ),
+				$section,
+				$reporter->format_cached_count( $cached['count'], $cached['at'] )
+			);
+		}
+
+		if ( $has_unknown ) {
+			$lines[] = __( 'Outstanding rows are counted the first time a run starts.', 'woocommerce' );
+		} else {
+			$lines[] = sprintf(
+				/* translators: %d: total rows still outstanding across every section */
+				_n(
+					'%d row is currently outstanding across every section.',
+					'%d rows are currently outstanding across every section.',
+					$known_total,
+					'woocommerce'
+				),
+				$known_total
+			);
+		}
+
+		$lines[] = implode( ' ', $section_lines );
+
+		$cached_losses = $migration_state->get_losses();
+
+		if ( null === $cached_losses ) {
+			$lines[] = __( 'Rows that will be skipped, and what they cost, are counted the first time a run starts.', 'woocommerce' );
+		} else {
+			$loss_lines = $reporter->summarize_cached_losses( is_array( $cached_losses['values'] ?? null ) ? $cached_losses['values'] : array() );
+
+			if ( ! empty( $loss_lines ) ) {
+				$lines[] = sprintf(
+					/* translators: %s: site-local date/time the skipped populations were counted at */
+					__( 'Skipped and lost, as of %s:', 'woocommerce' ),
+					$reporter->format_site_time( (int) $cached_losses['at'] )
+				);
+				$lines[] = implode( ' ', $loss_lines );
+			}
+		}
+
+		return implode( ' ', $lines );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/BulkNotificationWriter.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/BulkNotificationWriter.php
@@ -131,17 +131,33 @@ class BulkNotificationWriter {
 	private function insert_notification_rows( string $table, array $chunk ): int {
 		global $wpdb;
 
-		$columns      = array_keys( self::COLUMN_FORMATS );
-		$placeholders = '(' . implode( ', ', array_values( self::COLUMN_FORMATS ) ) . ')';
-		$values       = array();
+		$columns          = array_keys( self::COLUMN_FORMATS );
+		$values           = array();
+		$row_placeholders = array();
 
 		foreach ( $chunk as $row ) {
+			$placeholders = array();
+
 			foreach ( $columns as $column ) {
-				$values[] = $row['columns'][ $column ] ?? null;
+				$value = $row['columns'][ $column ] ?? null;
+
+				// A null column is written as a SQL NULL literal rather than through a
+				// placeholder: $wpdb->prepare() renders null as an empty string, which MySQL
+				// stores in a datetime column as '0000-00-00 00:00:00'. Core reads these
+				// columns with `IS NULL`, so a zero date would read as "already attempted".
+				if ( null === $value ) {
+					$placeholders[] = 'NULL';
+					continue;
+				}
+
+				$placeholders[] = self::COLUMN_FORMATS[ $column ];
+				$values[]       = $value;
 			}
+
+			$row_placeholders[] = '(' . implode( ', ', $placeholders ) . ')';
 		}
 
-		$row_placeholders = implode( ', ', array_fill( 0, count( $chunk ), $placeholders ) );
+		$row_placeholders = implode( ', ', $row_placeholders );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table and $columns are a fixed internal list, never user input; values are prepared via $wpdb->prepare().
 		$sql = $wpdb->prepare(

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/BulkNotificationWriter.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/BulkNotificationWriter.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * BulkNotificationWriter class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bulk-inserts legacy Back In Stock Notifications rows into the Core notification tables.
+ *
+ * Never routes through `Notification` + `save()`. Per chunk this does one multi-row INSERT
+ * into `wc_stock_notifications`, captures the contiguous id block from `$wpdb->insert_id` and
+ * the affected row count, then does one multi-row INSERT of the meta rows against that block.
+ * Both statements run inside a single transaction: a failure between them would leave Core
+ * rows with no `_wc_bis_legacy_id` marker, invisible to the candidate predicate and
+ * re-inserted on the next run. The contiguous-id-block assumption holds only for a single
+ * multi-row statement, so a batch larger than the chunk size is split into several chunks,
+ * each with its own transaction and id capture.
+ */
+class BulkNotificationWriter {
+
+	/**
+	 * Columns accepted on `wc_stock_notifications`, mapped to their `$wpdb->prepare()` format.
+	 *
+	 * @var array<string,string>
+	 */
+	private const COLUMN_FORMATS = array(
+		'product_id'            => '%d',
+		'user_id'               => '%d',
+		'user_email'            => '%s',
+		'status'                => '%s',
+		'date_created_gmt'      => '%s',
+		'date_modified_gmt'     => '%s',
+		'date_confirmed_gmt'    => '%s',
+		'date_last_attempt_gmt' => '%s',
+		'date_notified_gmt'     => '%s',
+		'date_cancelled_gmt'    => '%s',
+		'cancellation_source'   => '%s',
+	);
+
+	/**
+	 * Default number of notification rows written per statement/transaction.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_CHUNK_SIZE = 500;
+
+	/**
+	 * Maximum number of notification rows written by a single multi-row INSERT.
+	 *
+	 * @var positive-int
+	 */
+	private int $chunk_size;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int $chunk_size Maximum number of notification rows per multi-row INSERT and
+	 *                        transaction. Keeps a single statement inside `max_allowed_packet`.
+	 */
+	public function __construct( int $chunk_size = self::DEFAULT_CHUNK_SIZE ) {
+		$this->chunk_size = max( 1, $chunk_size );
+	}
+
+	/**
+	 * Insert notification rows together with their meta, in chunks, one transaction per chunk.
+	 *
+	 * @param array $rows List of rows, each `array{ columns: array<string,mixed>, meta: array<int,array{0:string,1:mixed}> }`.
+	 * @return int Number of notifications written.
+	 */
+	public function insert_notifications( array $rows ): int {
+		if ( empty( $rows ) ) {
+			return 0;
+		}
+
+		$written = 0;
+
+		foreach ( array_chunk( $rows, $this->chunk_size ) as $chunk ) {
+			$written += $this->write_chunk( array_values( $chunk ) );
+		}
+
+		return $written;
+	}
+
+	/**
+	 * Insert one chunk of rows inside a single transaction.
+	 *
+	 * @param array $chunk Rows for this chunk, at most `$this->chunk_size` entries.
+	 * @throws \Exception If either statement fails.
+	 * @return int Number of notifications written.
+	 */
+	private function write_chunk( array $chunk ): int {
+		global $wpdb;
+
+		$table      = $wpdb->prefix . 'wc_stock_notifications';
+		$meta_table = $wpdb->prefix . 'wc_stock_notificationmeta';
+
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			$written  = $this->insert_notification_rows( $table, $chunk );
+			$first_id = (int) $wpdb->insert_id;
+
+			$meta_rows = $this->build_meta_rows( $chunk, $first_id );
+
+			if ( ! empty( $meta_rows ) ) {
+				$this->insert_meta_rows( $meta_table, $meta_rows );
+			}
+		} catch ( \Exception $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			throw $e;
+		}
+
+		$wpdb->query( 'COMMIT' );
+
+		return $written;
+	}
+
+	/**
+	 * Insert the notification rows for one chunk with a single multi-row statement.
+	 *
+	 * @param string $table Notifications table name.
+	 * @param array  $chunk Rows for this chunk.
+	 * @throws \RuntimeException If the INSERT fails.
+	 * @return int Number of rows inserted.
+	 */
+	private function insert_notification_rows( string $table, array $chunk ): int {
+		global $wpdb;
+
+		$columns      = array_keys( self::COLUMN_FORMATS );
+		$placeholders = '(' . implode( ', ', array_values( self::COLUMN_FORMATS ) ) . ')';
+		$values       = array();
+
+		foreach ( $chunk as $row ) {
+			foreach ( $columns as $column ) {
+				$values[] = $row['columns'][ $column ] ?? null;
+			}
+		}
+
+		$row_placeholders = implode( ', ', array_fill( 0, count( $chunk ), $placeholders ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table and $columns are a fixed internal list, never user input; values are prepared via $wpdb->prepare().
+		$sql = $wpdb->prepare(
+			"INSERT INTO {$table} (" . implode( ', ', $columns ) . ") VALUES {$row_placeholders}",
+			$values
+		);
+
+		$result = $wpdb->query( $sql );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		if ( false === $result ) {
+			throw new \RuntimeException( 'Failed to insert stock notification rows: ' . $wpdb->last_error ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		return (int) $result;
+	}
+
+	/**
+	 * Expand each row's meta list into meta table records against a just-inserted id block.
+	 *
+	 * @param array $chunk    Rows for this chunk, in insertion order.
+	 * @param int   $first_id First id of the contiguous block `$wpdb->insert_id` returned.
+	 * @return array List of `array{0:int,1:string,2:mixed}` notification_id/key/value rows.
+	 */
+	private function build_meta_rows( array $chunk, int $first_id ): array {
+		$meta_rows = array();
+
+		foreach ( array_values( $chunk ) as $offset => $row ) {
+			$notification_id = $first_id + $offset;
+
+			foreach ( $row['meta'] as $meta ) {
+				$meta_rows[] = array( $notification_id, $meta[0], $meta[1] );
+			}
+		}
+
+		return $meta_rows;
+	}
+
+	/**
+	 * Insert the meta rows for one chunk with a single multi-row statement.
+	 *
+	 * @param string $meta_table Meta table name.
+	 * @param array  $meta_rows  List of `array{0:int,1:string,2:mixed}` rows.
+	 * @throws \RuntimeException If the INSERT fails.
+	 * @return void
+	 */
+	private function insert_meta_rows( string $meta_table, array $meta_rows ): void {
+		global $wpdb;
+
+		$values = array();
+
+		foreach ( $meta_rows as $meta_row ) {
+			$values[] = $meta_row[0];
+			$values[] = $meta_row[1];
+			// This writer is the sole owner of maybe_serialize() for meta values; callers
+			// (e.g. MetaMapper) must hand over unserialized values, or this double-serializes.
+			$values[] = maybe_serialize( $meta_row[2] );
+		}
+
+		$row_placeholders = implode( ', ', array_fill( 0, count( $meta_rows ), '(%d, %s, %s)' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $meta_table is a fixed internal table name, never user input; values are prepared via $wpdb->prepare().
+		$sql = $wpdb->prepare(
+			"INSERT INTO {$meta_table} (notification_id, meta_key, meta_value) VALUES {$row_placeholders}",
+			$values
+		);
+
+		$result = $wpdb->query( $sql );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		if ( false === $result ) {
+			throw new \RuntimeException( 'Failed to insert stock notification meta rows: ' . $wpdb->last_error ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/DbWriter.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/DbWriter.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * DbWriter class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Live writer for the Back In Stock Notifications migration.
+ *
+ * Notification inserts are delegated to `BulkNotificationWriter`. Meta written onto an
+ * existing notification — natural-key adoption markers and legacy unsubscribe tokens — is
+ * always inserted, never updated, and goes through direct SQL rather than `add_meta_data()`,
+ * which would bump `date_modified_gmt` on a row the merchant did not touch. `write_product_meta()`
+ * is the one exception, going through the product CRUD layer per the plan.
+ */
+class DbWriter implements WriterInterface {
+
+	/**
+	 * Bulk insert engine for `wc_stock_notifications` and its meta.
+	 *
+	 * @var BulkNotificationWriter
+	 */
+	private BulkNotificationWriter $bulk_writer;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param BulkNotificationWriter|null $bulk_writer Bulk insert engine to use. Defaults to a
+	 *                                                  new instance with the writer's default chunk size.
+	 */
+	public function __construct( ?BulkNotificationWriter $bulk_writer = null ) {
+		$this->bulk_writer = $bulk_writer ?? new BulkNotificationWriter();
+	}
+
+	/**
+	 * This writer performs real writes.
+	 *
+	 * @return bool
+	 */
+	public function is_dry_run(): bool {
+		return false;
+	}
+
+	/**
+	 * Insert notifications together with their meta, in chunks, one transaction per chunk.
+	 *
+	 * @param array $rows List of rows, each `array{ columns: array<string,mixed>, meta: array<int,array{0:string,1:mixed}> }`.
+	 * @return int Number of notifications written.
+	 */
+	public function insert_notifications( array $rows ): int {
+		return $this->bulk_writer->insert_notifications( $rows );
+	}
+
+	/**
+	 * Insert notification meta rows onto an existing notification.
+	 *
+	 * Used by natural-key adoption and by the legacy unsubscribe token. Rows are always
+	 * inserted, never updated, and written by direct SQL so no date_modified_gmt bump occurs.
+	 *
+	 * @param int   $notification_id Target notification id.
+	 * @param array $meta            List of `array{0:string,1:mixed}` key/value pairs.
+	 * @return int Number of meta rows written.
+	 */
+	public function insert_notification_meta( int $notification_id, array $meta ): int {
+		global $wpdb;
+
+		if ( empty( $meta ) ) {
+			return 0;
+		}
+
+		$meta_table = $wpdb->prefix . 'wc_stock_notificationmeta';
+		$values     = array();
+
+		foreach ( $meta as $pair ) {
+			$values[] = $notification_id;
+			$values[] = $pair[0];
+			// This is the sole owner of maybe_serialize() for meta values, matching
+			// BulkNotificationWriter; callers must hand over unserialized values.
+			$values[] = maybe_serialize( $pair[1] );
+		}
+
+		$row_placeholders = implode( ', ', array_fill( 0, count( $meta ), '(%d, %s, %s)' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $meta_table is a fixed internal table name, never user input; values are prepared via $wpdb->prepare().
+		$sql = $wpdb->prepare(
+			"INSERT INTO {$meta_table} (notification_id, meta_key, meta_value) VALUES {$row_placeholders}",
+			$values
+		);
+
+		$result = $wpdb->query( $sql );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		if ( false === $result ) {
+			return 0;
+		}
+
+		$this->invalidate_meta_cache( $notification_id );
+
+		return (int) $result;
+	}
+
+	/**
+	 * Write a meta row into the legacy notifications meta table.
+	 *
+	 * The migration's only write into the legacy schema: the `_wc_bis_migration_failed` marker.
+	 *
+	 * @param int    $legacy_id  Legacy notification id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @return bool
+	 */
+	public function write_legacy_meta( int $legacy_id, string $meta_key, $meta_value ): bool {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'woocommerce_bis_notificationsmeta';
+
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'bis_notifications_id' => $legacy_id,
+				'meta_key'             => $meta_key,
+				'meta_value'           => maybe_serialize( $meta_value ),
+			),
+			array( '%d', '%s', '%s' )
+		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+		return false !== $result;
+	}
+
+	/**
+	 * Write a site option.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Option value.
+	 * @return bool
+	 */
+	public function write_option( string $option, $value ): bool {
+		return update_option( $option, $value );
+	}
+
+	/**
+	 * Write product meta through the CRUD layer.
+	 *
+	 * @param int    $product_id Product id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @return bool
+	 */
+	public function write_product_meta( int $product_id, string $meta_key, $meta_value ): bool {
+		$product = wc_get_product( $product_id );
+
+		// A post that is typed as a product but will not resolve to one still needs its
+		// migration marker written, or it stays a candidate forever and stalls the section.
+		if ( ! $product ) {
+			return false !== update_post_meta( $product_id, $meta_key, $meta_value );
+		}
+
+		$product->update_meta_data( $meta_key, $meta_value );
+
+		return false !== $product->save();
+	}
+
+	/**
+	 * Invalidate the cached raw meta data for a notification.
+	 *
+	 * An adopted row, or one whose legacy token was just attached, may already be loaded
+	 * elsewhere in the request; the direct SQL writes above bypass `WC_Data`'s own cache
+	 * invalidation, so it is repeated here. The cache group matches `Notification`'s, which
+	 * is currently unset — this is a no-op today and stays correct if that ever changes.
+	 *
+	 * @param int $notification_id Notification id.
+	 * @return void
+	 */
+	private function invalidate_meta_cache( int $notification_id ): void {
+		$cache_key = Notification::generate_meta_cache_key( $notification_id, '' );
+		wp_cache_delete( $cache_key, '' );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/NullWriter.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/NullWriter.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * NullWriter class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Dry-run writer for the Back In Stock Notifications migration.
+ *
+ * Discards every write. Counts are computed the same way `DbWriter` would report them on
+ * success, so a dry run produces the same report shape as a live one.
+ */
+class NullWriter implements WriterInterface {
+
+	/**
+	 * This writer discards its writes.
+	 *
+	 * @return bool
+	 */
+	public function is_dry_run(): bool {
+		return true;
+	}
+
+	/**
+	 * Report the number of notifications that would have been written, without writing them.
+	 *
+	 * @param array $rows List of rows, each `array{ columns: array<string,mixed>, meta: array<int,array{0:string,1:mixed}> }`.
+	 * @return int Number of notifications that would have been written.
+	 */
+	public function insert_notifications( array $rows ): int {
+		return count( $rows );
+	}
+
+	/**
+	 * Report the number of meta rows that would have been written, without writing them.
+	 *
+	 * @param int   $notification_id Target notification id.
+	 * @param array $meta            List of `array{0:string,1:mixed}` key/value pairs.
+	 * @return int Number of meta rows that would have been written.
+	 */
+	public function insert_notification_meta( int $notification_id, array $meta ): int {
+		return count( $meta );
+	}
+
+	/**
+	 * Report success without writing into the legacy schema.
+	 *
+	 * @param int    $legacy_id  Legacy notification id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @return bool
+	 */
+	public function write_legacy_meta( int $legacy_id, string $meta_key, $meta_value ): bool {
+		return true;
+	}
+
+	/**
+	 * Report success without writing the option.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Option value.
+	 * @return bool
+	 */
+	public function write_option( string $option, $value ): bool {
+		return true;
+	}
+
+	/**
+	 * Report success without writing the product meta.
+	 *
+	 * @param int    $product_id Product id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @return bool
+	 */
+	public function write_product_meta( int $product_id, string $meta_key, $meta_value ): bool {
+		return true;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/WriterInterface.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Migration/Writers/WriterInterface.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * WriterInterface class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Every persistent write the migration performs goes through this contract.
+ *
+ * A dry run swaps DbWriter for NullWriter, so the migrators themselves carry no
+ * dry-run branching and both modes produce the same report shape.
+ */
+interface WriterInterface {
+
+	/**
+	 * Whether this writer discards its writes.
+	 *
+	 * @return bool
+	 */
+	public function is_dry_run(): bool;
+
+	/**
+	 * Insert notifications together with their meta, in chunks, one transaction per chunk.
+	 *
+	 * @param array $rows List of rows, each `array{ columns: array<string,mixed>, meta: array<int,array{0:string,1:mixed}> }`.
+	 * @return int Number of notifications written.
+	 */
+	public function insert_notifications( array $rows ): int;
+
+	/**
+	 * Insert notification meta rows onto an existing notification.
+	 *
+	 * Used by natural-key adoption and by the legacy unsubscribe token. Rows are always
+	 * inserted, never updated, and written by direct SQL so no date_modified_gmt bump occurs.
+	 *
+	 * @param int   $notification_id Target notification id.
+	 * @param array $meta            List of `array{0:string,1:mixed}` key/value pairs.
+	 * @return int Number of meta rows written.
+	 */
+	public function insert_notification_meta( int $notification_id, array $meta ): int;
+
+	/**
+	 * Write a meta row into the legacy notifications meta table.
+	 *
+	 * The migration's only write into the legacy schema: the `_wc_bis_migration_failed` marker.
+	 *
+	 * @param int    $legacy_id  Legacy notification id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @return bool
+	 */
+	public function write_legacy_meta( int $legacy_id, string $meta_key, $meta_value ): bool;
+
+	/**
+	 * Write a site option.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Option value.
+	 * @return bool
+	 */
+	public function write_option( string $option, $value ): bool;
+
+	/**
+	 * Write product meta through the CRUD layer.
+	 *
+	 * @param int    $product_id Product id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @return bool
+	 */
+	public function write_product_meta( int $product_id, string $meta_key, $meta_value ): bool;
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
@@ -77,6 +77,13 @@ class MockWPCLI {
 	public static $last_halt_code = null;
 
 	/**
+	 * Questions that reached a prompt, i.e. were asked without `--yes`.
+	 *
+	 * @var array
+	 */
+	public static $prompted_confirmations = array();
+
+	/**
 	 * Simulated user input for STDIN reading in tests.
 	 *
 	 * @var string
@@ -175,25 +182,33 @@ class MockWPCLI {
 	 * Clear every recorded message so one test cannot read another's output.
 	 */
 	public static function reset(): void {
-		self::$last_debug_message   = '';
-		self::$last_warning_message = '';
-		self::$last_log_message     = '';
-		self::$last_error_message   = '';
-		self::$last_success_message = '';
-		self::$all_log_messages     = array();
-		self::$all_success_messages = array();
-		self::$last_halt_code       = null;
-		self::$last_table           = array();
+		self::$last_debug_message     = '';
+		self::$last_warning_message   = '';
+		self::$last_log_message       = '';
+		self::$last_error_message     = '';
+		self::$last_success_message   = '';
+		self::$all_log_messages       = array();
+		self::$all_success_messages   = array();
+		self::$last_halt_code         = null;
+		self::$last_table             = array();
+		self::$prompted_confirmations = array();
 	}
 
 	/**
-	 * Mock confirm method.
+	 * Mock confirm method. Honours `--yes` the way WP-CLI does, so a command that forgets to
+	 * forward its $assoc_args shows up as a prompt that should never have been reached.
 	 *
-	 * @param string $question Question to confirm.
+	 * @param string $question   Question to confirm.
+	 * @param array  $assoc_args Associative arguments the command was invoked with.
 	 * @return bool Always returns true in tests.
 	 */
-	public static function confirm( $question ): bool {
+	public static function confirm( $question, $assoc_args = array() ): bool {
 		self::$last_log_message = $question;
+
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
+			self::$prompted_confirmations[] = $question;
+		}
+
 		return true;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
@@ -63,6 +63,20 @@ class MockWPCLI {
 	public static $all_success_messages = array();
 
 	/**
+	 * Rows passed to the last `WP_CLI\Utils\format_items()` call.
+	 *
+	 * @var array
+	 */
+	public static $last_table = array();
+
+	/**
+	 * Exit code passed to the last `halt()` call, or null when it was never called.
+	 *
+	 * @var int|null
+	 */
+	public static $last_halt_code = null;
+
+	/**
 	 * Simulated user input for STDIN reading in tests.
 	 *
 	 * @var string
@@ -149,6 +163,30 @@ class MockWPCLI {
 	}
 
 	/**
+	 * Mock halt method. Records the exit code instead of terminating the process.
+	 *
+	 * @param int $code Exit code.
+	 */
+	public static function halt( $code ): void {
+		self::$last_halt_code = $code;
+	}
+
+	/**
+	 * Clear every recorded message so one test cannot read another's output.
+	 */
+	public static function reset(): void {
+		self::$last_debug_message   = '';
+		self::$last_warning_message = '';
+		self::$last_log_message     = '';
+		self::$last_error_message   = '';
+		self::$last_success_message = '';
+		self::$all_log_messages     = array();
+		self::$all_success_messages = array();
+		self::$last_halt_code       = null;
+		self::$last_table           = array();
+	}
+
+	/**
 	 * Mock confirm method.
 	 *
 	 * @param string $question Question to confirm.
@@ -164,3 +202,5 @@ class MockWPCLI {
 if ( ! class_exists( 'WP_CLI' ) ) {
 	class_alias( MockWPCLI::class, 'WP_CLI' );
 }
+
+require_once __DIR__ . '/wp-cli-utils.php';

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/wp-cli-utils.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/wp-cli-utils.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Stand-ins for the `WP_CLI\Utils` helper functions, which only exist inside a wp-cli runtime.
+ *
+ * Loaded by MockWPCLI.php, which cannot declare them itself: phpcs allows a file to hold either
+ * an OO structure or function declarations, not both.
+ *
+ * @package WooCommerce\Tests\Internal\CLI\Migrator\Mocks
+ */
+
+declare( strict_types=1 );
+
+namespace WP_CLI\Utils;
+
+if ( ! function_exists( 'WP_CLI\\Utils\\format_items' ) ) {
+	/**
+	 * Stand in for WP-CLI's table formatter, recording the rows it was handed.
+	 *
+	 * @param string $format Output format, e.g. `table`.
+	 * @param array  $items  Rows to render.
+	 * @param array  $fields Columns to render.
+	 */
+	function format_items( $format, $items, $fields ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+		\Automattic\WooCommerce\Tests\Internal\CLI\Migrator\Mocks\MockWPCLI::$last_table = $items;
+	}
+}
+
+if ( ! function_exists( 'WP_CLI\\Utils\\make_progress_bar' ) ) {
+	/**
+	 * Stand in for WP-CLI's progress bar so command code that draws one can run under PHPUnit.
+	 *
+	 * @param string $message Progress bar label.
+	 * @param int    $count   Total number of ticks.
+	 * @return object
+	 */
+	function make_progress_bar( $message, $count ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+		return new class() {
+			/**
+			 * Advance the bar. No-op.
+			 *
+			 * @param int $increment Number of items completed.
+			 */
+			public function tick( $increment = 1 ) {} // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+
+			/**
+			 * Finish the bar. No-op.
+			 */
+			public function finish() {}
+		};
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/wp-cli-utils.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/wp-cli-utils.php
@@ -49,3 +49,17 @@ if ( ! function_exists( 'WP_CLI\\Utils\\make_progress_bar' ) ) {
 		};
 	}
 }
+
+if ( ! function_exists( 'WP_CLI\\Utils\\get_flag_value' ) ) {
+	/**
+	 * Stand in for WP-CLI's flag reader.
+	 *
+	 * @param array  $assoc_args    Associative arguments.
+	 * @param string $flag          Flag name.
+	 * @param mixed  $default_value Value to return when the flag is absent.
+	 * @return mixed
+	 */
+	function get_flag_value( $assoc_args, $flag, $default_value = null ) {
+		return isset( $assoc_args[ $flag ] ) ? $assoc_args[ $flag ] : $default_value;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShimTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShimTests.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Com
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Migration\Compat\LegacyUnsubscribeShim;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\LegacyHash;
 use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
 use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
 use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
@@ -271,6 +272,119 @@ class LegacyUnsubscribeShimTests extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $this->request_raw( $legacy_id, $round_tripped, 'notification' ) );
 		$this->assertSame( NotificationStatus::CANCELLED, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * @testdox a real legacy token should never encode to a + or / that URL parsing could mangle.
+	 */
+	public function test_a_real_token_never_encodes_to_plus_or_slash(): void {
+		// The legacy token is a sha256 hex digest, so its base64 form is drawn from a
+		// 16-character input alphabet that cannot reach base64 indices 62 (+) and 63 (/).
+		// The plan asks for a + and / round trip; this asserts why no real link can carry
+		// one, so a future reader does not add URL-safe base64 handling for a case that
+		// cannot occur. The synthetic double-encoded token below covers the escaping path.
+		$legacy_ids = array();
+
+		for ( $i = 0; $i < 10; $i++ ) {
+			$legacy_ids[] = $this->seed_legacy_row( "shopper{$i}@example.com" );
+		}
+
+		foreach ( $legacy_ids as $legacy_id ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- reproducing the legacy link format.
+			$encoded = base64_encode( $this->legacy_token( $legacy_id ) );
+
+			$this->assertMatchesRegularExpression( '/^[A-Za-z0-9=]+$/', $encoded );
+		}
+
+		$this->migrate();
+
+		$first = $legacy_ids[0];
+		$this->assertTrue( $this->request( $first, $this->legacy_token( $first ), 'notification' ) );
+		$this->assertSame( NotificationStatus::CANCELLED, $this->statuses_by_legacy_id()[ $first ] );
+	}
+
+	/**
+	 * @testdox the second urldecode() after base64_decode() should not be deletable as redundant.
+	 */
+	public function test_second_urldecode_after_base64_decode_is_required(): void {
+		global $wpdb;
+
+		$legacy_id       = 555555;
+		$notification_id = LegacyStore::add_core_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+		$meta_table      = $wpdb->prefix . 'wc_stock_notificationmeta';
+
+		// A token containing characters urlencode() must percent-escape, reproducing legacy's
+		// own double-encoding of the `bis_unsub` parameter (plan: "Input handling").
+		$token = 'legacy token/value+needs escaping';
+
+		$wpdb->insert(
+			$meta_table,
+			array(
+				'notification_id' => $notification_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'        => '_wc_bis_legacy_id',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value'      => (string) $legacy_id,
+			)
+		);
+		$wpdb->insert(
+			$meta_table,
+			array(
+				'notification_id' => $notification_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'        => '_wc_bis_legacy_unsub_hash',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value'      => LegacyHash::to_meta_value( $legacy_id, $token ),
+			)
+		);
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode, WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- reproducing the legacy link's own double-encoding.
+		$token_raw = base64_encode( urlencode( $token ) );
+
+		// Prove the fixture actually needs the second urldecode(): base64_decode() alone -
+		// what the shim would produce if that line were deleted - does not recover the token.
+		$this->assertNotSame( $token, base64_decode( $token_raw ), 'Fixture must require urldecode() to recover the real token.' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- asserting against the shim's own decode step.
+
+		$this->assertTrue( $this->request_raw( $legacy_id, $token_raw, 'notification' ) );
+		$this->assertSame( NotificationStatus::CANCELLED, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * @testdox the feature toggle being off should get the generic notice, never a fatal out of Notification::__construct().
+	 */
+	public function test_feature_toggle_off_gets_the_generic_notice(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'no' );
+
+		$this->assertTrue( $this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' ) );
+
+		$this->assert_stale_link_notice();
+		$this->assertSame( NotificationStatus::ACTIVE, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * @testdox a `bis_unsub` link should still get the generic notice once the legacy links flag and hash meta are gone.
+	 */
+	public function test_generic_notice_survives_the_legacy_meta_being_removed(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		$wpdb->delete( $wpdb->prefix . 'wc_stock_notificationmeta', array( 'meta_key' => '_wc_bis_legacy_unsub_hash' ) );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+
+		$this->assertTrue( $this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' ) );
+
+		$this->assert_stale_link_notice();
+		$this->assertSame( NotificationStatus::ACTIVE, LegacyStore::get_core_rows()[0]['status'], 'Nothing should be cancelled once resolution is impossible.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShimTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Compat/LegacyUnsubscribeShimTests.php
@@ -1,0 +1,442 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Compat;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Compat\LegacyUnsubscribeShim;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the shim that keeps legacy `bis_unsub` email links working after migration.
+ *
+ * Links are built the way the legacy extension built them - the token is the sha256 of an
+ * AES-256-CBC encryption of `{id}-{product}-{create_date}`, base64-encoded into the query
+ * string - so these exercise the real URL shape rather than a hand-made one.
+ */
+class LegacyUnsubscribeShimTests extends WC_Unit_Test_Case {
+
+	/**
+	 * A 32-byte key, as the legacy extension stored per notification.
+	 *
+	 * @var string
+	 */
+	private const HASH_KEY = '0123456789abcdef0123456789abcdef';
+
+	/**
+	 * A 16-byte IV, as the legacy extension stored per notification.
+	 *
+	 * @var string
+	 */
+	private const HASH_IV = 'fedcba9876543210';
+
+	/**
+	 * Legacy `create_date` shared by the seeded rows.
+	 *
+	 * @var int
+	 */
+	private const CREATE_DATE = 1600000000;
+
+	/**
+	 * Shim under test.
+	 *
+	 * @var LegacyUnsubscribeShim
+	 */
+	private LegacyUnsubscribeShim $shim;
+
+	/**
+	 * A published simple product the seeded rows point at.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up the legacy tables, the feature toggle and the shim.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		$this->shim       = wc_get_container()->get( LegacyUnsubscribeShim::class );
+		$this->product_id = $this->create_product();
+
+		wc_clear_notices();
+	}
+
+	/**
+	 * Clear the request state, the legacy tables and the options.
+	 */
+	public function tearDown(): void {
+		unset( $_GET['bis_unsub'], $_GET['bis_unsub_id'], $_GET['bis_unsub_ref'] );
+
+		wc_clear_notices();
+		LegacyStore::drop_tables();
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+		delete_option( 'woocommerce_feature_customer_stock_notifications_enabled' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox a migrated row should be cancelled by its own legacy link.
+	 */
+	public function test_legacy_link_cancels_the_migrated_row(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		$this->assertTrue( $this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' ) );
+
+		$row = LegacyStore::get_core_rows()[0];
+		$this->assertSame( NotificationStatus::CANCELLED, $row['status'] );
+		$this->assertSame( NotificationCancellationSource::USER, $row['cancellation_source'] );
+	}
+
+	/**
+	 * @testdox the stored meta should hold a digest of the token, never the token itself.
+	 */
+	public function test_stored_meta_is_a_digest_not_the_raw_token(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		$token  = $this->legacy_token( $legacy_id );
+		$stored = LegacyStore::get_core_meta( '_wc_bis_legacy_unsub_hash' );
+		$value  = reset( $stored )[0];
+
+		$this->assertStringStartsWith( $legacy_id . ':', $value );
+		$this->assertStringNotContainsString( $token, $value, 'The raw token must never be stored.' );
+		$this->assertTrue( wp_verify_fast_hash( $token, substr( $value, strlen( $legacy_id . ':' ) ) ) );
+	}
+
+	/**
+	 * @testdox a pre-1.2.0 link should get the generic notice and change nothing.
+	 */
+	public function test_pre_1_2_0_link_gets_the_generic_notice(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		// Links from before 1.2.0 carried no `bis_unsub_id`.
+		$this->assertTrue( $this->request( 0, $this->legacy_token( $legacy_id ), 'notification' ) );
+
+		$this->assert_stale_link_notice();
+		$this->assertSame( NotificationStatus::ACTIVE, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * @testdox a confirmation link should cancel every row for the same product and email.
+	 */
+	public function test_confirmation_link_is_product_scoped(): void {
+		$first  = $this->seed_legacy_row( 'shopper@example.com' );
+		$second = $this->seed_legacy_row( 'shopper@example.com', $this->create_product() );
+		$this->migrate();
+
+		$this->assertTrue( $this->request( $first, $this->legacy_token( $first ), 'confirmation' ) );
+
+		$statuses = $this->statuses_by_legacy_id();
+
+		$this->assertSame( NotificationStatus::CANCELLED, $statuses[ $first ] );
+		$this->assertSame( NotificationStatus::ACTIVE, $statuses[ $second ], 'A different product is out of scope.' );
+	}
+
+	/**
+	 * @testdox a guest notification link should cancel every legacy row for that email.
+	 */
+	public function test_guest_notification_link_is_email_scoped(): void {
+		$first  = $this->seed_legacy_row( 'shopper@example.com' );
+		$second = $this->seed_legacy_row( 'shopper@example.com', $this->create_product() );
+		$other  = $this->seed_legacy_row( 'someone-else@example.com' );
+		$this->migrate();
+
+		$this->assertTrue( $this->request( $first, $this->legacy_token( $first ), 'notification' ) );
+
+		$statuses = $this->statuses_by_legacy_id();
+
+		$this->assertSame( NotificationStatus::CANCELLED, $statuses[ $first ] );
+		$this->assertSame( NotificationStatus::CANCELLED, $statuses[ $second ] );
+		$this->assertSame( NotificationStatus::ACTIVE, $statuses[ $other ], 'Another address is out of scope.' );
+	}
+
+	/**
+	 * @testdox a native Core notification should never be cancelled by a legacy link.
+	 */
+	public function test_native_core_notification_is_not_swept_in(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		$native = new Notification();
+		$native->set_product_id( $this->create_product() );
+		$native->set_user_email( 'shopper@example.com' );
+		$native->set_status( NotificationStatus::ACTIVE );
+		$native->save();
+
+		$this->assertTrue( $this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' ) );
+
+		$reloaded = new Notification( $native->get_id() );
+		$this->assertSame( NotificationStatus::ACTIVE, $reloaded->get_status(), 'A native signup carries its own link.' );
+	}
+
+	/**
+	 * @testdox editing the Core created date should not break the link.
+	 */
+	public function test_editing_the_core_created_date_does_not_break_the_link(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		$notification = new Notification( (int) LegacyStore::get_core_rows()[0]['id'] );
+		$notification->set_date_created( time() );
+		$notification->save();
+
+		$this->assertTrue( $this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' ) );
+
+		$this->assertSame( NotificationStatus::CANCELLED, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * @testdox both links of an adopted duplicate pair should work, and neither token should cross over.
+	 */
+	public function test_adopted_duplicates_keep_both_links_and_reject_a_crossed_token(): void {
+		$first  = $this->seed_legacy_row( 'shopper@example.com' );
+		$second = $this->seed_legacy_row( 'shopper@example.com' );
+
+		// One row per batch: the first has to be inserted before the second can adopt it.
+		$this->migrate( 1 );
+
+		$this->assertCount( 1, LegacyStore::get_core_rows(), 'The duplicate pair collapses onto one row.' );
+
+		// A token minted for one legacy id, presented with the other's id, must not verify.
+		$this->assertTrue( $this->request( $second, $this->legacy_token( $first ), 'notification' ) );
+		$this->assert_stale_link_notice();
+		$this->assertSame( NotificationStatus::ACTIVE, LegacyStore::get_core_rows()[0]['status'] );
+
+		wc_clear_notices();
+
+		$this->assertTrue( $this->request( $second, $this->legacy_token( $second ), 'notification' ) );
+		$this->assertSame( NotificationStatus::CANCELLED, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * @testdox an unknown id, a tampered token and an already-cancelled row should all read the same.
+	 */
+	public function test_every_stale_cause_produces_the_same_response(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		$this->assertTrue( $this->request( 999999, $this->legacy_token( $legacy_id ), 'notification' ) );
+		$unknown_id_notices = wc_get_notices();
+		wc_clear_notices();
+
+		$this->assertTrue( $this->request( $legacy_id, 'tampered-token', 'notification' ) );
+		$tampered_notices = wc_get_notices();
+		wc_clear_notices();
+
+		// An already-cancelled row resolves and verifies, but has nothing left to cancel.
+		$this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' );
+		wc_clear_notices();
+		$this->assertTrue( $this->request( $legacy_id, $this->legacy_token( $legacy_id ), 'notification' ) );
+		$already_cancelled_notices = wc_get_notices();
+
+		$this->assertSame( $unknown_id_notices, $tampered_notices, 'The cause must not be distinguishable.' );
+		$this->assertNotEmpty( $already_cancelled_notices, 'An already-cancelled row still gets a notice.' );
+	}
+
+	/**
+	 * @testdox a padded base64 token should survive the link's url encoding.
+	 */
+	public function test_padded_token_survives_the_links_url_encoding(): void {
+		$legacy_id = $this->seed_legacy_row( 'shopper@example.com' );
+		$this->migrate();
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- reproducing the legacy link format.
+		$encoded = base64_encode( $this->legacy_token( $legacy_id ) );
+
+		$this->assertStringEndsWith( '=', $encoded, 'This fixture needs a padded token.' );
+
+		// PHP has already decoded the query string by the time the shim reads $_GET, so what
+		// the shim receives is what the link's urlencode() round-tripped to.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- the legacy link used urlencode(), so the round trip has to as well.
+		$round_tripped = urldecode( urlencode( $encoded ) );
+
+		$this->assertTrue( $this->request_raw( $legacy_id, $round_tripped, 'notification' ) );
+		$this->assertSame( NotificationStatus::CANCELLED, LegacyStore::get_core_rows()[0]['status'] );
+	}
+
+	/**
+	 * Seed a legacy row carrying both hash secrets.
+	 *
+	 * @param string   $email      Subscriber email.
+	 * @param int|null $product_id Product the row points at, defaulting to the shared one.
+	 * @return int The legacy id.
+	 */
+	private function seed_legacy_row( string $email, ?int $product_id = null ): int {
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id'  => $product_id ?? $this->product_id,
+				'user_email'  => $email,
+				'create_date' => self::CREATE_DATE,
+			)
+		);
+
+		LegacyStore::add_meta( $legacy_id, '_hash_key', self::HASH_KEY );
+		LegacyStore::add_meta( $legacy_id, '_hash_iv', self::HASH_IV );
+
+		return $legacy_id;
+	}
+
+	/**
+	 * Reproduce the legacy extension's `WC_BIS_Notification_Data::get_hash()`.
+	 *
+	 * @param int $legacy_id Legacy notification id.
+	 * @return string
+	 */
+	private function legacy_token( int $legacy_id ): string {
+		global $wpdb;
+
+		// Table name is $wpdb->prefix-based, never user input.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$product_id = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT product_id FROM {$wpdb->prefix}woocommerce_bis_notifications WHERE id = %d", $legacy_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		$input     = "{$legacy_id}-{$product_id}-" . self::CREATE_DATE;
+		$encrypted = openssl_encrypt( $input, 'AES-256-CBC', self::HASH_KEY, 0, self::HASH_IV );
+
+		return hash( 'sha256', $encrypted );
+	}
+
+	/**
+	 * Migrate every outstanding legacy row.
+	 *
+	 * @param int $batch_size Rows per batch.
+	 * @return void
+	 */
+	private function migrate( int $batch_size = 100 ): void {
+		$migrator = new NotificationsMigrator( new Reporter() );
+		$cursor   = 0;
+
+		while ( true ) {
+			$batch = $migrator->get_batch( $cursor, $batch_size );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$migrator->migrate_batch( $batch, new DbWriter() );
+			$cursor = (int) end( $batch );
+		}
+	}
+
+	/**
+	 * Drive one legacy unsubscribe request, base64-encoding the token as the link does.
+	 *
+	 * @param int    $legacy_id Value for `bis_unsub_id`; 0 omits the parameter entirely.
+	 * @param string $token     Raw legacy token.
+	 * @param string $ref       Value for `bis_unsub_ref`.
+	 * @return bool True when the shim redirected, which every terminal outcome does.
+	 */
+	private function request( int $legacy_id, string $token, string $ref ): bool {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- reproducing the legacy link format.
+		return $this->request_raw( $legacy_id, base64_encode( $token ), $ref );
+	}
+
+	/**
+	 * Drive one legacy unsubscribe request with an already-encoded token value.
+	 *
+	 * @param int    $legacy_id     Value for `bis_unsub_id`; 0 omits the parameter entirely.
+	 * @param string $encoded_token Value as PHP would hand it over in `$_GET`.
+	 * @param string $ref           Value for `bis_unsub_ref`.
+	 * @return bool True when the shim redirected.
+	 */
+	private function request_raw( int $legacy_id, string $encoded_token, string $ref ): bool {
+		$_GET['bis_unsub']     = $encoded_token;
+		$_GET['bis_unsub_ref'] = $ref;
+
+		if ( $legacy_id > 0 ) {
+			$_GET['bis_unsub_id'] = (string) $legacy_id;
+		} else {
+			unset( $_GET['bis_unsub_id'] );
+		}
+
+		$redirected = false;
+
+		// The shim redirects and exits; throwing from the filter stops it before the exit.
+		$catcher = static function () {
+			throw new \RuntimeException( 'redirected' );
+		};
+
+		add_filter( 'wp_redirect', $catcher );
+
+		try {
+			$this->shim->maybe_process_legacy_unsubscribe();
+		} catch ( \RuntimeException $exception ) {
+			$redirected = 'redirected' === $exception->getMessage();
+		} finally {
+			remove_filter( 'wp_redirect', $catcher );
+		}
+
+		return $redirected;
+	}
+
+	/**
+	 * Map each migrated Core row's status by the legacy id it carries.
+	 *
+	 * @return array<int,string>
+	 */
+	private function statuses_by_legacy_id(): array {
+		$statuses = array();
+		$rows     = array();
+
+		foreach ( LegacyStore::get_core_rows() as $row ) {
+			$rows[ (int) $row['id'] ] = $row['status'];
+		}
+
+		foreach ( LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) as $notification_id => $legacy_ids ) {
+			foreach ( $legacy_ids as $legacy_id ) {
+				$statuses[ (int) $legacy_id ] = $rows[ $notification_id ];
+			}
+		}
+
+		return $statuses;
+	}
+
+	/**
+	 * Assert the uniform stale-link notice was added.
+	 *
+	 * @return void
+	 */
+	private function assert_stale_link_notice(): void {
+		$notices = wc_get_notices();
+		$texts   = wp_list_pluck( $notices['notice'] ?? array(), 'notice' );
+
+		$this->assertContains(
+			'This unsubscribe link is invalid or has expired.',
+			$texts,
+			'The stale-link message belongs under the notice type, not success.'
+		);
+	}
+
+	/**
+	 * Create a published simple product.
+	 *
+	 * @return int
+	 */
+	private function create_product(): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Migration test product' );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Helpers/LegacyStore.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Helpers/LegacyStore.php
@@ -76,6 +76,25 @@ class LegacyStore {
 	}
 
 	/**
+	 * Create the Core stock notification tables for the current site.
+	 *
+	 * WooCommerce installs these once, so a blog created mid-test never gets them. Cloning
+	 * the main site's definitions keeps this in step with the real schema without
+	 * duplicating it here.
+	 *
+	 * @return void
+	 */
+	public static function create_core_tables(): void {
+		global $wpdb;
+
+		foreach ( array( 'wc_stock_notifications', 'wc_stock_notificationmeta' ) as $table ) {
+			// Table names are $wpdb->prefix-based, never user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+			$wpdb->query( "CREATE TABLE IF NOT EXISTS {$wpdb->prefix}{$table} LIKE {$wpdb->base_prefix}{$table}" );
+		}
+	}
+
+	/**
 	 * Drop the three legacy tables.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Helpers/LegacyStore.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Helpers/LegacyStore.php
@@ -1,0 +1,293 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers;
+
+/**
+ * Creates and seeds the legacy Back In Stock Notifications tables for migration tests.
+ *
+ * The legacy extension is not installed in the test environment, so its three tables are
+ * created here with the same schema the extension's installer uses. Column defaults match
+ * the legacy schema so a seeded row that omits a column looks exactly like one the
+ * extension would have written.
+ */
+class LegacyStore {
+
+	/**
+	 * Create the three legacy tables, dropping any left over from a previous test.
+	 *
+	 * @return void
+	 */
+	public static function create_tables(): void {
+		global $wpdb;
+
+		self::drop_tables();
+
+		$collate = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+
+		// Table names are $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+		$wpdb->query(
+			"CREATE TABLE {$wpdb->prefix}woocommerce_bis_notifications (
+				`id` BIGINT UNSIGNED NOT NULL auto_increment,
+				`type` VARCHAR(128) default 'one-time' NOT NULL,
+				`product_id` BIGINT UNSIGNED NOT NULL,
+				`user_id` BIGINT UNSIGNED NOT NULL,
+				`user_email` VARCHAR(191) NOT NULL,
+				`create_date` INT UNSIGNED default 0 NOT NULL,
+				`subscribe_date` INT UNSIGNED default 0 NOT NULL,
+				`last_notified_date` INT UNSIGNED default 0 NOT NULL,
+				`is_queued` CHAR(3) default 'off' NOT NULL,
+				`is_active` CHAR(3) default 'off' NOT NULL,
+				`is_verified` CHAR(3) default 'yes' NOT NULL,
+				PRIMARY KEY  (`id`),
+				KEY `product_id` (`product_id`)
+			) {$collate}"
+		);
+
+		$wpdb->query(
+			"CREATE TABLE {$wpdb->prefix}woocommerce_bis_notificationsmeta (
+				meta_id BIGINT UNSIGNED NOT NULL auto_increment,
+				bis_notifications_id BIGINT UNSIGNED NOT NULL,
+				meta_key varchar(191) default NULL,
+				meta_value longtext NULL,
+				PRIMARY KEY  (meta_id),
+				KEY bis_notifications_id (bis_notifications_id),
+				KEY meta_key (meta_key(191))
+			) {$collate}"
+		);
+
+		$wpdb->query(
+			"CREATE TABLE {$wpdb->prefix}woocommerce_bis_activity (
+				`id` BIGINT UNSIGNED NOT NULL auto_increment,
+				`notification_id` BIGINT UNSIGNED NOT NULL,
+				`product_id` BIGINT UNSIGNED NOT NULL,
+				`type` VARCHAR(20) NOT NULL,
+				`user_id` BIGINT UNSIGNED NOT NULL,
+				`user_email` VARCHAR(255) NOT NULL,
+				`object_id` BIGINT UNSIGNED default 0 NOT NULL,
+				`date` INT UNSIGNED NOT NULL,
+				`note` text NULL,
+				PRIMARY KEY  (`id`),
+				KEY `notification_id` (`notification_id`)
+			) {$collate}"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+	}
+
+	/**
+	 * Drop the three legacy tables.
+	 *
+	 * @return void
+	 */
+	public static function drop_tables(): void {
+		global $wpdb;
+
+		foreach ( array( 'woocommerce_bis_notifications', 'woocommerce_bis_notificationsmeta', 'woocommerce_bis_activity' ) as $table ) {
+			// Table names are $wpdb->prefix-based, never user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}{$table}" );
+		}
+	}
+
+	/**
+	 * Empty the Core stock notification tables and the legacy ones, without dropping them.
+	 *
+	 * @return void
+	 */
+	public static function truncate_all(): void {
+		global $wpdb;
+
+		$tables = array(
+			'woocommerce_bis_notifications',
+			'woocommerce_bis_notificationsmeta',
+			'woocommerce_bis_activity',
+			'wc_stock_notifications',
+			'wc_stock_notificationmeta',
+		);
+
+		foreach ( $tables as $table ) {
+			// Table names are $wpdb->prefix-based, never user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}{$table}" );
+		}
+	}
+
+	/**
+	 * Insert one legacy notification row.
+	 *
+	 * @param array<string,mixed> $overrides Column values overriding the defaults.
+	 * @return int The inserted legacy id.
+	 */
+	public static function add_notification( array $overrides = array() ): int {
+		global $wpdb;
+
+		$row = array_merge(
+			array(
+				'type'               => 'one-time',
+				'product_id'         => 0,
+				'user_id'            => 0,
+				'user_email'         => 'shopper@example.com',
+				'create_date'        => 1600000000,
+				'subscribe_date'     => 1600000000,
+				'last_notified_date' => 0,
+				'is_queued'          => 'off',
+				'is_active'          => 'on',
+				'is_verified'        => 'yes',
+			),
+			$overrides
+		);
+
+		$wpdb->insert( $wpdb->prefix . 'woocommerce_bis_notifications', $row ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Insert one legacy notification meta row.
+	 *
+	 * @param int    $legacy_id  Legacy notification id.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value, serialized when not scalar.
+	 * @return void
+	 */
+	public static function add_meta( int $legacy_id, string $meta_key, $meta_value ): void {
+		global $wpdb;
+
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prefix . 'woocommerce_bis_notificationsmeta',
+			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Column names in the legacy meta table, not a query argument.
+				'meta_key'             => $meta_key,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- As above.
+				'meta_value'           => maybe_serialize( $meta_value ),
+				'bis_notifications_id' => $legacy_id,
+			)
+		);
+	}
+
+	/**
+	 * Insert one legacy activity row.
+	 *
+	 * @param int                 $legacy_id Legacy notification id.
+	 * @param string              $type      Activity type, e.g. `unsubscribed`.
+	 * @param int                 $date      Activity date, as a Unix timestamp.
+	 * @param array<string,mixed> $overrides Other column values.
+	 * @return void
+	 */
+	public static function add_activity( int $legacy_id, string $type, int $date, array $overrides = array() ): void {
+		global $wpdb;
+
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prefix . 'woocommerce_bis_activity',
+			array_merge(
+				array(
+					'notification_id' => $legacy_id,
+					'product_id'      => 0,
+					'type'            => $type,
+					'user_id'         => 0,
+					'user_email'      => 'shopper@example.com',
+					'object_id'       => 0,
+					'date'            => $date,
+					'note'            => '',
+				),
+				$overrides
+			)
+		);
+	}
+
+	/**
+	 * Insert a Core notification row directly, bypassing `Notification::save()`.
+	 *
+	 * Used for rows Core's own validation would refuse today - an address that fails
+	 * `is_email()`, for instance - which still exist on real stores.
+	 *
+	 * @param array<string,mixed> $overrides Column values overriding the defaults.
+	 * @return int The inserted notification id.
+	 */
+	public static function add_core_notification( array $overrides = array() ): int {
+		global $wpdb;
+
+		$row = array_merge(
+			array(
+				'product_id'        => 0,
+				'user_id'           => 0,
+				'user_email'        => 'shopper@example.com',
+				'status'            => 'active',
+				'date_created_gmt'  => gmdate( 'Y-m-d H:i:s', 1600000000 ),
+				'date_modified_gmt' => gmdate( 'Y-m-d H:i:s', 1600000000 ),
+			),
+			$overrides
+		);
+
+		$wpdb->insert( $wpdb->prefix . 'wc_stock_notifications', $row ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Read every Core notification row, ascending by id.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function get_core_rows(): array {
+		global $wpdb;
+
+		// Table name is $wpdb->prefix-based, never user input.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+		return (array) $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}wc_stock_notifications ORDER BY id ASC", ARRAY_A );
+	}
+
+	/**
+	 * Read the Core meta values stored under one key, keyed by notification id.
+	 *
+	 * @param string $meta_key Meta key.
+	 * @return array<int,array<int,string>> Values per notification id.
+	 */
+	public static function get_core_meta( string $meta_key ): array {
+		global $wpdb;
+
+		// Table name is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+		$rows = (array) $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT notification_id, meta_value FROM {$wpdb->prefix}wc_stock_notificationmeta WHERE meta_key = %s ORDER BY id ASC",
+				$meta_key
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+
+		$indexed = array();
+
+		foreach ( $rows as $row ) {
+			$indexed[ (int) $row['notification_id'] ][] = (string) $row['meta_value'];
+		}
+
+		return $indexed;
+	}
+
+	/**
+	 * Read the legacy meta values stored under one key for one legacy row.
+	 *
+	 * @param int    $legacy_id Legacy notification id.
+	 * @param string $meta_key  Meta key.
+	 * @return array<int,mixed> Values, unserialized.
+	 */
+	public static function get_legacy_meta( int $legacy_id, string $meta_key ): array {
+		global $wpdb;
+
+		// Table name is $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+		$values = (array) $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT meta_value FROM {$wpdb->prefix}woocommerce_bis_notificationsmeta WHERE bis_notifications_id = %d AND meta_key = %s",
+				$legacy_id,
+				$meta_key
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+
+		return array_map( 'maybe_unserialize', $values );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/CancellationSourceMinerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/CancellationSourceMinerTests.php
@@ -1,0 +1,254 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\CancellationSourceMiner;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for CancellationSourceMiner.
+ *
+ * Exercises the real `woocommerce_bis_activity` table via $wpdb, since the miner's whole
+ * job is a batched SQL lookup against it. The table is created in setUp() and dropped in
+ * tearDown() because it belongs to the legacy extension schema, not Core's.
+ */
+class CancellationSourceMinerTests extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CancellationSourceMiner
+	 */
+	private $sut;
+
+	/**
+	 * @before
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new CancellationSourceMiner();
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'woocommerce_bis_activity';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is built from $wpdb->prefix and cannot be a prepared placeholder.
+		$wpdb->query(
+			"CREATE TABLE IF NOT EXISTS {$table} (
+				id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				notification_id BIGINT UNSIGNED NOT NULL,
+				product_id BIGINT UNSIGNED NOT NULL,
+				type VARCHAR(20) NOT NULL,
+				user_id BIGINT UNSIGNED NOT NULL,
+				user_email VARCHAR(255) NOT NULL,
+				object_id BIGINT UNSIGNED DEFAULT 0 NOT NULL,
+				date INT UNSIGNED NOT NULL,
+				note text NULL,
+				PRIMARY KEY (id)
+			) {$wpdb->get_charset_collate()}"
+		); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- fixed DDL with no user input, test-only.
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * @after
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'woocommerce_bis_activity' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- fixed DDL, test-only.
+		parent::tearDown();
+	}
+
+	/**
+	 * Insert one activity row for the given notification.
+	 *
+	 * @param int    $notification_id Legacy notification id.
+	 * @param string $type            Activity type.
+	 * @param int    $user_id         Activity actor user id.
+	 * @param int    $date            Activity epoch date.
+	 */
+	private function insert_activity( int $notification_id, string $type, int $user_id, int $date ): void {
+		global $wpdb;
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_bis_activity',
+			array(
+				'notification_id' => $notification_id,
+				'product_id'      => 1,
+				'type'            => $type,
+				'user_id'         => $user_id,
+				'user_email'      => 'customer@example.com',
+				'object_id'       => 0,
+				'date'            => $date,
+				'note'            => '',
+			),
+			array( '%d', '%d', '%s', '%d', '%s', '%d', '%d', '%s' )
+		);
+	}
+
+	/**
+	 * @testdox unsubscribed activity should always resolve to USER, even when its actor differs from the notification's own user.
+	 */
+	public function test_unsubscribed_resolves_to_user(): void {
+		$this->insert_activity( 101, 'unsubscribed', 999, 1000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 101,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::USER, $result[101]['source'] );
+		$this->assertSame( 1000, $result[101]['date'] );
+	}
+
+	/**
+	 * @testdox deactivated activity with a differing non-zero user_id should resolve to ADMIN.
+	 */
+	public function test_deactivated_with_differing_user_resolves_to_admin(): void {
+		$this->insert_activity( 102, 'deactivated', 7, 2000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 102,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::ADMIN, $result[102]['source'] );
+	}
+
+	/**
+	 * @testdox deactivated activity with user_id 0 should resolve to SYSTEM.
+	 */
+	public function test_deactivated_with_zero_user_resolves_to_system(): void {
+		$this->insert_activity( 103, 'deactivated', 0, 3000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 103,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::SYSTEM, $result[103]['source'] );
+	}
+
+	/**
+	 * @testdox deactivated activity whose user_id matches the notification's own user should resolve to USER.
+	 */
+	public function test_deactivated_with_matching_user_resolves_to_user(): void {
+		$this->insert_activity( 104, 'deactivated', 5, 4000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 104,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::USER, $result[104]['source'] );
+	}
+
+	/**
+	 * @testdox no matching activity row should resolve to SYSTEM with a null date.
+	 */
+	public function test_no_activity_resolves_to_system(): void {
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 105,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::SYSTEM, $result[105]['source'] );
+		$this->assertNull( $result[105]['date'] );
+	}
+
+	/**
+	 * @testdox mine() should take the latest cancelling event when a notification has more than one.
+	 */
+	public function test_takes_latest_event_per_notification(): void {
+		$this->insert_activity( 106, 'deactivated', 0, 1000 );
+		$this->insert_activity( 106, 'unsubscribed', 5, 2000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 106,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::USER, $result[106]['source'] );
+		$this->assertSame( 2000, $result[106]['date'] );
+	}
+
+	/**
+	 * @testdox mine() should ignore non-cancelling activity types such as subscribed.
+	 */
+	public function test_ignores_non_cancelling_activity_types(): void {
+		$this->insert_activity( 107, 'subscribed', 5, 1000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 107,
+					'user_id' => 5,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::SYSTEM, $result[107]['source'] );
+		$this->assertNull( $result[107]['date'] );
+	}
+
+	/**
+	 * @testdox mine() should resolve a batch of several notifications in one call.
+	 */
+	public function test_resolves_a_batch_of_notifications(): void {
+		$this->insert_activity( 108, 'unsubscribed', 5, 1000 );
+		$this->insert_activity( 109, 'deactivated', 0, 2000 );
+
+		$result = $this->sut->mine(
+			array(
+				array(
+					'id'      => 108,
+					'user_id' => 5,
+				),
+				array(
+					'id'      => 109,
+					'user_id' => 6,
+				),
+				array(
+					'id'      => 110,
+					'user_id' => 7,
+				),
+			)
+		);
+
+		$this->assertSame( NotificationCancellationSource::USER, $result[108]['source'] );
+		$this->assertSame( NotificationCancellationSource::SYSTEM, $result[109]['source'] );
+		$this->assertSame( NotificationCancellationSource::SYSTEM, $result[110]['source'] );
+		$this->assertNull( $result[110]['date'] );
+	}
+
+	/**
+	 * @testdox mine() should return an empty array for an empty batch.
+	 */
+	public function test_returns_empty_array_for_empty_batch(): void {
+		$this->assertSame( array(), $this->sut->mine( array() ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/DateMapperTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/DateMapperTests.php
@@ -1,0 +1,315 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\DateMapper;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for DateMapper.
+ */
+class DateMapperTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Migration run timestamp shared by every test: 2024-01-01 00:00:00 UTC.
+	 *
+	 * @var int
+	 */
+	private const MIGRATION_TIMESTAMP = 1704067200;
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var DateMapper
+	 */
+	private $sut;
+
+	/**
+	 * @before
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new DateMapper( self::MIGRATION_TIMESTAMP );
+	}
+
+	/**
+	 * @testdox date_created_gmt should use create_date when it is plausible.
+	 */
+	public function test_date_created_gmt_uses_plausible_create_date(): void {
+		$create_date = self::MIGRATION_TIMESTAMP - DAY_IN_SECONDS;
+
+		$result = $this->sut->date_created_gmt( array( 'create_date' => $create_date ) );
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $create_date ), $result );
+	}
+
+	/**
+	 * @testdox date_created_gmt should fall back to subscribe_date when create_date is corrupt.
+	 * @dataProvider provider_corrupt_create_dates
+	 *
+	 * @param int $corrupt_create_date Test case value.
+	 */
+	public function test_date_created_gmt_falls_back_to_subscribe_date_when_corrupt( int $corrupt_create_date ): void {
+		$subscribe_date = self::MIGRATION_TIMESTAMP - 1000;
+
+		$result = $this->sut->date_created_gmt(
+			array(
+				'create_date'    => $corrupt_create_date,
+				'subscribe_date' => $subscribe_date,
+			)
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $subscribe_date ), $result );
+	}
+
+	/**
+	 * @testdox date_created_gmt should fall back to the migration timestamp when both create_date and subscribe_date are unusable.
+	 * @dataProvider provider_corrupt_create_dates
+	 *
+	 * @param int $corrupt_create_date Test case value.
+	 */
+	public function test_date_created_gmt_falls_back_to_migration_timestamp( int $corrupt_create_date ): void {
+		$result = $this->sut->date_created_gmt(
+			array(
+				'create_date'    => $corrupt_create_date,
+				'subscribe_date' => 0,
+			)
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', self::MIGRATION_TIMESTAMP ), $result );
+	}
+
+	/**
+	 * Corrupt/rejected create_date values: 0, before the 2015 floor, and past now+1day.
+	 *
+	 * @return array
+	 */
+	public function provider_corrupt_create_dates(): array {
+		return array(
+			'zero'                     => array( 0 ),
+			'before 2015 floor'        => array( 1420070400 - 1 ),
+			'past now + 1 day ceiling' => array( self::MIGRATION_TIMESTAMP + DAY_IN_SECONDS + 1 ),
+		);
+	}
+
+	/**
+	 * @testdox date_created_gmt should accept create_date exactly on the plausibility boundaries.
+	 * @dataProvider provider_boundary_create_dates
+	 *
+	 * @param int $boundary_create_date Test case value.
+	 */
+	public function test_date_created_gmt_accepts_boundary_values( int $boundary_create_date ): void {
+		$result = $this->sut->date_created_gmt( array( 'create_date' => $boundary_create_date ) );
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $boundary_create_date ), $result );
+	}
+
+	/**
+	 * Boundary values that must still be accepted: exactly the 2015 floor, and exactly now+1day.
+	 *
+	 * @return array
+	 */
+	public function provider_boundary_create_dates(): array {
+		return array(
+			'exactly the 2015 floor' => array( 1420070400 ),
+			'exactly now + 1 day'    => array( self::MIGRATION_TIMESTAMP + DAY_IN_SECONDS ),
+		);
+	}
+
+	/**
+	 * @testdox date_modified_gmt should always be the migration timestamp.
+	 */
+	public function test_date_modified_gmt(): void {
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', self::MIGRATION_TIMESTAMP ), $this->sut->date_modified_gmt() );
+	}
+
+	/**
+	 * @testdox date_confirmed_gmt should use subscribe_date when it is set.
+	 */
+	public function test_date_confirmed_gmt_uses_subscribe_date(): void {
+		$subscribe_date = self::MIGRATION_TIMESTAMP - 500;
+
+		$result = $this->sut->date_confirmed_gmt(
+			array(
+				'subscribe_date' => $subscribe_date,
+				'create_date'    => self::MIGRATION_TIMESTAMP - 9000,
+			)
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $subscribe_date ), $result );
+	}
+
+	/**
+	 * @testdox date_confirmed_gmt should fall back to create_date when subscribe_date is 0.
+	 */
+	public function test_date_confirmed_gmt_falls_back_to_create_date(): void {
+		$create_date = self::MIGRATION_TIMESTAMP - 9000;
+
+		$result = $this->sut->date_confirmed_gmt(
+			array(
+				'subscribe_date' => 0,
+				'create_date'    => $create_date,
+			)
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $create_date ), $result );
+	}
+
+	/**
+	 * @testdox date_confirmed_gmt should fall back to the epoch when both dates are 0.
+	 */
+	public function test_date_confirmed_gmt_falls_back_to_epoch_when_both_zero(): void {
+		$result = $this->sut->date_confirmed_gmt(
+			array(
+				'subscribe_date' => 0,
+				'create_date'    => 0,
+			)
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', 0 ), $result );
+	}
+
+	/**
+	 * @testdox date_last_attempt_gmt should be null when last_notified_date is 0.
+	 */
+	public function test_date_last_attempt_gmt_is_null_when_zero(): void {
+		$this->assertNull( $this->sut->date_last_attempt_gmt( array( 'last_notified_date' => 0 ) ) );
+	}
+
+	/**
+	 * @testdox date_last_attempt_gmt should format last_notified_date when set.
+	 */
+	public function test_date_last_attempt_gmt_formats_when_set(): void {
+		$last_notified_date = self::MIGRATION_TIMESTAMP - 200;
+
+		$result = $this->sut->date_last_attempt_gmt( array( 'last_notified_date' => $last_notified_date ) );
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $last_notified_date ), $result );
+	}
+
+	/**
+	 * @testdox date_notified_gmt should be null for every status except sent.
+	 * @dataProvider provider_non_sent_statuses
+	 *
+	 * @param string $status Test case value.
+	 */
+	public function test_date_notified_gmt_is_null_for_non_sent_statuses( string $status ): void {
+		$result = $this->sut->date_notified_gmt( array( 'last_notified_date' => self::MIGRATION_TIMESTAMP - 100 ), $status );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Every NotificationStatus value except sent.
+	 *
+	 * @return array
+	 */
+	public function provider_non_sent_statuses(): array {
+		return array(
+			'pending'   => array( NotificationStatus::PENDING ),
+			'active'    => array( NotificationStatus::ACTIVE ),
+			'cancelled' => array( NotificationStatus::CANCELLED ),
+		);
+	}
+
+	/**
+	 * @testdox date_notified_gmt should be null for status sent when last_notified_date is 0.
+	 */
+	public function test_date_notified_gmt_is_null_when_sent_but_never_notified(): void {
+		$result = $this->sut->date_notified_gmt( array( 'last_notified_date' => 0 ), NotificationStatus::SENT );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox date_notified_gmt should format last_notified_date for status sent.
+	 */
+	public function test_date_notified_gmt_formats_when_sent(): void {
+		$last_notified_date = self::MIGRATION_TIMESTAMP - 100;
+
+		$result = $this->sut->date_notified_gmt( array( 'last_notified_date' => $last_notified_date ), NotificationStatus::SENT );
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $last_notified_date ), $result );
+	}
+
+	/**
+	 * @testdox date_cancelled_gmt should be null for every status except cancelled.
+	 * @dataProvider provider_non_cancelled_statuses
+	 *
+	 * @param string $status Test case value.
+	 */
+	public function test_date_cancelled_gmt_is_null_for_non_cancelled_statuses( string $status ): void {
+		$result = $this->sut->date_cancelled_gmt( array(), $status, self::MIGRATION_TIMESTAMP - 10 );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Every NotificationStatus value except cancelled.
+	 *
+	 * @return array
+	 */
+	public function provider_non_cancelled_statuses(): array {
+		return array(
+			'pending' => array( NotificationStatus::PENDING ),
+			'active'  => array( NotificationStatus::ACTIVE ),
+			'sent'    => array( NotificationStatus::SENT ),
+		);
+	}
+
+	/**
+	 * @testdox date_cancelled_gmt should prefer the mined activity date when present.
+	 */
+	public function test_date_cancelled_gmt_prefers_activity_date(): void {
+		$activity_date = self::MIGRATION_TIMESTAMP - 10;
+
+		$result = $this->sut->date_cancelled_gmt(
+			array(
+				'last_notified_date' => self::MIGRATION_TIMESTAMP - 500,
+				'create_date'        => self::MIGRATION_TIMESTAMP - 9000,
+			),
+			NotificationStatus::CANCELLED,
+			$activity_date
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $activity_date ), $result );
+	}
+
+	/**
+	 * @testdox date_cancelled_gmt should fall back to last_notified_date when there is no activity date.
+	 */
+	public function test_date_cancelled_gmt_falls_back_to_last_notified_date(): void {
+		$last_notified_date = self::MIGRATION_TIMESTAMP - 500;
+
+		$result = $this->sut->date_cancelled_gmt(
+			array(
+				'last_notified_date' => $last_notified_date,
+				'create_date'        => self::MIGRATION_TIMESTAMP - 9000,
+			),
+			NotificationStatus::CANCELLED,
+			null
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $last_notified_date ), $result );
+	}
+
+	/**
+	 * @testdox date_cancelled_gmt should fall back to create_date when there is no activity date or last_notified_date.
+	 */
+	public function test_date_cancelled_gmt_falls_back_to_create_date(): void {
+		$create_date = self::MIGRATION_TIMESTAMP - 9000;
+
+		$result = $this->sut->date_cancelled_gmt(
+			array(
+				'last_notified_date' => 0,
+				'create_date'        => $create_date,
+			),
+			NotificationStatus::CANCELLED,
+			null
+		);
+
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $create_date ), $result );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/LegacyHashTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/LegacyHashTests.php
@@ -1,0 +1,139 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\LegacyHash;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for LegacyHash.
+ *
+ * `compute()` must reproduce `WC_BIS_Notification_Data::get_hash()` from the legacy Back
+ * In Stock Notifications extension byte for byte, since it is what lets an already-sent
+ * unsubscribe link keep working after migration.
+ */
+class LegacyHashTests extends WC_Unit_Test_Case {
+
+	/**
+	 * @before
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! function_exists( 'wp_fast_hash' ) || ! function_exists( 'wp_verify_fast_hash' ) ) {
+			$this->markTestSkipped( 'wp_fast_hash()/wp_verify_fast_hash() require WordPress 6.8 or newer.' );
+		}
+	}
+
+	/**
+	 * @testdox compute() should reproduce the legacy get_hash() token for a fixture row.
+	 */
+	public function test_compute_matches_legacy_get_hash_fixture(): void {
+		// @todo Replace this fixture with a token captured from a real delivered legacy
+		// email before merge. In the absence of a real legacy install to capture one from,
+		// this reimplements `WC_BIS_Notification_Data::get_hash()`'s exact inputs
+		// (`{id}-{product_id}-{create_date}`, AES-256-CBC via openssl_encrypt(), then a
+		// sha256 digest) independently here, so the test does not simply call
+		// LegacyHash::compute() and compare it to itself.
+		$legacy_id          = 42;
+		$product_id         = 917;
+		$legacy_create_date = 1700000000;
+		$hash_key           = 'this-is-a-32-byte-legacy-hash-k';
+		$hash_iv            = 'legacy-iv-16-byt';
+
+		$expected_input     = "{$legacy_id}-{$product_id}-{$legacy_create_date}";
+		$expected_encrypted = openssl_encrypt( $expected_input, 'AES-256-CBC', $hash_key, 0, $hash_iv );
+		$expected_token     = hash( 'sha256', $expected_encrypted );
+
+		$result = LegacyHash::compute( $legacy_id, $product_id, $legacy_create_date, $hash_key, $hash_iv );
+
+		$this->assertSame( $expected_token, $result );
+	}
+
+	/**
+	 * @testdox compute() should return null when the hash key secret is missing.
+	 */
+	public function test_compute_returns_null_when_key_missing(): void {
+		$result = LegacyHash::compute( 42, 917, 1700000000, '', 'legacy-iv-16-byt' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox compute() should return null when the hash iv secret is missing.
+	 */
+	public function test_compute_returns_null_when_iv_missing(): void {
+		$result = LegacyHash::compute( 42, 917, 1700000000, 'this-is-a-32-byte-legacy-hash-k', '' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox compute() should return null when both secrets are missing.
+	 */
+	public function test_compute_returns_null_when_both_secrets_missing(): void {
+		$this->assertNull( LegacyHash::compute( 42, 917, 1700000000, '', '' ) );
+	}
+
+	/**
+	 * @testdox to_meta_value() should store the hashed form of the token, never the raw token.
+	 */
+	public function test_to_meta_value_stores_hashed_form_not_raw_token(): void {
+		$token      = hash( 'sha256', 'some-encrypted-legacy-payload' );
+		$meta_value = LegacyHash::to_meta_value( 17, $token );
+
+		$this->assertStringStartsWith( '17:', $meta_value );
+		$this->assertNotSame( $token, substr( $meta_value, 3 ), 'The raw token must never be the stored value.' );
+		$this->assertStringNotContainsString( $token, $meta_value, 'The stored meta value must not contain the raw token.' );
+	}
+
+	/**
+	 * @testdox to_meta_value()/parse()/verify() should round-trip a token end to end.
+	 */
+	public function test_round_trips_through_parse_and_verify(): void {
+		$legacy_id  = 99;
+		$token      = hash( 'sha256', 'another-encrypted-legacy-payload' );
+		$meta_value = LegacyHash::to_meta_value( $legacy_id, $token );
+
+		$parsed = LegacyHash::parse( $meta_value );
+
+		$this->assertNotNull( $parsed );
+		$this->assertSame( $legacy_id, $parsed[0] );
+
+		$this->assertTrue( LegacyHash::verify( $meta_value, $token ) );
+		$this->assertFalse( LegacyHash::verify( $meta_value, hash( 'sha256', 'a-different-token' ) ) );
+	}
+
+	/**
+	 * @testdox parse() should reject malformed stored values.
+	 * @dataProvider provider_malformed_meta_values
+	 *
+	 * @param string $meta_value Test case value.
+	 */
+	public function test_parse_rejects_malformed_values( string $meta_value ): void {
+		$this->assertNull( LegacyHash::parse( $meta_value ) );
+	}
+
+	/**
+	 * Malformed `_wc_bis_legacy_unsub_hash` values that parse() must reject.
+	 *
+	 * @return array
+	 */
+	public function provider_malformed_meta_values(): array {
+		return array(
+			'no colon'         => array( 'abcdef123456' ),
+			'empty id'         => array( ':abcdef123456' ),
+			'empty digest'     => array( '17:' ),
+			'non numeric id'   => array( 'seventeen:abcdef123456' ),
+			'completely empty' => array( '' ),
+		);
+	}
+
+	/**
+	 * @testdox verify() should return false for a malformed stored value.
+	 */
+	public function test_verify_returns_false_for_malformed_meta_value(): void {
+		$this->assertFalse( LegacyHash::verify( 'not-a-valid-value', 'some-token' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/StatusMapperTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Mapping/StatusMapperTests.php
@@ -1,0 +1,178 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Mapping;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Mapping\StatusMapper;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for StatusMapper.
+ */
+class StatusMapperTests extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Should map a legacy row to the expected Core status across the full flag truth table.
+	 * @dataProvider provider_legacy_rows
+	 *
+	 * @param array  $legacy_row Test case value.
+	 * @param array  $legacy_meta Test case value.
+	 * @param string $expected Test case value.
+	 */
+	public function test_map( array $legacy_row, array $legacy_meta, string $expected ): void {
+		$this->assertSame( $expected, StatusMapper::map( $legacy_row, $legacy_meta ) );
+	}
+
+	/**
+	 * Truth table for StatusMapper::map(). Rules are evaluated top-down, first match wins:
+	 * 1. is_verified='no' OR meta awaiting_verification='yes' -> pending.
+	 * 2. last_notified_date > 0 AND last_notified_date >= subscribe_date -> sent.
+	 * 3. is_active='on' -> active.
+	 * 4. else -> cancelled.
+	 *
+	 * @return array
+	 */
+	public function provider_legacy_rows(): array {
+		return array(
+			// Rule 1: unverified column, regardless of the other flags.
+			'rule 1 - is_verified no wins over sent-looking dates'    => array(
+				array(
+					'is_verified'        => 'no',
+					'last_notified_date' => 100,
+					'subscribe_date'     => 50,
+					'is_active'          => 'on',
+				),
+				array(),
+				NotificationStatus::PENDING,
+			),
+			'rule 1 - is_verified no wins over active-looking flags'  => array(
+				array(
+					'is_verified'        => 'no',
+					'last_notified_date' => 0,
+					'subscribe_date'     => 0,
+					'is_active'          => 'on',
+				),
+				array(),
+				NotificationStatus::PENDING,
+			),
+			// Rule 1: awaiting_verification meta, independent of is_verified.
+			'rule 1 - awaiting_verification meta wins over active'    => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 0,
+					'subscribe_date'     => 0,
+					'is_active'          => 'on',
+				),
+				array( 'awaiting_verification' => 'yes' ),
+				NotificationStatus::PENDING,
+			),
+			'rule 1 - awaiting_verification meta wins over sent'      => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 200,
+					'subscribe_date'     => 100,
+					'is_active'          => 'off',
+				),
+				array( 'awaiting_verification' => 'yes' ),
+				NotificationStatus::PENDING,
+			),
+			// Rule 2: delivered-and-not-re-armed, both halves of "is_active".
+			'rule 2 - delivered, not re-armed, is_active on maps to sent (not active)' => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 100,
+					'subscribe_date'     => 100,
+					'is_active'          => 'on',
+				),
+				array(),
+				NotificationStatus::SENT,
+			),
+			'rule 2 - delivered, not re-armed, is_active off maps to sent'            => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 100,
+					'subscribe_date'     => 50,
+					'is_active'          => 'off',
+				),
+				array(),
+				NotificationStatus::SENT,
+			),
+			// Rule 2: the admin "send now" case. subscribe_date is 0 (never re-armed) and
+			// last_notified_date is set; a strict `>` plus `subscribe_date != 0` legacy-style
+			// test would wrongly drop this into cancelled since 0 fails "!= 0".
+			'rule 2 - admin send-now with unset subscribe_date maps to sent, not cancelled' => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 500,
+					'subscribe_date'     => 0,
+					'is_active'          => 'off',
+				),
+				array(),
+				NotificationStatus::SENT,
+			),
+			// Rule 2: equality boundary (last_notified_date == subscribe_date) still counts as sent.
+			'rule 2 - last_notified_date equal to subscribe_date maps to sent'        => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 300,
+					'subscribe_date'     => 300,
+					'is_active'          => 'off',
+				),
+				array(),
+				NotificationStatus::SENT,
+			),
+			// Rule 3: re-armed (subscribe_date advanced past last_notified_date) and active.
+			'rule 3 - re-armed and is_active on maps to active'                       => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 100,
+					'subscribe_date'     => 200,
+					'is_active'          => 'on',
+				),
+				array(),
+				NotificationStatus::ACTIVE,
+			),
+			'rule 3 - never notified and is_active on maps to active'                 => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 0,
+					'subscribe_date'     => 0,
+					'is_active'          => 'on',
+				),
+				array(),
+				NotificationStatus::ACTIVE,
+			),
+			// Rule 4: re-armed but not active, and never notified and not active.
+			'rule 4 - re-armed and is_active off maps to cancelled'                   => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 100,
+					'subscribe_date'     => 200,
+					'is_active'          => 'off',
+				),
+				array(),
+				NotificationStatus::CANCELLED,
+			),
+			'rule 4 - never notified and is_active off maps to cancelled'             => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 0,
+					'subscribe_date'     => 0,
+					'is_active'          => 'off',
+				),
+				array(),
+				NotificationStatus::CANCELLED,
+			),
+			'rule 4 - missing is_active column maps to cancelled'                     => array(
+				array(
+					'is_verified'        => 'yes',
+					'last_notified_date' => 0,
+					'subscribe_date'     => 0,
+				),
+				array(),
+				NotificationStatus::CANCELLED,
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/MigrationControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/MigrationControllerTests.php
@@ -29,6 +29,10 @@ class MigrationControllerTests extends WC_Unit_Test_Case {
 
 		$this->clear_options();
 
+		// The shim hooks itself in its constructor, so a cached resolution from an earlier
+		// test would make registration look like a no-op here.
+		$this->reset_container_resolutions();
+
 		$this->controller = new MigrationController();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/MigrationControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/MigrationControllerTests.php
@@ -1,0 +1,187 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Compat\LegacyUnsubscribeShim;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationController;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the registration gates: what a store that never had the legacy extension pays
+ * for the migration existing, and what the shim's own flag controls.
+ */
+class MigrationControllerTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var MigrationController
+	 */
+	private MigrationController $controller;
+
+	/**
+	 * Set up a clean option state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->clear_options();
+
+		$this->controller = new MigrationController();
+	}
+
+	/**
+	 * Clear the options and the hooks registration may have added.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_debug_tools' );
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'template_redirect' );
+
+		$this->clear_options();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox a store that never installed the legacy extension should register nothing.
+	 */
+	public function test_clean_store_registers_nothing(): void {
+		$this->controller->register();
+
+		$this->assertFalse( has_filter( 'woocommerce_debug_tools', array( $this->controller, 'handle_woocommerce_debug_tools' ) ) );
+		$this->assertFalse( has_action( 'admin_notices', array( $this->controller, 'maybe_render_double_send_notice' ) ) );
+		$this->assertFalse( $this->shim_is_hooked(), 'The shim must not register on a clean store.' );
+	}
+
+	/**
+	 * @testdox registration should issue no queries on a clean store.
+	 */
+	public function test_clean_store_registration_issues_no_queries(): void {
+		$queries = array();
+
+		$recorder = function ( $query ) use ( &$queries ) {
+			$queries[] = $query;
+
+			return $query;
+		};
+
+		add_filter( 'query', $recorder );
+		$this->controller->register();
+		remove_filter( 'query', $recorder );
+
+		$table_probes = array_filter(
+			$queries,
+			static function ( $query ) {
+				return false !== stripos( $query, 'SHOW TABLES LIKE' ) || false !== stripos( $query, 'woocommerce_bis_' );
+			}
+		);
+
+		$this->assertSame( array(), array_values( $table_probes ), 'Registration must not probe for the legacy tables.' );
+	}
+
+	/**
+	 * @testdox a store that once had the legacy extension should get the Tools entry.
+	 */
+	public function test_store_with_legacy_history_registers_the_tools_entry(): void {
+		update_option( 'wc_bis_db_version', '1.2.0' );
+
+		$this->controller->register();
+
+		$this->assertNotFalse( has_filter( 'woocommerce_debug_tools', array( $this->controller, 'handle_woocommerce_debug_tools' ) ) );
+		$this->assertFalse( $this->shim_is_hooked(), 'The shim needs its own flag, not just legacy history.' );
+	}
+
+	/**
+	 * @testdox the shim should register only while the legacy-links flag is set.
+	 */
+	public function test_shim_registers_only_with_the_legacy_links_flag(): void {
+		update_option( 'wc_bis_db_version', '1.2.0' );
+		update_option( 'wc_bis_migration_has_legacy_links', 'yes' );
+
+		$this->controller->register();
+
+		$this->assertTrue( $this->shim_is_hooked() );
+	}
+
+	/**
+	 * @testdox the Tools entry should be absent for a user without manage_woocommerce.
+	 */
+	public function test_tools_entry_is_absent_without_the_capability(): void {
+		update_option( 'wc_bis_db_version', '1.2.0' );
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'customer' ) ) );
+
+		$this->assertSame( array(), $this->controller->handle_woocommerce_debug_tools( array() ) );
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertNotEmpty( $this->controller->handle_woocommerce_debug_tools( array() ) );
+	}
+
+	/**
+	 * @testdox the double-send notice should only render for a capable user with migrated rows.
+	 */
+	public function test_double_send_notice_needs_the_capability_and_migrated_rows(): void {
+		update_option( 'wc_bis_db_version', '1.2.0' );
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'customer' ) ) );
+		$this->assertSame( '', $this->render_double_send_notice() );
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertSame( '', $this->render_double_send_notice(), 'Nothing migrated yet, so nothing to warn about.' );
+	}
+
+	/**
+	 * Whether the legacy unsubscribe shim has hooked itself into the request lifecycle.
+	 *
+	 * Checked by walking the hook's callbacks rather than by resolving the shim from the
+	 * container, since resolving it is what registers it.
+	 *
+	 * @return bool
+	 */
+	private function shim_is_hooked(): bool {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter['template_redirect'] ) ) {
+			return false;
+		}
+
+		foreach ( $wp_filter['template_redirect']->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof LegacyUnsubscribeShim ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Capture whatever the double-send notice renders.
+	 *
+	 * @return string
+	 */
+	private function render_double_send_notice(): string {
+		ob_start();
+		$this->controller->maybe_render_double_send_notice();
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Delete every option registration reads, and drop any legacy tables left behind.
+	 *
+	 * @return void
+	 */
+	private function clear_options(): void {
+		LegacyStore::drop_tables();
+
+		delete_option( 'wc_bis_db_version' );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigratorMigrationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigratorMigrationTests.php
@@ -1,0 +1,176 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\EmailSettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the email settings section, which merges per sub-key rather than writing whole
+ * settings arrays, and for the legacy-to-Core email pairing read back from what landed.
+ */
+class EmailSettingsMigratorMigrationTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Legacy option to Core option, as the migrator maps them.
+	 *
+	 * @var array<string,string>
+	 */
+	private const OPTION_MAP = array(
+		'woocommerce_bis_notification_received_settings' => 'woocommerce_customer_stock_notification_settings',
+		'woocommerce_bis_notification_verify_settings'   => 'woocommerce_customer_stock_notification_verify_settings',
+		'woocommerce_bis_notification_confirm_settings'  => 'woocommerce_customer_stock_notification_verified_settings',
+	);
+
+	/**
+	 * Run state.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Set up a clean state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->clear_options();
+		$this->state = new MigrationState();
+	}
+
+	/**
+	 * Clear the options this section reads and writes.
+	 */
+	public function tearDown(): void {
+		$this->clear_options();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox migrating one sub-key should leave a hand-edited sibling alone.
+	 */
+	public function test_sub_key_write_does_not_clobber_a_sibling(): void {
+		update_option(
+			'woocommerce_bis_notification_received_settings',
+			array(
+				'subject' => 'Legacy subject',
+				'heading' => 'Legacy heading',
+			)
+		);
+
+		$this->migrate();
+
+		$core            = (array) get_option( 'woocommerce_customer_stock_notification_settings' );
+		$core['heading'] = 'Merchant heading';
+		update_option( 'woocommerce_customer_stock_notification_settings', $core );
+
+		$legacy            = (array) get_option( 'woocommerce_bis_notification_received_settings' );
+		$legacy['subject'] = 'New legacy subject';
+		update_option( 'woocommerce_bis_notification_received_settings', $legacy );
+
+		$this->migrate();
+
+		$core = (array) get_option( 'woocommerce_customer_stock_notification_settings' );
+
+		$this->assertSame( 'New legacy subject', $core['subject'], 'A changed source must still move.' );
+		$this->assertSame( 'Merchant heading', $core['heading'], 'A hand-edited sibling must survive.' );
+	}
+
+	/**
+	 * @testdox the copy of each legacy email should land in its paired Core email.
+	 */
+	public function test_each_legacy_email_lands_in_its_paired_core_option(): void {
+		foreach ( array_keys( self::OPTION_MAP ) as $legacy_key ) {
+			update_option( $legacy_key, array( 'subject' => "Subject from {$legacy_key}" ) );
+		}
+
+		$this->migrate();
+
+		foreach ( self::OPTION_MAP as $legacy_key => $core_key ) {
+			$core = (array) get_option( $core_key );
+
+			$this->assertSame( "Subject from {$legacy_key}", $core['subject'] ?? '', "Copy landed in the wrong Core email for {$legacy_key}." );
+		}
+	}
+
+	/**
+	 * @testdox a merchant-edited sub-key should be reported once and then stop being outstanding.
+	 */
+	public function test_merchant_edited_sub_key_is_reported_once(): void {
+		update_option( 'woocommerce_bis_notification_verify_settings', array( 'subject' => 'Legacy subject' ) );
+		$this->migrate();
+
+		$core            = (array) get_option( 'woocommerce_customer_stock_notification_verify_settings' );
+		$core['subject'] = 'Merchant subject';
+		update_option( 'woocommerce_customer_stock_notification_verify_settings', $core );
+
+		$counts = $this->migrate();
+
+		$this->assertGreaterThanOrEqual( 1, $counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 );
+		$this->assertSame(
+			'Merchant subject',
+			( (array) get_option( 'woocommerce_customer_stock_notification_verify_settings' ) )['subject']
+		);
+
+		$this->assertSame( array(), $this->build_migrator()->get_batch( 0, 50 ), 'The skip is recorded, so nothing stays outstanding.' );
+	}
+
+	/**
+	 * Run the email section to completion.
+	 *
+	 * @param bool $force Whether to overwrite merchant-edited values.
+	 * @return array<string,int> Accumulated outcome counts.
+	 */
+	private function migrate( bool $force = false ): array {
+		$migrator = $this->build_migrator( $force );
+		$counts   = array();
+		$batches  = 0;
+
+		while ( true ) {
+			$batch = $migrator->get_batch( 0, 50 );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			foreach ( $migrator->migrate_batch( $batch, new DbWriter() ) as $outcome => $count ) {
+				$counts[ $outcome ] = ( $counts[ $outcome ] ?? 0 ) + $count;
+			}
+
+			++$batches;
+			$this->assertLessThan( 10, $batches, 'The emails section failed to drain.' );
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Build a migrator sharing this test's state.
+	 *
+	 * @param bool $force Whether to overwrite merchant-edited values.
+	 * @return EmailSettingsMigrator
+	 */
+	private function build_migrator( bool $force = false ): EmailSettingsMigrator {
+		return new EmailSettingsMigrator( $this->state, new Reporter(), $force );
+	}
+
+	/**
+	 * Delete the legacy and Core email options, plus the run state.
+	 *
+	 * @return void
+	 */
+	private function clear_options(): void {
+		delete_option( 'wc_bis_migration_state' );
+
+		foreach ( self::OPTION_MAP as $legacy_key => $core_key ) {
+			delete_option( $legacy_key );
+			delete_option( $core_key );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigratorTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/EmailSettingsMigratorTests.php
@@ -1,0 +1,70 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\EmailSettingsMigrator;
+use ReflectionClass;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for EmailSettingsMigrator's legacy-to-Core email option-name pairing.
+ *
+ * Legacy `confirm` (the post-signup confirmation email) must map to Core `verified`, not
+ * `verify` — `verify` is the double opt-in email and `verified` is the confirmation sent
+ * after it, so reversing the two swaps their copy.
+ */
+class EmailSettingsMigratorTests extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox the OPTION_MAP should pair legacy confirm with Core verified, not verify.
+	 */
+	public function test_option_map_pairs_confirm_with_verified_not_verify(): void {
+		$option_map = $this->get_option_map();
+
+		$this->assertArrayHasKey( 'woocommerce_bis_notification_confirm_settings', $option_map );
+		$this->assertSame(
+			'woocommerce_customer_stock_notification_verified_settings',
+			$option_map['woocommerce_bis_notification_confirm_settings'],
+			'Legacy confirm must map to Core verified, not verify.'
+		);
+	}
+
+	/**
+	 * @testdox the OPTION_MAP should pair legacy verify with Core verify, not verified.
+	 */
+	public function test_option_map_pairs_verify_with_verify_not_verified(): void {
+		$option_map = $this->get_option_map();
+
+		$this->assertArrayHasKey( 'woocommerce_bis_notification_verify_settings', $option_map );
+		$this->assertSame(
+			'woocommerce_customer_stock_notification_verify_settings',
+			$option_map['woocommerce_bis_notification_verify_settings']
+		);
+	}
+
+	/**
+	 * @testdox the OPTION_MAP should pair legacy received with Core stock notification settings.
+	 */
+	public function test_option_map_pairs_received_with_notification_settings(): void {
+		$option_map = $this->get_option_map();
+
+		$this->assertArrayHasKey( 'woocommerce_bis_notification_received_settings', $option_map );
+		$this->assertSame(
+			'woocommerce_customer_stock_notification_settings',
+			$option_map['woocommerce_bis_notification_received_settings']
+		);
+	}
+
+	/**
+	 * Read EmailSettingsMigrator::OPTION_MAP via reflection, since it is a private constant
+	 * and this pairing has no other public surface to assert against directly.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_option_map(): array {
+		$reflection = new ReflectionClass( EmailSettingsMigrator::class );
+
+		return $reflection->getConstant( 'OPTION_MAP' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigratorAdoptionTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigratorAdoptionTests.php
@@ -1,0 +1,418 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for natural-key adoption: a legacy row that matches an existing Core notification
+ * marks that row instead of inserting a duplicate.
+ *
+ * The natural key is deliberately narrower than `SignupService::is_already_signed_up()`,
+ * so several of these cases assert the opposite of what signup would have concluded.
+ */
+class NotificationsMigratorAdoptionTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Migrator under test.
+	 *
+	 * @var NotificationsMigrator
+	 */
+	private NotificationsMigrator $migrator;
+
+	/**
+	 * A published simple product every seeded row points at.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up the legacy tables and a product to subscribe to.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+
+		// Autoloaded options survive the per-test transaction rollback through the object
+		// cache, so they are cleared on the way in as well as on the way out.
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		$this->migrator   = new NotificationsMigrator( new Reporter() );
+		$this->product_id = $this->create_product();
+	}
+
+	/**
+	 * Drop the legacy tables and the options the migration writes.
+	 */
+	public function tearDown(): void {
+		LegacyStore::drop_tables();
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox a legacy row matching a Core notification should mark it rather than duplicate it.
+	 */
+	public function test_matching_core_row_is_adopted_not_duplicated(): void {
+		$existing = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		$outcomes = $this->migrate_all();
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_ADOPTED ] ?? 0 );
+		$this->assertCount( 1, LegacyStore::get_core_rows(), 'Adoption must not insert a second row.' );
+		$this->assertSame( array( (string) $legacy_id ), LegacyStore::get_core_meta( '_wc_bis_legacy_id' )[ $existing ] );
+		$this->assertSame( array( (string) $legacy_id ), LegacyStore::get_core_meta( '_wc_bis_legacy_adopted' )[ $existing ] );
+	}
+
+	/**
+	 * @testdox adoption should leave the target's status, dates and meta untouched.
+	 */
+	public function test_adoption_leaves_the_target_untouched(): void {
+		$existing = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+		$before   = LegacyStore::get_core_rows()[0];
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+				'is_active'  => 'off',
+			)
+		);
+
+		$this->migrate_all();
+
+		$after = LegacyStore::get_core_rows()[0];
+		$this->assertSame( $before, $after, 'The merchant\'s own row must survive adoption byte for byte.' );
+		$this->assertSame( $existing, (int) $after['id'] );
+	}
+
+	/**
+	 * @testdox a cancelled Core row should not be adopted.
+	 */
+	public function test_cancelled_core_row_is_not_adopted(): void {
+		$this->create_core_notification( 'shopper@example.com', NotificationStatus::CANCELLED );
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		$outcomes = $this->migrate_all();
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_MIGRATED ] ?? 0 );
+		$this->assertCount( 2, LegacyStore::get_core_rows(), 'A cancelled row is not a signup, so a fresh row is inserted.' );
+	}
+
+	/**
+	 * @testdox an active Core row should win over a cancelled one sharing the natural key.
+	 */
+	public function test_active_target_wins_over_cancelled(): void {
+		$this->create_core_notification( 'shopper@example.com', NotificationStatus::CANCELLED );
+		$active = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		$this->migrate_all();
+
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+		$this->assertSame( array( $active => array( (string) $legacy_id ) ), LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) );
+	}
+
+	/**
+	 * @testdox a registered legacy row should not adopt a guest Core row for the same email.
+	 */
+	public function test_registered_legacy_row_does_not_adopt_a_guest_core_row(): void {
+		$user_id = $this->factory()->user->create( array( 'user_email' => 'registered-guest@example.com' ) );
+		$this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_id'    => $user_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		$outcomes = $this->migrate_all();
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_MIGRATED ] ?? 0 );
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox a guest legacy row should not adopt a registered Core row for the same email.
+	 */
+	public function test_guest_legacy_row_does_not_adopt_a_registered_core_row(): void {
+		$user_id = $this->factory()->user->create( array( 'user_email' => 'guest-registered@example.com' ) );
+		$this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE, $user_id );
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_id'    => 0,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		$outcomes = $this->migrate_all();
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_MIGRATED ] ?? 0 );
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox a legacy address that fails is_email() should still adopt its Core counterpart.
+	 */
+	public function test_address_failing_is_email_still_adopts(): void {
+		$address = 'shopper@localhost';
+		$this->assertFalse( is_email( $address ), 'This address must fail is_email() for the test to mean anything.' );
+
+		// Core's own validation refuses this address today, so the row is inserted directly:
+		// the point is a row that already exists on the store, not one Core would create now.
+		$existing = LegacyStore::add_core_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => $address,
+			)
+		);
+
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => $address,
+			)
+		);
+
+		$outcomes = $this->migrate_all();
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_ADOPTED ] ?? 0 );
+		$this->assertSame( array( (string) $legacy_id ), LegacyStore::get_core_meta( '_wc_bis_legacy_id' )[ $existing ] );
+	}
+
+	/**
+	 * @testdox two duplicate legacy rows in one batch should resolve to a single target.
+	 */
+	public function test_duplicate_legacy_rows_in_one_batch_resolve_to_one_target(): void {
+		$existing = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		$first  = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+		$second = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		$this->migrate_all();
+
+		$this->assertCount( 1, LegacyStore::get_core_rows() );
+		$this->assertSame(
+			array( (string) $first, (string) $second ),
+			LegacyStore::get_core_meta( '_wc_bis_legacy_id' )[ $existing ],
+			'Both legacy ids must resolve to the one target row.'
+		);
+	}
+
+	/**
+	 * @testdox two duplicate legacy rows in different batches should resolve to a single target.
+	 */
+	public function test_duplicate_legacy_rows_across_batches_resolve_to_one_target(): void {
+		$existing = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		$first = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'other@example.com',
+			)
+		);
+
+		$second = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		// One row per batch, so a within-batch dedupe would not see the pair.
+		$cursor = 0;
+		while ( true ) {
+			$batch = $this->migrator->get_batch( $cursor, 1 );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$this->migrator->migrate_batch( $batch, new DbWriter() );
+			$cursor = (int) end( $batch );
+		}
+
+		$this->assertSame(
+			array( (string) $first, (string) $second ),
+			LegacyStore::get_core_meta( '_wc_bis_legacy_id' )[ $existing ]
+		);
+	}
+
+	/**
+	 * @testdox duplicate legacy rows mapping to sent should migrate as two separate rows.
+	 */
+	public function test_duplicate_sent_rows_migrate_separately(): void {
+		$first  = LegacyStore::add_notification(
+			array(
+				'product_id'         => $this->product_id,
+				'user_email'         => 'shopper@example.com',
+				'last_notified_date' => 1600000100,
+			)
+		);
+		$second = LegacyStore::add_notification(
+			array(
+				'product_id'         => $this->product_id,
+				'user_email'         => 'shopper@example.com',
+				'last_notified_date' => 1600000200,
+			)
+		);
+
+		foreach ( array( $first, $second ) as $legacy_id ) {
+			LegacyStore::add_meta( $legacy_id, '_hash_key', str_pad( 'key-' . $legacy_id, 32, '0' ) );
+			LegacyStore::add_meta( $legacy_id, '_hash_iv', str_pad( 'iv-' . $legacy_id, 16, '0' ) );
+		}
+
+		$this->migrate_all();
+
+		$rows = LegacyStore::get_core_rows();
+		$this->assertCount( 2, $rows, 'A sent row is never an adoption target, so both rows migrate.' );
+
+		$markers = LegacyStore::get_core_meta( '_wc_bis_legacy_id' );
+		$this->assertSame( array( (string) $first ), $markers[ (int) $rows[0]['id'] ] );
+		$this->assertSame( array( (string) $second ), $markers[ (int) $rows[1]['id'] ] );
+
+		$tokens = LegacyStore::get_core_meta( '_wc_bis_legacy_unsub_hash' );
+		$this->assertCount( 1, $tokens[ (int) $rows[0]['id'] ] );
+		$this->assertCount( 1, $tokens[ (int) $rows[1]['id'] ] );
+		$this->assertNotSame( $tokens[ (int) $rows[0]['id'] ][0], $tokens[ (int) $rows[1]['id'] ][0], 'Each row carries its own token.' );
+	}
+
+	/**
+	 * @testdox posted_attributes should be part of the natural key.
+	 */
+	public function test_posted_attributes_are_part_of_the_natural_key(): void {
+		$existing = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+		LegacyStore::add_meta( $legacy_id, 'posted_attributes', array( 'attribute_pa_color' => 'blue' ) );
+
+		$outcomes = $this->migrate_all();
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_MIGRATED ] ?? 0, 'A different variation choice is a different signup.' );
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+		$this->assertArrayNotHasKey( $existing, LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) );
+	}
+
+	/**
+	 * @testdox an adopted row loaded before adoption should see the marker afterwards.
+	 */
+	public function test_adopted_row_meta_cache_is_invalidated(): void {
+		$existing = $this->create_core_notification( 'shopper@example.com', NotificationStatus::ACTIVE );
+
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'shopper@example.com',
+			)
+		);
+
+		// Load the target into memory first: the marker is written by direct SQL, so a stale
+		// meta cache would hide it from every later read in the same request.
+		$loaded = new Notification( $existing );
+		$this->assertSame( '', (string) $loaded->get_meta( '_wc_bis_legacy_id' ) );
+
+		$this->migrate_all();
+
+		$reloaded = new Notification( $existing );
+		$this->assertSame( (string) $legacy_id, (string) $reloaded->get_meta( '_wc_bis_legacy_id' ) );
+	}
+
+	/**
+	 * Migrate every outstanding candidate row through the live writer.
+	 *
+	 * @return array<string,int> Outcome counts.
+	 */
+	private function migrate_all(): array {
+		return $this->migrator->migrate_batch( $this->migrator->get_batch( 0, 500 ), new DbWriter() );
+	}
+
+	/**
+	 * Create a Core notification the way a native signup would.
+	 *
+	 * @param string $email   Subscriber email.
+	 * @param string $status  Notification status.
+	 * @param int    $user_id Subscriber user id, or 0 for a guest.
+	 * @return int The notification id.
+	 */
+	private function create_core_notification( string $email, string $status, int $user_id = 0 ): int {
+		$notification = new Notification();
+		$notification->set_product_id( $this->product_id );
+		$notification->set_user_id( $user_id );
+		$notification->set_user_email( $email );
+		$notification->set_status( $status );
+		$notification->save();
+
+		return $notification->get_id();
+	}
+
+	/**
+	 * Create a published simple product.
+	 *
+	 * @return int
+	 */
+	private function create_product(): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Migration test product' );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigratorTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/NotificationsMigratorTests.php
@@ -1,0 +1,408 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\NullWriter;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Integration tests for the notifications section of the BIS migration: the candidate
+ * predicate, the per-column mapping, the dry run, and the batch accounting invariant.
+ */
+class NotificationsMigratorTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Migrator under test.
+	 *
+	 * @var NotificationsMigrator
+	 */
+	private NotificationsMigrator $migrator;
+
+	/**
+	 * Reporter shared with the migrator.
+	 *
+	 * @var Reporter
+	 */
+	private Reporter $reporter;
+
+	/**
+	 * A published simple product every seeded row points at unless it says otherwise.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up the legacy tables and a product to subscribe to.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+
+		// Autoloaded options survive the per-test transaction rollback through the object
+		// cache, so they are cleared on the way in as well as on the way out.
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		$this->reporter   = new Reporter();
+		$this->migrator   = new NotificationsMigrator( $this->reporter );
+		$this->product_id = $this->create_product();
+	}
+
+	/**
+	 * Drop the legacy tables and the options the migration writes.
+	 */
+	public function tearDown(): void {
+		LegacyStore::drop_tables();
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox the candidate predicate should exclude every row that cannot be migrated.
+	 */
+	public function test_predicate_excludes_ineligible_rows(): void {
+		$eligible = LegacyStore::add_notification( array( 'product_id' => $this->product_id ) );
+
+		$unverified_by_column = LegacyStore::add_notification(
+			array(
+				'product_id'  => $this->product_id,
+				'is_verified' => 'no',
+			)
+		);
+
+		$unverified_by_meta = LegacyStore::add_notification( array( 'product_id' => $this->product_id ) );
+		LegacyStore::add_meta( $unverified_by_meta, 'awaiting_verification', 'yes' );
+
+		$trashed_product = $this->create_product();
+		wp_trash_post( $trashed_product );
+		LegacyStore::add_notification( array( 'product_id' => $trashed_product ) );
+
+		$page_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
+		LegacyStore::add_notification( array( 'product_id' => $page_id ) );
+
+		LegacyStore::add_notification( array( 'product_id' => 999999 ) );
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => str_repeat( 'a', 95 ) . '@example.com',
+			)
+		);
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'not-an-email',
+			)
+		);
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => '',
+			)
+		);
+
+		$this->assertSame( array( $eligible ), $this->migrator->get_batch( 0, 100 ) );
+		$this->assertSame( 1, $this->migrator->count_remaining() );
+
+		$this->assertSame( 2, $this->migrator->count_unverified_excluded(), 'Both unverified rows should be counted.' );
+		$this->assertSame( 1, $this->migrator->count_email_too_long() );
+		$this->assertSame( 2, $this->migrator->count_invalid_email(), 'The empty and malformed addresses are both invalid.' );
+		$this->assertSame( 3, $this->migrator->count_product_missing(), 'Trashed, non-product and missing products all count.' );
+
+		$this->assertNotContains( $unverified_by_column, $this->migrator->get_batch( 0, 100 ) );
+	}
+
+	/**
+	 * @testdox no migrated row should land in the pending status.
+	 */
+	public function test_no_migrated_row_lands_in_pending(): void {
+		LegacyStore::add_notification( array( 'product_id' => $this->product_id ) );
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'is_active'  => 'off',
+				'user_email' => 'cancelled@example.com',
+			)
+		);
+		LegacyStore::add_notification(
+			array(
+				'product_id'         => $this->product_id,
+				'last_notified_date' => 1600000100,
+				'user_email'         => 'sent@example.com',
+			)
+		);
+
+		$this->migrate_all();
+
+		foreach ( LegacyStore::get_core_rows() as $row ) {
+			$this->assertNotSame( NotificationStatus::PENDING, $row['status'] );
+		}
+	}
+
+	/**
+	 * @testdox get_batch should be side-effect free.
+	 */
+	public function test_get_batch_is_side_effect_free(): void {
+		$first  = LegacyStore::add_notification( array( 'product_id' => $this->product_id ) );
+		$second = LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => 'second@example.com',
+			)
+		);
+
+		$this->assertSame( array( $first, $second ), $this->migrator->get_batch( 0, 100 ) );
+		$this->assertSame( array( $first, $second ), $this->migrator->get_batch( 0, 100 ) );
+		$this->assertSame( 2, $this->migrator->count_remaining() );
+	}
+
+	/**
+	 * @testdox a dry run should write nothing while reporting the same outcomes as a real run.
+	 */
+	public function test_dry_run_writes_nothing_and_reports_the_same_shape(): void {
+		$ids = array(
+			LegacyStore::add_notification( array( 'product_id' => $this->product_id ) ),
+			LegacyStore::add_notification(
+				array(
+					'product_id' => $this->product_id,
+					'user_email' => 'second@example.com',
+					'is_active'  => 'off',
+				)
+			),
+		);
+
+		$dry_outcomes = $this->migrator->migrate_batch( $ids, new NullWriter() );
+
+		$this->assertSame( array(), LegacyStore::get_core_rows(), 'A dry run must not insert Core rows.' );
+		$this->assertFalse( get_option( 'wc_bis_migration_has_migrated_rows' ), 'A dry run must not write options.' );
+		$this->assertSame( 2, $this->migrator->count_remaining(), 'A dry run must leave every row outstanding.' );
+
+		$real_migrator = new NotificationsMigrator( new Reporter() );
+		$real_outcomes = $real_migrator->migrate_batch( $ids, new DbWriter() );
+
+		$this->assertSame( $dry_outcomes, $real_outcomes, 'The dry run report must be shape-identical to the real one.' );
+	}
+
+	/**
+	 * @testdox a migrated row should carry the mapped Core column values.
+	 */
+	public function test_migrated_row_carries_mapped_columns(): void {
+		$user_id = $this->factory()->user->create();
+
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id'     => $this->product_id,
+				'user_id'        => $user_id,
+				'user_email'     => '  Shopper@Example.com ',
+				'create_date'    => 1600000000,
+				'subscribe_date' => 1600000500,
+			)
+		);
+		LegacyStore::add_meta( $legacy_id, '_customer_locale', 'el_GR' );
+		LegacyStore::add_meta( $legacy_id, 'posted_attributes', array( 'attribute_pa_color' => 'blue' ) );
+
+		$this->migrate_all();
+
+		$rows = LegacyStore::get_core_rows();
+		$this->assertCount( 1, $rows );
+
+		$row = $rows[0];
+		$this->assertSame( $this->product_id, (int) $row['product_id'] );
+		$this->assertSame( $user_id, (int) $row['user_id'] );
+		$this->assertSame( 'shopper@example.com', $row['user_email'], 'The email should be trimmed and lowercased.' );
+		$this->assertSame( NotificationStatus::ACTIVE, $row['status'] );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', 1600000000 ), $row['date_created_gmt'] );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', 1600000500 ), $row['date_confirmed_gmt'] );
+		$this->assertNull( $row['date_last_attempt_gmt'] );
+		$this->assertNull( $row['date_notified_gmt'] );
+		$this->assertNull( $row['date_cancelled_gmt'] );
+		$this->assertNull( $row['cancellation_source'] );
+
+		$notification_id = (int) $row['id'];
+		$this->assertSame( array( 'el_GR' ), LegacyStore::get_core_meta( '_customer_locale' )[ $notification_id ] );
+		$this->assertSame(
+			array( maybe_serialize( array( 'attribute_pa_color' => 'blue' ) ) ),
+			LegacyStore::get_core_meta( 'posted_attributes' )[ $notification_id ],
+			'posted_attributes must be serialized exactly once, by the writer.'
+		);
+		$this->assertSame( array( (string) $legacy_id ), LegacyStore::get_core_meta( '_wc_bis_legacy_id' )[ $notification_id ] );
+		$this->assertSame( 'yes', get_option( 'wc_bis_migration_has_migrated_rows' ) );
+	}
+
+	/**
+	 * @testdox a delivered row should map to sent and carry its delivery clocks.
+	 */
+	public function test_delivered_row_maps_to_sent_with_its_clocks(): void {
+		LegacyStore::add_notification(
+			array(
+				'product_id'         => $this->product_id,
+				'create_date'        => 1600000000,
+				'subscribe_date'     => 1600000100,
+				'last_notified_date' => 1600000200,
+			)
+		);
+
+		$this->migrate_all();
+
+		$row = LegacyStore::get_core_rows()[0];
+		$this->assertSame( NotificationStatus::SENT, $row['status'] );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', 1600000200 ), $row['date_notified_gmt'] );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', 1600000200 ), $row['date_last_attempt_gmt'] );
+		$this->assertSame( 1, $this->migrator->get_recurring_lost_count() );
+	}
+
+	/**
+	 * @testdox a cancelled row should take its source and date from the activity log.
+	 */
+	public function test_cancelled_row_takes_source_and_date_from_activity(): void {
+		$legacy_id = LegacyStore::add_notification(
+			array(
+				'product_id'  => $this->product_id,
+				'is_active'   => 'off',
+				'create_date' => 1600000000,
+			)
+		);
+		LegacyStore::add_activity( $legacy_id, 'unsubscribed', 1600009999 );
+
+		$this->migrate_all();
+
+		$row = LegacyStore::get_core_rows()[0];
+		$this->assertSame( NotificationStatus::CANCELLED, $row['status'] );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', 1600009999 ), $row['date_cancelled_gmt'] );
+		$this->assertSame( NotificationCancellationSource::USER, $row['cancellation_source'] );
+	}
+
+	/**
+	 * @testdox a cancelled row with no activity should fall back to the system source.
+	 */
+	public function test_cancelled_row_without_activity_falls_back_to_system(): void {
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $this->product_id,
+				'is_active'  => 'off',
+			)
+		);
+
+		$this->migrate_all();
+
+		$row = LegacyStore::get_core_rows()[0];
+		$this->assertSame( NotificationStatus::CANCELLED, $row['status'] );
+		$this->assertSame( NotificationCancellationSource::SYSTEM, $row['cancellation_source'] );
+	}
+
+	/**
+	 * @testdox every admitted row should leave the batch as migrated, adopted or failed.
+	 */
+	public function test_admitted_rows_equal_migrated_plus_adopted_plus_failed(): void {
+		for ( $i = 0; $i < 5; $i++ ) {
+			LegacyStore::add_notification(
+				array(
+					'product_id' => $this->product_id,
+					'user_email' => "shopper{$i}@example.com",
+				)
+			);
+		}
+
+		$admitted = $this->migrator->get_batch( 0, 100 );
+		$this->assertCount( 5, $admitted );
+
+		$outcomes = $this->migrator->migrate_batch( $admitted, new DbWriter() );
+
+		$accounted = ( $outcomes[ Reporter::OUTCOME_MIGRATED ] ?? 0 )
+			+ ( $outcomes[ Reporter::OUTCOME_ADOPTED ] ?? 0 )
+			+ ( $outcomes[ Reporter::OUTCOME_FAILED ] ?? 0 );
+
+		$this->assertSame( count( $admitted ), $accounted, 'No row may leave a batch by a third route.' );
+		$this->assertSame( 0, $this->migrator->count_remaining() );
+	}
+
+	/**
+	 * @testdox legacy meta should be read with one query per batch, not one per row.
+	 */
+	public function test_legacy_meta_is_read_once_per_batch(): void {
+		for ( $i = 0; $i < 5; $i++ ) {
+			$legacy_id = LegacyStore::add_notification(
+				array(
+					'product_id' => $this->product_id,
+					'user_email' => "shopper{$i}@example.com",
+				)
+			);
+			LegacyStore::add_meta( $legacy_id, '_customer_locale', 'en_US' );
+		}
+
+		$batch = $this->migrator->get_batch( 0, 100 );
+
+		global $wpdb;
+		$meta_table = $wpdb->prefix . 'woocommerce_bis_notificationsmeta';
+		$queries    = 0;
+
+		$counter = function ( $query ) use ( &$queries, $meta_table ) {
+			if ( false !== strpos( $query, $meta_table ) && 0 === stripos( ltrim( $query ), 'SELECT' ) ) {
+				++$queries;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $counter );
+		$this->migrator->migrate_batch( $batch, new DbWriter() );
+		remove_filter( 'query', $counter );
+
+		$this->assertSame( 1, $queries, 'Legacy meta must be fetched once for the whole batch.' );
+	}
+
+	/**
+	 * @testdox get_batch should honour the cursor and the batch size.
+	 */
+	public function test_get_batch_honours_cursor_and_size(): void {
+		$ids = array();
+		for ( $i = 0; $i < 4; $i++ ) {
+			$ids[] = LegacyStore::add_notification(
+				array(
+					'product_id' => $this->product_id,
+					'user_email' => "shopper{$i}@example.com",
+				)
+			);
+		}
+
+		$this->assertSame( array_slice( $ids, 0, 2 ), $this->migrator->get_batch( 0, 2 ) );
+		$this->assertSame( array_slice( $ids, 2, 2 ), $this->migrator->get_batch( $ids[1], 2 ) );
+		$this->assertSame( array(), $this->migrator->get_batch( end( $ids ), 2 ) );
+	}
+
+	/**
+	 * Migrate every outstanding candidate row through the live writer.
+	 *
+	 * @return array<string,int> Outcome counts.
+	 */
+	private function migrate_all(): array {
+		return $this->migrator->migrate_batch( $this->migrator->get_batch( 0, 500 ), new DbWriter() );
+	}
+
+	/**
+	 * Create a published simple product.
+	 *
+	 * @return int
+	 */
+	private function create_product(): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Migration test product' );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/ProductMetaMigratorTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/ProductMetaMigratorTests.php
@@ -1,0 +1,223 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Config;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\ProductMetaMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\NullWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EligibilityService;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\StockManagementHelper;
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the product meta section: the polarity inversion between the legacy
+ * "disabled" flag and Core's "enable signups" flag, and the per-product fingerprint that
+ * stands in for a marker here.
+ */
+class ProductMetaMigratorTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Legacy post meta key holding the "sign-ups disabled" flag.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_META_KEY = '_wc_bis_disabled';
+
+	/**
+	 * Run state, used by the migrator for fingerprint hashing.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Set up a clean run state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_option( 'wc_bis_migration_state' );
+		$this->state = new MigrationState();
+	}
+
+	/**
+	 * Clear the run state.
+	 */
+	public function tearDown(): void {
+		delete_option( 'wc_bis_migration_state' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox a legacy disabled flag should become a Core signups-disabled flag.
+	 */
+	public function test_legacy_disabled_becomes_core_signups_disabled(): void {
+		$product_id = $this->create_product_with_legacy_flag( 'yes' );
+
+		$this->migrate();
+
+		$this->assertSame( 'no', get_post_meta( $product_id, Config::get_product_signups_meta_key(), true ) );
+	}
+
+	/**
+	 * @testdox a product with no legacy flag should have nothing written.
+	 */
+	public function test_absent_legacy_flag_writes_nothing(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->migrate();
+
+		$this->assertSame( '', get_post_meta( $product->get_id(), Config::get_product_signups_meta_key(), true ) );
+		$this->assertSame( '', get_post_meta( $product->get_id(), '_wc_bis_migration_signups_written', true ) );
+	}
+
+	/**
+	 * @testdox a legacy flag set to anything but yes should write nothing.
+	 */
+	public function test_legacy_flag_other_than_yes_writes_nothing(): void {
+		$product_id = $this->create_product_with_legacy_flag( 'no' );
+
+		$this->migrate();
+
+		$this->assertSame( '', get_post_meta( $product_id, Config::get_product_signups_meta_key(), true ) );
+	}
+
+	/**
+	 * @testdox a variation should resolve to its parent's flag with no rows of its own.
+	 */
+	public function test_variation_resolves_to_its_parent_without_fan_out(): void {
+		$variable = WC_Helper_Product::create_variation_product();
+		$variable->update_meta_data( self::LEGACY_META_KEY, 'yes' );
+		$variable->save();
+
+		$this->migrate();
+
+		$variation_id = $variable->get_children()[0];
+
+		$this->assertSame( 'no', get_post_meta( $variable->get_id(), Config::get_product_signups_meta_key(), true ) );
+		$this->assertSame( '', get_post_meta( $variation_id, Config::get_product_signups_meta_key(), true ), 'No fan-out rows.' );
+
+		$eligibility = new EligibilityService();
+		$eligibility->init( new StockManagementHelper() );
+
+		$this->assertFalse( $eligibility->product_allows_signups( wc_get_product( $variation_id ) ) );
+	}
+
+	/**
+	 * @testdox a migrated product should not be visited again.
+	 */
+	public function test_migrated_product_leaves_the_candidate_set(): void {
+		$this->create_product_with_legacy_flag( 'yes' );
+
+		$this->migrate();
+
+		$this->assertSame( array(), $this->build_migrator()->get_batch( 0, 10 ) );
+		$this->assertSame( 0, $this->build_migrator()->count_remaining() );
+	}
+
+	/**
+	 * @testdox a merchant edit after migration should be reported and left alone.
+	 */
+	public function test_merchant_edit_is_skipped_and_reported(): void {
+		$product_id = $this->create_product_with_legacy_flag( 'yes' );
+
+		$this->migrate();
+
+		update_post_meta( $product_id, Config::get_product_signups_meta_key(), 'yes' );
+
+		$migrator = $this->build_migrator();
+		$batch    = $migrator->get_batch( 0, 10 );
+
+		$this->assertSame( array( $product_id ), $batch, 'A merchant edit brings the product back.' );
+
+		$outcomes = $migrator->migrate_batch( $batch, new DbWriter() );
+
+		$this->assertSame( 1, $outcomes[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 );
+		$this->assertSame( 'yes', get_post_meta( $product_id, Config::get_product_signups_meta_key(), true ) );
+		$this->assertSame( array(), $this->build_migrator()->get_batch( 0, 10 ), 'The skip is recorded, so it reports once.' );
+	}
+
+	/**
+	 * @testdox force should overwrite a merchant edit.
+	 */
+	public function test_force_overwrites_a_merchant_edit(): void {
+		$product_id = $this->create_product_with_legacy_flag( 'yes' );
+
+		$this->migrate();
+		update_post_meta( $product_id, Config::get_product_signups_meta_key(), 'yes' );
+		$this->migrate();
+
+		$this->migrate( true );
+
+		$this->assertSame( 'no', get_post_meta( $product_id, Config::get_product_signups_meta_key(), true ) );
+	}
+
+	/**
+	 * @testdox a dry run should write nothing.
+	 */
+	public function test_dry_run_writes_nothing(): void {
+		$product_id = $this->create_product_with_legacy_flag( 'yes' );
+
+		$migrator = $this->build_migrator();
+		$migrator->migrate_batch( $migrator->get_batch( 0, 10 ), new NullWriter() );
+
+		$this->assertSame( '', get_post_meta( $product_id, Config::get_product_signups_meta_key(), true ) );
+		$this->assertSame( '', get_post_meta( $product_id, '_wc_bis_migration_signups_written', true ) );
+	}
+
+	/**
+	 * Run the product meta section to completion.
+	 *
+	 * @param bool $force Whether to overwrite merchant edits.
+	 * @return void
+	 */
+	private function migrate( bool $force = false ): void {
+		$migrator = $this->build_migrator( $force );
+		$cursor   = 0;
+		$batches  = 0;
+
+		while ( true ) {
+			$batch = $migrator->get_batch( $cursor, 10 );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$migrator->migrate_batch( $batch, new DbWriter() );
+			$cursor = (int) end( $batch );
+
+			++$batches;
+			$this->assertLessThan( 10, $batches, 'The product meta section failed to drain.' );
+		}
+	}
+
+	/**
+	 * Build a migrator sharing this test's state.
+	 *
+	 * @param bool $force Whether to overwrite merchant edits.
+	 * @return ProductMetaMigrator
+	 */
+	private function build_migrator( bool $force = false ): ProductMetaMigrator {
+		return new ProductMetaMigrator( new Reporter(), $this->state, $force );
+	}
+
+	/**
+	 * Create a simple product carrying the legacy flag.
+	 *
+	 * @param string $value Legacy flag value.
+	 * @return int The product id.
+	 */
+	private function create_product_with_legacy_flag( string $value ): int {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->update_meta_data( self::LEGACY_META_KEY, $value );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/SettingsMigratorMigrationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Migrators/SettingsMigratorMigrationTests.php
@@ -1,0 +1,245 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Migrators;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\SettingsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\NullWriter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the general settings section, where nothing carries a per-row marker and the
+ * fingerprint is the only thing standing between a re-run and a merchant's own edits.
+ */
+class SettingsMigratorMigrationTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Legacy option holding the signup toggle.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_ALLOW_SIGNUPS = 'wc_bis_allow_signups';
+
+	/**
+	 * Core option the signup toggle migrates to.
+	 *
+	 * @var string
+	 */
+	private const CORE_ALLOW_SIGNUPS = 'woocommerce_customer_stock_notifications_allow_signups';
+
+	/**
+	 * Legacy option holding the unverified-deletion threshold, an integer.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_THRESHOLD = 'wc_bis_delete_unverified_days_threshold';
+
+	/**
+	 * Core option the threshold migrates to.
+	 *
+	 * @var string
+	 */
+	private const CORE_THRESHOLD = 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold';
+
+	/**
+	 * Run state.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Set up a clean state and legacy options.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->clear_options();
+		$this->state = new MigrationState();
+	}
+
+	/**
+	 * Clear everything this section reads or writes.
+	 */
+	public function tearDown(): void {
+		$this->clear_options();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox an absent Core option should be written.
+	 */
+	public function test_absent_option_is_written(): void {
+		update_option( self::LEGACY_ALLOW_SIGNUPS, 'no' );
+
+		$this->migrate();
+
+		$this->assertSame( 'no', get_option( self::CORE_ALLOW_SIGNUPS ) );
+	}
+
+	/**
+	 * @testdox an option this migration wrote should be rewritten only when the legacy source changed.
+	 */
+	public function test_unchanged_option_is_rewritten_only_when_the_source_changes(): void {
+		update_option( self::LEGACY_ALLOW_SIGNUPS, 'no' );
+		$this->migrate();
+
+		$migrator = $this->build_migrator();
+		$this->assertSame( array(), $migrator->get_batch( 0, 10 ), 'Nothing changed, so nothing is outstanding.' );
+
+		update_option( self::LEGACY_ALLOW_SIGNUPS, 'yes' );
+
+		$this->assertContains( self::LEGACY_ALLOW_SIGNUPS, $this->build_migrator()->get_batch( 0, 10 ) );
+
+		$this->migrate();
+		$this->assertSame( 'yes', get_option( self::CORE_ALLOW_SIGNUPS ) );
+	}
+
+	/**
+	 * @testdox a merchant-edited option should be left alone and reported once.
+	 */
+	public function test_merchant_edited_option_is_skipped_and_reported_once(): void {
+		update_option( self::LEGACY_ALLOW_SIGNUPS, 'no' );
+		$this->migrate();
+
+		update_option( self::CORE_ALLOW_SIGNUPS, 'yes' );
+
+		$counts = $this->migrate();
+
+		$this->assertSame( 1, $counts[ Reporter::OUTCOME_SKIPPED_USER_MODIFIED ] ?? 0 );
+		$this->assertSame( 'yes', get_option( self::CORE_ALLOW_SIGNUPS ), 'The merchant\'s value must survive.' );
+
+		// Reported once: the skip is recorded, so the option stops being outstanding.
+		$this->assertSame( array(), $this->build_migrator()->get_batch( 0, 10 ) );
+	}
+
+	/**
+	 * @testdox force should overwrite only a merchant-edited option.
+	 */
+	public function test_force_overwrites_only_the_merchant_edited_case(): void {
+		update_option( self::LEGACY_ALLOW_SIGNUPS, 'no' );
+		$this->migrate();
+
+		update_option( self::CORE_ALLOW_SIGNUPS, 'yes' );
+		$this->migrate();
+
+		$counts = $this->migrate( true );
+
+		$this->assertSame( 1, $counts[ Reporter::OUTCOME_MIGRATED ] ?? 0 );
+		$this->assertSame( 'no', get_option( self::CORE_ALLOW_SIGNUPS ), 'Force writes the legacy value over the edit.' );
+	}
+
+	/**
+	 * @testdox an integer option should round-trip without reporting itself as edited.
+	 */
+	public function test_integer_option_round_trips_without_a_false_edit(): void {
+		update_option( self::LEGACY_THRESHOLD, 30 );
+
+		$this->migrate();
+
+		// Loose comparison: within one request the option cache hands back the int that was
+		// written, while a later request reads the string the database stored.
+		$this->assertEquals( 30, get_option( self::CORE_THRESHOLD ) );
+		$this->assertSame(
+			array(),
+			$this->build_migrator()->get_batch( 0, 10 ),
+			'A value that reads back as a string must not look like a merchant edit.'
+		);
+	}
+
+	/**
+	 * @testdox a dry run should write nothing and still drain the section.
+	 */
+	public function test_dry_run_writes_nothing_and_drains(): void {
+		update_option( self::LEGACY_ALLOW_SIGNUPS, 'no' );
+
+		$migrator = $this->build_migrator();
+		$writer   = new NullWriter();
+
+		$batches = 0;
+		while ( true ) {
+			$batch = $migrator->get_batch( 0, 10 );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$migrator->migrate_batch( $batch, $writer );
+			++$batches;
+
+			$this->assertLessThan( 5, $batches, 'A dry run must terminate.' );
+		}
+
+		$this->assertFalse( get_option( self::CORE_ALLOW_SIGNUPS ) );
+		$this->assertNull( $this->state->get_option_fingerprint( self::CORE_ALLOW_SIGNUPS ) );
+	}
+
+	/**
+	 * Run the settings section to completion.
+	 *
+	 * @param bool $force Whether to overwrite merchant-edited options.
+	 * @return array<string,int> Outcome counts from the last batch.
+	 */
+	private function migrate( bool $force = false ): array {
+		$migrator = $this->build_migrator( $force );
+		$counts   = array();
+		$batches  = 0;
+
+		while ( true ) {
+			$batch = $migrator->get_batch( 0, 10 );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			foreach ( $migrator->migrate_batch( $batch, new DbWriter() ) as $outcome => $count ) {
+				$counts[ $outcome ] = ( $counts[ $outcome ] ?? 0 ) + $count;
+			}
+
+			++$batches;
+			$this->assertLessThan( 10, $batches, 'The settings section failed to drain.' );
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Build a migrator sharing this test's state.
+	 *
+	 * @param bool $force Whether to overwrite merchant-edited options.
+	 * @return SettingsMigrator
+	 */
+	private function build_migrator( bool $force = false ): SettingsMigrator {
+		return new SettingsMigrator( $this->state, new Reporter(), $force );
+	}
+
+	/**
+	 * Delete every option this section touches, plus the run state.
+	 *
+	 * @return void
+	 */
+	private function clear_options(): void {
+		delete_option( 'wc_bis_migration_state' );
+
+		foreach (
+			array(
+				self::LEGACY_ALLOW_SIGNUPS,
+				self::CORE_ALLOW_SIGNUPS,
+				self::LEGACY_THRESHOLD,
+				self::CORE_THRESHOLD,
+				'wc_bis_double_opt_in_required',
+				'woocommerce_customer_stock_notifications_require_double_opt_in',
+				'wc_bis_account_required',
+				'woocommerce_customer_stock_notifications_require_account',
+				'wc_bis_create_new_account_on_registration',
+				'woocommerce_customer_stock_notifications_create_account_on_signup',
+			) as $option
+		) {
+			delete_option( $option );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/MultisiteTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/MultisiteTests.php
@@ -1,0 +1,320 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration;
+
+use Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificationsDataStore;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\MigrationBatchProcessor;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\ToolsRegistrar;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Multisite coverage for the BIS-to-Core stock notifications migration.
+ *
+ * Everything the migration touches - the legacy and Core tables, the `wc_bis_migration_state`
+ * option, the `wc_bis_migration_has_legacy_links` flag, and the CLI lock they carry - is
+ * `$wpdb->prefix`-scoped, so a run on one site of a network must never be visible to, or
+ * blocked by, another site.
+ *
+ * @group ms-required
+ */
+class MultisiteTests extends WC_Unit_Test_Case {
+
+	/**
+	 * A second site on the network, created fresh for each test.
+	 *
+	 * @var int|null
+	 */
+	private ?int $other_site_id = null;
+
+	/**
+	 * Skip outside a network install, then seed the legacy tables and the feature toggle on
+	 * both the main site and the second site.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite coverage only applies on a network install.' );
+		}
+
+		$this->login_as_role( 'administrator' );
+
+		$this->other_site_id = (int) self::factory()->blog->create();
+
+		$this->seed_site();
+
+		// Roles are per-site: without this the administrator created above has no
+		// capabilities on the second site, which would hide its Tools entry for reasons
+		// that have nothing to do with the migration.
+		add_user_to_blog( $this->other_site_id, get_current_user_id(), 'administrator' );
+
+		switch_to_blog( $this->other_site_id );
+		$this->seed_site();
+		restore_current_blog();
+	}
+
+	/**
+	 * Restore the current blog even when a test failed mid-switch, then drop the legacy
+	 * tables and clear the migration options on both sites.
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->other_site_id ) {
+			while ( function_exists( 'ms_is_switched' ) && ms_is_switched() ) {
+				restore_current_blog();
+			}
+
+			switch_to_blog( $this->other_site_id );
+			$this->unseed_site();
+			restore_current_blog();
+
+			$this->unseed_site();
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox migrating on one site of a network should leave another site's legacy rows unmigrated.
+	 */
+	public function test_migration_on_one_site_leaves_other_sites_legacy_rows_unmigrated(): void {
+		$product_id = $this->create_product();
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $product_id,
+				'user_email' => 'main-site-shopper@example.com',
+			)
+		);
+
+		switch_to_blog( $this->other_site_id );
+		$other_product_id = $this->create_product();
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $other_product_id,
+				'user_email' => 'other-site-shopper@example.com',
+			)
+		);
+		restore_current_blog();
+
+		$migrated = $this->run_migration_to_completion();
+		$this->assertNotEmpty( $migrated, 'Sanity: the run on the main site actually migrated something.' );
+
+		switch_to_blog( $this->other_site_id );
+
+		try {
+			$this->assertSame(
+				array(),
+				LegacyStore::get_core_rows(),
+				"The other site's Core notifications table must stay empty."
+			);
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * @testdox migrating on one site of a network should leave another site's migration state option absent.
+	 */
+	public function test_migration_on_one_site_leaves_other_sites_state_option_absent(): void {
+		$this->create_product();
+		LegacyStore::add_notification( array( 'user_email' => 'main-site-shopper@example.com' ) );
+
+		$this->run_migration_to_completion();
+
+		$this->assertNotFalse( get_option( 'wc_bis_migration_state' ), 'Sanity: the main site wrote its own state option.' );
+
+		switch_to_blog( $this->other_site_id );
+
+		try {
+			$this->assertFalse(
+				get_option( 'wc_bis_migration_state' ),
+				"The other site's migration state option must not exist."
+			);
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * @testdox migrating on one site of a network should leave another site's Tools entry still offering to start.
+	 */
+	public function test_migration_on_one_site_leaves_other_sites_tools_entry_offering_to_start(): void {
+		$this->create_product();
+		LegacyStore::add_notification( array( 'user_email' => 'main-site-shopper@example.com' ) );
+
+		$this->run_migration_to_completion();
+
+		switch_to_blog( $this->other_site_id );
+
+		// Capabilities are cached per blog on the current user object, so they have to be
+		// re-read after the switch or the Tools entry is hidden for the wrong reason.
+		wp_set_current_user( get_current_user_id() );
+
+		try {
+			$tools = ( new ToolsRegistrar() )->handle_woocommerce_debug_tools( array() );
+
+			$this->assertArrayHasKey( 'start_bis_migration', $tools, "The other site's Tools entry must still offer to start." );
+			$this->assertArrayNotHasKey( 'stop_bis_migration', $tools, "The other site's Tools entry must not offer to stop." );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * @testdox the migration state option should be site-scoped, not shared across the network.
+	 */
+	public function test_state_option_is_site_scoped(): void {
+		( new MigrationState() )->set_cursor( 'notifications', 42 );
+
+		switch_to_blog( $this->other_site_id );
+
+		try {
+			$this->assertSame(
+				0,
+				( new MigrationState() )->get_cursor( 'notifications' ),
+				"The other site's cursor must not see the main site's value."
+			);
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * @testdox the has-legacy-links flag should be site-scoped, not shared across the network.
+	 */
+	public function test_has_legacy_links_flag_is_site_scoped(): void {
+		update_option( 'wc_bis_migration_has_legacy_links', 1 );
+
+		switch_to_blog( $this->other_site_id );
+
+		try {
+			$this->assertFalse(
+				get_option( 'wc_bis_migration_has_legacy_links' ),
+				"The other site's has-legacy-links flag must not be set."
+			);
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * @testdox the CLI lock should be site-scoped: holding it on one site must not block another site from acquiring its own.
+	 */
+	public function test_cli_lock_is_site_scoped(): void {
+		$main_site_state = new MigrationState();
+		$this->assertTrue( $main_site_state->acquire_lock( 'main-site-owner' ) );
+
+		switch_to_blog( $this->other_site_id );
+
+		try {
+			$other_site_state = new MigrationState();
+
+			$this->assertFalse(
+				$other_site_state->is_lock_held(),
+				"The other site must not see the main site's lock as held."
+			);
+			$this->assertTrue(
+				$other_site_state->acquire_lock( 'other-site-owner' ),
+				'The other site must be able to acquire its own lock.'
+			);
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertTrue( $main_site_state->is_lock_held(), "The main site's own lock must be unaffected." );
+	}
+
+	/**
+	 * Run the migration to completion on the current site, via the same batch processor
+	 * the background run uses.
+	 *
+	 * @return int Number of batches processed.
+	 */
+	private function run_migration_to_completion(): int {
+		$requirements = new Requirements();
+		$requirements->init( wc_get_container()->get( StockNotificationsDataStore::class ) );
+
+		$processor = new MigrationBatchProcessor();
+		$processor->init( $requirements );
+
+		$batches = 0;
+
+		while ( true ) {
+			$batch = $processor->get_next_batch_to_process( 50 );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$processor->process_batch( $batch );
+			++$batches;
+
+			$this->assertLessThan( 60, $batches, 'The run failed to terminate.' );
+		}
+
+		return $batches;
+	}
+
+	/**
+	 * Set up the current site: the feature toggle and fresh, empty legacy tables.
+	 *
+	 * @return void
+	 */
+	private function seed_site(): void {
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+
+		// A blog created mid-test never ran WooCommerce's installer, so its administrator
+		// role has core capabilities only. Roles are cached per site, hence the refresh.
+		wp_roles()->for_site( get_current_blog_id() );
+		$administrator = get_role( 'administrator' );
+
+		if ( $administrator && ! $administrator->has_cap( 'manage_woocommerce' ) ) {
+			$administrator->add_cap( 'manage_woocommerce' );
+		}
+
+		LegacyStore::create_tables();
+		LegacyStore::create_core_tables();
+		LegacyStore::truncate_all();
+
+		$this->clear_migration_options();
+	}
+
+	/**
+	 * Tear down the current site: drop the legacy tables and clear everything the migration
+	 * persists, including the autoloaded flags.
+	 *
+	 * @return void
+	 */
+	private function unseed_site(): void {
+		LegacyStore::drop_tables();
+		$this->clear_migration_options();
+		delete_option( 'woocommerce_feature_customer_stock_notifications_enabled' );
+	}
+
+	/**
+	 * Clear every option the migration persists on the current site.
+	 *
+	 * @return void
+	 */
+	private function clear_migration_options(): void {
+		delete_option( 'wc_bis_migration_state' );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+	}
+
+	/**
+	 * Create a published simple product on the current site.
+	 *
+	 * @return int
+	 */
+	private function create_product(): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Multisite migration test product' );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Report/ReporterTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Report/ReporterTests.php
@@ -1,0 +1,210 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Report;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for what the migration writes to the log and how it reports itself.
+ *
+ * The migration touches a store's entire subscriber list, so the load-bearing assertion
+ * here is that no log line ever carries an email address or any other row content: these
+ * files get pasted into support tickets.
+ */
+class ReporterTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Log lines captured for the run, as `severity => [messages]`.
+	 *
+	 * @var array<string,array<int,string>>
+	 */
+	private array $logged = array();
+
+	/**
+	 * Capture everything written through the WooCommerce logger.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->logged = array();
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		add_filter( 'woocommerce_logger_log_message', array( $this, 'capture_log_message' ), 10, 3 );
+	}
+
+	/**
+	 * Stop capturing and clean up.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_logger_log_message', array( $this, 'capture_log_message' ), 10 );
+
+		LegacyStore::drop_tables();
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Record a log message written during a test.
+	 *
+	 * @param string $message The message.
+	 * @param string $level   Severity.
+	 * @param array  $context Log context.
+	 * @return string The unmodified message.
+	 */
+	public function capture_log_message( $message, $level, $context ) {
+		if ( 'bis-migration' === ( $context['source'] ?? '' ) ) {
+			$this->logged[ $level ][] = (string) $message;
+		}
+
+		return $message;
+	}
+
+	/**
+	 * @testdox no log line should ever carry row content, at any severity.
+	 */
+	public function test_no_log_line_carries_row_content(): void {
+		$product = new \WC_Product_Simple();
+		$product->save();
+
+		$migrated = LegacyStore::add_notification(
+			array(
+				'product_id' => $product->get_id(),
+				'user_email' => 'migrated@example.com',
+			)
+		);
+
+		$failing = LegacyStore::add_notification(
+			array(
+				'product_id' => $product->get_id(),
+				'user_email' => 'failing@example.com',
+			)
+		);
+
+		$migrator = new NotificationsMigrator( new Reporter() );
+		$batch    = $migrator->get_batch( 0, 10 );
+
+		$thrower = static function ( $query ) {
+			if ( false !== strpos( $query, 'failing@example.com' ) ) {
+				throw new \RuntimeException( 'forced row failure' );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $thrower );
+		$migrator->migrate_batch( $batch, new DbWriter() );
+		remove_filter( 'query', $thrower );
+
+		$this->assertNotEmpty( $this->logged, 'The run should have logged something.' );
+
+		foreach ( $this->logged as $level => $messages ) {
+			foreach ( $messages as $message ) {
+				$this->assertStringNotContainsString( '@example.com', $message, "An address leaked into a {$level} line." );
+			}
+		}
+
+		$this->assertContains( "section=notifications id={$failing} outcome=failed", $this->logged['error'] ?? array() );
+		$this->assertNotContains( "section=notifications id={$migrated} outcome=failed", $this->logged['error'] ?? array() );
+	}
+
+	/**
+	 * @testdox only an error-severity outcome should mark the run as failed.
+	 */
+	public function test_only_error_severity_marks_the_run_as_failed(): void {
+		$reporter = new Reporter();
+
+		$reporter->record( 'notifications', Reporter::OUTCOME_MIGRATED, 1 );
+		$reporter->record( 'notifications', Reporter::OUTCOME_UNVERIFIED, 2 );
+
+		$this->assertFalse( $reporter->has_errors(), 'A skip is a warning, not an error.' );
+
+		$reporter->record( 'notifications', Reporter::OUTCOME_FAILED, 3 );
+
+		$this->assertTrue( $reporter->has_errors() );
+	}
+
+	/**
+	 * @testdox a batch-level exception should be reported as an error.
+	 */
+	public function test_batch_exception_is_reported_as_an_error(): void {
+		$reporter = new Reporter();
+
+		$reporter->report_exception( 'notifications', new \RuntimeException( 'lost connection' ) );
+
+		$this->assertTrue( $reporter->has_errors() );
+		$this->assertContains( 'section=notifications batch failed: lost connection', $this->logged['error'] ?? array() );
+	}
+
+	/**
+	 * @testdox the outcome table should carry one row per section and outcome.
+	 */
+	public function test_table_has_one_row_per_section_and_outcome(): void {
+		$reporter = new Reporter();
+
+		$reporter->record( 'notifications', Reporter::OUTCOME_MIGRATED, 1 );
+		$reporter->record( 'notifications', Reporter::OUTCOME_MIGRATED, 2 );
+		$reporter->record( 'settings', Reporter::OUTCOME_SKIPPED_USER_MODIFIED, 1 );
+
+		$table = $reporter->get_table();
+
+		$this->assertContains(
+			array(
+				'section' => 'notifications',
+				'outcome' => Reporter::OUTCOME_MIGRATED,
+				'count'   => 2,
+			),
+			$table
+		);
+		$this->assertContains(
+			array(
+				'section' => 'settings',
+				'outcome' => Reporter::OUTCOME_SKIPPED_USER_MODIFIED,
+				'count'   => 1,
+			),
+			$table
+		);
+	}
+
+	/**
+	 * @testdox timestamps should render in site-local time, not UTC.
+	 */
+	public function test_timestamps_render_in_site_local_time(): void {
+		$original_offset = get_option( 'gmt_offset' );
+		$original_zone   = get_option( 'timezone_string' );
+
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 5 );
+
+		$timestamp = 1600000000;
+		$format    = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+		$rendered  = ( new Reporter() )->format_site_time( $timestamp );
+
+		$this->assertSame( wp_date( $format, $timestamp ), $rendered );
+		$this->assertNotSame( gmdate( $format, $timestamp ), $rendered, 'A five-hour offset must show.' );
+
+		update_option( 'gmt_offset', $original_offset );
+		update_option( 'timezone_string', $original_zone );
+	}
+
+	/**
+	 * @testdox a cached count should be rendered with the time it was computed.
+	 */
+	public function test_cached_count_carries_its_timestamp(): void {
+		$reporter = new Reporter();
+		$rendered = $reporter->format_cached_count( 42, 1600000000 );
+
+		$this->assertStringContainsString( '42', $rendered );
+		$this->assertStringContainsString( $reporter->format_site_time( 1600000000 ), $rendered );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/RequirementsTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/RequirementsTests.php
@@ -1,0 +1,100 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration;
+
+use Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificationsDataStore;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the checks a run makes before it starts and on every batch.
+ */
+class RequirementsTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Requirements under test.
+	 *
+	 * @var Requirements
+	 */
+	private Requirements $requirements;
+
+	/**
+	 * Set up the legacy tables and the feature toggle.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+
+		$this->requirements = new Requirements();
+		$this->requirements->init( wc_get_container()->get( StockNotificationsDataStore::class ) );
+	}
+
+	/**
+	 * Drop the legacy tables and the toggle.
+	 */
+	public function tearDown(): void {
+		LegacyStore::drop_tables();
+		delete_option( 'woocommerce_feature_customer_stock_notifications_enabled' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox every requirement met should pass.
+	 */
+	public function test_all_requirements_met(): void {
+		$this->assertTrue( $this->requirements->check() );
+	}
+
+	/**
+	 * @testdox the feature being off should fail with Features-screen guidance, not a fatal.
+	 */
+	public function test_feature_off_fails_with_guidance(): void {
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'no' );
+
+		$result = $this->requirements->check();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'feature_disabled', $result->get_error_code() );
+		$this->assertStringContainsString( 'Features', $result->get_error_message() );
+	}
+
+	/**
+	 * @testdox missing legacy tables should fail and name the table.
+	 */
+	public function test_missing_legacy_tables_fail_and_name_the_table(): void {
+		global $wpdb;
+
+		LegacyStore::drop_tables();
+
+		$result = $this->requirements->check();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'legacy_tables_missing', $result->get_error_code() );
+		$this->assertStringContainsString( $wpdb->prefix . 'woocommerce_bis_notifications', $result->get_error_message() );
+	}
+
+	/**
+	 * @testdox the queued-row count should be zero while the legacy extension is inactive.
+	 */
+	public function test_queued_rows_are_ignored_without_the_legacy_extension(): void {
+		$product = new \WC_Product_Simple();
+		$product->save();
+
+		LegacyStore::add_notification(
+			array(
+				'product_id' => $product->get_id(),
+				'is_queued'  => 'on',
+			)
+		);
+
+		$this->assertFalse( class_exists( 'WC_Back_In_Stock' ), 'This test assumes the legacy extension is not loaded.' );
+		$this->assertSame( 0, $this->requirements->count_legacy_queued_rows(), 'Nothing will ever drain that queue.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/RetentionInteractionTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/RetentionInteractionTests.php
@@ -1,0 +1,159 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration;
+
+use Automattic\WooCommerce\Internal\StockNotifications\DataRetentionController;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Migrators\NotificationsMigrator;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Report\Reporter;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\DbWriter;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests that the migration and Core's unverified-row retention sweep do not interfere.
+ *
+ * The retention threshold is deliberately absent from the candidate path: reading it there
+ * would make the population being migrated depend on a setting a merchant can change
+ * mid-run.
+ */
+class RetentionInteractionTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Core option holding the unverified-deletion threshold, in days.
+	 *
+	 * @var string
+	 */
+	private const THRESHOLD_OPTION = 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold';
+
+	/**
+	 * A published simple product every seeded row points at.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up the legacy tables and a product to subscribe to.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+		delete_option( self::THRESHOLD_OPTION );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		$product = new \WC_Product_Simple();
+		$product->save();
+		$this->product_id = $product->get_id();
+	}
+
+	/**
+	 * Clean up the tables, the threshold and the daily task.
+	 */
+	public function tearDown(): void {
+		( new DataRetentionController() )->clear_daily_task();
+
+		LegacyStore::drop_tables();
+		delete_option( self::THRESHOLD_OPTION );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox the candidate set should be identical whatever the retention threshold is.
+	 */
+	public function test_candidate_set_ignores_the_retention_threshold(): void {
+		$this->seed_rows( 3 );
+
+		update_option( self::THRESHOLD_OPTION, 1 );
+		$one_day = $this->candidates();
+
+		update_option( self::THRESHOLD_OPTION, 365 );
+		$one_year = $this->candidates();
+
+		$this->assertNotEmpty( $one_day );
+		$this->assertSame( $one_day, $one_year, 'The threshold must not reach the candidate query.' );
+	}
+
+	/**
+	 * @testdox the retention sweep should delete nothing the migration wrote.
+	 */
+	public function test_retention_sweep_leaves_migrated_rows_alone(): void {
+		$this->seed_rows( 3, 1500000000 );
+
+		$this->migrate();
+		$before = LegacyStore::get_core_rows();
+		$this->assertCount( 3, $before );
+
+		update_option( self::THRESHOLD_OPTION, 1 );
+		( new DataRetentionController() )->do_wc_customer_stock_notifications_daily();
+
+		$this->assertSame( $before, LegacyStore::get_core_rows(), 'No migrated row is pending, so none is swept.' );
+
+		// And a re-run adds nothing back, since every row still carries its marker.
+		$this->migrate();
+		$this->assertSame( $before, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox writing the threshold should schedule the daily task once.
+	 */
+	public function test_writing_the_threshold_schedules_the_daily_task_once(): void {
+		$controller = new DataRetentionController();
+
+		$this->assertFalse( wp_get_schedule( DataRetentionController::DAILY_TASK_HOOK ) );
+
+		update_option( self::THRESHOLD_OPTION, 30 );
+		$this->assertSame( 'daily', wp_get_schedule( DataRetentionController::DAILY_TASK_HOOK ) );
+
+		$first_run = wp_next_scheduled( DataRetentionController::DAILY_TASK_HOOK );
+
+		update_option( self::THRESHOLD_OPTION, 30 );
+		$this->assertSame( $first_run, wp_next_scheduled( DataRetentionController::DAILY_TASK_HOOK ), 'Rewriting the same value must not reschedule.' );
+
+		$controller->clear_daily_task();
+	}
+
+	/**
+	 * Seed eligible legacy rows.
+	 *
+	 * @param int $count       How many rows to seed.
+	 * @param int $create_date Legacy create date, as a Unix timestamp.
+	 * @return void
+	 */
+	private function seed_rows( int $count, int $create_date = 1600000000 ): void {
+		for ( $i = 0; $i < $count; $i++ ) {
+			LegacyStore::add_notification(
+				array(
+					'product_id'  => $this->product_id,
+					'user_email'  => "shopper{$i}@example.com",
+					'create_date' => $create_date,
+				)
+			);
+		}
+	}
+
+	/**
+	 * The current candidate legacy ids.
+	 *
+	 * @return int[]
+	 */
+	private function candidates(): array {
+		return ( new NotificationsMigrator( new Reporter() ) )->get_batch( 0, 100 );
+	}
+
+	/**
+	 * Migrate every outstanding legacy row.
+	 *
+	 * @return void
+	 */
+	private function migrate(): void {
+		$migrator = new NotificationsMigrator( new Reporter() );
+		$migrator->migrate_batch( $migrator->get_batch( 0, 100 ), new DbWriter() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/CliTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/CliTests.php
@@ -202,6 +202,37 @@ class CliTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox --yes should skip the confirmation prompt on every command that writes.
+	 */
+	public function test_yes_skips_the_confirmation_prompt(): void {
+		$this->seed_notifications( 1 );
+		update_option( 'wc_bis_migration_has_legacy_links', 'yes' );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+		$this->assertSame( array(), MockWPCLI::$prompted_confirmations );
+
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+		$this->assertSame( array(), MockWPCLI::$prompted_confirmations );
+
+		$this->cli()->disable_legacy_links( array(), array( 'yes' => true ) );
+		$this->assertSame( array(), MockWPCLI::$prompted_confirmations );
+	}
+
+	/**
+	 * @testdox every writing command should still confirm when --yes is absent.
+	 */
+	public function test_every_writing_command_confirms_without_yes(): void {
+		$this->seed_notifications( 1 );
+		update_option( 'wc_bis_migration_has_legacy_links', 'yes' );
+
+		$this->cli()->run( array(), array() );
+		$this->cli()->rollback( array(), array() );
+		$this->cli()->disable_legacy_links( array(), array() );
+
+		$this->assertCount( 3, MockWPCLI::$prompted_confirmations );
+	}
+
+	/**
 	 * @testdox a held CLI lock should stop run, rollback and disable-legacy-links alike.
 	 */
 	public function test_a_held_lock_stops_every_writing_command(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/CliTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/CliTests.php
@@ -1,0 +1,729 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Runners;
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\Cli;
+use Automattic\WooCommerce\Tests\Internal\CLI\Migrator\Mocks\MockWPCLI;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for `wp wc bis-migrate`: the gates every subcommand passes through, the concurrency
+ * refusals in both directions, the CLI-only run knobs, and the two commands that only exist
+ * here - `rollback` and `disable-legacy-links`.
+ */
+class CliTests extends WC_Unit_Test_Case {
+
+	/**
+	 * A 32-byte legacy hash key, as the legacy extension stored per notification.
+	 *
+	 * @var string
+	 */
+	private const HASH_KEY = '0123456789abcdef0123456789abcdef';
+
+	/**
+	 * A 16-byte legacy hash IV.
+	 *
+	 * @var string
+	 */
+	private const HASH_IV = 'fedcba9876543210';
+
+	/**
+	 * Run state, read back to assert what a command did to the lock and the cursors.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * A published simple product every seeded row points at.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up the legacy tables, the feature toggle and a WP_CLI that records instead of exiting.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Referencing the mock is what aliases it to the global WP_CLI the command calls.
+		MockWPCLI::reset();
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+		update_option( 'wc_bis_db_version', '1.2.0' );
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+
+		$this->clear_migration_options();
+
+		$this->state      = new MigrationState();
+		$this->product_id = $this->create_product();
+
+		$this->set_processor_enqueued( false );
+	}
+
+	/**
+	 * Drop the legacy tables, the container replacements and everything the migration persists.
+	 */
+	public function tearDown(): void {
+		$this->reset_container_replacements();
+		$this->reset_container_resolutions();
+
+		LegacyStore::drop_tables();
+		$this->clear_migration_options();
+		delete_option( 'wc_bis_db_version' );
+		delete_option( 'woocommerce_feature_customer_stock_notifications_enabled' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox --force should be refused without --yes.
+	 */
+	public function test_force_requires_yes(): void {
+		$this->seed_notifications( 1 );
+
+		$this->cli()->run( array(), array( 'force' => true ) );
+
+		$this->assertSame( '--force requires --yes.', MockWPCLI::$last_error_message );
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox a store that never installed the legacy extension should exit cleanly with nothing to migrate.
+	 */
+	public function test_clean_store_reports_nothing_to_migrate(): void {
+		delete_option( 'wc_bis_db_version' );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'never installed', MockWPCLI::$last_success_message );
+		$this->assertSame( '', MockWPCLI::$last_error_message, 'Nothing to migrate is a success, not an error.' );
+	}
+
+	/**
+	 * @testdox --force-discover should get past the option gate and reach the requirements check.
+	 */
+	public function test_force_discover_skips_the_option_gate(): void {
+		delete_option( 'wc_bis_db_version' );
+		LegacyStore::drop_tables();
+
+		$this->cli()->run(
+			array(),
+			array(
+				'force-discover' => true,
+				'yes'            => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'woocommerce_bis_notifications', MockWPCLI::$last_success_message );
+		$this->assertStringNotContainsString( 'never installed', MockWPCLI::$last_success_message );
+	}
+
+	/**
+	 * @testdox the feature toggle being off should stop the run without writing or erroring.
+	 */
+	public function test_feature_off_stops_the_run(): void {
+		$this->seed_notifications( 1 );
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'no' );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'Features', MockWPCLI::$last_success_message );
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox an unknown --section value should be rejected and name the valid sections.
+	 */
+	public function test_unknown_section_is_rejected(): void {
+		$this->cli()->run(
+			array(),
+			array(
+				'section' => 'notifications,widgets',
+				'yes'     => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'widgets', MockWPCLI::$last_error_message );
+		$this->assertStringContainsString( 'product-meta', MockWPCLI::$last_error_message );
+	}
+
+	/**
+	 * @testdox run should refuse while a background run is enqueued, and --force must not override it.
+	 */
+	public function test_run_refuses_while_the_processor_is_enqueued(): void {
+		$this->seed_notifications( 1 );
+		$this->set_processor_enqueued( true );
+
+		$this->cli()->run(
+			array(),
+			array(
+				'force' => true,
+				'yes'   => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'already in progress in the background', MockWPCLI::$last_error_message );
+		$this->assertStringContainsString( '--force does not override this', MockWPCLI::$last_error_message );
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox rollback should refuse while a background run is enqueued.
+	 */
+	public function test_rollback_refuses_while_the_processor_is_enqueued(): void {
+		$this->set_processor_enqueued( true );
+
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'in progress in the background', MockWPCLI::$last_error_message );
+	}
+
+	/**
+	 * @testdox disable-legacy-links should refuse while a background run is enqueued.
+	 */
+	public function test_disable_legacy_links_refuses_while_the_processor_is_enqueued(): void {
+		update_option( 'wc_bis_migration_has_legacy_links', 'yes' );
+		$this->set_processor_enqueued( true );
+
+		$this->cli()->disable_legacy_links( array(), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'in progress in the background', MockWPCLI::$last_error_message );
+		$this->assertSame( 'yes', get_option( 'wc_bis_migration_has_legacy_links' ) );
+	}
+
+	/**
+	 * @testdox a held CLI lock should stop run, rollback and disable-legacy-links alike.
+	 */
+	public function test_a_held_lock_stops_every_writing_command(): void {
+		$this->seed_notifications( 1 );
+
+		$this->state->acquire_lock( 'another run (pid 1)' );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+		$this->assertStringContainsString( 'Could not acquire the migration CLI lock', MockWPCLI::$last_error_message );
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+		$this->assertStringContainsString( 'Could not acquire the migration CLI lock', MockWPCLI::$last_error_message );
+
+		MockWPCLI::reset();
+		$this->cli()->disable_legacy_links( array(), array( 'yes' => true ) );
+		$this->assertStringContainsString( 'Could not acquire the migration CLI lock', MockWPCLI::$last_error_message );
+	}
+
+	/**
+	 * @testdox a lock left behind by a dead run should be reclaimed so the next run proceeds.
+	 */
+	public function test_a_stale_lock_is_reclaimed(): void {
+		$this->seed_notifications( 1 );
+
+		$this->state->acquire_lock( 'dead run (pid 1)' );
+		$this->age_the_lock( 2 * HOUR_IN_SECONDS );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertSame( '', MockWPCLI::$last_error_message );
+		$this->assertCount( 1, LegacyStore::get_core_rows() );
+		$this->assertNull( $this->state->get_lock(), 'The run should release the lock it reclaimed.' );
+	}
+
+	/**
+	 * @testdox legacy rows still queued by the active extension should refuse a run until --force.
+	 */
+	public function test_queued_rows_refuse_a_run_until_forced(): void {
+		$this->seed_notifications( 1 );
+
+		$this->replace_requirements_with_queued_rows( 3 );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( '3 legacy row(s) are still queued', MockWPCLI::$last_error_message );
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+
+		MockWPCLI::reset();
+		$this->cli()->run(
+			array(),
+			array(
+				'force' => true,
+				'yes'   => true,
+			)
+		);
+
+		$this->assertSame( '', MockWPCLI::$last_error_message );
+		$this->assertCount( 1, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox a plain run should migrate every eligible row, release the lock and report success.
+	 */
+	public function test_run_migrates_every_row(): void {
+		$this->seed_notifications( 3 );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertCount( 3, LegacyStore::get_core_rows() );
+		$this->assertSame( 'Run complete.', MockWPCLI::$last_success_message );
+		$this->assertNull( $this->state->get_lock() );
+		$this->assertNull( MockWPCLI::$last_halt_code );
+	}
+
+	/**
+	 * @testdox --dry-run should write nothing and still release the lock.
+	 */
+	public function test_dry_run_writes_nothing(): void {
+		$this->seed_notifications( 2 );
+
+		$this->cli()->run( array(), array( 'dry-run' => true ) );
+
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+		$this->assertSame( 'Dry run complete.', MockWPCLI::$last_success_message );
+		$this->assertNull( $this->state->get_lock() );
+	}
+
+	/**
+	 * @testdox --max-batches should bound the CLI loop.
+	 */
+	public function test_max_batches_bounds_the_loop(): void {
+		$this->seed_notifications( 6 );
+
+		$this->cli()->run(
+			array(),
+			array(
+				'section'     => 'notifications',
+				'batch-size'  => 2,
+				'max-batches' => 2,
+				'yes'         => true,
+			)
+		);
+
+		$this->assertCount( 4, LegacyStore::get_core_rows(), 'Two batches of two is where the run should stop.' );
+	}
+
+	/**
+	 * @testdox --retry-failed should clear the permanent-failure marker and re-admit the row.
+	 */
+	public function test_retry_failed_re_admits_a_failed_row(): void {
+		$legacy_ids = $this->seed_notifications( 2 );
+		$failed_id  = $legacy_ids[0];
+
+		LegacyStore::add_meta( $failed_id, '_wc_bis_migration_failed', array( 'reason' => 'exception' ) );
+
+		$this->cli()->run(
+			array(),
+			array(
+				'section' => 'notifications',
+				'yes'     => true,
+			)
+		);
+		$this->assertCount( 1, LegacyStore::get_core_rows(), 'A marked row stays out of the candidate set.' );
+
+		MockWPCLI::reset();
+		$this->cli()->run(
+			array(),
+			array(
+				'section'      => 'notifications',
+				'retry-failed' => true,
+				'yes'          => true,
+			)
+		);
+
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+		$this->assertSame( array(), LegacyStore::get_legacy_meta( $failed_id, '_wc_bis_migration_failed' ) );
+	}
+
+	/**
+	 * @testdox --retry-failed should be ignored under --dry-run.
+	 */
+	public function test_retry_failed_is_ignored_under_dry_run(): void {
+		$legacy_ids = $this->seed_notifications( 1 );
+
+		LegacyStore::add_meta( $legacy_ids[0], '_wc_bis_migration_failed', array( 'reason' => 'exception' ) );
+
+		$this->cli()->run(
+			array(),
+			array(
+				'retry-failed' => true,
+				'dry-run'      => true,
+			)
+		);
+
+		$this->assertCount( 1, LegacyStore::get_legacy_meta( $legacy_ids[0], '_wc_bis_migration_failed' ) );
+	}
+
+	/**
+	 * @testdox a run with an error-severity outcome should halt non-zero.
+	 */
+	public function test_error_severity_halts_non_zero(): void {
+		$legacy_ids = $this->seed_notifications( 2 );
+		$failing_id = $legacy_ids[1];
+
+		// The adoption lookup is the only per-row query, so failing it is the cleanest way to
+		// simulate a row that cannot be mapped.
+		$thrower = static function ( $query ) use ( $failing_id ) {
+			if ( false !== strpos( $query, "shopper{$failing_id}@example.com" ) ) {
+				throw new \RuntimeException( 'forced row failure' );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $thrower );
+
+		try {
+			$this->cli()->run(
+				array(),
+				array(
+					'section' => 'notifications',
+					'yes'     => true,
+				)
+			);
+		} finally {
+			remove_filter( 'query', $thrower );
+		}
+
+		$this->assertSame( 1, MockWPCLI::$last_halt_code );
+		$this->assertStringContainsString( 'error-severity outcomes', MockWPCLI::$last_warning_message );
+	}
+
+	/**
+	 * @testdox verify should report a status a merchant changed after migrating as a mismatch.
+	 */
+	public function test_verify_reports_a_status_mismatch(): void {
+		$this->seed_notifications( 1 );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->set_core_status( LegacyStore::get_core_rows()[0]['id'], NotificationStatus::CANCELLED );
+
+		MockWPCLI::reset();
+		$this->cli()->verify( array(), array() );
+
+		$this->assertStringContainsString( 'status mismatches', MockWPCLI::$last_error_message );
+		$this->assertSame( '', MockWPCLI::$last_success_message );
+	}
+
+	/**
+	 * @testdox verify should pass on an untouched migration and write nothing.
+	 */
+	public function test_verify_passes_on_an_untouched_migration(): void {
+		$this->seed_notifications( 2 );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$before = LegacyStore::get_core_rows();
+
+		MockWPCLI::reset();
+		$this->cli()->verify( array(), array() );
+
+		$this->assertStringContainsString( 'Verified', MockWPCLI::$last_success_message );
+		$this->assertSame( $before, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox rollback should delete the rows it inserted and clear the migration flags.
+	 */
+	public function test_rollback_deletes_inserted_rows(): void {
+		$this->seed_notifications( 2 );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+		$this->assertSame( array(), LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) );
+		$this->assertFalse( get_option( 'wc_bis_migration_has_legacy_links' ) );
+		$this->assertFalse( get_option( 'wc_bis_migration_has_migrated_rows' ) );
+		$this->assertSame( 'Rollback complete.', MockWPCLI::$last_success_message );
+	}
+
+	/**
+	 * @testdox rollback --dry-run should report what it would do without deleting anything.
+	 */
+	public function test_rollback_dry_run_deletes_nothing(): void {
+		$this->seed_notifications( 2 );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'dry-run' => true ) );
+
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+		$this->assertStringContainsString( 'would be deleted', implode( ' ', MockWPCLI::$all_log_messages ) );
+		$this->assertSame( 'Dry run complete.', MockWPCLI::$last_success_message );
+	}
+
+	/**
+	 * @testdox rollback should leave a row whose status a merchant changed after migrating.
+	 */
+	public function test_rollback_refuses_a_merchant_changed_row(): void {
+		$this->seed_notifications( 2 );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$rows = LegacyStore::get_core_rows();
+		$this->set_core_status( $rows[0]['id'], NotificationStatus::CANCELLED );
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+
+		$remaining = LegacyStore::get_core_rows();
+		$this->assertCount( 1, $remaining );
+		$this->assertSame( (string) $rows[0]['id'], (string) $remaining[0]['id'] );
+		$this->assertStringContainsString( '1 row(s) left untouched', implode( ' ', MockWPCLI::$all_log_messages ) );
+	}
+
+	/**
+	 * @testdox rollback should keep an adopted row and only remove the markers it added to it.
+	 */
+	public function test_rollback_keeps_an_adopted_row(): void {
+		$legacy_ids = $this->seed_notifications( 1 );
+
+		$adopted_id = LegacyStore::add_core_notification(
+			array(
+				'product_id' => $this->product_id,
+				'user_email' => "shopper{$legacy_ids[0]}@example.com",
+				'status'     => NotificationStatus::ACTIVE,
+			)
+		);
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+		$this->assertCount( 1, LegacyStore::get_core_rows(), 'The legacy row should have adopted the existing Core row.' );
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+
+		$rows = LegacyStore::get_core_rows();
+		$this->assertCount( 1, $rows );
+		$this->assertSame( (string) $adopted_id, (string) $rows[0]['id'] );
+		$this->assertSame( array(), LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) );
+		$this->assertSame( array(), LegacyStore::get_core_meta( '_wc_bis_legacy_adopted' ) );
+	}
+
+	/**
+	 * @testdox rollback should refuse outright once the legacy tables are gone, rather than report zero.
+	 */
+	public function test_rollback_refuses_without_the_legacy_tables(): void {
+		$this->seed_notifications( 1 );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		LegacyStore::drop_tables();
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'Refusing to roll back', MockWPCLI::$last_error_message );
+		$this->assertCount( 1, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox disable-legacy-links should drop the token hashes and the flag but keep the legacy id marker.
+	 */
+	public function test_disable_legacy_links_keeps_the_idempotency_marker(): void {
+		$this->seed_notifications( 1, true );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertNotEmpty( LegacyStore::get_core_meta( '_wc_bis_legacy_unsub_hash' ) );
+		$this->assertSame( 'yes', get_option( 'wc_bis_migration_has_legacy_links' ) );
+
+		MockWPCLI::reset();
+		$this->cli()->disable_legacy_links( array(), array( 'yes' => true ) );
+
+		$this->assertSame( array(), LegacyStore::get_core_meta( '_wc_bis_legacy_unsub_hash' ) );
+		$this->assertNotEmpty( LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) );
+		$this->assertFalse( get_option( 'wc_bis_migration_has_legacy_links' ) );
+	}
+
+	/**
+	 * @testdox a run after disable-legacy-links should still write nothing, and rollback should still work.
+	 */
+	public function test_rollback_still_works_after_disable_legacy_links(): void {
+		$this->seed_notifications( 2, true );
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->cli()->disable_legacy_links( array(), array( 'yes' => true ) );
+
+		MockWPCLI::reset();
+		$this->cli()->run( array(), array( 'yes' => true ) );
+		$this->assertCount( 2, LegacyStore::get_core_rows(), 'The legacy id marker still makes the run idempotent.' );
+
+		MockWPCLI::reset();
+		$this->cli()->rollback( array(), array( 'yes' => true ) );
+
+		$this->assertSame( array(), LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox a second run should write nothing and report nothing outstanding.
+	 */
+	public function test_a_second_run_writes_nothing(): void {
+		$this->seed_notifications( 3 );
+
+		$this->cli()->run( array(), array( 'yes' => true ) );
+		$first = LegacyStore::get_core_rows();
+
+		MockWPCLI::reset();
+		$this->cli()->run( array(), array( 'yes' => true ) );
+
+		$this->assertSame( $first, LegacyStore::get_core_rows() );
+		$this->assertSame( 'Run complete.', MockWPCLI::$last_success_message );
+	}
+
+	/**
+	 * @testdox status should report the cached outstanding counts rather than counting the legacy rows itself.
+	 */
+	public function test_status_runs_no_counts_of_its_own(): void {
+		$this->seed_notifications( 2 );
+
+		$counted = array();
+
+		// Only the notifications table matters here. `status` does count the permanent-failure
+		// markers in the meta table, which is a different, deliberately live figure.
+		$recorder = function ( $query ) use ( &$counted ) {
+			if ( false !== stripos( $query, 'COUNT(' ) && false !== stripos( $query, 'woocommerce_bis_notifications ' ) ) {
+				$counted[] = $query;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $recorder );
+		$this->cli()->status( array(), array() );
+		remove_filter( 'query', $recorder );
+
+		$this->assertSame( array(), $counted, 'status must read the cached counts, never compute them.' );
+	}
+
+	/**
+	 * Build a command instance against the current container replacements.
+	 *
+	 * @return Cli
+	 */
+	private function cli(): Cli {
+		return new Cli();
+	}
+
+	/**
+	 * Replace the batch processing controller with one reporting the given enqueued state.
+	 *
+	 * @param bool $enqueued What `is_enqueued()` should report.
+	 * @return void
+	 */
+	private function set_processor_enqueued( bool $enqueued ): void {
+		$controller = $this->createMock( BatchProcessingController::class );
+		$controller->method( 'is_enqueued' )->willReturn( $enqueued );
+
+		wc_get_container()->replace( BatchProcessingController::class, $controller );
+	}
+
+	/**
+	 * Replace the requirements check with one reporting outstanding legacy queued rows, as
+	 * only an active legacy extension can.
+	 *
+	 * @param int $count Rows to report as queued.
+	 * @return void
+	 */
+	private function replace_requirements_with_queued_rows( int $count ): void {
+		$requirements = $this->createMock( Requirements::class );
+		$requirements->method( 'check' )->willReturn( true );
+		$requirements->method( 'count_legacy_queued_rows' )->willReturn( $count );
+
+		wc_get_container()->replace( Requirements::class, $requirements );
+	}
+
+	/**
+	 * Push the current lock's acquisition time into the past.
+	 *
+	 * @param int $seconds How far back to move it.
+	 * @return void
+	 */
+	private function age_the_lock( int $seconds ): void {
+		$state                        = get_option( 'wc_bis_migration_state' );
+		$state['lock']['acquired_at'] = time() - $seconds;
+
+		update_option( 'wc_bis_migration_state', $state );
+	}
+
+	/**
+	 * Set a Core notification's status by direct SQL, as a merchant edit in admin would.
+	 *
+	 * @param int|string $notification_id Core notification id.
+	 * @param string     $status          New status.
+	 * @return void
+	 */
+	private function set_core_status( $notification_id, string $status ): void {
+		global $wpdb;
+
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prefix . 'wc_stock_notifications',
+			array( 'status' => $status ),
+			array( 'id' => (int) $notification_id )
+		);
+	}
+
+	/**
+	 * Seed eligible legacy notification rows, one per unique email.
+	 *
+	 * @param int  $count       How many rows to seed.
+	 * @param bool $with_secrets Whether to add the `_hash_key`/`_hash_iv` pair a legacy
+	 *                           unsubscribe token is derived from.
+	 * @return int[] The seeded legacy ids, ascending.
+	 */
+	private function seed_notifications( int $count, bool $with_secrets = false ): array {
+		global $wpdb;
+
+		$ids = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$legacy_id = LegacyStore::add_notification( array( 'product_id' => $this->product_id ) );
+			$ids[]     = $legacy_id;
+
+			// The email carries the legacy id so a single row can be singled out in a query.
+			$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$wpdb->prefix . 'woocommerce_bis_notifications',
+				array( 'user_email' => "shopper{$legacy_id}@example.com" ),
+				array( 'id' => $legacy_id )
+			);
+
+			if ( $with_secrets ) {
+				LegacyStore::add_meta( $legacy_id, '_hash_key', self::HASH_KEY );
+				LegacyStore::add_meta( $legacy_id, '_hash_iv', self::HASH_IV );
+			}
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Clear every option the migration persists, including the autoloaded flags that survive
+	 * the per-test transaction rollback through the object cache.
+	 *
+	 * @return void
+	 */
+	private function clear_migration_options(): void {
+		delete_option( 'wc_bis_migration_state' );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+	}
+
+	/**
+	 * Create a published simple product.
+	 *
+	 * @return int
+	 */
+	private function create_product(): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Migration test product' );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/MigrationBatchProcessorTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/MigrationBatchProcessorTests.php
@@ -1,0 +1,401 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Runners;
+
+use Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificationsDataStore;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Requirements;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\MigrationBatchProcessor;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the batch processor that drives the whole migration: section batching,
+ * termination, resumption after an interrupted run, and idempotency across runs.
+ */
+class MigrationBatchProcessorTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Processor under test.
+	 *
+	 * @var MigrationBatchProcessor
+	 */
+	private MigrationBatchProcessor $processor;
+
+	/**
+	 * Run state, shared with the processor through the option it persists to.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * A published simple product every seeded row points at.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up the legacy tables, the feature toggle and a product to subscribe to.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+
+		$this->clear_migration_options();
+
+		$requirements = new Requirements();
+		$requirements->init( wc_get_container()->get( StockNotificationsDataStore::class ) );
+
+		$this->processor = new MigrationBatchProcessor();
+		$this->processor->init( $requirements );
+
+		$this->state      = new MigrationState();
+		$this->product_id = $this->create_product();
+	}
+
+	/**
+	 * Drop the legacy tables and clear everything the migration persists.
+	 */
+	public function tearDown(): void {
+		LegacyStore::drop_tables();
+		$this->clear_migration_options();
+		delete_option( 'woocommerce_feature_customer_stock_notifications_enabled' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox a batch should be section-prefixed and never span two sections.
+	 */
+	public function test_batch_items_are_section_prefixed_and_single_section(): void {
+		$this->seed_notifications( 3 );
+
+		$batch = $this->processor->get_next_batch_to_process( 10 );
+
+		$this->assertNotEmpty( $batch );
+
+		$sections = array();
+		foreach ( $batch as $item ) {
+			$this->assertMatchesRegularExpression( '/^[a-z-]+::.+$/', (string) $item );
+			$sections[] = explode( '::', (string) $item, 2 )[0];
+		}
+
+		$this->assertSame( array( 'notifications' ), array_values( array_unique( $sections ) ) );
+	}
+
+	/**
+	 * @testdox get_next_batch_to_process should be side-effect free.
+	 */
+	public function test_get_next_batch_is_side_effect_free(): void {
+		$this->seed_notifications( 3 );
+
+		$first  = $this->processor->get_next_batch_to_process( 2 );
+		$cursor = $this->state->get_cursor( 'notifications' );
+		$second = $this->processor->get_next_batch_to_process( 2 );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( $cursor, $this->state->get_cursor( 'notifications' ) );
+	}
+
+	/**
+	 * @testdox a multi-batch run should migrate every row and end with an empty probe.
+	 */
+	public function test_multi_batch_run_terminates_with_an_empty_probe(): void {
+		$this->seed_notifications( 7 );
+
+		$batches = $this->run_to_completion( 2 );
+
+		$this->assertGreaterThan( 1, $batches, 'The run should have taken several batches.' );
+		$this->assertCount( 7, LegacyStore::get_core_rows() );
+		$this->assertSame( array(), $this->processor->get_next_batch_to_process( 50 ) );
+	}
+
+	/**
+	 * @testdox a second run should write nothing.
+	 */
+	public function test_second_run_writes_nothing(): void {
+		$this->seed_notifications( 4 );
+
+		$this->run_to_completion( 50 );
+		$after_first = LegacyStore::get_core_rows();
+
+		$this->run_to_completion( 50 );
+
+		$this->assertSame( $after_first, LegacyStore::get_core_rows(), 'A re-run must not write anything.' );
+	}
+
+	/**
+	 * @testdox deleting migrated rows should re-admit exactly those rows on the next run.
+	 */
+	public function test_deleted_rows_return_on_the_next_run(): void {
+		$legacy_ids = $this->seed_notifications( 4 );
+
+		$this->run_to_completion( 50 );
+
+		$deleted = array( $legacy_ids[0], $legacy_ids[2] );
+		$this->delete_core_rows_for( $deleted );
+
+		$this->assertSame( $deleted, $this->raw_batch( 50 ), 'Only the deleted rows should be outstanding.' );
+
+		$this->run_to_completion( 50 );
+
+		$this->assertCount( 4, LegacyStore::get_core_rows() );
+		$this->assertSame( array(), $this->processor->get_next_batch_to_process( 50 ) );
+	}
+
+	/**
+	 * @testdox a row deleted behind an in-flight cursor should be picked up by the pass reset.
+	 */
+	public function test_row_deleted_behind_the_cursor_is_picked_up(): void {
+		$legacy_ids = $this->seed_notifications( 4 );
+
+		// Migrate the first two rows, leaving the cursor part-way through the section.
+		$batch = $this->processor->get_next_batch_to_process( 2 );
+		$this->processor->process_batch( $batch );
+		$this->assertSame( $legacy_ids[1], $this->state->get_cursor( 'notifications' ) );
+
+		$this->delete_core_rows_for( array( $legacy_ids[0] ) );
+
+		// The remaining rows are ahead of the cursor, so they drain first; only then does the
+		// probe restart the pass and find the row that fell back in behind it.
+		$this->run_to_completion( 2 );
+
+		$this->assertCount( 4, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox a held CLI lock should empty the batch and stop processing.
+	 */
+	public function test_a_held_lock_stops_the_processor(): void {
+		$this->seed_notifications( 2 );
+
+		$batch = $this->processor->get_next_batch_to_process( 50 );
+		$this->assertNotEmpty( $batch );
+
+		$this->state->acquire_lock( 'cli' );
+
+		$this->assertSame( array(), $this->processor->get_next_batch_to_process( 50 ) );
+
+		$this->processor->process_batch( $batch );
+		$this->assertSame( array(), LegacyStore::get_core_rows(), 'A locked run must not write.' );
+
+		$this->state->release_lock();
+		$this->run_to_completion( 50 );
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox toggling the feature off mid-run should stop the run and leave it resumable.
+	 */
+	public function test_feature_toggled_off_mid_run_stops_and_resumes(): void {
+		$this->seed_notifications( 4 );
+
+		$this->processor->process_batch( $this->processor->get_next_batch_to_process( 2 ) );
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'no' );
+
+		$this->assertSame( array(), $this->processor->get_next_batch_to_process( 50 ) );
+		$this->assertCount( 2, LegacyStore::get_core_rows(), 'Nothing more may migrate while the feature is off.' );
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+
+		$this->run_to_completion( 50 );
+		$this->assertCount( 4, LegacyStore::get_core_rows() );
+	}
+
+	/**
+	 * @testdox losing the state option mid-run should end at the same place as an uninterrupted run.
+	 */
+	public function test_losing_the_state_option_mid_run_ends_identically(): void {
+		$legacy_ids = $this->seed_notifications( 5 );
+
+		$this->processor->process_batch( $this->processor->get_next_batch_to_process( 2 ) );
+
+		delete_option( 'wc_bis_migration_state' );
+
+		$this->run_to_completion( 2 );
+
+		$rows = LegacyStore::get_core_rows();
+		$this->assertCount( 5, $rows );
+
+		$markers             = LegacyStore::get_core_meta( '_wc_bis_legacy_id' );
+		$migrated_legacy_ids = array_map( 'intval', array_merge( ...array_values( $markers ) ) );
+		sort( $migrated_legacy_ids );
+
+		$this->assertSame( $legacy_ids, $migrated_legacy_ids, 'Every legacy row migrates exactly once.' );
+	}
+
+	/**
+	 * @testdox a run interrupted inside process_batch should migrate the rest and only the rest.
+	 */
+	public function test_run_interrupted_inside_process_batch_resumes(): void {
+		$legacy_ids = $this->seed_notifications( 5 );
+
+		// A killed worker leaves the markers written by the rows that made it through and no
+		// cursor for the batch it died in; the next run re-queries from those markers.
+		$this->processor->process_batch( array( 'notifications::' . $legacy_ids[0] ) );
+		delete_option( 'wc_bis_migration_state' );
+
+		$this->run_to_completion( 2 );
+
+		$this->assertCount( 5, LegacyStore::get_core_rows() );
+
+		foreach ( LegacyStore::get_core_meta( '_wc_bis_legacy_id' ) as $values ) {
+			$this->assertCount( 1, $values, 'No legacy row may be migrated twice.' );
+		}
+	}
+
+	/**
+	 * @testdox a per-row failure should mark the row, leave the batch intact, and let the run finish.
+	 */
+	public function test_per_row_failure_marks_the_row_and_the_run_terminates(): void {
+		$legacy_ids = $this->seed_notifications( 3 );
+		$failing_id = $legacy_ids[1];
+
+		$thrower = function ( $query ) use ( $failing_id ) {
+			// The adoption lookup is the only per-row query, so failing it is the cleanest way
+			// to simulate a row that cannot be mapped.
+			if ( false !== strpos( $query, "shopper{$failing_id}@example.com" ) ) {
+				throw new \RuntimeException( 'forced row failure' );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $thrower );
+		$this->run_to_completion( 50 );
+		remove_filter( 'query', $thrower );
+
+		$this->assertCount( 2, LegacyStore::get_core_rows() );
+
+		$marker = LegacyStore::get_legacy_meta( $failing_id, '_wc_bis_migration_failed' );
+		$this->assertCount( 1, $marker );
+		$this->assertSame( 'exception', $marker[0]['reason'] );
+
+		$this->assertSame( array(), $this->processor->get_next_batch_to_process( 50 ), 'A failed row leaves the candidate set.' );
+	}
+
+	/**
+	 * Run the processor until it reports an empty batch.
+	 *
+	 * @param int $size Batch size to request.
+	 * @return int Number of batches processed.
+	 */
+	private function run_to_completion( int $size ): int {
+		$batches = 0;
+
+		while ( true ) {
+			$batch = $this->processor->get_next_batch_to_process( $size );
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$this->processor->process_batch( $batch );
+			++$batches;
+
+			$this->assertLessThan( 60, $batches, 'The run failed to terminate.' );
+		}
+
+		return $batches;
+	}
+
+	/**
+	 * The next batch's raw legacy ids, with the section prefix stripped.
+	 *
+	 * @param int $size Batch size to request.
+	 * @return int[]
+	 */
+	private function raw_batch( int $size ): array {
+		return array_map(
+			static function ( $item ) {
+				return (int) explode( '::', (string) $item, 2 )[1];
+			},
+			$this->processor->get_next_batch_to_process( $size )
+		);
+	}
+
+	/**
+	 * Seed a number of eligible legacy notification rows, one per unique email.
+	 *
+	 * @param int $count How many rows to seed.
+	 * @return int[] The seeded legacy ids, ascending.
+	 */
+	private function seed_notifications( int $count ): array {
+		global $wpdb;
+
+		$ids = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$legacy_id = LegacyStore::add_notification( array( 'product_id' => $this->product_id ) );
+			$ids[]     = $legacy_id;
+
+			// The email carries the legacy id so a single row can be singled out in a query.
+			$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$wpdb->prefix . 'woocommerce_bis_notifications',
+				array( 'user_email' => "shopper{$legacy_id}@example.com" ),
+				array( 'id' => $legacy_id )
+			);
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Delete the Core rows carrying the given legacy ids, markers and all.
+	 *
+	 * @param int[] $legacy_ids Legacy ids whose migrated rows should be removed.
+	 * @return void
+	 */
+	private function delete_core_rows_for( array $legacy_ids ): void {
+		global $wpdb;
+
+		foreach ( $legacy_ids as $legacy_id ) {
+			// Table names are $wpdb->prefix-based, never user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+			$notification_id = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT notification_id FROM {$wpdb->prefix}wc_stock_notificationmeta WHERE meta_key = %s AND meta_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					'_wc_bis_legacy_id',
+					(string) $legacy_id
+				)
+			);
+
+			$wpdb->delete( $wpdb->prefix . 'wc_stock_notifications', array( 'id' => $notification_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->delete( $wpdb->prefix . 'wc_stock_notificationmeta', array( 'notification_id' => $notification_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		}
+	}
+
+	/**
+	 * Clear every option the migration persists, including the autoloaded flags that
+	 * survive the per-test transaction rollback through the object cache.
+	 *
+	 * @return void
+	 */
+	private function clear_migration_options(): void {
+		delete_option( 'wc_bis_migration_state' );
+		delete_option( 'wc_bis_migration_has_legacy_links' );
+		delete_option( 'wc_bis_migration_has_migrated_rows' );
+	}
+
+	/**
+	 * Create a published simple product.
+	 *
+	 * @return int
+	 */
+	private function create_product(): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Migration test product' );
+		$product->save();
+
+		return $product->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/ToolsRegistrarTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Runners/ToolsRegistrarTests.php
@@ -1,0 +1,181 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Runners;
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\MigrationState;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\MigrationBatchProcessor;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Runners\ToolsRegistrar;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Tools screen entry: who may see and run it, how it refuses to race a CLI
+ * run, and what it is allowed to query while rendering.
+ */
+class ToolsRegistrarTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Registrar under test.
+	 *
+	 * @var ToolsRegistrar
+	 */
+	private ToolsRegistrar $registrar;
+
+	/**
+	 * Run state.
+	 *
+	 * @var MigrationState
+	 */
+	private MigrationState $state;
+
+	/**
+	 * Set up the legacy tables, an admin user and a clean state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
+
+		LegacyStore::create_tables();
+		LegacyStore::truncate_all();
+		delete_option( 'wc_bis_migration_state' );
+
+		$this->registrar = wc_get_container()->get( ToolsRegistrar::class );
+		$this->state     = new MigrationState();
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Dequeue anything a test enqueued and clear the state.
+	 */
+	public function tearDown(): void {
+		wc_get_container()->get( BatchProcessingController::class )->remove_processor( MigrationBatchProcessor::class );
+
+		LegacyStore::drop_tables();
+		delete_option( 'wc_bis_migration_state' );
+		delete_option( 'woocommerce_feature_customer_stock_notifications_enabled' );
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox the tool entry and both callbacks should refuse a user without manage_woocommerce.
+	 */
+	public function test_capability_is_required_for_the_entry_and_both_callbacks(): void {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'customer' ) ) );
+
+		$this->assertSame( array(), $this->registrar->handle_woocommerce_debug_tools( array() ) );
+		$this->assertSame( 'You do not have permission to do this.', $this->registrar->start() );
+		$this->assertSame( 'You do not have permission to do this.', $this->registrar->stop() );
+
+		$this->assertFalse(
+			wc_get_container()->get( BatchProcessingController::class )->is_enqueued( MigrationBatchProcessor::class ),
+			'A refused start must not enqueue anything.'
+		);
+	}
+
+	/**
+	 * @testdox starting should enqueue the processor and swap the entry for a stop button.
+	 */
+	public function test_start_enqueues_and_swaps_the_entry(): void {
+		$tools = $this->registrar->handle_woocommerce_debug_tools( array() );
+		$this->assertArrayHasKey( 'start_bis_migration', $tools );
+
+		$this->registrar->start();
+
+		$this->assertTrue(
+			wc_get_container()->get( BatchProcessingController::class )->is_enqueued( MigrationBatchProcessor::class )
+		);
+
+		$tools = $this->registrar->handle_woocommerce_debug_tools( array() );
+		$this->assertArrayHasKey( 'stop_bis_migration', $tools );
+		$this->assertArrayNotHasKey( 'start_bis_migration', $tools );
+
+		$this->assertStringContainsString( 'stopped', $this->registrar->stop() );
+	}
+
+	/**
+	 * @testdox starting should refuse while a CLI run holds the lock, and name the run.
+	 */
+	public function test_start_refuses_while_a_cli_lock_is_held(): void {
+		$this->state->acquire_lock( 'cli-run-1' );
+
+		$message = $this->registrar->start();
+
+		$this->assertStringContainsString( 'cli-run-1', $message );
+		$this->assertFalse(
+			wc_get_container()->get( BatchProcessingController::class )->is_enqueued( MigrationBatchProcessor::class ),
+			'A refused start must not enqueue anything.'
+		);
+
+		$this->state->release_lock();
+	}
+
+	/**
+	 * @testdox starting twice should not enqueue twice.
+	 */
+	public function test_start_is_idempotent(): void {
+		$this->registrar->start();
+
+		$this->assertSame( 'Migration already in progress, nothing done.', $this->registrar->start() );
+	}
+
+	/**
+	 * @testdox stopping should report nothing to do when no run is enqueued.
+	 */
+	public function test_stop_without_a_run_reports_nothing_done(): void {
+		$this->assertSame( 'Migration not in progress, nothing done.', $this->registrar->stop() );
+	}
+
+	/**
+	 * @testdox rendering the Tools entry should not count the legacy tables.
+	 */
+	public function test_rendering_the_entry_runs_no_counts(): void {
+		$product = new \WC_Product_Simple();
+		$product->save();
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			LegacyStore::add_notification(
+				array(
+					'product_id' => $product->get_id(),
+					'user_email' => "shopper{$i}@example.com",
+				)
+			);
+		}
+
+		// Start the run once, so the counts are cached and the description has figures to render.
+		$this->registrar->start();
+
+		$counting_queries = 0;
+
+		$counter = function ( $query ) use ( &$counting_queries ) {
+			if ( false !== stripos( $query, 'COUNT(' ) && false !== stripos( $query, 'woocommerce_bis_' ) ) {
+				++$counting_queries;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $counter );
+		$tools = $this->registrar->handle_woocommerce_debug_tools( array() );
+		remove_filter( 'query', $counter );
+
+		$this->assertSame( 0, $counting_queries, 'The Tools screen must render from the cached counts.' );
+		$this->assertStringContainsString( 'notifications: 3', $tools['stop_bis_migration']['desc'] );
+	}
+
+	/**
+	 * @testdox starting a run should reset every section cursor.
+	 */
+	public function test_start_resets_the_cursors(): void {
+		$this->state->set_cursor( 'notifications', 42 );
+
+		$this->registrar->start();
+
+		$this->assertSame( 0, $this->state->get_cursor( 'notifications' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Writers/BulkNotificationWriterTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Migration/Writers/BulkNotificationWriterTests.php
@@ -1,0 +1,136 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Writers;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Migration\Writers\BulkNotificationWriter;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\Migration\Helpers\LegacyStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the bulk writer: null handling, chunking, and the transaction that keeps a Core
+ * row from being left behind without its migration marker.
+ */
+class BulkNotificationWriterTests extends WC_Unit_Test_Case {
+
+	/**
+	 * Empty the Core tables before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+
+		// Table names are $wpdb->prefix-based, never user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+	}
+
+	/**
+	 * @testdox a null date column should be written as SQL NULL, not a zero date.
+	 */
+	public function test_null_dates_are_written_as_null(): void {
+		( new BulkNotificationWriter() )->insert_notifications( array( $this->build_row( 'shopper@example.com' ) ) );
+
+		$row = LegacyStore::get_core_rows()[0];
+
+		$this->assertNull( $row['date_last_attempt_gmt'], 'Core reads this column with IS NULL.' );
+		$this->assertNull( $row['date_notified_gmt'] );
+		$this->assertNull( $row['date_cancelled_gmt'] );
+		$this->assertNull( $row['cancellation_source'] );
+	}
+
+	/**
+	 * @testdox each row's meta should land against that row.
+	 */
+	public function test_meta_lands_against_its_own_row(): void {
+		( new BulkNotificationWriter() )->insert_notifications(
+			array(
+				$this->build_row( 'first@example.com', array( array( '_wc_bis_legacy_id', 11 ) ) ),
+				$this->build_row( 'second@example.com', array( array( '_wc_bis_legacy_id', 22 ) ) ),
+			)
+		);
+
+		$rows    = LegacyStore::get_core_rows();
+		$markers = LegacyStore::get_core_meta( '_wc_bis_legacy_id' );
+
+		$this->assertSame( array( '11' ), $markers[ (int) $rows[0]['id'] ] );
+		$this->assertSame( array( '22' ), $markers[ (int) $rows[1]['id'] ] );
+	}
+
+	/**
+	 * @testdox a chunked write should keep every row's meta with its own row.
+	 */
+	public function test_chunked_write_keeps_meta_aligned(): void {
+		$rows = array();
+
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$rows[] = $this->build_row( "shopper{$i}@example.com", array( array( '_wc_bis_legacy_id', $i ) ) );
+		}
+
+		// A chunk size below the row count forces several statements, each with its own id block.
+		( new BulkNotificationWriter( 2 ) )->insert_notifications( $rows );
+
+		$core_rows = LegacyStore::get_core_rows();
+		$markers   = LegacyStore::get_core_meta( '_wc_bis_legacy_id' );
+
+		$this->assertCount( 5, $core_rows );
+
+		foreach ( $core_rows as $index => $core_row ) {
+			$this->assertSame( array( (string) ( $index + 1 ) ), $markers[ (int) $core_row['id'] ] );
+		}
+	}
+
+	/**
+	 * @testdox a failure between the two inserts should roll the whole chunk back.
+	 */
+	public function test_failed_meta_insert_rolls_the_chunk_back(): void {
+		$writer = new BulkNotificationWriter();
+		$rows   = array( $this->build_row( 'shopper@example.com', array( array( '_wc_bis_legacy_id', 11 ) ) ) );
+
+		$thrower = static function ( $query ) {
+			if ( false !== stripos( $query, 'wc_stock_notificationmeta' ) && 0 === stripos( ltrim( $query ), 'INSERT' ) ) {
+				throw new \RuntimeException( 'meta insert failed' );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $thrower );
+
+		try {
+			$writer->insert_notifications( $rows );
+			$this->fail( 'The writer should have propagated the failure.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertSame( 'meta insert failed', $exception->getMessage() );
+		} finally {
+			remove_filter( 'query', $thrower );
+		}
+
+		$this->assertSame( array(), LegacyStore::get_core_rows(), 'An unmarked Core row must never be left behind.' );
+	}
+
+	/**
+	 * Build one writer row.
+	 *
+	 * @param string $email Subscriber email.
+	 * @param array  $meta  Meta rows in writer shape.
+	 * @return array{columns: array<string,mixed>, meta: array<int,array{0:string,1:mixed}>}
+	 */
+	private function build_row( string $email, array $meta = array() ): array {
+		return array(
+			'columns' => array(
+				'product_id'        => 1,
+				'user_id'           => 0,
+				'user_email'        => $email,
+				'status'            => NotificationStatus::ACTIVE,
+				'date_created_gmt'  => gmdate( 'Y-m-d H:i:s', 1600000000 ),
+				'date_modified_gmt' => gmdate( 'Y-m-d H:i:s', 1600000000 ),
+			),
+			'meta'    => $meta,
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

**Moves subscribers off the Back In Stock Notifications extension and into Core stock notifications, without breaking the unsubscribe links in emails already sent.**

Opt-in. Nothing runs until a merchant starts it.

- **Migrates** subscribers, email settings, plugin settings and per-product signup flags. Fixed section order, resumable, idempotent.
- **Two entry points, one state.** WooCommerce → Status → Tools (Action Scheduler) or `wp wc bis-migrate`. Either can resume the other.
- **Adopts, never duplicates.** A legacy row matching an existing Core notification adopts it and is marked as adopted, so `rollback` deletes only rows this migration inserted.
- **Keeps old unsubscribe links alive.** Legacy `bis_unsub` links are served by a shim that verifies against a stored digest of the legacy token — the raw token is never persisted. Registers only while `wc_bis_migration_has_legacy_links` is set; `disable-legacy-links` retires it.
- **Leaves the legacy extension's data intact.** Read-only against legacy tables. `rollback` reverses the Core side.

`wp wc bis-migrate <status|run|verify|rollback|disable-legacy-links>` — `run` takes `--dry-run`, `--section`, `--batch-size`, `--max-batches`, `--retry-failed`, `--force`, `--yes`, `--force-discover`.

#### Backward compatibility

- All new code is under `Internal\StockNotifications\Migration`. No existing signature, hook, script handle or interface changed.
- `EmailActionController::unsubscribe()` is **new and additive**; the shim and the email flow share it. No method was added to an interface.
- One deliberate behavior change: unsubscribing a notification that is already `cancelled` or `sent` is now a no-op instead of re-saving the row. Previously a repeat click rewrote `date_cancelled`.
- Multisite: state, rows, the Tools entry and the CLI lock are all site-scoped, covered by tests under `WP_MULTISITE=1`.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Needs a store with Back In Stock Notifications installed and some subscribers.

**Migrate**

1. Enable the Customer stock notifications feature.
2. `wp wc bis-migrate status` — confirm it reports legacy rows found.
3. `wp wc bis-migrate run --dry-run` — reports counts, writes nothing. Re-run `status`: still zero migrated.
4. `wp wc bis-migrate run --yes` — completes without prompting.
5. `wp wc bis-migrate verify` — no discrepancies.
6. Check the subscribers appear under the Core stock notifications list, and the legacy tables are untouched.

**Old unsubscribe links still work**

7. Before migrating, save an unsubscribe URL from a legacy email (`?bis_unsub=…&bis_unsub_id=…`).
8. After migrating, open it. Expect the subscription cancelled and a confirmation notice.
9. Open it a second time. Expect a notice, no error, no change.
10. `wp wc bis-migrate disable-legacy-links --yes`, then open it again. Expect the generic stale-link notice, nothing cancelled.

**Resume and reverse**

11. `wp wc bis-migrate run --max-batches=1 --yes`, then run again with no limit — expect it to pick up where it stopped, with no duplicates.
12. Start a run from WooCommerce → Status → Tools, then try `wp wc bis-migrate run` — expect it to refuse while the background run is enqueued.
13. `wp wc bis-migrate rollback --yes` — expect inserted rows gone, adopted rows kept.

<!-- End testing instructions -->

### Testing that has already taken place:

- 309 PHPUnit tests over the migration (`--filter StockNotifications`), plus 6 multisite tests under `WP_MULTISITE=1`. 217 CLI Migrator tests pass unchanged against the shared WP-CLI mock.
- Covers: adoption vs insert, resume, dry run, rollback in all four states (inserted / adopted / merchant-changed / tables dropped), retention interaction, concurrency refusals in both directions, stale-lock reclaim, and the unsubscribe shim's decode and verification path.
- `phpcs` clean (per-file and full branch diff). PHPStan clean on all changed source; no baseline entries added.

Two bugs found by this test pass and fixed here: `run` fataled on its first batch (`$wpdb` returns ids as strings, `set_cursor()` is `int`-typed under `strict_types`), and `--dry-run` looped forever (no marker is written, so the cursor reset re-fetched the same rows). A third: `--yes` never skipped the prompt, because `WP_CLI::confirm()` was called without `$assoc_args`.

Not yet tested on a large production-scale dataset.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entry added manually: `plugins/woocommerce/changelog/wooplug-5001-add-stock-notifications-migration`.
