### PR TITLE
Only treat address fields as hidden when the flag is exactly true

### DIFF
--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -909,7 +909,7 @@ class WC_Checkout {
 				if ( ! isset( $data[ $key ] ) ) {
 					continue;
 				}
-				$required    = ! empty( $field['required'] ) && empty( $field['hidden'] );
+				$required    = ! empty( $field['required'] ) && true !== ( $field['hidden'] ?? false );
 				$format      = array_filter( isset( $field['validate'] ) ? (array) $field['validate'] : array() );
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -195,7 +195,7 @@ class WC_Form_Handler {
 			$value = apply_filters( 'woocommerce_process_myaccount_field_' . $key, $value );
 
 			// Validation: Required fields.
-			if ( ! empty( $field['required'] ) && empty( $field['hidden'] ) && empty( $value ) ) {
+			if ( ! empty( $field['required'] ) && true !== ( $field['hidden'] ?? false ) && empty( $value ) ) {
 				/* translators: %s: Field name. */
 				wc_add_notice( sprintf( __( '%s is a required field.', 'woocommerce' ), $field['label'] ), 'error', array( 'id' => $key ) );
 			}

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -217,14 +217,17 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'validate_posted_data' skips the required check for fields hidden via the country locale.
+	 * @testdox 'validate_posted_data' skips the required check only for fields whose locale hidden flag is exactly true.
 	 *
-	 * @testWith [true]
-	 *           [false]
+	 * @testWith [true, false]
+	 *           [false, true]
+	 *           ["yes", true]
+	 *           [1, true]
 	 *
-	 * @param bool $hidden Whether the locale marks the postcode field as hidden.
+	 * @param mixed $hidden                Value of the locale's hidden flag for the postcode field.
+	 * @param bool  $expect_required_error Whether a required-field error is expected.
 	 */
-	public function test_validate_posted_data_skips_required_check_for_hidden_fields( $hidden ) {
+	public function test_validate_posted_data_skips_required_check_for_hidden_fields( $hidden, $expect_required_error ) {
 		$locale_filter = function ( $locale ) use ( $hidden ) {
 			$locale['ES']['postcode']['hidden'] = $hidden;
 			return $locale;
@@ -243,10 +246,10 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->sut->validate_posted_data( $data, $errors );
 
 		$required_error = $errors->get_error_message( 'billing_postcode_required' );
-		if ( $hidden ) {
-			$this->assertEmpty( $required_error, 'Hidden fields should not trigger a required-field error.' );
+		if ( $expect_required_error ) {
+			$this->assertNotEmpty( $required_error, 'Fields not hidden with exactly true should still trigger a required-field error.' );
 		} else {
-			$this->assertNotEmpty( $required_error, 'Visible required fields should still trigger a required-field error.' );
+			$this->assertEmpty( $required_error, 'Hidden fields should not trigger a required-field error.' );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#67706 made the checkout and My Account validators skip the required check for hidden address fields, treating any truthy `hidden` value as hidden. But the browser-side code that actually hides these fields (`address-i18n.js`) only does so when the flag is exactly `true`, and always has. With the truthy check, a field marked hidden with `'yes'` or `1` actually stayed visible and starred as required while the server silently accepts it empty. Before #67706 those values had no effect anywhere, so such fields simply behaved as required fields (even when invisible).

This PR makes the server use the same strict check as the browser: only `hidden => true` skips required validation. Even though not the most common pattern, the goal is backwards compatibility: a field marked hidden with anything other than `true` has never been hidden or exempted from validation in any released WooCommerce, and with this change it stays that way.

We're also intentionally not adopting the Store API's reading of the flag (`wc_string_to_bool()`) for the same reasons.

Closes [WOOAIRR-154](https://linear.app/a8c/issue/WOOAIRR-154/ai-regression-reviewtrunk-server-emptydollarfieldhidden-diverges-from).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add a snippet marking a required field hidden with a non-boolean value:
    ```php
    add_filter( 'woocommerce_get_country_locale', function ( $locale ) {
        $locale['ES']['postcode']['hidden']   = 'yes';
        $locale['ES']['postcode']['required'] = true;
        return $locale;
    } );
    ```
2. On a legacy checkout page, select "Spain" as country. Confirm the postcode field stays visible and marked required.
3. Place an order leaving it empty. You should get an error.
4. Change the snippet to `'hidden' => true`.
5. Go again to the legacy checkout page and choose "Spain" as country. Confirm the postcode field is not visible this time and you can submit with no error.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Adjusts unreleased behavior introduced in #67706.

</details>