### PR TITLE
Keep download permissions when a downloadable line item is only partially refunded

### DIFF
--- a/plugins/woocommerce/changelog/67008-partial-refund-keeps-download-permissions
+++ b/plugins/woocommerce/changelog/67008-partial-refund-keeps-download-permissions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Keep a customer's download permissions when a downloadable line item is only partially refunded; permissions are now revoked only once no unrefunded quantity of the product remains on the order.
+Keep a customer's download permissions when an explicit quantity of a downloadable line item is only partially refunded; amount-only refunds keep the previous all-or-nothing behavior, and the new woocommerce_refund_should_revoke_download_permissions filter allows overriding the decision.

--- a/plugins/woocommerce/changelog/67008-partial-refund-keeps-download-permissions
+++ b/plugins/woocommerce/changelog/67008-partial-refund-keeps-download-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep a customer's download permissions when a downloadable line item is only partially refunded; permissions are now revoked only once no unrefunded quantity of the product remains on the order.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -671,33 +671,6 @@ function wc_create_refund( $args = array() ) {
 		 */
 		do_action( 'woocommerce_create_refund', $refund, $args );
 
-		// Determine which refunded products still have unrefunded quantity left on the order,
-		// so download permissions are only revoked once no purchased quantity remains (#67008).
-		// The quantities are read from the refund object because a 'woocommerce_create_refund'
-		// callback may have adjusted them; the refund is not saved yet, so
-		// get_qty_refunded_for_item() still covers previous refunds only.
-		$products_with_remaining_qty = array();
-		if ( ! empty( $refunded_order_and_products ) ) {
-			$refund_quantities = array();
-			foreach ( $refund->get_items( 'line_item' ) as $refunded_item ) {
-				$refunded_item_id = absint( $refunded_item->get_meta( '_refunded_item_id' ) );
-				if ( $refunded_item_id ) {
-					$current_qty                            = isset( $refund_quantities[ $refunded_item_id ] ) ? $refund_quantities[ $refunded_item_id ] : 0;
-					$refund_quantities[ $refunded_item_id ] = $current_qty + abs( (float) $refunded_item->get_quantity() );
-				}
-			}
-
-			foreach ( $order->get_items() as $order_item_id => $order_item ) {
-				$remaining_qty = $order_item->get_quantity()
-					- abs( (float) $order->get_qty_refunded_for_item( $order_item_id ) )
-					- ( isset( $refund_quantities[ $order_item_id ] ) ? $refund_quantities[ $order_item_id ] : 0 );
-
-				if ( $remaining_qty > 0 ) {
-					$products_with_remaining_qty[ $order_item->get_product_id() ] = true;
-				}
-			}
-		}
-
 		if ( $refund->save() ) {
 			if ( $args['refund_payment'] ) {
 				$result = wc_refund_payment( $order, $refund->get_amount(), $refund->get_reason() );
@@ -716,11 +689,56 @@ function wc_create_refund( $args = array() ) {
 			}
 
 			// delete downloads that were refunded using order and product id, if present.
-			if ( ! empty( $refunded_order_and_products ) ) {
+			if ( ! empty( $refunded_order_and_products ) && $order instanceof WC_Order ) {
 				$download_data_store = WC_Data_Store::load( 'customer-download' );
-				foreach ( $refunded_order_and_products as $refunded_order_and_product ) {
-					// A partially refunded product keeps its download permissions while unrefunded quantity remains (#67008).
-					if ( isset( $products_with_remaining_qty[ $refunded_order_and_product['product_id'] ] ) ) {
+
+				// Quantities refunded by the refund that was just saved, per original order item.
+				// Read from the refund object so 'woocommerce_create_refund' adjustments are included.
+				$current_refund_quantities = array();
+				foreach ( $refund->get_items( 'line_item' ) as $refunded_item ) {
+					$original_item_id = absint( $refunded_item->get_meta( '_refunded_item_id' ) );
+					if ( $original_item_id ) {
+						$already_counted                                = isset( $current_refund_quantities[ $original_item_id ] ) ? $current_refund_quantities[ $original_item_id ] : 0;
+						$current_refund_quantities[ $original_item_id ] = $already_counted + abs( (float) $refunded_item->get_quantity() );
+					}
+				}
+
+				// Products that still have unrefunded quantity across all line items of the order.
+				// The refund is already saved at this point, so get_qty_refunded_for_item() covers
+				// all refunds, including the current one, exactly once.
+				$products_with_remaining_qty = array();
+				foreach ( $order->get_items() as $order_item_id => $order_item ) {
+					if ( ! $order_item instanceof WC_Order_Item_Product ) {
+						continue;
+					}
+
+					$remaining_qty = $order_item->get_quantity() - abs( (float) $order->get_qty_refunded_for_item( $order_item_id ) );
+					if ( $remaining_qty > 0 ) {
+						$products_with_remaining_qty[ $order_item->get_product_id() ] = true;
+					}
+				}
+
+				foreach ( $refunded_order_and_products as $refunded_item_id => $refunded_order_and_product ) {
+					$product_id = $refunded_order_and_product['product_id'];
+
+					// Refunding an explicit quantity keeps the download permissions while unrefunded
+					// quantity of the product remains on the order. Amount-only refunds keep the
+					// historical all-or-nothing behavior and always revoke (#67008).
+					$is_quantity_refund = ! empty( $current_refund_quantities[ $refunded_item_id ] );
+					$should_revoke      = ! ( $is_quantity_refund && isset( $products_with_remaining_qty[ $product_id ] ) );
+
+					/**
+					 * Filters whether creating a refund should revoke the download permissions of a
+					 * refunded product on the order.
+					 *
+					 * @since 11.2.0
+					 *
+					 * @param bool            $should_revoke Whether the download permissions will be revoked.
+					 * @param int             $product_id    The id of the refunded product.
+					 * @param WC_Order        $order         The order the refund belongs to.
+					 * @param WC_Order_Refund $refund        The newly created refund.
+					 */
+					if ( ! apply_filters( 'woocommerce_refund_should_revoke_download_permissions', $should_revoke, $product_id, $order, $refund ) ) {
 						continue;
 					}
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -580,7 +580,6 @@ function wc_create_refund( $args = array() ) {
 		$refund_item_count           = 0;
 		$refund                      = new WC_Order_Refund( $args['refund_id'] );
 		$refunded_order_and_products = array();
-		$refund_quantities           = array();
 
 		if ( 0 > $args['amount'] || $args['amount'] > $remaining_refund_amount ) {
 			throw new Exception( __( 'Invalid refund amount.', 'woocommerce' ) );
@@ -628,8 +627,6 @@ function wc_create_refund( $args = array() ) {
 						'order_id'   => $order->get_id(),
 						'product_id' => $item->get_product_id(),
 					);
-
-					$refund_quantities[ $item_id ] = abs( (float) $qty );
 				}
 
 				$class         = get_class( $item );
@@ -657,23 +654,6 @@ function wc_create_refund( $args = array() ) {
 			}
 		}
 
-		// Determine which refunded products still have unrefunded quantity left on the order,
-		// so download permissions are only revoked once no purchased quantity remains (#67008).
-		// The refund is not saved yet, so get_qty_refunded_for_item() covers previous refunds only;
-		// the quantities of the refund being created are added from $refund_quantities.
-		$products_with_remaining_qty = array();
-		if ( ! empty( $refunded_order_and_products ) ) {
-			foreach ( $order->get_items() as $order_item_id => $order_item ) {
-				$remaining_qty = $order_item->get_quantity()
-					- abs( (float) $order->get_qty_refunded_for_item( $order_item_id ) )
-					- ( isset( $refund_quantities[ $order_item_id ] ) ? $refund_quantities[ $order_item_id ] : 0 );
-
-				if ( $remaining_qty > 0 ) {
-					$products_with_remaining_qty[ $order_item->get_product_id() ] = true;
-				}
-			}
-		}
-
 		$refund->update_taxes();
 		$refund->calculate_totals( false );
 		$refund->set_total( $args['amount'] * -1 );
@@ -690,6 +670,33 @@ function wc_create_refund( $args = array() ) {
 		 * @since 3.0.0
 		 */
 		do_action( 'woocommerce_create_refund', $refund, $args );
+
+		// Determine which refunded products still have unrefunded quantity left on the order,
+		// so download permissions are only revoked once no purchased quantity remains (#67008).
+		// The quantities are read from the refund object because a 'woocommerce_create_refund'
+		// callback may have adjusted them; the refund is not saved yet, so
+		// get_qty_refunded_for_item() still covers previous refunds only.
+		$products_with_remaining_qty = array();
+		if ( ! empty( $refunded_order_and_products ) ) {
+			$refund_quantities = array();
+			foreach ( $refund->get_items( 'line_item' ) as $refunded_item ) {
+				$refunded_item_id = absint( $refunded_item->get_meta( '_refunded_item_id' ) );
+				if ( $refunded_item_id ) {
+					$current_qty                            = isset( $refund_quantities[ $refunded_item_id ] ) ? $refund_quantities[ $refunded_item_id ] : 0;
+					$refund_quantities[ $refunded_item_id ] = $current_qty + abs( (float) $refunded_item->get_quantity() );
+				}
+			}
+
+			foreach ( $order->get_items() as $order_item_id => $order_item ) {
+				$remaining_qty = $order_item->get_quantity()
+					- abs( (float) $order->get_qty_refunded_for_item( $order_item_id ) )
+					- ( isset( $refund_quantities[ $order_item_id ] ) ? $refund_quantities[ $order_item_id ] : 0 );
+
+				if ( $remaining_qty > 0 ) {
+					$products_with_remaining_qty[ $order_item->get_product_id() ] = true;
+				}
+			}
+		}
 
 		if ( $refund->save() ) {
 			if ( $args['refund_payment'] ) {

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -580,6 +580,7 @@ function wc_create_refund( $args = array() ) {
 		$refund_item_count           = 0;
 		$refund                      = new WC_Order_Refund( $args['refund_id'] );
 		$refunded_order_and_products = array();
+		$refund_quantities           = array();
 
 		if ( 0 > $args['amount'] || $args['amount'] > $remaining_refund_amount ) {
 			throw new Exception( __( 'Invalid refund amount.', 'woocommerce' ) );
@@ -627,6 +628,8 @@ function wc_create_refund( $args = array() ) {
 						'order_id'   => $order->get_id(),
 						'product_id' => $item->get_product_id(),
 					);
+
+					$refund_quantities[ $item_id ] = abs( (float) $qty );
 				}
 
 				$class         = get_class( $item );
@@ -651,6 +654,23 @@ function wc_create_refund( $args = array() ) {
 
 				$refund->add_item( $refunded_item );
 				$refund_item_count += $qty;
+			}
+		}
+
+		// Determine which refunded products still have unrefunded quantity left on the order,
+		// so download permissions are only revoked once no purchased quantity remains (#67008).
+		// The refund is not saved yet, so get_qty_refunded_for_item() covers previous refunds only;
+		// the quantities of the refund being created are added from $refund_quantities.
+		$products_with_remaining_qty = array();
+		if ( ! empty( $refunded_order_and_products ) ) {
+			foreach ( $order->get_items() as $order_item_id => $order_item ) {
+				$remaining_qty = $order_item->get_quantity()
+					- abs( (float) $order->get_qty_refunded_for_item( $order_item_id ) )
+					- ( isset( $refund_quantities[ $order_item_id ] ) ? $refund_quantities[ $order_item_id ] : 0 );
+
+				if ( $remaining_qty > 0 ) {
+					$products_with_remaining_qty[ $order_item->get_product_id() ] = true;
+				}
 			}
 		}
 
@@ -692,6 +712,11 @@ function wc_create_refund( $args = array() ) {
 			if ( ! empty( $refunded_order_and_products ) ) {
 				$download_data_store = WC_Data_Store::load( 'customer-download' );
 				foreach ( $refunded_order_and_products as $refunded_order_and_product ) {
+					// A partially refunded product keeps its download permissions while unrefunded quantity remains (#67008).
+					if ( isset( $products_with_remaining_qty[ $refunded_order_and_product['product_id'] ] ) ) {
+						continue;
+					}
+
 					$downloads = $download_data_store->get_downloads( $refunded_order_and_product );
 					if ( ! empty( $downloads ) ) {
 						foreach ( $downloads as $download ) {

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -559,27 +559,32 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Creates an order holding a downloadable product with a granted download permission.
+	 * Creates a completed order holding a downloadable product with granted download permissions.
 	 *
 	 * @param int $quantity Ordered quantity of the downloadable product.
 	 * @return array Array with 'order', 'product' and 'item_id' keys.
 	 */
-	private function create_order_with_downloadable_product_permission( int $quantity ): array {
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_downloadable( true );
-		$product->save();
+	private function create_completed_order_with_downloadable_product( int $quantity ): array {
+		$approved_directories = wc_get_container()->get( \Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register::class );
+		if ( ! $approved_directories->approved_directory_exists( 'https://example.com/' ) ) {
+			$approved_directories->add_approved_directory( 'https://example.com/' );
+		}
+
+		$product = WC_Helper_Product::create_downloadable_product(
+			array(
+				array(
+					'name' => 'Test download',
+					'file' => 'https://example.com/file.zip',
+				),
+			)
+		);
 
 		$order = new WC_Order();
 		$order->add_product( $product, $quantity );
+		$order->set_billing_email( 'customer@example.com' );
 		$order->calculate_totals();
 		$order->save();
-
-		$download = new WC_Customer_Download();
-		$download->set_user_id( 1 );
-		$download->set_order_id( $order->get_id() );
-		$download->set_product_id( $product->get_id() );
-		$download->set_download_id( wp_generate_uuid4() );
-		$download->save();
+		$order->update_status( OrderStatus::COMPLETED );
 
 		return array(
 			'order'   => $order,
@@ -605,92 +610,45 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a partial quantity refund of a downloadable item keeps the download permission.
+	 * Test how refunding affects the download permissions of the refunded product.
+	 *
+	 * Refunding an explicit quantity keeps the permissions while unrefunded quantity remains;
+	 * amount-only refunds keep the historical all-or-nothing behavior and revoke.
 	 *
 	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 *
+	 * @testWith [3, 1, 1]
+	 *           [2, 1, 1]
+	 *           [2, 2, 0]
+	 *           [1, 0, 0]
+	 *
+	 * @param int $ordered_qty                  Ordered quantity of the downloadable product.
+	 * @param int $refund_qty                   Quantity being refunded (0 = amount-only refund).
+	 * @param int $expected_remaining_downloads Expected number of remaining download permissions.
 	 */
-	public function test_partial_quantity_refund_keeps_download_permission() {
-		$env    = $this->create_order_with_downloadable_product_permission( 3 );
+	public function test_refund_download_permission_revocation( int $ordered_qty, int $refund_qty, int $expected_remaining_downloads ) {
+		$env    = $this->create_completed_order_with_downloadable_product( $ordered_qty );
 		$order  = $env['order'];
 		$item   = $order->get_items( 'line_item' )[ $env['item_id'] ];
+		$amount = $refund_qty > 0 ? wc_format_decimal( $item->get_total() / $ordered_qty * $refund_qty ) : 1;
+
+		$this->assertCount( 1, $this->get_download_permissions( $order, $env['product'] ), 'The completed order must have granted a download permission.' );
+
 		$refund = wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
-				'amount'     => wc_format_decimal( $item->get_total() / 3 ),
+				'amount'     => $amount,
 				'line_items' => array(
 					$env['item_id'] => array(
-						'qty'          => 1,
-						'refund_total' => wc_format_decimal( $item->get_total() / 3 ),
+						'qty'          => $refund_qty,
+						'refund_total' => $amount,
 					),
 				),
 			)
 		);
 
 		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
-		$this->assertCount(
-			1,
-			$this->get_download_permissions( $order, $env['product'] ),
-			'A partial quantity refund must keep the download permission while unrefunded quantity remains.'
-		);
-	}
-
-	/**
-	 * Test that an amount-only partial refund of a downloadable item keeps the download permission.
-	 *
-	 * @see https://github.com/woocommerce/woocommerce/issues/67008
-	 */
-	public function test_amount_only_partial_refund_keeps_download_permission() {
-		$env    = $this->create_order_with_downloadable_product_permission( 1 );
-		$order  = $env['order'];
-		$refund = wc_create_refund(
-			array(
-				'order_id'   => $order->get_id(),
-				'amount'     => 1,
-				'line_items' => array(
-					$env['item_id'] => array(
-						'qty'          => 0,
-						'refund_total' => 1,
-					),
-				),
-			)
-		);
-
-		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
-		$this->assertCount(
-			1,
-			$this->get_download_permissions( $order, $env['product'] ),
-			'An amount-only partial refund must keep the download permission while the full quantity remains.'
-		);
-	}
-
-	/**
-	 * Test that refunding the full quantity of a downloadable item still revokes the download permission.
-	 *
-	 * @see https://github.com/woocommerce/woocommerce/issues/67008
-	 */
-	public function test_full_quantity_refund_revokes_download_permission() {
-		$env    = $this->create_order_with_downloadable_product_permission( 2 );
-		$order  = $env['order'];
-		$item   = $order->get_items( 'line_item' )[ $env['item_id'] ];
-		$refund = wc_create_refund(
-			array(
-				'order_id'   => $order->get_id(),
-				'amount'     => $item->get_total(),
-				'line_items' => array(
-					$env['item_id'] => array(
-						'qty'          => 2,
-						'refund_total' => $item->get_total(),
-					),
-				),
-			)
-		);
-
-		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
-		$this->assertCount(
-			0,
-			$this->get_download_permissions( $order, $env['product'] ),
-			'Refunding the entire quantity must revoke the download permission.'
-		);
+		$this->assertCount( $expected_remaining_downloads, $this->get_download_permissions( $order, $env['product'] ) );
 	}
 
 	/**
@@ -699,7 +657,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 * @see https://github.com/woocommerce/woocommerce/issues/67008
 	 */
 	public function test_second_refund_completing_quantity_revokes_download_permission() {
-		$env   = $this->create_order_with_downloadable_product_permission( 2 );
+		$env   = $this->create_completed_order_with_downloadable_product( 2 );
 		$order = $env['order'];
 		$item  = $order->get_items( 'line_item' )[ $env['item_id'] ];
 		$half  = wc_format_decimal( $item->get_total() / 2 );
@@ -752,7 +710,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 * @see https://github.com/woocommerce/woocommerce/issues/67008
 	 */
 	public function test_refunding_one_of_two_lines_of_same_product_keeps_download_permission() {
-		$env   = $this->create_order_with_downloadable_product_permission( 1 );
+		$env   = $this->create_completed_order_with_downloadable_product( 1 );
 		$order = $env['order'];
 
 		// Add a second line item of the same product.
@@ -789,7 +747,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 * @see https://github.com/woocommerce/woocommerce/issues/67008
 	 */
 	public function test_create_refund_hook_changing_quantity_is_respected_for_download_permissions() {
-		$env   = $this->create_order_with_downloadable_product_permission( 2 );
+		$env   = $this->create_completed_order_with_downloadable_product( 2 );
 		$order = $env['order'];
 		$item  = $order->get_items( 'line_item' )[ $env['item_id'] ];
 
@@ -821,6 +779,135 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			0,
 			$this->get_download_permissions( $order, $env['product'] ),
 			'A hook callback refunding the full quantity must lead to the permission being revoked.'
+		);
+	}
+
+	/**
+	 * Test that the 'woocommerce_refund_should_revoke_download_permissions' filter can
+	 * override the keep/revoke decision in both directions.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_refund_download_permission_revocation_filter() {
+		// Opt out of revocation on a full-quantity refund.
+		$env   = $this->create_completed_order_with_downloadable_product( 1 );
+		$order = $env['order'];
+		$item  = $order->get_items( 'line_item' )[ $env['item_id'] ];
+
+		add_filter( 'woocommerce_refund_should_revoke_download_permissions', '__return_false' );
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $item->get_total(),
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $item->get_total(),
+					),
+				),
+			)
+		);
+		remove_filter( 'woocommerce_refund_should_revoke_download_permissions', '__return_false' );
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'The filter must be able to keep permissions on a full refund.'
+		);
+
+		// Opt into revocation on a partial refund.
+		$env2   = $this->create_completed_order_with_downloadable_product( 3 );
+		$order2 = $env2['order'];
+		$item2  = $order2->get_items( 'line_item' )[ $env2['item_id'] ];
+		$third  = wc_format_decimal( $item2->get_total() / 3 );
+
+		add_filter( 'woocommerce_refund_should_revoke_download_permissions', '__return_true' );
+		$refund2 = wc_create_refund(
+			array(
+				'order_id'   => $order2->get_id(),
+				'amount'     => $third,
+				'line_items' => array(
+					$env2['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $third,
+					),
+				),
+			)
+		);
+		remove_filter( 'woocommerce_refund_should_revoke_download_permissions', '__return_true' );
+
+		$this->assertNotWPError( $refund2, 'The refund should be created successfully.' );
+		$this->assertCount(
+			0,
+			$this->get_download_permissions( $order2, $env2['product'] ),
+			'The filter must be able to force revocation on a partial refund.'
+		);
+	}
+
+	/**
+	 * Test that fee lines (including negative fees) do not interfere with the
+	 * download permission handling of product line items.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_fee_refunds_do_not_affect_download_permissions() {
+		$env   = $this->create_completed_order_with_downloadable_product( 2 );
+		$order = $env['order'];
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_name( 'Handling' );
+		$fee->set_total( 5 );
+		$order->add_item( $fee );
+
+		$discount = new WC_Order_Item_Fee();
+		$discount->set_name( 'Loyalty discount' );
+		$discount->set_total( -3 );
+		$order->add_item( $discount );
+
+		$order->calculate_totals();
+		$order->save();
+
+		// Refunding only the fee must not touch the product's download permission.
+		$fee_refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 5,
+				'line_items' => array(
+					$fee->get_id() => array(
+						'qty'          => 0,
+						'refund_total' => 5,
+					),
+				),
+			)
+		);
+		$this->assertNotWPError( $fee_refund, 'The fee refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'Refunding a fee only must not revoke the download permission of the product.'
+		);
+
+		// A partial quantity refund of the product keeps the permission despite the fee lines.
+		$item    = $order->get_items( 'line_item' )[ $env['item_id'] ];
+		$partial = wc_format_decimal( $item->get_total() / 2 );
+		$refund  = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $partial,
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $partial,
+					),
+				),
+			)
+		);
+		$this->assertNotWPError( $refund, 'The partial product refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'The partial quantity refund must keep the permission with fee lines on the order.'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -781,4 +781,46 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			'The permission must be kept while another line item of the same product retains quantity.'
 		);
 	}
+
+	/**
+	 * Test that a 'woocommerce_create_refund' callback raising the refunded quantity to the
+	 * full amount is respected when revoking download permissions.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_create_refund_hook_changing_quantity_is_respected_for_download_permissions() {
+		$env   = $this->create_order_with_downloadable_product_permission( 2 );
+		$order = $env['order'];
+		$item  = $order->get_items( 'line_item' )[ $env['item_id'] ];
+
+		// Turn the partial refund into a full-quantity refund from a hook callback.
+		$raise_quantity = function ( $refund ) {
+			foreach ( $refund->get_items( 'line_item' ) as $refunded_item ) {
+				$refunded_item->set_quantity( -2 );
+			}
+		};
+		add_action( 'woocommerce_create_refund', $raise_quantity );
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $item->get_total(),
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $item->get_total(),
+					),
+				),
+			)
+		);
+
+		remove_action( 'woocommerce_create_refund', $raise_quantity );
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount(
+			0,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'A hook callback refunding the full quantity must lead to the permission being revoked.'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -557,4 +557,228 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$order->delete();
 		$customer->delete();
 	}
+
+	/**
+	 * Creates an order holding a downloadable product with a granted download permission.
+	 *
+	 * @param int $quantity Ordered quantity of the downloadable product.
+	 * @return array Array with 'order', 'product' and 'item_id' keys.
+	 */
+	private function create_order_with_downloadable_product_permission( int $quantity ): array {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_downloadable( true );
+		$product->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product, $quantity );
+		$order->calculate_totals();
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( 1 );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $product->get_id() );
+		$download->set_download_id( wp_generate_uuid4() );
+		$download->save();
+
+		return array(
+			'order'   => $order,
+			'product' => $product,
+			'item_id' => array_key_first( $order->get_items( 'line_item' ) ),
+		);
+	}
+
+	/**
+	 * Returns the download permissions stored for a given order/product pair.
+	 *
+	 * @param WC_Order   $order   The order.
+	 * @param WC_Product $product The product.
+	 * @return array
+	 */
+	private function get_download_permissions( WC_Order $order, WC_Product $product ): array {
+		return WC_Data_Store::load( 'customer-download' )->get_downloads(
+			array(
+				'order_id'   => $order->get_id(),
+				'product_id' => $product->get_id(),
+			)
+		);
+	}
+
+	/**
+	 * Test that a partial quantity refund of a downloadable item keeps the download permission.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_partial_quantity_refund_keeps_download_permission() {
+		$env    = $this->create_order_with_downloadable_product_permission( 3 );
+		$order  = $env['order'];
+		$item   = $order->get_items( 'line_item' )[ $env['item_id'] ];
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => wc_format_decimal( $item->get_total() / 3 ),
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => wc_format_decimal( $item->get_total() / 3 ),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'A partial quantity refund must keep the download permission while unrefunded quantity remains.'
+		);
+	}
+
+	/**
+	 * Test that an amount-only partial refund of a downloadable item keeps the download permission.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_amount_only_partial_refund_keeps_download_permission() {
+		$env    = $this->create_order_with_downloadable_product_permission( 1 );
+		$order  = $env['order'];
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 1,
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 0,
+						'refund_total' => 1,
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'An amount-only partial refund must keep the download permission while the full quantity remains.'
+		);
+	}
+
+	/**
+	 * Test that refunding the full quantity of a downloadable item still revokes the download permission.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_full_quantity_refund_revokes_download_permission() {
+		$env    = $this->create_order_with_downloadable_product_permission( 2 );
+		$order  = $env['order'];
+		$item   = $order->get_items( 'line_item' )[ $env['item_id'] ];
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $item->get_total(),
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 2,
+						'refund_total' => $item->get_total(),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount(
+			0,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'Refunding the entire quantity must revoke the download permission.'
+		);
+	}
+
+	/**
+	 * Test that a second refund completing the item quantity revokes the download permission.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_second_refund_completing_quantity_revokes_download_permission() {
+		$env   = $this->create_order_with_downloadable_product_permission( 2 );
+		$order = $env['order'];
+		$item  = $order->get_items( 'line_item' )[ $env['item_id'] ];
+		$half  = wc_format_decimal( $item->get_total() / 2 );
+
+		$first = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $half,
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $half,
+					),
+				),
+			)
+		);
+		$this->assertNotWPError( $first, 'The first refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'The download permission must survive the first partial refund.'
+		);
+
+		// A fresh order instance mirrors a later request handling the second refund.
+		$order  = wc_get_order( $order->get_id() );
+		$second = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $half,
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $half,
+					),
+				),
+			)
+		);
+		$this->assertNotWPError( $second, 'The second refund should be created successfully.' );
+		$this->assertCount(
+			0,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'Completing the refunded quantity across two refunds must revoke the download permission.'
+		);
+	}
+
+	/**
+	 * Test that fully refunding one line item keeps the permission when another line item
+	 * of the same product still has unrefunded quantity.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67008
+	 */
+	public function test_refunding_one_of_two_lines_of_same_product_keeps_download_permission() {
+		$env   = $this->create_order_with_downloadable_product_permission( 1 );
+		$order = $env['order'];
+
+		// Add a second line item of the same product.
+		$order->add_product( $env['product'], 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		$first_item = $order->get_items( 'line_item' )[ $env['item_id'] ];
+		$refund     = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $first_item->get_total(),
+				'line_items' => array(
+					$env['item_id'] => array(
+						'qty'          => 1,
+						'refund_total' => $first_item->get_total(),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount(
+			1,
+			$this->get_download_permissions( $order, $env['product'] ),
+			'The permission must be kept while another line item of the same product retains quantity.'
+		);
+	}
 }


### PR DESCRIPTION
**Problem:** When a refund touched a downloadable line item, `wc_create_refund()` deleted every download permission for that product on the order — even if only 1 of 3 units was refunded. The customer lost access to files they still paid for.

**Cause:** The revocation loop only checked *whether* a line item was refunded, not *how much* of its quantity remained.

**Fix:** After the refund is saved, the function reads the refunded quantities from the refund object and checks, per product, whether any unrefunded quantity is left across all line items of the order.

- Refunding an explicit quantity keeps the download permissions while unrefunded quantity remains. Refunding the full quantity still revokes them.
- Amount-only refunds keep the previous all-or-nothing behavior and always revoke.
- The final decision passes through a new filter, `woocommerce_refund_should_revoke_download_permissions`, so extensions can override it.

Closes #67008.

**How to test:**

1. Create a downloadable product with a file. Keep "Grant access to downloadable products after payment" enabled.
2. Place an order for 3 units and mark it as Completed.
3. Open the order and confirm a download permission exists under "Downloadable product permissions".
4. Refund 1 unit (Refund → quantity 1).
5. Reload the order: the download permission is still there. Before this fix it was gone.
6. Refund the remaining 2 units.
7. Reload the order: the download permission is removed.

**Testing done:**

- `WC_Order_Functions_Test` passes locally (28 tests), HPOS on and off; PHPStan clean.
- New tests: a `@testWith` matrix for partial, boundary (ordered 2 / refunded 1), full and amount-only refunds; a second refund completing the quantity; two line items of the same product; a `woocommerce_create_refund` callback changing the quantity; the new filter; fee lines (including negative fees).
- Bug reproduced and fix verified on a clean WooCommerce 11.1.0 test site, including refunds with 19% tax and fee-only refunds.

**Changelog:** included as `changelog/67008-partial-refund-keeps-download-permissions`.

**AI tools:** AI-assisted (Claude); reviewed, tested and owned by me.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
