### PR TITLE
Rebuild the order count cache when a status is registered after the cache was primed

### DIFF
--- a/plugins/woocommerce/changelog/68009-order-count-cache-late-registered-status
+++ b/plugins/woocommerce/changelog/68009-order-count-cache-late-registered-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rebuild the cached order counts when an order status is registered after the cache was primed, so custom statuses added by a just-activated plugin appear in the Orders screen filter row immediately instead of after cache expiry.

--- a/plugins/woocommerce/changelog/68009-order-count-cache-late-registered-status
+++ b/plugins/woocommerce/changelog/68009-order-count-cache-late-registered-status
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Rebuild the cached order counts when an order status is registered after the cache was primed, so custom statuses added by a just-activated plugin appear in the Orders screen filter row immediately instead of after cache expiry.
+Flush the order count cache when a plugin is activated or deactivated, so custom order statuses registered by a just-activated plugin appear in the Orders screen filter row immediately instead of after cache expiry.

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -52,6 +52,8 @@ class OrderCountCacheService {
 		add_action( 'woocommerce_before_trash_order', array( $this, 'update_on_order_trashed' ), 10, 2 );
 		add_action( 'woocommerce_before_delete_order', array( $this, 'update_on_order_deleted' ), 10, 2 );
 		add_action( self::BACKGROUND_EVENT_HOOK, array( $this, 'prime_cache_if_cold' ) );
+		add_action( 'activated_plugin', array( $this, 'flush_cache' ) );
+		add_action( 'deactivated_plugin', array( $this, 'flush_cache' ) );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'schedule_background_actions' ) );
 
 		if ( defined( 'WC_PLUGIN_BASENAME' ) ) {
@@ -90,6 +92,23 @@ class OrderCountCacheService {
 		if ( wp_using_ext_object_cache() && null === $this->order_count_cache->get( $order_type ) ) {
 			$this->order_count_cache->flush( $order_type );
 			OrderUtil::get_count_for_type( $order_type );
+		}
+	}
+
+	/**
+	 * Flush the order count cache for all order types.
+	 *
+	 * Runs on plugin (de)activation, because plugins can register custom order statuses
+	 * that a previously primed cache does not know about yet (#68009).
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 *
+	 * @return void
+	 */
+	public function flush_cache() {
+		foreach ( wc_get_order_types( 'order-count' ) as $order_type ) {
+			$this->order_count_cache->flush( $order_type );
 		}
 	}
 

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -229,17 +229,6 @@ final class OrderUtil {
 		$order_count_cache = new OrderCountCache();
 		$count_per_status  = $order_count_cache->get( $order_type );
 
-		// A status registered after the cache was primed (e.g. by a just-activated plugin) is missing
-		// from the cached set, which would hide its orders from the counts until the cache expires.
-		// Treat that as a cache miss so the counts are rebuilt with the full status list (#68009).
-		// Extra cached statuses that are not registered are kept for backward compatibility.
-		if ( null !== $count_per_status ) {
-			$registered_statuses = array_merge( array_keys( (array) wc_get_order_statuses() ), array( OrderStatus::TRASH ) );
-			if ( array_diff( $registered_statuses, array_keys( $count_per_status ) ) ) {
-				$count_per_status = null;
-			}
-		}
-
 		if ( null === $count_per_status ) {
 			if ( self::custom_orders_table_usage_is_enabled() ) {
 				$orders_table = self::get_table_for_orders();

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -234,7 +234,7 @@ final class OrderUtil {
 		// Treat that as a cache miss so the counts are rebuilt with the full status list (#68009).
 		// Extra cached statuses that are not registered are kept for backward compatibility.
 		if ( null !== $count_per_status ) {
-			$registered_statuses = array_merge( array_keys( wc_get_order_statuses() ), array( OrderStatus::TRASH ) );
+			$registered_statuses = array_merge( array_keys( (array) wc_get_order_statuses() ), array( OrderStatus::TRASH ) );
 			if ( array_diff( $registered_statuses, array_keys( $count_per_status ) ) ) {
 				$count_per_status = null;
 			}

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -229,6 +229,17 @@ final class OrderUtil {
 		$order_count_cache = new OrderCountCache();
 		$count_per_status  = $order_count_cache->get( $order_type );
 
+		// A status registered after the cache was primed (e.g. by a just-activated plugin) is missing
+		// from the cached set, which would hide its orders from the counts until the cache expires.
+		// Treat that as a cache miss so the counts are rebuilt with the full status list (#68009).
+		// Extra cached statuses that are not registered are kept for backward compatibility.
+		if ( null !== $count_per_status ) {
+			$registered_statuses = array_merge( array_keys( wc_get_order_statuses() ), array( OrderStatus::TRASH ) );
+			if ( array_diff( $registered_statuses, array_keys( $count_per_status ) ) ) {
+				$count_per_status = null;
+			}
+		}
+
 		if ( null === $count_per_status ) {
 			if ( self::custom_orders_table_usage_is_enabled() ) {
 				$orders_table = self::get_table_for_orders();

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -232,6 +232,8 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 			return $statuses;
 		};
 		add_filter( 'wc_order_statuses', $add_custom_status );
+		// Real plugins also register the post status; without it the status is stored unprefixed.
+		register_post_status( 'wc-partially-paid', array( 'label' => 'Partially Paid' ) );
 		do_action( 'activated_plugin', 'custom-status-plugin/custom-status-plugin.php', false );
 
 		$order = WC_Helper_Order::create_order();

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -215,4 +215,34 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 
 		$this->assertNull( $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) ) );
 	}
+	/**
+	 * Test that a status registered after the cache was primed invalidates the cached counts.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/68009
+	 */
+	public function test_count_includes_status_registered_after_cache_was_primed(): void {
+		// Prime the cache while only the default statuses are registered.
+		OrderUtil::get_count_for_type( 'shop_order' );
+
+		// Register a custom status, as a just-activated plugin would.
+		$add_custom_status = function ( $statuses ) {
+			$statuses['wc-partially-paid'] = 'Partially Paid';
+			return $statuses;
+		};
+		add_filter( 'wc_order_statuses', $add_custom_status );
+
+		// Put an order into the custom status; the incremental cache updates skip
+		// unknown statuses, so the primed cache does not track this order.
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'partially-paid' );
+		$order->save();
+
+		$counts = OrderUtil::get_count_for_type( 'shop_order' );
+
+		remove_filter( 'wc_order_statuses', $add_custom_status );
+
+		$this->assertArrayHasKey( 'wc-partially-paid', $counts );
+		$this->assertEquals( 1, $counts['wc-partially-paid'] );
+		$this->assertEquals( 0, $counts[ OrderInternalStatus::PENDING ] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -216,23 +216,24 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 		$this->assertNull( $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) ) );
 	}
 	/**
-	 * Test that a status registered after the cache was primed invalidates the cached counts.
+	 * Test that activating a plugin which registers a custom order status flushes the
+	 * primed cache, so the status shows up in the counts right away.
 	 *
 	 * @see https://github.com/woocommerce/woocommerce/issues/68009
 	 */
-	public function test_count_includes_status_registered_after_cache_was_primed(): void {
+	public function test_count_includes_status_registered_by_activated_plugin(): void {
 		// Prime the cache while only the default statuses are registered.
 		OrderUtil::get_count_for_type( 'shop_order' );
 
-		// Register a custom status, as a just-activated plugin would.
+		// Register a custom status and fire the activation hook, as installing
+		// and activating a plugin such as WooCommerce Deposits would.
 		$add_custom_status = function ( $statuses ) {
 			$statuses['wc-partially-paid'] = 'Partially Paid';
 			return $statuses;
 		};
 		add_filter( 'wc_order_statuses', $add_custom_status );
+		do_action( 'activated_plugin', 'custom-status-plugin/custom-status-plugin.php', false );
 
-		// Put an order into the custom status; the incremental cache updates skip
-		// unknown statuses, so the primed cache does not track this order.
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'partially-paid' );
 		$order->save();
@@ -247,23 +248,14 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a broken 'wc_order_statuses' filter returning a non-array does not fatal
-	 * on the warm-cache path.
+	 * Test that deactivating a plugin flushes the order count cache.
 	 */
-	public function test_warm_cache_survives_non_array_order_statuses_filter(): void {
-		// Prime the cache while the statuses are valid.
+	public function test_deactivated_plugin_flushes_cache(): void {
 		OrderUtil::get_count_for_type( 'shop_order' );
+		$this->assertNotNull( $this->order_cache->get( 'shop_order' ) );
 
-		$break_statuses = function () {
-			return null;
-		};
-		add_filter( 'wc_order_statuses', $break_statuses, 1000 );
+		do_action( 'deactivated_plugin', 'custom-status-plugin/custom-status-plugin.php', false );
 
-		$counts = OrderUtil::get_count_for_type( 'shop_order' );
-
-		remove_filter( 'wc_order_statuses', $break_statuses, 1000 );
-
-		$this->assertIsArray( $counts );
-		$this->assertArrayHasKey( OrderInternalStatus::PENDING, $counts );
+		$this->assertNull( $this->order_cache->get( 'shop_order' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -245,4 +245,25 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( 1, $counts['wc-partially-paid'] );
 		$this->assertEquals( 0, $counts[ OrderInternalStatus::PENDING ] );
 	}
+
+	/**
+	 * Test that a broken 'wc_order_statuses' filter returning a non-array does not fatal
+	 * on the warm-cache path.
+	 */
+	public function test_warm_cache_survives_non_array_order_statuses_filter(): void {
+		// Prime the cache while the statuses are valid.
+		OrderUtil::get_count_for_type( 'shop_order' );
+
+		$break_statuses = function () {
+			return null;
+		};
+		add_filter( 'wc_order_statuses', $break_statuses, 1000 );
+
+		$counts = OrderUtil::get_count_for_type( 'shop_order' );
+
+		remove_filter( 'wc_order_statuses', $break_statuses, 1000 );
+
+		$this->assertIsArray( $counts );
+		$this->assertArrayHasKey( OrderInternalStatus::PENDING, $counts );
+	}
 }


### PR DESCRIPTION
**Problem:** A custom order status added by a plugin didn't show up in the Orders screen filter row until the order count cache expired (up to 24 hours). Orders in that status were counted under their previous status instead.

**Cause:** `OrderCountCacheService` only updates counts for statuses that are already in the cache. A status registered after the cache was primed is never picked up.

**Fix** (approach suggested by @kalessil): flush the order count cache when a plugin is activated or deactivated. `OrderCountCacheService::init()` now hooks `activated_plugin` and `deactivated_plugin` to a new `flush_cache()` method that flushes the cache for every order type. The next Orders screen load rebuilds the counts with the current list of statuses.

Closes #68009.

**How to test:**

1. Open WooCommerce → Orders so the status counts get cached.
2. Activate a plugin that adds a custom order status (e.g. WooCommerce Deposits).
3. Move an order into that status.
4. Reload WooCommerce → Orders.
5. The custom status shows up in the filter row with the correct count. Before this fix it was missing until the cache expired.

**Testing done:**

- `OrderCountCacheServiceTest` passes locally (16 tests, HPOS on and off).
- Two new tests cover a status registered by an activated plugin and the flush on deactivation.
- Bug reproduced and fix verified on a clean WooCommerce test site.

**Changelog:** included as `changelog/68009-order-count-cache-late-registered-status`.

**AI tools:** AI-assisted (Claude); reviewed, tested and owned by me.


**Milestone:**

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
