### PR TITLE
[Payments NOX] Disable Helcim recommendations temporarily

### DIFF
--- a/plugins/woocommerce/changelog/disable-helcim-recommendations
+++ b/plugins/woocommerce/changelog/disable-helcim-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Temporarily disable Helcim payment provider recommendations.

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
@@ -180,7 +180,6 @@ class PaymentsExtensionSuggestions {
 					),
 				),
 			),
-			self::HELCIM,
 			self::PAYPAL_WALLET,
 			self::AFFIRM,
 			self::AFTERPAY,
@@ -217,7 +216,6 @@ class PaymentsExtensionSuggestions {
 			self::SQUARE, // Use the default details.
 			self::VISA,
 			self::AIRWALLEX,
-			self::HELCIM,
 			self::PAYPAL_WALLET,
 			self::AMAZON_PAY,
 			self::AFFIRM,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
@@ -467,7 +467,7 @@ class PaymentsRestControllerIntegrationTest extends WC_Unit_Test_Case {
 		// We also have the 3 offline payment methods.
 		$this->assertCount( 3, $data['offline_payment_methods'] );
 		// We only have PSPs because there is no payment gateway enabled.
-		$this->assertCount( 5, $data['suggestions'] );
+		$this->assertCount( 4, $data['suggestions'] );
 		// Assert we get the suggestion categories.
 		$this->assertCount( 4, $data['suggestion_categories'] );
 
@@ -513,7 +513,7 @@ class PaymentsRestControllerIntegrationTest extends WC_Unit_Test_Case {
 		// We also have the 3 offline payment methods.
 		$this->assertCount( 3, $data['offline_payment_methods'] );
 		// We get all the suggestions.
-		$this->assertCount( 9, $data['suggestions'] );
+		$this->assertCount( 8, $data['suggestions'] );
 		// Assert we get the suggestion categories.
 		$this->assertCount( 4, $data['suggestion_categories'] );
 
@@ -683,7 +683,7 @@ class PaymentsRestControllerIntegrationTest extends WC_Unit_Test_Case {
 		// We also have the 3 offline payment methods.
 		$this->assertCount( 3, $data['offline_payment_methods'] );
 		// We get all the suggestions.
-		$this->assertCount( 9, $data['suggestions'] );
+		$this->assertCount( 8, $data['suggestions'] );
 		// Assert we get the suggestion categories.
 		$this->assertCount( 4, $data['suggestion_categories'] );
 
@@ -881,8 +881,8 @@ class PaymentsRestControllerIntegrationTest extends WC_Unit_Test_Case {
 
 		// We also have the 3 offline payment methods.
 		$this->assertCount( 3, $data['offline_payment_methods'] );
-		// We don't get BNPL suggestions since WooPayments is active (even if not enabled), so only 6 suggestions are returned.
-		$this->assertCount( 6, $data['suggestions'] );
+		// We don't get BNPL suggestions since WooPayments is active (even if not enabled), so only 5 suggestions are returned.
+		$this->assertCount( 5, $data['suggestions'] );
 		// Assert we get the suggestion categories.
 		$this->assertCount( 4, $data['suggestion_categories'] );
 
@@ -1095,8 +1095,8 @@ class PaymentsRestControllerIntegrationTest extends WC_Unit_Test_Case {
 
 		// We also have the 3 offline payment methods.
 		$this->assertCount( 3, $data['offline_payment_methods'] );
-		// We don't get BNPL suggestions since WooPayments is active, so only 6 suggestions are returned.
-		$this->assertCount( 6, $data['suggestions'] );
+		// We don't get BNPL suggestions since WooPayments is active, so only 5 suggestions are returned.
+		$this->assertCount( 5, $data['suggestions'] );
 		// Assert we get the suggestion categories.
 		$this->assertCount( 4, $data['suggestion_categories'] );
 
@@ -1264,8 +1264,8 @@ class PaymentsRestControllerIntegrationTest extends WC_Unit_Test_Case {
 
 		// We also have the 3 offline payment methods.
 		$this->assertCount( 3, $data['offline_payment_methods'] );
-		// We get BNPL suggestions since WooPayments or Stripe are not active, so 8 suggestions are returned.
-		$this->assertCount( 8, $data['suggestions'] );
+		// We get BNPL suggestions since WooPayments or Stripe are not active, so 7 suggestions are returned.
+		$this->assertCount( 7, $data['suggestions'] );
 		// Assert we get the suggestion categories.
 		$this->assertCount( 4, $data['suggestion_categories'] );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/fixtures/expected-country-placements.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/fixtures/expected-country-placements.php
@@ -33,7 +33,6 @@ return array(
 			'square',
 			'visa_as',
 			'gocardless',
-			'helcim',
 		),
 		'other_bnpl'      => array(
 			'affirm',
@@ -53,7 +52,6 @@ return array(
 			'square',
 			'visa_as',
 			'airwallex',
-			'helcim',
 		),
 		'other_express_checkout' => array(
 			'amazon_pay',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Helcim recommendations need to be temporarily disabled while keeping the integration details introduced in #66960 available for a future reactivation. This removes Helcim from the United States and Canada recommendation catalogs—the only countries where it was placed—while preserving its provider metadata, resource links, icon, gateway adapter, and provider mappings.

The per-country placement fixture and Payments providers REST count expectations now reflect the smaller recommendation set. The all-country placement contract ensures Helcim is not surfaced elsewhere, while the existing base-details test continues to protect the retained metadata.

**Backward compatibility:** The Payments providers response intentionally returns one fewer suggestion for United States and Canadian merchants. Its schema, public signatures, hooks, installed-gateway behavior, multisite behavior, and install-layout handling are unchanged.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not included yet. The visual change is the removal of the Helcim recommendation card from the United States and Canada Payments settings screens.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'Payments(ExtensionSuggestions(Test|CountryPlacementTest)|RestControllerIntegrationTest)'` and confirm all 468 tests pass.
2. Set the store country to the United States, go to **WooCommerce → Settings → Payments**, expand **More payment options**, and confirm Helcim is not recommended.
3. Change the store country to Canada, return to **WooCommerce → Settings → Payments**, expand **More payment options**, and confirm Helcim is not recommended.
4. Confirm the automated `PaymentsExtensionSuggestionsTest::test_helcim_has_complete_base_details` case passes, demonstrating that Helcim's retained plugin metadata, links, icon, title, and description remain available.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The country-placement contract was run test-first: changing only the CA/US expectations produced the four expected baseline/offline failures, and removing the production placements returned the suite to green.
- The rebased affected suite passed on PHP 8.1: 468 tests and 5,665 assertions.
- `PaymentsRestControllerIntegrationTest` passed independently: 79 tests and 574 assertions.
- Changed-file PHP lint, full branch lint, focused PHPStan, changelog validation, `git diff --check`, and the staged verification gate passed.
- The complete PHP suite ran 14,142 tests. Six branch-related REST count failures were corrected and verified by the green REST class. Four unrelated failures remain reproducible in isolation: one database-update note test, one database auto-update test, and two Saved for Later block-metadata tests.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to investigate the existing placement, update the implementation, tests, and changelog, run local verification, and draft this pull request.
