### PR TITLE
Retry failed WC Tracker snapshots on the next scheduled run

### DIFF
--- a/plugins/woocommerce/changelog/fix-38574-tracker-retry-snapshots
+++ b/plugins/woocommerce/changelog/fix-38574-tracker-retry-snapshots
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Retry failed usage-tracking snapshot deliveries on the next scheduled run instead of silently dropping them for a week.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -84,14 +84,14 @@ class WC_Tracker {
 			}
 		}
 
+		// Recorded before building the snapshot so overlapping override sends are still suppressed.
+		update_option( 'woocommerce_tracker_last_attempt', time(), false );
+
 		$body = wp_json_encode( self::get_tracking_data() );
 		if ( false === $body ) {
 			self::record_send_failure( false, 0, 'json_encode_failure', 0 );
 			return;
 		}
-
-		// Recorded before sending so overlapping override sends are still suppressed.
-		update_option( 'woocommerce_tracker_last_attempt', time(), false );
 
 		$response = wp_safe_remote_post(
 			self::$api_url,

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -151,7 +151,7 @@ class WC_Tracker {
 		if ( $give_up ) {
 			update_option( 'woocommerce_tracker_last_send', time() );
 			delete_option( 'woocommerce_tracker_send_failures' );
-		} elseif ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+		} elseif ( true === wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
 			update_option( 'woocommerce_tracker_send_failures', $failures, false );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -113,8 +113,8 @@ class WC_Tracker {
 	/**
 	 * Record the outcome of a delivery attempt.
 	 *
-	 * The send time is only recorded once the snapshot is accepted, so a transient failure
-	 * leaves it pending and the next scheduled run retries it.
+	 * The send time is recorded after acceptance or permanent abandonment. A transient failure
+	 * remains pending for the next run.
 	 *
 	 * @param array|WP_Error $response   Response from wp_safe_remote_post().
 	 * @param int            $body_bytes Size of the posted snapshot.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -86,6 +86,7 @@ class WC_Tracker {
 
 		$body = wp_json_encode( self::get_tracking_data() );
 		if ( false === $body ) {
+			self::record_send_failure( false, 0, 'json_encode_failure', 0 );
 			return;
 		}
 
@@ -113,8 +114,7 @@ class WC_Tracker {
 	 * Record the outcome of a delivery attempt.
 	 *
 	 * The send time is only recorded once the snapshot is accepted, so a transient failure
-	 * leaves it pending and the next scheduled run retries it. Consecutive failures are
-	 * counted so a persistent outage does not retry forever.
+	 * leaves it pending and the next scheduled run retries it.
 	 *
 	 * @param array|WP_Error $response   Response from wp_safe_remote_post().
 	 * @param int            $body_bytes Size of the posted snapshot.
@@ -128,18 +128,37 @@ class WC_Tracker {
 			return;
 		}
 
+		self::record_send_failure( self::is_retryable_status( $status ), $status, is_wp_error( $response ) ? (string) $response->get_error_code() : '', $body_bytes );
+	}
+
+	/**
+	 * Record a failed delivery attempt.
+	 *
+	 * Consecutive retryable failures are counted so a persistent outage does not retry forever;
+	 * a non-retryable failure or the last allowed attempt gives up on the current snapshot.
+	 * Retry state is only kept while tracking is still enabled, since opting out may have
+	 * happened while the request was in flight.
+	 *
+	 * @param bool   $retryable  Whether the next scheduled run should try again.
+	 * @param int    $status     HTTP status code, 0 when no response was received.
+	 * @param string $error_code Error code when no response was received.
+	 * @param int    $body_bytes Size of the snapshot.
+	 */
+	private static function record_send_failure( $retryable, $status, $error_code, $body_bytes ): void {
 		$failures = (int) get_option( 'woocommerce_tracker_send_failures', 0 ) + 1;
-		$give_up  = ! self::is_retryable_status( $status ) || self::MAX_CONSECUTIVE_SEND_FAILURES <= $failures;
+		$give_up  = ! $retryable || self::MAX_CONSECUTIVE_SEND_FAILURES <= $failures;
 
 		if ( $give_up ) {
 			update_option( 'woocommerce_tracker_last_send', time() );
 			delete_option( 'woocommerce_tracker_send_failures' );
-		} else {
+		} elseif ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
 			update_option( 'woocommerce_tracker_send_failures', $failures, false );
 		}
 
 		if ( 413 === $status ) {
 			$message = 'WooCommerce tracker snapshot delivery failed; the snapshot is too large for the service and will not be retried.';
+		} elseif ( 'json_encode_failure' === $error_code ) {
+			$message = 'WooCommerce tracker snapshot could not be encoded and will not be retried.';
 		} elseif ( $give_up ) {
 			$message = 'WooCommerce tracker snapshot delivery failed; giving up until the next interval.';
 		} else {
@@ -151,7 +170,7 @@ class WC_Tracker {
 			array(
 				'source'      => 'woocommerce-tracker',
 				'http_status' => $status,
-				'error_code'  => is_wp_error( $response ) ? $response->get_error_code() : '',
+				'error_code'  => $error_code,
 				'failures'    => $failures,
 				'body_bytes'  => $body_bytes,
 			)

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -78,8 +78,8 @@ class WC_Tracker {
 			}
 		} else {
 			// Make sure there is at least a 1 hour delay between override sends, we don't want duplicate calls due to double clicking links.
-			$last_send = self::get_last_send_time();
-			if ( $last_send && $last_send > strtotime( '-1 hours' ) ) {
+			$last_attempt = max( (int) self::get_last_send_time(), (int) get_option( 'woocommerce_tracker_last_attempt', 0 ) );
+			if ( $last_attempt > strtotime( '-1 hours' ) ) {
 				return;
 			}
 		}
@@ -88,6 +88,9 @@ class WC_Tracker {
 		if ( false === $body ) {
 			return;
 		}
+
+		// Recorded before sending so overlapping override sends are still suppressed.
+		update_option( 'woocommerce_tracker_last_attempt', time(), false );
 
 		$response = wp_safe_remote_post(
 			self::$api_url,
@@ -103,7 +106,7 @@ class WC_Tracker {
 			)
 		);
 
-		self::record_send_result( $response );
+		self::record_send_result( $response, strlen( $body ) );
 	}
 
 	/**
@@ -113,9 +116,10 @@ class WC_Tracker {
 	 * leaves it pending and the next scheduled run retries it. Consecutive failures are
 	 * counted so a persistent outage does not retry forever.
 	 *
-	 * @param array|WP_Error $response Response from wp_safe_remote_post().
+	 * @param array|WP_Error $response   Response from wp_safe_remote_post().
+	 * @param int            $body_bytes Size of the posted snapshot.
 	 */
-	private static function record_send_result( $response ): void {
+	private static function record_send_result( $response, $body_bytes ): void {
 		$status = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
 
 		if ( 200 <= $status && 300 > $status ) {
@@ -134,13 +138,22 @@ class WC_Tracker {
 			update_option( 'woocommerce_tracker_send_failures', $failures, false );
 		}
 
+		if ( 413 === $status ) {
+			$message = 'WooCommerce tracker snapshot delivery failed; the snapshot is too large for the service and will not be retried.';
+		} elseif ( $give_up ) {
+			$message = 'WooCommerce tracker snapshot delivery failed; giving up until the next interval.';
+		} else {
+			$message = 'WooCommerce tracker snapshot delivery failed; it will be retried on the next run.';
+		}
+
 		wc_get_logger()->warning(
-			$give_up ? 'WooCommerce tracker snapshot delivery failed; giving up until the next interval.' : 'WooCommerce tracker snapshot delivery failed; it will be retried on the next run.',
+			$message,
 			array(
 				'source'      => 'woocommerce-tracker',
 				'http_status' => $status,
 				'error_code'  => is_wp_error( $response ) ? $response->get_error_code() : '',
 				'failures'    => $failures,
+				'body_bytes'  => $body_bytes,
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -39,6 +39,15 @@ class WC_Tracker {
 	private static $api_url = 'https://tracking.woocommerce.com/v1/';
 
 	/**
+	 * Consecutive failed deliveries after which the current snapshot is abandoned.
+	 *
+	 * Retries happen on the daily tracker action, so this bounds retrying to a few days.
+	 *
+	 * @var int
+	 */
+	private const MAX_CONSECUTIVE_SEND_FAILURES = 3;
+
+	/**
 	 * Hook into cron event.
 	 */
 	public static function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingFinal, WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag -- Not an injection.
@@ -75,23 +84,78 @@ class WC_Tracker {
 			}
 		}
 
-		// Update time first before sending to ensure it is set.
-		update_option( 'woocommerce_tracker_last_send', time() );
+		$body = wp_json_encode( self::get_tracking_data() );
+		if ( false === $body ) {
+			return;
+		}
 
-		$params = self::get_tracking_data();
-		wp_safe_remote_post(
+		$response = wp_safe_remote_post(
 			self::$api_url,
 			array(
 				'method'      => 'POST',
-				'timeout'     => 45,
+				'timeout'     => 10,
 				'redirection' => 5,
 				'httpversion' => '1.0',
-				'blocking'    => false,
+				'blocking'    => true,
 				'headers'     => array( 'user-agent' => 'WooCommerceTracker/' . md5( esc_url_raw( home_url( '/' ) ) ) . ';' ),
-				'body'        => wp_json_encode( $params ),
+				'body'        => $body,
 				'cookies'     => array(),
 			)
 		);
+
+		self::record_send_result( $response );
+	}
+
+	/**
+	 * Record the outcome of a delivery attempt.
+	 *
+	 * The send time is only recorded once the snapshot is accepted, so a transient failure
+	 * leaves it pending and the next scheduled run retries it. Consecutive failures are
+	 * counted so a persistent outage does not retry forever.
+	 *
+	 * @param array|WP_Error $response Response from wp_safe_remote_post().
+	 */
+	private static function record_send_result( $response ): void {
+		$status = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 <= $status && 300 > $status ) {
+			update_option( 'woocommerce_tracker_last_send', time() );
+			delete_option( 'woocommerce_tracker_send_failures' );
+			return;
+		}
+
+		$failures = (int) get_option( 'woocommerce_tracker_send_failures', 0 ) + 1;
+		$give_up  = ! self::is_retryable_status( $status ) || self::MAX_CONSECUTIVE_SEND_FAILURES <= $failures;
+
+		if ( $give_up ) {
+			update_option( 'woocommerce_tracker_last_send', time() );
+			delete_option( 'woocommerce_tracker_send_failures' );
+		} else {
+			update_option( 'woocommerce_tracker_send_failures', $failures, false );
+		}
+
+		wc_get_logger()->warning(
+			$give_up ? 'WooCommerce tracker snapshot delivery failed; giving up until the next interval.' : 'WooCommerce tracker snapshot delivery failed; it will be retried on the next run.',
+			array(
+				'source'      => 'woocommerce-tracker',
+				'http_status' => $status,
+				'error_code'  => is_wp_error( $response ) ? $response->get_error_code() : '',
+				'failures'    => $failures,
+			)
+		);
+	}
+
+	/**
+	 * Whether a delivery failure with the given status is worth retrying.
+	 *
+	 * Transport failures (status 0), rate limiting, timeouts and server errors are retried;
+	 * other client errors mean the snapshot itself was rejected.
+	 *
+	 * @param int $status HTTP status code, 0 for a transport failure.
+	 * @return bool
+	 */
+	private static function is_retryable_status( $status ) {
+		return 0 === $status || in_array( $status, array( 408, 425, 429 ), true ) || 500 <= $status;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1805,6 +1805,7 @@ final class WooCommerce {
 		}
 		if ( false === wc_string_to_bool( $value ) ) {
 			as_unschedule_all_actions( 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce' );
+			delete_option( 'woocommerce_tracker_send_failures' );
 		} else {
 			$this->schedule_tracking_action();
 		}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -15829,12 +15829,6 @@ parameters:
 			path: includes/class-wc-tracker.php
 
 		-
-			message: '#^Parameter \#2 \$args of function wp_safe_remote_post expects array\{method\?\: string, timeout\?\: float, redirection\?\: int, httpversion\?\: string, user\-agent\?\: string, reject_unsafe_urls\?\: bool, blocking\?\: bool, headers\?\: array\|string, \.\.\.\}, array\{method\: ''POST'', timeout\: 45, redirection\: 5, httpversion\: ''1\.0'', blocking\: false, headers\: array\{user\-agent\: non\-falsy\-string\}, body\: non\-empty\-string\|false, cookies\: array\{\}\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-tracker.php
-
-		-
 			message: '#^Property WC_Shipping_Method\:\:\$enabled \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -186,6 +186,39 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should bound consecutive failures for any truthy value of the tracking option.
+	 *
+	 * @testWith ["yes"]
+	 *           ["1"]
+	 *
+	 * @param string $allow_tracking Stored value of the tracking option.
+	 */
+	public function test_consecutive_failures_are_bounded_for_any_truthy_tracking_value( string $allow_tracking ): void {
+		update_option( 'woocommerce_allow_tracking', $allow_tracking );
+		$requests = 0;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$requests ) {
+				++$requests;
+				return array( 'response' => array( 'code' => 503 ) );
+			}
+		);
+		$this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data();
+		$this->assertSame( 1, (int) get_option( 'woocommerce_tracker_send_failures' ), 'The first failure should persist a count of one.' );
+
+		WC_Tracker::send_tracking_data();
+		$this->assertSame( 2, (int) get_option( 'woocommerce_tracker_send_failures' ), 'The second failure should persist a count of two.' );
+
+		WC_Tracker::send_tracking_data();
+
+		$this->assertSame( 3, $requests, 'Each daily run should retry while the snapshot is still pending.' );
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5, 'The third consecutive failure should record the send time so the snapshot is abandoned.' );
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Giving up should clear the failure counter.' );
+	}
+
+	/**
 	 * @testdox Should retry on the next daily run after a failed delivery without waiting for the weekly interval.
 	 */
 	public function test_failed_send_is_retried_on_next_run(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -138,13 +138,14 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_retryable_failure_keeps_snapshot_pending( $status ): void {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
-		update_option( 'woocommerce_tracker_last_send', strtotime( '-2 weeks' ) );
+		$last_send = strtotime( '-2 weeks' );
+		update_option( 'woocommerce_tracker_last_send', $last_send );
 		$this->fake_tracker_response( $status );
 		$logger = $this->expect_tracker_warning();
 
 		WC_Tracker::send_tracking_data();
 
-		$this->assertSame( strtotime( '-2 weeks' ), (int) get_option( 'woocommerce_tracker_last_send' ), 'A retryable failure must leave the last send time unchanged so the next daily run retries.' );
+		$this->assertSame( $last_send, (int) get_option( 'woocommerce_tracker_last_send' ), 'A retryable failure must leave the last send time unchanged so the next daily run retries.' );
 		$this->assertSame( 1, (int) get_option( 'woocommerce_tracker_send_failures' ), 'A retryable failure should increment the failure counter.' );
 		$this->assertCount( 1, $logger->warnings, 'A failed delivery should be logged as a warning.' );
 		$this->assertSame( 'woocommerce-tracker', $logger->warnings[0]['source'] );

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -99,6 +99,178 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should send a blocking request with a short timeout so the response can be inspected.
+	 */
+	public function test_send_tracking_data_uses_blocking_request(): void {
+		$request_args = null;
+		$this->fake_tracker_response( 200, $request_args );
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertTrue( $request_args['blocking'], 'The tracker request must be blocking to read the response.' );
+		$this->assertSame( 10, $request_args['timeout'], 'The tracker request timeout should be short.' );
+	}
+
+	/**
+	 * @testdox Should record the send time and clear the failure counter after a successful delivery.
+	 */
+	public function test_successful_send_records_last_send_and_clears_failures(): void {
+		update_option( 'woocommerce_tracker_send_failures', 2 );
+		$this->fake_tracker_response( 204 );
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5, 'A 2xx response should record the send time.' );
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'A 2xx response should clear the failure counter.' );
+	}
+
+	/**
+	 * @testdox Should not record the send time and should count the failure when delivery fails with a retryable error.
+	 *
+	 * @testWith [500]
+	 *           [503]
+	 *           [429]
+	 *           [408]
+	 *           [425]
+	 *           ["wp_error"]
+	 *
+	 * @param int|string $status HTTP status, or "wp_error" for a transport failure.
+	 */
+	public function test_retryable_failure_keeps_snapshot_pending( $status ): void {
+		update_option( 'woocommerce_tracker_last_send', strtotime( '-2 weeks' ) );
+		$this->fake_tracker_response( $status );
+		$logger = $this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data();
+
+		$this->assertSame( strtotime( '-2 weeks' ), (int) get_option( 'woocommerce_tracker_last_send' ), 'A retryable failure must leave the last send time unchanged so the next daily run retries.' );
+		$this->assertSame( 1, (int) get_option( 'woocommerce_tracker_send_failures' ), 'A retryable failure should increment the failure counter.' );
+		$this->assertCount( 1, $logger->warnings, 'A failed delivery should be logged as a warning.' );
+		$this->assertSame( 'woocommerce-tracker', $logger->warnings[0]['source'] );
+	}
+
+	/**
+	 * @testdox Should give up on the snapshot when the server rejects it with a non-retryable status.
+	 *
+	 * @testWith [400]
+	 *           [403]
+	 *           [404]
+	 *           [410]
+	 *
+	 * @param int $status HTTP status.
+	 */
+	public function test_non_retryable_failure_records_last_send( int $status ): void {
+		update_option( 'woocommerce_tracker_send_failures', 1 );
+		$this->fake_tracker_response( $status );
+		$this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5, 'A non-retryable failure should record the send time so the snapshot is not retried.' );
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Giving up should clear the failure counter.' );
+	}
+
+	/**
+	 * @testdox Should give up on the snapshot after the maximum number of consecutive failures.
+	 */
+	public function test_max_consecutive_failures_records_last_send(): void {
+		update_option( 'woocommerce_tracker_send_failures', 2 );
+		$this->fake_tracker_response( 503 );
+		$this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5, 'The third consecutive failure should record the send time.' );
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Giving up should clear the failure counter.' );
+	}
+
+	/**
+	 * @testdox Should retry on the next daily run after a failed delivery without waiting for the weekly interval.
+	 */
+	public function test_failed_send_is_retried_on_next_run(): void {
+		$requests = 0;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$requests ) {
+				++$requests;
+				return 1 === $requests ? new WP_Error( 'http_request_failed', 'Timed out' ) : array( 'response' => array( 'code' => 200 ) );
+			}
+		);
+		$this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data();
+		WC_Tracker::send_tracking_data();
+
+		$this->assertSame( 2, $requests, 'The second run should retry because the first delivery did not record a send time.' );
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5 );
+	}
+
+	/**
+	 * Fake the tracker HTTP response.
+	 *
+	 * @param int|string $status       HTTP status code, or "wp_error" for a transport failure.
+	 * @param array|null $request_args Receives the request arguments by reference.
+	 */
+	private function fake_tracker_response( $status, &$request_args = null ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args ) use ( $status, &$request_args ) {
+				$request_args = $args;
+				if ( 'wp_error' === $status ) {
+					return new WP_Error( 'http_request_failed', 'Timed out' );
+				}
+				return array(
+					'headers'  => array(),
+					'body'     => '',
+					'response' => array(
+						'code'    => $status,
+						'message' => '',
+					),
+				);
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Inject a fake logger that records warning contexts.
+	 *
+	 * @return object Fake logger with a public `warnings` array of contexts.
+	 */
+	private function expect_tracker_warning() {
+		$logger = new class() implements WC_Logger_Interface {
+			/**
+			 * Recorded warning contexts.
+			 *
+			 * @var array
+			 */
+			public $warnings = array();
+
+			// phpcs:disable Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {}
+			public function log( $level, $message, $context = array() ) {}
+			public function emergency( $message, $context = array() ) {}
+			public function alert( $message, $context = array() ) {}
+			public function critical( $message, $context = array() ) {}
+			public function error( $message, $context = array() ) {}
+			public function warning( $message, $context = array() ) {
+				$this->warnings[] = $context;
+			}
+			public function notice( $message, $context = array() ) {}
+			public function info( $message, $context = array() ) {}
+			public function debug( $message, $context = array() ) {}
+			// phpcs:enable
+		};
+		add_filter(
+			'woocommerce_logging_class',
+			static function () use ( $logger ) {
+				return $logger;
+			}
+		);
+		return $logger;
+	}
+	/**
 	 * @testDox Test the features compatibility data for plugin tracking data.
 	 */
 	public function test_get_tracking_data_plugin_feature_compatibility() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -137,6 +137,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	 * @param int|string $status HTTP status, or "wp_error" for a transport failure.
 	 */
 	public function test_retryable_failure_keeps_snapshot_pending( $status ): void {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
 		update_option( 'woocommerce_tracker_last_send', strtotime( '-2 weeks' ) );
 		$this->fake_tracker_response( $status );
 		$logger = $this->expect_tracker_warning();
@@ -262,6 +263,55 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		WC()->handle_tracking_setting_change( 'yes', 'no' );
 
 		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Opting out should discard pending retry state.' );
+	}
+
+	/**
+	 * @testdox Should treat a snapshot that cannot be encoded as a non-retryable failure.
+	 */
+	public function test_unencodable_snapshot_is_logged_and_not_retried(): void {
+		$requests = 0;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$requests ) {
+				++$requests;
+				return array( 'response' => array( 'code' => 200 ) );
+			}
+		);
+		add_filter(
+			'woocommerce_tracker_data',
+			function ( $data ) {
+				$data['unencodable'] = INF;
+				return $data;
+			}
+		);
+		update_option( 'woocommerce_tracker_send_failures', 1 );
+		$logger = $this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertSame( 0, $requests, 'An unencodable snapshot must not be posted.' );
+		$this->assertSame( 'json_encode_failure', $logger->warnings[0]['error_code'] );
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5, 'An unencodable snapshot should not be retried daily.' );
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Giving up should clear the failure counter.' );
+	}
+
+	/**
+	 * @testdox Should not record retry state when tracking was turned off while the request was in flight.
+	 */
+	public function test_retry_state_is_not_recorded_after_opt_out_during_request(): void {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		add_filter(
+			'pre_http_request',
+			function () {
+				update_option( 'woocommerce_allow_tracking', 'no' );
+				return array( 'response' => array( 'code' => 503 ) );
+			}
+		);
+		$this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Retry state must not be created once tracking is off.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -206,6 +206,65 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should suppress a second override send within an hour of a failed attempt.
+	 */
+	public function test_override_send_is_suppressed_within_an_hour_of_a_failed_attempt(): void {
+		$request_args = null;
+		$requests     = 0;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$requests ) {
+				++$requests;
+				return new WP_Error( 'http_request_failed', 'Timed out' );
+			}
+		);
+		$this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertSame( 1, $requests, 'A failed override send must still block a second override send within the hour.' );
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_attempt' ), 5, 'Every attempt should record its time.' );
+		$this->assertFalse( get_option( 'woocommerce_tracker_last_send' ), 'A failed attempt must not record a send time.' );
+	}
+
+	/**
+	 * @testdox Should include the payload size in the failure log.
+	 */
+	public function test_failure_log_includes_payload_size(): void {
+		$this->fake_tracker_response( 503 );
+		$logger = $this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertGreaterThan( 0, $logger->warnings[0]['body_bytes'], 'The failure log should report the payload size.' );
+	}
+
+	/**
+	 * @testdox Should report a rejected oversized snapshot distinctly.
+	 */
+	public function test_too_large_snapshot_is_logged_as_such(): void {
+		$this->fake_tracker_response( 413 );
+		$logger = $this->expect_tracker_warning();
+
+		WC_Tracker::send_tracking_data( true );
+
+		$this->assertStringContainsString( 'too large', $logger->messages[0] );
+		$this->assertEqualsWithDelta( time(), (int) get_option( 'woocommerce_tracker_last_send' ), 5, 'An oversized snapshot is not retried.' );
+	}
+
+	/**
+	 * @testdox Should clear the failure counter when tracking is turned off.
+	 */
+	public function test_opting_out_clears_failure_counter(): void {
+		update_option( 'woocommerce_tracker_send_failures', 2 );
+
+		WC()->handle_tracking_setting_change( 'yes', 'no' );
+
+		$this->assertFalse( get_option( 'woocommerce_tracker_send_failures' ), 'Opting out should discard pending retry state.' );
+	}
+
+	/**
 	 * Fake the tracker HTTP response.
 	 *
 	 * @param int|string $status       HTTP status code, or "wp_error" for a transport failure.
@@ -236,7 +295,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Inject a fake logger that records warning contexts.
 	 *
-	 * @return object Fake logger with a public `warnings` array of contexts.
+	 * @return object Fake logger with public `warnings` (contexts) and `messages` arrays.
 	 */
 	private function expect_tracker_warning() {
 		$logger = new class() implements WC_Logger_Interface {
@@ -247,6 +306,13 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 			 */
 			public $warnings = array();
 
+			/**
+			 * Recorded warning messages.
+			 *
+			 * @var array
+			 */
+			public $messages = array();
+
 			// phpcs:disable Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {}
 			public function log( $level, $message, $context = array() ) {}
@@ -256,6 +322,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 			public function error( $message, $context = array() ) {}
 			public function warning( $message, $context = array() ) {
 				$this->warnings[] = $context;
+				$this->messages[] = $message;
 			}
 			public function notice( $message, $context = array() ) {}
 			public function info( $message, $context = array() ) {}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Tracker::send_tracking_data()` records `woocommerce_tracker_last_send` before posting the weekly snapshot and posts with `blocking => false`, so the response is never inspected. Any transient network or server failure silently loses that week's snapshot: the daily tracker action finds `last_send` fresh and skips sending for the rest of the week.

This PR makes the request blocking with a 10-second per-request timeout and records `last_send` only once the snapshot is accepted with a 2xx status. A transient failure (transport error, 408/425/429, 5xx) leaves the snapshot pending and the existing daily Action Scheduler action retries it on its next run. Consecutive failures are counted in a non-autoloaded `woocommerce_tracker_send_failures` option; the snapshot is abandoned after three consecutive failures, or immediately when the server rejects it with another 4xx, so a persistent outage does not retry forever. Failures are logged as warnings under the `woocommerce-tracker` source with the HTTP status and payload size but not the payload itself; a snapshot the service rejects as too large (HTTP 413), or one that cannot be JSON-encoded, is named as such and not retried, since retrying cannot fix it. The one-hour guard between override sends keys on a `woocommerce_tracker_last_attempt` option recorded before each send, so a failed or in-flight override send still suppresses a repeated one. Turning usage tracking off discards the failure counter, and a response arriving after opt-out does not recreate it.

No public signature, hook, scheduling, or uninstall change is involved: the daily recurring action already provides the retry cadence. The stale PHPStan baseline entry for the old request arguments is removed rather than replaced, since the `false` return of `wp_json_encode()` is now handled explicitly.

This is an alternative to #68117 with the same goal and a much smaller surface; see that PR for the discussion.

**Backward compatibility:** `send_tracking_data( $override )` keeps its signature and the `woocommerce_tracker_send_event` action keeps its arguments. The request now waits for the response, bounded by a 10-second timeout that applies per HTTP request rather than to the call as a whole (with `redirection => 5`, a redirected request can wait longer in total), where it previously did not wait for one (the WP HTTP API makes no promise about what a non-blocking request costs, only that no response is returned). A client-side timeout is treated as a retryable failure, so a snapshot the service accepted slowly may be delivered again on the next run. Callers that invoke `send_tracking_data( true )` synchronously from an admin request (for example the Helper connect flow) should expect that wait. Behavioural trade-offs: during an outage `get_tracking_data()` runs once a day for up to three days instead of once a week; and sites that filter `woocommerce_tracker_event_recurrence` to a longer interval retry at that interval.

Closes #38574.

### How to test the changes in this Pull Request:

1. From the repository root, run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'WC_Tracker_Test|WC_Recurring_Actions_Test'` and confirm all tests pass. The new `WC_Tracker_Test` cases cover the blocking request, stamping on 2xx, pending-on-retryable-failure, giving up on 4xx and after three consecutive failures, the retry on the next run, the override guard after a failed attempt, the three-attempt bound for every truthy form of `woocommerce_allow_tracking`, the failure log contents, and clearing the counter on opt-out.
2. On a local site with usage tracking enabled (**WooCommerce → Settings → Advanced → WooCommerce.com** → "Allow usage of WooCommerce to be tracked"), simulate a tracker outage with a snippet such as:
   ```php
   add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
       return str_starts_with( $url, 'https://tracking.woocommerce.com/' ) ? new WP_Error( 'http_request_failed', 'Simulated outage' ) : $pre;
   }, 10, 3 );
   ```
3. Run `wp option delete woocommerce_tracker_last_send` and then `wp action-scheduler run --hooks=woocommerce_tracker_send_event_wrapper` (or trigger the `woocommerce_tracker_send_event_wrapper` action from **Tools → Scheduled Actions**).
4. Confirm `wp option get woocommerce_tracker_last_send` is still unset, `wp option get woocommerce_tracker_send_failures` is `1`, and a warning appears in **WooCommerce → Status → Logs** under the `woocommerce-tracker` source.
5. Remove the snippet and run the action again. Confirm `woocommerce_tracker_last_send` is now set to the current time and `woocommerce_tracker_send_failures` is deleted.
6. Re-add the snippet, set `wp option update woocommerce_tracker_send_failures 2`, delete `woocommerce_tracker_last_send`, run the action once more, and confirm `last_send` is set (the snapshot was abandoned after the third consecutive failure) and the counter is deleted.

### Testing that has already taken place:

- `WC_Tracker_Test|WC_Recurring_Actions_Test|WC_Helper`: 106 tests, 559 assertions, passing (the 22 new `WC_Tracker_Test` cases were written first and failed against trunk).
- PHPStan on `includes/class-wc-tracker.php`: no errors (one stale baseline entry removed, none added). PHPCS branch lint clean.
- Multisite variant (`WP_MULTISITE=1`) of the same suites: 105 of 106 pass. The one failure, `WC_Helper_Subscriptions_API_Test::test_administrator_can_activate_plugin`, fails identically on trunk under multisite and does not touch the tracker.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually: `plugins/woocommerce/changelog/fix-38574-tracker-retry-snapshots`.

</details>

---
🤖 Generated with [Claude Code](https://claude.ai/code)







