### PR TITLE
Fix false error after order cancellation refresh

### DIFF
--- a/plugins/woocommerce/changelog/fix-cancel-order-refresh-error
+++ b/plugins/woocommerce/changelog/fix-cancel-order-refresh-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a false order cancellation error after shoppers refresh the return page.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -882,6 +882,10 @@ class WC_Form_Handler {
 			$order_can_cancel = $order->has_status( $valid_statuses );
 			$redirect         = isset( $_GET['redirect'] ) ? wp_unslash( $_GET['redirect'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
+			if ( WC()->session instanceof WC_Session_Handler && ! WC()->session->has_session() ) {
+				WC()->session->set_customer_session_cookie( true );
+			}
+
 			if ( $user_can_cancel && $order_can_cancel && $order->get_id() === $order_id && hash_equals( $order->get_order_key(), $order_key ) ) {
 
 				// Cancel the order + restore stock.
@@ -898,7 +902,13 @@ class WC_Form_Handler {
 				wc_add_notice( __( 'Invalid order.', 'woocommerce' ), 'error' );
 			}
 
-			$redirect = $redirect ? $redirect : remove_query_arg( array( 'cancel_order', 'order', 'order_id', 'redirect', '_wpnonce' ) );
+			if ( ! $redirect ) {
+				$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				$redirect    = remove_query_arg( array( 'cancel_order', 'order', 'order_id', 'redirect', '_wpnonce' ), $request_uri );
+			}
+
+			$redirect = $redirect ? $redirect : wc_get_cart_url();
+			$redirect = $redirect ? $redirect : home_url();
 			wp_safe_redirect( $redirect );
 			exit;
 		}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -902,6 +902,11 @@ class WC_Form_Handler {
 				wc_add_notice( __( 'Invalid order.', 'woocommerce' ), 'error' );
 			}
 
+			if ( ! $redirect && ! doing_action( 'wp_loaded' ) ) {
+				// Preserve the historical return behavior for extensions that call this public method directly.
+				return;
+			}
+
 			if ( ! $redirect ) {
 				$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				$redirect    = remove_query_arg( array( 'cancel_order', 'order', 'order_id', 'redirect', '_wpnonce' ), $request_uri );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -898,10 +898,9 @@ class WC_Form_Handler {
 				wc_add_notice( __( 'Invalid order.', 'woocommerce' ), 'error' );
 			}
 
-			if ( $redirect ) {
-				wp_safe_redirect( $redirect );
-				exit;
-			}
+			$redirect = $redirect ? $redirect : remove_query_arg( array( 'cancel_order', 'order', 'order_id', 'redirect', '_wpnonce' ) );
+			wp_safe_redirect( $redirect );
+			exit;
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -128,7 +128,7 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
 		wp_set_current_user( $user_id );
 		$order             = WC_Helper_Order::create_order( $user_id );
-		$filtered_endpoint = wc_get_page_permalink( 'myaccount' );
+		$filtered_endpoint = home_url( '/filtered-cancel-page/' );
 		$filter            = static function ( string $url ) use ( $filtered_endpoint ): string {
 			$query = wp_parse_url( $url, PHP_URL_QUERY );
 			return $filtered_endpoint . '?' . $query;
@@ -139,6 +139,8 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 		remove_filter( 'woocommerce_get_cancel_order_url_raw', $filter );
 
 		$this->dispatch_cancel_order_expecting_redirect( wp_make_link_relative( $filtered_endpoint ) );
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::CANCELLED ), 'The order should be cancelled before the filtered redirect.' );
 	}
 
 	/**
@@ -156,6 +158,67 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 		$this->dispatch_cancel_order_expecting_redirect( $redirect_to );
 
 		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::CANCELLED ), 'The order should be cancelled before the custom redirect.' );
+	}
+
+	/**
+	 * @testdox cancel_order() redirects to the cart when the request URI is unavailable.
+	 * @dataProvider unavailable_request_uri_provider
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 *
+	 * @param string|null $request_uri Request URI to use, or null to remove it.
+	 */
+	public function test_cancel_order_redirects_to_cart_when_request_uri_is_unavailable( ?string $request_uri ): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$order = WC_Helper_Order::create_order( $user_id );
+
+		$this->prepare_cancel_order_request( $order );
+		if ( null === $request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $request_uri;
+		}
+
+		$this->dispatch_cancel_order_expecting_redirect( wc_get_cart_url() );
+	}
+
+	/**
+	 * Provides unavailable request URI values.
+	 *
+	 * @return array<string,array{string|null}>
+	 */
+	public function unavailable_request_uri_provider(): array {
+		return array(
+			'missing request URI' => array( null ),
+			'empty request URI'   => array( '' ),
+		);
+	}
+
+	/**
+	 * @testdox cancel_order() persists the cancellation notice for a fresh guest session.
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 */
+	public function test_cancel_order_persists_notice_for_fresh_guest_session(): void {
+		wp_set_current_user( 0 );
+		WC()->session = new WC_Session_Handler();
+		WC()->session->init_session_cookie();
+
+		$this->assertFalse( WC()->session->has_session(), 'The guest should start without a cookie-backed session.' );
+
+		$order = WC_Helper_Order::create_order( 0 );
+		$this->prepare_cancel_order_request( $order );
+		$this->dispatch_cancel_order_expecting_redirect( wp_make_link_relative( $order->get_cancel_endpoint() ) );
+
+		$this->assertTrue( WC()->session->has_session(), 'Cancelling the guest order should establish a session.' );
+
+		WC()->session->save_data();
+		$saved_session_data = WC()->session->get_session( WC()->session->get_customer_id(), array() );
+		WC()->session->destroy_session();
+		$saved_notices = maybe_unserialize( $saved_session_data['wc_notices'] ?? array() );
+
+		$this->assertNotEmpty( $saved_notices['notice'] ?? array(), 'The cancellation notice should be saved for the redirect.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -161,6 +161,22 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox cancel_order() returns to direct callers when no custom redirect is provided.
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 */
+	public function test_cancel_order_returns_to_direct_callers_without_custom_redirect(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$order = WC_Helper_Order::create_order( $user_id );
+
+		$this->prepare_cancel_order_request( $order );
+		WC_Form_Handler::cancel_order();
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::CANCELLED ), 'The direct call should cancel the order and return control to the caller.' );
+	}
+
+	/**
 	 * @testdox cancel_order() redirects to the cart when the request URI is unavailable.
 	 * @dataProvider unavailable_request_uri_provider
 	 *
@@ -439,11 +455,18 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	 * @param string $expected_redirect Expected redirect URL.
 	 */
 	private function dispatch_cancel_order_expecting_redirect( string $expected_redirect ): void {
+		global $wp_current_filter;
+
+		$current_filter_backup = $wp_current_filter;
+		$wp_current_filter[]   = 'wp_loaded'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- The test dispatches the handler in its registered action context.
+
 		try {
 			WC_Form_Handler::cancel_order();
 		} catch ( RuntimeException $e ) {
 			$this->assertSame( $expected_redirect, $e->getMessage(), 'The cancellation request should redirect to a clean URL.' );
 			return;
+		} finally {
+			$wp_current_filter = $current_filter_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action stack after the simulated dispatch.
 		}
 
 		$this->fail( 'Expected cancel_order() to redirect after handling the request.' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -7,10 +7,26 @@
 
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Enums\OrderStatus;
+
 /**
  * WC_Form_Handler tests.
  */
 class WC_Form_Handler_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Original GET data.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private array $original_get = array();
+
+	/**
+	 * Original request URI.
+	 *
+	 * @var string|null
+	 */
+	private ?string $original_request_uri = null;
 
 	/**
 	 * Original POST data.
@@ -39,6 +55,9 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->original_request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : null;
+
+		$this->original_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$this->original_post    = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$this->original_request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$this->original_session = WC()->session;
@@ -57,6 +76,12 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
 
+		$_GET = $this->original_get;
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
 		$_POST    = $this->original_post;
 		$_REQUEST = $this->original_request;
 
@@ -76,6 +101,88 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	 */
 	public function intercept_redirect( string $location ): void {
 		throw new RuntimeException( esc_url_raw( $location ) );
+	}
+
+	/**
+	 * @testdox cancel_order() redirects to a clean endpoint when no custom redirect is provided.
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 */
+	public function test_cancel_order_redirects_to_clean_endpoint_without_custom_redirect(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$order = WC_Helper_Order::create_order( $user_id );
+
+		$this->prepare_cancel_order_request( $order );
+		$this->dispatch_cancel_order_expecting_redirect( wp_make_link_relative( $order->get_cancel_endpoint() ) );
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::CANCELLED ), 'The order should be cancelled before the clean redirect.' );
+	}
+
+	/**
+	 * @testdox cancel_order() preserves a filtered cancel URL base when it removes request arguments.
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 */
+	public function test_cancel_order_preserves_filtered_cancel_url_base(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$order             = WC_Helper_Order::create_order( $user_id );
+		$filtered_endpoint = wc_get_page_permalink( 'myaccount' );
+		$filter            = static function ( string $url ) use ( $filtered_endpoint ): string {
+			$query = wp_parse_url( $url, PHP_URL_QUERY );
+			return $filtered_endpoint . '?' . $query;
+		};
+
+		add_filter( 'woocommerce_get_cancel_order_url_raw', $filter );
+		$this->prepare_cancel_order_request( $order );
+		remove_filter( 'woocommerce_get_cancel_order_url_raw', $filter );
+
+		$this->dispatch_cancel_order_expecting_redirect( wp_make_link_relative( $filtered_endpoint ) );
+	}
+
+	/**
+	 * @testdox cancel_order() preserves a custom redirect.
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 */
+	public function test_cancel_order_preserves_custom_redirect(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$order       = WC_Helper_Order::create_order( $user_id );
+		$redirect_to = wc_get_page_permalink( 'myaccount' );
+
+		$this->prepare_cancel_order_request( $order, $redirect_to );
+		$this->dispatch_cancel_order_expecting_redirect( $redirect_to );
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::CANCELLED ), 'The order should be cancelled before the custom redirect.' );
+	}
+
+	/**
+	 * @testdox cancel_order() redirects safely when the order ID belongs to a refund.
+	 *
+	 * @covers WC_Form_Handler::cancel_order()
+	 */
+	public function test_cancel_order_redirects_safely_for_refund_id(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$order  = WC_Helper_Order::create_order( $user_id );
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 1,
+				'order_id' => $order->get_id(),
+				'reason'   => 'Test refund',
+			)
+		);
+
+		$this->assertInstanceOf( WC_Order_Refund::class, $refund, 'The test requires a refund order.' );
+		$this->prepare_cancel_order_request( $order );
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+
+		$_GET['order_id']       = (string) $refund->get_id();
+		$_SERVER['REQUEST_URI'] = add_query_arg( 'order_id', $refund->get_id(), $request_uri );
+
+		$this->dispatch_cancel_order_expecting_redirect( wp_make_link_relative( $order->get_cancel_endpoint() ) );
 	}
 
 	/**
@@ -248,6 +355,35 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 		$_REQUEST = array(
 			'save-account-details-nonce' => $nonce,
 		);
+	}
+
+	/**
+	 * Prepares a cancel-order request from the public order URL.
+	 *
+	 * @param WC_Order $order    Order to cancel.
+	 * @param string   $redirect Optional redirect URL.
+	 */
+	private function prepare_cancel_order_request( WC_Order $order, string $redirect = '' ): void {
+		$url   = $order->get_cancel_order_url_raw( $redirect );
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		parse_str( (string) $query, $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The test builds a signed cancellation request.
+		$_SERVER['REQUEST_URI'] = wp_make_link_relative( $url );
+	}
+
+	/**
+	 * Dispatches the cancel-order handler and expects a redirect.
+	 *
+	 * @param string $expected_redirect Expected redirect URL.
+	 */
+	private function dispatch_cancel_order_expecting_redirect( string $expected_redirect ): void {
+		try {
+			WC_Form_Handler::cancel_order();
+		} catch ( RuntimeException $e ) {
+			$this->assertSame( $expected_redirect, $e->getMessage(), 'The cancellation request should redirect to a clean URL.' );
+			return;
+		}
+
+		$this->fail( 'Expected cancel_order() to redirect after handling the request.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Order cancellation URLs can contain state-changing query arguments without a separate `redirect` value. WooCommerce cancelled the order but left those arguments in the browser address bar. A refresh then processed the request again and showed a false "Your order can no longer be cancelled" error.

This change always redirects after WooCommerce handles the cancellation request. When no custom redirect exists, it removes only the cancellation arguments from the current URL. This keeps the shopper on the same page, preserves extension-filtered cancel URL bases, and makes refresh safe.

The tests cover the default cancel URL, an extension-filtered URL base, an explicit custom redirect, and an invalid refund-order ID.

### Backward compatibility
Backward compatibility: This change does not modify a public signature, hook name, or hook argument. Explicit redirects are unchanged. Direct calls to WC_Form_Handler::cancel_order() without a redirect keep their historical return behavior. Normal cancellation requests without an explicit redirect now redirect and exit during wp_loaded at priority 20. As a result, later wp_loaded callbacks and the later wp and template_redirect hooks do not run for these browser requests. This prevents the state-changing cancellation URL from running again after a refresh.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #26743.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not applicable. This changes redirect behavior and does not change the visual UI.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Configure a payment gateway that uses `WC_Order::get_cancel_order_url_raw()` without a custom redirect, such as legacy PayPal Standard.
2. Start checkout as a customer and continue to the external payment page.
3. Select the gateway action that cancels payment and returns to the store.
4. Confirm that WooCommerce cancels the order and shows the cancellation notice.
5. Confirm that the returned URL does not contain `cancel_order`, `order`, `order_id`, `redirect`, or `_wpnonce` arguments.
6. Refresh the page and confirm that the false "Your order can no longer be cancelled" error does not appear.
7. Cancel a pending order from My account and confirm that its explicit redirect still returns to the expected account page.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `WC_Form_Handler_Test` passed on PHP 8.1: 8 tests and 23 assertions.
- PHP lint passed for the changed files.
- Branch-wide PHP and JavaScript lint passed.
- PHPStan passed for `includes/class-wc-form-handler.php`.
- The final diff received correctness, test, project-standards, security, and independent adversarial reviews.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a false error notice that shows after cancellation refresh

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to investigate the issue, implement the fix, add tests, and review the final change.
