### PR TITLE
Add support for border and shadow styles to the Product Quantity block and apply them to the Cart quantity selector

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -262,7 +262,7 @@ Display an input field customers can use to select the number of products to add
 - **Name:** woocommerce/add-to-cart-with-options-quantity-selector
 - **Category:** woocommerce-product-elements
 - **Ancestor:** woocommerce/add-to-cart-with-options
-- **Supports:** color (background, text), interactivity
+- **Supports:** color (background, text), interactivity, shadow
 
 ## Variation Description (Beta) - woocommerce/add-to-cart-with-options-variation-description
 

--- a/plugins/woocommerce/changelog/fix-WOOTHME-492-product-quantity-extra-style
+++ b/plugins/woocommerce/changelog/fix-WOOTHME-492-product-quantity-extra-style
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for border and shadow styles to the Product Quantity block and also apply them to the Cart quantity selector

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -11,14 +11,19 @@
 	}
 }
 
+// Default border lives in :where() so user/theme styles for the Product
+// Quantity block (applied via block.json selectors, including Cart) override it.
+:where(.wc-block-components-quantity-selector:has(input:not([type="hidden"]))) {
+	border: 1px solid $universal-translucent-border-color;
+	border-radius: $universal-border-radius;
+}
+
 .wc-block-components-quantity-selector {
 	&:where(:has(input:not([type="hidden"]))) {
-		border: 1px solid $universal-translucent-border-color;
-		border-radius: $universal-border-radius;
 		box-sizing: border-box;
 		display: flex;
 		position: relative;
-		width: 107px;
+		min-width: 107px;
 	}
 
 	// Extra label for specificity needed in the editor.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -23,7 +23,7 @@
 		"shadow": true
 	},
 	"selectors": {
-		"root": ".wp-block-woocommerce-add-to-cart-with-options-quantity-selector, .wc-block-add-to-cart-with-options-grouped-product-item-selector .wc-block-components-quantity-selector"
+		"root": ".wp-block-woocommerce-add-to-cart-with-options-quantity-selector, .wc-block-add-to-cart-with-options-grouped-product-item-selector .wc-block-components-quantity-selector, .wc-block-cart-item__quantity .wc-block-components-quantity-selector"
 	},
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"viewScriptModule": "woocommerce/add-to-cart-with-options-quantity-selector"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -15,8 +15,12 @@
 			"text": true
 		},
 		"__experimentalBorder": {
-			"radius": true
-		}
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		},
+		"shadow": true
 	},
 	"selectors": {
 		"root": ".wp-block-woocommerce-add-to-cart-with-options-quantity-selector, .wc-block-add-to-cart-with-options-grouped-product-item-selector .wc-block-components-quantity-selector"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -21,10 +21,12 @@
 // Default radius lives on the block wrapper so user/theme border-radius
 // styles (inline or global) override it, then inner elements inherit.
 :where(.wc-block-add-to-cart-with-options__quantity-selector) {
+	border: 1px solid $universal-translucent-border-color;
 	border-radius: $universal-border-radius;
 }
 
-.wc-block-add-to-cart-with-options__quantity-selector .wc-block-components-quantity-selector {
+.wc-block-add-to-cart-with-options__quantity-selector .wc-block-components-quantity-selector:where(:has(input:not([type="hidden"]))) {
+	border-width: 0;
 	border-radius: inherit;
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOTHME-492.

Similar to https://github.com/woocommerce/woocommerce/pull/68000, but when I created the previous PR I missed WOOTHME-492 that issue so I didn't know we also wanted to support custom border and box shadow. This PR implements that and make the Cart block quantity selectors inherit the same styles as well.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Styles > Blocks > Product Quantity (Beta).
2. Change some of its styles.
3. Verify they are applied in the editor and frontend.
4. Go to the Cart page and verify the styles are also applied to the Cart block quantity selector.

Purple default | Purple on this branch | Custom styles
--- | --- | ---
<img width="397" height="290" alt="imatge" src="https://github.com/user-attachments/assets/0a1a8abc-2e05-4362-b2b5-09726e6d10d4" /> | <img width="397" height="290" alt="imatge" src="https://github.com/user-attachments/assets/5551fa50-830b-4413-a97e-cb4c29831ebb" /> | <img width="397" height="290" alt="imatge" src="https://github.com/user-attachments/assets/3a6f357b-9b4a-40c9-a49c-4c677b6c7ce8" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->