### PR TITLE
[Email Editor] Fix broken editor when Yoast SEO Premium is active

### DIFF
--- a/packages/php/email-editor/changelog/fix-yoast-replace-editor-reentry
+++ b/packages/php/email-editor/changelog/fix-yoast-replace-editor-reentry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render the email editor HTML only once per request — a plugin calling WP_Screen::get() from admin_enqueue_scripts (e.g. Yoast SEO Premium) re-fires the replace_editor filter mid-render and echoed a second editor container that broke the editor

--- a/packages/php/email-editor/src/Engine/class-assets-manager.php
+++ b/packages/php/email-editor/src/Engine/class-assets-manager.php
@@ -57,6 +57,13 @@ class Assets_Manager {
 	private Email_Editor_Logger $logger;
 
 	/**
+	 * Whether the email editor HTML has been rendered.
+	 *
+	 * @var bool
+	 */
+	private bool $editor_html_rendered = false;
+
+	/**
 	 * Assets Manager constructor with all dependencies.
 	 *
 	 * @param Settings_Controller $settings_controller Settings controller instance.
@@ -124,9 +131,18 @@ class Assets_Manager {
 	/**
 	 * Render the email editor's required HTML and admin header.
 	 *
+	 * Renders at most once per instance; repeated calls are no-ops.
+	 *
 	 * @param string $element_id Optional. The ID of the main container element. Default is 'woocommerce-email-editor'.
 	 */
 	public function render_email_editor_html( string $element_id = 'woocommerce-email-editor' ): void {
+		// Integrations render from the `replace_editor` filter, which re-fires while
+		// admin-header.php runs whenever a plugin calls WP_Screen::get() from
+		// admin_enqueue_scripts; a second container echoed inside <head> breaks the page.
+		if ( $this->editor_html_rendered ) {
+			return;
+		}
+		$this->editor_html_rendered = true;
 		// @phpstan-ignore-next-line -- PHPStan tried to check if the file exists.
 		require_once ABSPATH . 'wp-admin/admin-header.php';
 		echo '<div id="' . esc_attr( $element_id ) . '" class="block-editor block-editor__container hide-if-no-js"></div>';

--- a/packages/php/email-editor/tests/unit/Engine/Assets_Manager_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Assets_Manager_Test.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\EmailEditor\Engine;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger;
+
+/**
+ * Unit test class for Assets_Manager.
+ */
+class Assets_Manager_Test extends \Email_Editor_Unit_Test {
+	/**
+	 * Test that render_email_editor_html outputs the editor container once and nothing on repeated calls.
+	 *
+	 * Integrations render from the `replace_editor` filter, which can re-enter while
+	 * admin-header.php runs (a plugin calling WP_Screen::get() from admin_enqueue_scripts
+	 * re-fires the filter); the second call must not echo another editor container.
+	 */
+	public function testItRendersEditorHtmlOnlyOnce(): void {
+		$this->define_abspath_with_stub_admin_header();
+
+		$assets_manager = new Assets_Manager(
+			$this->createMock( Settings_Controller::class ),
+			$this->createMock( Theme_Controller::class ),
+			$this->createMock( User_Theme::class ),
+			$this->createMock( Email_Editor_Logger::class )
+		);
+
+		ob_start();
+		$assets_manager->render_email_editor_html();
+		$first_output = ob_get_clean();
+		$this->assertStringContainsString( 'id="woocommerce-email-editor"', (string) $first_output, 'The first render call must output the editor container' );
+
+		ob_start();
+		$assets_manager->render_email_editor_html();
+		$this->assertSame( '', ob_get_clean(), 'A repeated render call must not output a second editor container' );
+	}
+
+	/**
+	 * Point ABSPATH at a temp directory with a stub wp-admin/admin-header.php so
+	 * render_email_editor_html() can run outside a WordPress install.
+	 */
+	private function define_abspath_with_stub_admin_header(): void {
+		if ( defined( 'ABSPATH' ) ) {
+			if ( ! file_exists( ABSPATH . 'wp-admin/admin-header.php' ) ) {
+				$this->markTestSkipped( 'ABSPATH is already defined and has no admin-header.php to stub.' );
+			}
+			return;
+		}
+
+		$abspath = sys_get_temp_dir() . '/email-editor-assets-manager-test-' . uniqid() . '/';
+		mkdir( $abspath . 'wp-admin', 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- No WP_Filesystem in package unit tests.
+		file_put_contents( $abspath . 'wp-admin/admin-header.php', "<?php\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- No WP_Filesystem in package unit tests.
+		define( 'ABSPATH', $abspath );
+	}
+}

--- a/plugins/woocommerce/changelog/fix-yoast-replace-editor-reentry
+++ b/plugins/woocommerce/changelog/fix-yoast-replace-editor-reentry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the block email editor loading in a broken state when a plugin (e.g. Yoast SEO Premium) calls WP_Screen::get() from admin_enqueue_scripts, re-entering the replace_editor filter mid-render

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -78,6 +78,13 @@ class Integration {
 	private \WC_Email $wc_email_instance;
 
 	/**
+	 * Whether the email editor page has been rendered.
+	 *
+	 * @var bool
+	 */
+	private bool $editor_rendered = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -266,6 +273,14 @@ class Integration {
 	public function replace_editor( $replace, $post ) {
 		$current_screen = get_current_screen();
 		if ( self::EMAIL_POST_TYPE === $post->post_type && $current_screen ) {
+			// This callback re-enters while the editor renders: WP_Screen::get() re-applies
+			// the `replace_editor` filter, and plugins call it from admin_enqueue_scripts,
+			// which admin-header.php fires mid-render. Rendering again would echo a second
+			// editor container inside <head> and break the page.
+			if ( $this->editor_rendered ) {
+				return true;
+			}
+			$this->editor_rendered = true;
 			$this->maybe_refresh_scratchpad( $post );
 			$this->editor_page_renderer->render();
 			return true;

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/IntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/IntegrationTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
 
 use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 use Automattic\WooCommerce\Internal\EmailEditor\Package;
+use Automattic\WooCommerce\Internal\EmailEditor\PageRenderer;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
 use WC_Unit_Test_Case;
 
@@ -67,6 +68,7 @@ class IntegrationTest extends WC_Unit_Test_Case {
 
 		$this->posts_manager->clear_caches();
 		update_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
+		unset( $GLOBALS['current_screen'] );
 
 		parent::tearDown();
 	}
@@ -565,6 +567,74 @@ class IntegrationTest extends WC_Unit_Test_Case {
 		if ( ! $dependency_check->are_dependencies_met() ) {
 			$this->markTestSkipped( 'The test environment does not fulfill minimal requirements for the block email editor.' );
 		}
+	}
+
+	/**
+	 * @testdox Should render the editor only once when the replace_editor filter re-enters during rendering.
+	 */
+	public function test_replace_editor_renders_only_once_on_reentry(): void {
+		$post = $this->create_woo_email_post( 'customer_processing_order', 'publish' );
+		set_current_screen( Integration::EMAIL_POST_TYPE );
+
+		// A fresh instance keeps the fake renderer and the tripped guard off the container-cached one.
+		$integration = new Integration();
+
+		$fake_renderer = new class() extends PageRenderer {
+			/**
+			 * Number of render() calls.
+			 *
+			 * @var int
+			 */
+			public int $render_calls = 0;
+
+			/**
+			 * Callback invoked from render() to simulate the re-entrant filter application.
+			 *
+			 * @var \Closure|null
+			 */
+			public ?\Closure $on_render = null;
+
+			/**
+			 * Constructor override skipping the container wiring.
+			 */
+			public function __construct() {
+			}
+
+			/**
+			 * Count render calls and re-enter like WP_Screen::get() does mid-render.
+			 */
+			public function render() {
+				++$this->render_calls;
+				if ( $this->on_render ) {
+					( $this->on_render )();
+				}
+			}
+		};
+
+		$renderer_property = new \ReflectionProperty( Integration::class, 'editor_page_renderer' );
+		$renderer_property->setAccessible( true );
+		$renderer_property->setValue( $integration, $fake_renderer );
+
+		// While render() runs, admin-header.php fires admin_enqueue_scripts, where a plugin
+		// calling WP_Screen::get() re-applies the `replace_editor` filter. Re-enter only
+		// once — like the real flow, where the second admin-header require is a no-op —
+		// so a broken guard fails the count assertion instead of recursing forever.
+		$has_reentered            = false;
+		$reentrant_result         = null;
+		$fake_renderer->on_render = function () use ( $integration, $post, &$has_reentered, &$reentrant_result ) {
+			if ( $has_reentered ) {
+				return;
+			}
+			$has_reentered    = true;
+			$reentrant_result = $integration->replace_editor( false, $post );
+		};
+
+		$this->assertTrue( $integration->replace_editor( false, $post ), 'The outer call must replace the editor' );
+		$this->assertTrue( $reentrant_result, 'The re-entrant call must still report the editor as replaced' );
+		$this->assertSame( 1, $fake_renderer->render_calls, 'The re-entrant call must not render the editor again' );
+
+		$ordinary_post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$this->assertFalse( $integration->replace_editor( false, $ordinary_post ), 'Posts of other types must keep the default editor after the guard trips' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With Yoast SEO Premium active, the block email editor loads dead: the page renders but nothing responds to clicks. WordPress can re-apply the `replace_editor` filter while the email editor is still rendering (other plugins may trigger this during asset enqueuing), and the second call renders a second editor container on the page, breaking its markup and blocking all interaction.

This PR adds a check in Woo and also in the email editor package:

- `Integration::replace_editor` (WooCommerce): renders the editor at most once per request.
- `Assets_Manager::render_email_editor_html` (email-editor package): renders at most once per instance, so other integrators of the package get the same fix.

I added the fix to both because the package guard fixes the duplicate container for every email-editor integrator, while the Woo guard also stops the re-entrant call from repeating the additional code (mostly assets enqueueing) added by Woo on top of the editor's code.

The conflict is not specific to Yoast — any plugin that re-triggers the filter mid-render causes it — so the guards are needed regardless of a Yoast-side fix. Yoast has been notified separately.

**Backward compatibility:** `Assets_Manager::render_email_editor_html()` is public package API and now renders at most once per instance (documented in its docblock). A second call was already broken before this change, so no working integration is affected. The `replace_editor` filter returns the same values as before; only the duplicate render side effect is removed.

Closes https://github.com/woocommerce/woocommerce/issues/68147, WOOPLUG-7633

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block email editor: `wp option update woocommerce_feature_block_email_editor_enabled yes` (or via WooCommerce → Settings → Advanced → Features).
2. Install and activate Yoast SEO and Yoast SEO Premium 28.3. If you have no Premium license, reproduce the same re-entry with this mu-plugin instead:
   ```php
   <?php
   add_action( 'admin_enqueue_scripts', function () {
       WP_Screen::get()->is_block_editor();
   } );
   ```
3. Go to WooCommerce → Settings → Emails, open the Actions menu on any email and click Edit.
4. Without this PR: the editor renders but nothing reacts to clicks (canvas, sidebar, toolbar), and the DOM contains two `#woocommerce-email-editor` divs with the admin stylesheets moved into `<body>`.
5. With this PR: the editor is fully interactive, the DOM contains a single `#woocommerce-email-editor` div, and stylesheets stay in `<head>`.
6. Deactivate the Yoast plugins (or the mu-plugin) and confirm the editor still works.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested the fix on local wp-env (WordPress latest, PHP 8.1, Twenty Twenty-Five) with Yoast SEO 28.3 + Yoast SEO Premium 28.3.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The fix, tests, and this description were authored with Claude Code under my direction; I reviewed and tested the result.
