### PR TITLE
Fix the product and add to cart hook docblocks

### DIFF
--- a/plugins/woocommerce/changelog/67855-hook-docs-product-add-to-cart
+++ b/plugins/woocommerce/changelog/67855-hook-docs-product-add-to-cart
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Document loop_shop_per_page in WC_Query, correct the product grid, product button and quantity input hook docblocks, and fix the add to cart @since values.
+Fix the product and add to cart block hook docblocks.

--- a/plugins/woocommerce/changelog/67855-hook-docs-product-add-to-cart
+++ b/plugins/woocommerce/changelog/67855-hook-docs-product-add-to-cart
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Document loop_shop_per_page in WC_Query, correct the product button and quantity input hook docblocks, and fix the add to cart @since values.
+Document loop_shop_per_page in WC_Query, correct the product grid, product button and quantity input hook docblocks, and fix the add to cart @since values.

--- a/plugins/woocommerce/changelog/67855-hook-docs-product-add-to-cart
+++ b/plugins/woocommerce/changelog/67855-hook-docs-product-add-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document loop_shop_per_page in WC_Query, correct the product button and quantity input hook docblocks, and fix the add to cart @since values.

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md
@@ -681,7 +681,7 @@ do_action( 'woocommerce_set_additional_field_value', string $key, mixed $value, 
 
 ### Source
 
-- [Blocks/Domain/Services/CheckoutFields.php](../../../../../../src/Blocks/Domain/Services/CheckoutFields.php)
+- [Blocks/Domain/Services/CheckoutFieldsStorage.php](../../../../../../src/Blocks/Domain/Services/CheckoutFieldsStorage.php)
 
 ---
 

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -1175,8 +1175,15 @@ Allows backward compatibility with the `rest_request_after_callbacks` filter by 
 Allow filtering of the add to cart button arguments.
 
 ```php
-apply_filters( 'woocommerce_loop_add_to_cart_args' )
+apply_filters( 'woocommerce_loop_add_to_cart_args', array $args, \WC_Product $product )
 ```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $args | array | Button arguments, with a `class` string and an `attributes` array. |
+| $product | \WC_Product | Product the button is rendered for. |
 
 ### Source
 

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -564,7 +564,20 @@ apply_filters( 'woocommerce_blocks_hook_compatibility_additional_data', array $d
 
 ### Description
 
-Accepts an array of hooked data. The array should be in the following format: [ [ hook => `<hook-name>`, function => `<function-name>`, priority => `<priority>`, ], ... ] Where:
+Accepts an array of hooked data. The array should be in the following format:
+
+```text
+[
+  [
+    hook => <hook-name>,
+    function => <function-name>,
+    priority => <priority>,
+ ],
+ ...
+]
+```
+
+Where:
 
 - hook-name is the name of the hook that have the functions hooked to.
 - function-name is the hooked function name.

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -674,13 +674,13 @@ apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', bool $is_cacheabl
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| $is_cacheable | bool | The list of script dependencies. |
+| $is_cacheable | bool | Whether the product grid is cacheable. True to enable cache, false to disable. |
 | $query_args | array | Query args for the products query passed to BlocksWpQuery. |
 
 ### Returns
 
 
-`array` True to enable cache, false to disable cache.
+`bool` True to enable cache, false to disable cache.
 
 ### Source
 

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -1459,17 +1459,17 @@ apply_filters( 'woocommerce_product_tabs', array $tabs )
 ## woocommerce_quantity_input_placeholder
 
 
-Filter the placeholder value allowed for the product.
+Filter the placeholder shown in the quantity input.
 
 ```php
-apply_filters( 'woocommerce_quantity_input_placeholder', int $max_value, \WC_Product $product )
+apply_filters( 'woocommerce_quantity_input_placeholder', int $placeholder, \WC_Product $product )
 ```
 
 ### Parameters
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| $max_value | int | Maximum quantity value. |
+| $placeholder | int | Placeholder for the quantity input. |
 | $product | \WC_Product | Product object. |
 
 ### Source

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -74,6 +74,7 @@
 - [`woocommerce_store_api_product_quantity_{$value_type}`](#woocommerce_store_api_product_quantity_value_type)
 - [woocommerce_store_api_rate_limit_id](#woocommerce_store_api_rate_limit_id)
 - [woocommerce_store_api_rate_limit_options](#woocommerce_store_api_rate_limit_options)
+- [woocommerce_thankyou_order_failed_text](#woocommerce_thankyou_order_failed_text)
 - [woocommerce_thankyou_order_received_title](#woocommerce_thankyou_order_received_title)
 - [woocommerce_use_block_notices_in_classic_theme](#woocommerce_use_block_notices_in_classic_theme)
 - [woocommerce_variation_option_name](#woocommerce_variation_option_name)
@@ -1051,7 +1052,7 @@ apply_filters( 'woocommerce_get_default_value_for_{$key}', null $value, string $
 
 ### Source
 
-- [Blocks/Domain/Services/CheckoutFields.php](../../../../../../src/Blocks/Domain/Services/CheckoutFields.php)
+- [Blocks/Domain/Services/CheckoutFieldsStorage.php](../../../../../../src/Blocks/Domain/Services/CheckoutFieldsStorage.php)
 
 ---
 
@@ -1074,7 +1075,7 @@ apply_filters( 'woocommerce_get_default_value_for_{$missing_field}', null $value
 
 ### Source
 
-- [Blocks/Domain/Services/CheckoutFields.php](../../../../../../src/Blocks/Domain/Services/CheckoutFields.php)
+- [Blocks/Domain/Services/CheckoutFieldsStorage.php](../../../../../../src/Blocks/Domain/Services/CheckoutFieldsStorage.php)
 
 ---
 
@@ -1838,6 +1839,32 @@ apply_filters( 'woocommerce_store_api_rate_limit_options', array $rate_limit_opt
 ### Source
 
 - [StoreApi/Utilities/RateLimits.php](../../../../../../src/StoreApi/Utilities/RateLimits.php)
+
+---
+
+## woocommerce_thankyou_order_failed_text
+
+
+Filters the message shown when an order has failed.
+
+```php
+apply_filters( 'woocommerce_thankyou_order_failed_text', string $message, \WC_Order $order )
+```
+
+### Description
+
+Runs after the legacy order-received filter so callbacks can customize the final failed-order message.
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $message | string | The failed order message. |
+| $order | \WC_Order | The failed order. |
+
+### Source
+
+- [Blocks/BlockTypes/OrderConfirmation/Status.php](../../../../../../src/Blocks/BlockTypes/OrderConfirmation/Status.php)
 
 ---
 

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -584,7 +584,9 @@ class WC_Query {
 		/**
 		 * Filters the number of products shown per page in a product loop.
 		 *
-		 * Only applies when the query does not already set posts_per_page.
+		 * In WC_Query::product_query() this applies only when the query does not already
+		 * set posts_per_page. Other callers, such as the Product Collection block, apply it
+		 * unconditionally.
 		 *
 		 * @since 1.0.0
 		 *

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -581,6 +581,15 @@ class WC_Query {
 		$q->set( 'post__in', array_unique( (array) apply_filters( 'loop_shop_post_in', array() ) ) );
 
 		// Work out how many products to query.
+		/**
+		 * Filters the number of products shown per page in a product loop.
+		 *
+		 * Only applies when the query does not already set posts_per_page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $per_page Products per page. Defaults to the store's columns times its rows setting.
+		 */
 		$q->set( 'posts_per_page', $q->get( 'posts_per_page' ) ? $q->get( 'posts_per_page' ) : apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
 
 		// Store reference to this query.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -49330,12 +49330,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
 
 		-
-			message: '#^@param Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WC_Product \$product does not accept actual type of parameter\: WC_Product\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\GroupedProductItemSelector\:\:get_button_markup\(\) should return string but returns string\|false\.$#'
 			identifier: return.type
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -349,9 +349,9 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		/**
 		 * Filters whether or not the product grid is cacheable.
 		 *
-		 * @param boolean $is_cacheable The list of script dependencies.
+		 * @param boolean $is_cacheable Whether the product grid is cacheable. True to enable cache, false to disable.
 		 * @param array $query_args Query args for the products query passed to BlocksWpQuery.
-		 * @return array True to enable cache, false to disable cache.
+		 * @return boolean True to enable cache, false to disable cache.
 		 *
 		 * @since 2.5.0
 		 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -222,7 +222,7 @@ class AddToCartForm extends AbstractBlock {
 		/**
 		 * Trigger the single product add to cart action for each product type.
 		 *
-		 * @since 9.7.0
+		 * @since 7.6.0
 		 */
 		do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -659,7 +659,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			/**
 			 * Trigger the single product add to cart action that prints the markup.
 			 *
-			 * @since 9.7.0
+			 * @since 9.8.0
 			 */
 			do_action( 'woocommerce_' . $product_type . '_add_to_cart' );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -57,11 +57,11 @@ class GroupedProductItemSelector extends AbstractBlock {
 				'min_value'   => 0,
 				'max_value'   => $max_value,
 				/**
-				 * Filter the placeholder value allowed for the product.
+				 * Filter the placeholder shown in the quantity input.
 				 *
 				 * @since 3.10.0
-				 * @param int        $max_value Maximum quantity value.
-				 * @param WC_Product $product   Product object.
+				 * @param int         $placeholder Placeholder for the quantity input.
+				 * @param \WC_Product $product     Product object.
 				 */
 				'placeholder' => apply_filters( 'woocommerce_quantity_input_placeholder', 0, $product ),
 			)

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -59,7 +59,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 				/**
 				 * Filter the placeholder shown in the quantity input.
 				 *
-				 * @since 3.10.0
+				 * @since 4.0.0
 				 * @param int         $placeholder Placeholder for the quantity input.
 				 * @param \WC_Product $product     Product object.
 				 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -211,6 +211,9 @@ class ProductButton extends AbstractBlock {
 		 * Allow filtering of the add to cart button arguments.
 		 *
 		 * @since 9.7.0
+		 *
+		 * @param array       $args    Button arguments, with a `class` string and an `attributes` array.
+		 * @param \WC_Product $product Product the button is rendered for.
 		 */
 		$args = apply_filters(
 			'woocommerce_loop_add_to_cart_args',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
@@ -220,8 +220,7 @@ class Controller extends AbstractBlock {
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );
 
-		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Documented in WC_Query::product_query().
 		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -140,8 +140,7 @@ class ProductQuery extends AbstractBlock {
 			$post_template_has_support_for_grid_view
 		);
 
-		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Documented in WC_Query::product_query().
 		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -110,11 +110,11 @@ abstract class AbstractTemplateCompatibility {
 	 *
 	 * The array format:
 	 * [
-	 *   `<hook-name>` => [
-	 *     block_names => [ `<block-name>`, ... ],
+	 *   <hook-name> => [
+	 *     block_names => [ <block-name>, ... ],
 	 *     position => before|after,
 	 *     hooked => [
-	 *       `<function-name>` => `<priority>`,
+	 *       <function-name> => <priority>,
 	 *        ...
 	 *     ],
 	 *  ],
@@ -154,14 +154,18 @@ abstract class AbstractTemplateCompatibility {
 		 *
 		 * Accepts an array of hooked data. The array should be in the following
 		 * format:
+		 *
+		 * ```text
 		 * [
 		 *   [
-		 *     hook => `<hook-name>`,
-		 *     function => `<function-name>`,
-		 *     priority => `<priority>`,
+		 *     hook => <hook-name>,
+		 *     function => <function-name>,
+		 *     priority => <priority>,
 		 *  ],
 		 *  ...
 		 * ]
+		 * ```
+		 *
 		 * Where:
 		 * - hook-name is the name of the hook that have the functions hooked to.
 		 * - function-name is the hooked function name.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

> ⚠️ Stacked on #68153. Review that first; this targets its branch and will be retargeted to trunk once it merges.

Hook docblock fixes in the product and add to cart blocks, each regenerated through `build:docs`.

**Please review commit by commit.** Every commit is a single hook and carries its own reasoning: what was wrong, how I verified it, and why the value I picked is the right one. That matters most for the `@since` corrections, where the justification is a chain of commits and release tags that the combined diff throws away.

Supersedes #67837, which fixed the same `AbstractProductGrid.php` docblock but hand-edited `filters.md` because `build:docs` was broken when it was opened.

Part of #67855.

**Backward compatibility:** none. Every PHP change is inside a comment or docblock; no executable line changes, and no hook is added, removed, renamed or moved.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/block-library build:docs`, then `git status`; there should be no diff, meaning the committed reference matches the source.
2. Confirm `loop_shop_per_page` now has a docblock in `WC_Query::product_query()`, and that the two Blocks call sites (`ProductQuery.php`, `ProductCollection/Controller.php`) name it in their `phpcs:ignore`. The hook stays out of `filters.md` on purpose: core owns it, Blocks only re-fires it.
3. Find `woocommerce_blocks_hook_compatibility_additional_data` in `filters.md`; the array example should render as a fenced code block rather than one run-on line.

<!-- End testing instructions -->

### Testing that has already taken place:

- `build:docs` idempotent; `phpcs-changed` clean across the branch; full `composer run-script phpstan` clean, including the baseline check; `markdownlint-cli2` clean on the generated docs and `migrated-hooks.md`.
- Every `@since` traced to its introducing commit with `git tag --contains`. For `AddToCartForm.php` I also walked the `woocommerce/woocommerce-blocks` composer pin history to confirm 9.7.x was never bundled and that 9.8.0 first shipped in 7.6.0.
- Documentation-only; no runtime testing applies.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Use of AI Tools

This PR was authored with Claude Code; I reviewed the changes.


