### PR TITLE
fix: prefill classic checkout shipping fields from the saved address

### DIFF
--- a/plugins/woocommerce/changelog/30258-fix-shipping-address-prefill
+++ b/plugins/woocommerce/changelog/30258-fix-shipping-address-prefill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop the classic checkout prefilling the shipping fields with the billing address when the customer has a different shipping address saved to their account.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -34,6 +34,21 @@ class WC_Checkout {
 	);
 
 	/**
+	 * Shipping address fields that WC_AJAX::update_order_review() copies the billing address into while
+	 * "Ship to a different address?" is unticked.
+	 *
+	 * @var string[]
+	 */
+	private const BILLING_MIRRORED_ADDRESS_FIELDS = array(
+		'country',
+		'state',
+		'postcode',
+		'city',
+		'address_1',
+		'address_2',
+	);
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var WC_Checkout|null
@@ -60,6 +75,14 @@ class WC_Checkout {
 	 * @var WC_Customer
 	 */
 	private $logged_in_customer = null;
+
+	/**
+	 * Caches the customer read from the database, without the session applied on top. False once
+	 * it is known to be unusable. @see get_account_customer_for_shipping_input.
+	 *
+	 * @var WC_Customer|false|null
+	 */
+	private $account_customer = null;
 
 	/**
 	 * Gets the main WC_Checkout Instance.
@@ -1492,19 +1515,22 @@ class WC_Checkout {
 			return $value;
 		}
 
-		/**
-		 * For logged in customers, pull data from their account rather than the session which may contain incomplete data.
-		 * Another reason is that WC sets shipping address to the billing address on the checkout updates unless the
-		 * "ship to another address" box is checked. @see issue #20975.
-		 */
 		$customer_object = false;
 
 		if ( is_user_logged_in() ) {
 			// Load customer object, but keep it cached to avoid reloading it multiple times.
 			if ( is_null( $this->logged_in_customer ) ) {
+				// Account data with the session applied on top, so anything the customer changed earlier
+				// in the session wins over what their account has stored.
 				$this->logged_in_customer = new WC_Customer( get_current_user_id(), true );
 			}
 			$customer_object = $this->logged_in_customer;
+
+			$account_customer = $this->get_account_customer_for_shipping_input( $input );
+
+			if ( $account_customer ) {
+				$customer_object = $account_customer;
+			}
 		}
 
 		if ( ! $customer_object ) {
@@ -1522,5 +1548,53 @@ class WC_Checkout {
 		}
 
 		return apply_filters( 'default_checkout_' . $input, $value, $input );
+	}
+
+	/**
+	 * Get the account address to prefill a shipping field from, when the session copy can't be trusted.
+	 *
+	 * While "Ship to a different address?" is unticked every checkout update posts the billing address as
+	 * the shipping address, and WC_AJAX::update_order_review() stores that copy on the customer, so it
+	 * prefills the shipping fields on the next page load. @see issue #30258. Only applies when the session
+	 * address still looks like that copy, so an address the customer entered themselves is never discarded,
+	 * and only when the account address is complete enough to calculate rates from.
+	 *
+	 * @param string $input Name of the input we want to grab data for. e.g. shipping_country.
+	 * @return WC_Customer|false The customer read from the database, or false to keep using the session.
+	 */
+	private function get_account_customer_for_shipping_input( $input ) {
+		if ( 0 !== strpos( $input, 'shipping_' ) || ! in_array( substr( $input, 9 ), self::BILLING_MIRRORED_ADDRESS_FIELDS, true ) ) {
+			return false;
+		}
+
+		if ( is_null( $this->account_customer ) ) {
+			// Assigned first: reading the customer fires filters that can re-enter get_value().
+			$this->account_customer = false;
+
+			if ( $this->session_shipping_address_is_copy_of_billing() ) {
+				$account_customer = new WC_Customer( get_current_user_id() );
+
+				if ( $account_customer->has_full_shipping_address() ) {
+					$this->account_customer = $account_customer;
+				}
+			}
+		}
+
+		return $this->account_customer;
+	}
+
+	/**
+	 * Check whether the session's shipping address is the billing copy update_order_review() writes.
+	 *
+	 * @return bool
+	 */
+	private function session_shipping_address_is_copy_of_billing() {
+		foreach ( self::BILLING_MIRRORED_ADDRESS_FIELDS as $field ) {
+			if ( $this->logged_in_customer->{"get_shipping_$field"}( 'edit' ) !== $this->logged_in_customer->{"get_billing_$field"}( 'edit' ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -278,8 +278,6 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * This method uses the current country's locale to determine if a field is required, or falls back to the default
 	 * locale if there's no country-specific setting for that field.
 	 *
-	 * This method is only used internally by StoreAPI, and not by the classic/shortcode checkout.
-	 *
 	 * @since 9.8.0
 	 * @return bool Whether the customer has a full shipping address (city, state, postcode, country).
 	 * Only required fields are checked based on the country locale.

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -1354,43 +1354,51 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox 'update_order_review' copies the billing address into the shipping address.
+	 *
 	 * The classic checkout posts the billing address in the s_* fields while "Ship to a different
 	 * address?" is unticked, so that rates and taxes match where the order will really go. Which
 	 * shipping fields that copy covers decides which ones WC_Checkout::get_value() can't trust to
 	 * prefill from. @see issue #30258.
 	 */
-	public function test_update_order_review_copies_billing_into_the_shipping_address() {
-		$product = WC_Helper_Product::create_simple_product();
-		WC()->cart->add_to_cart( $product->get_id() );
-
-		WC()->customer->set_shipping_first_name( 'Saved' );
-		WC()->customer->set_shipping_company( 'Saved Company' );
-		WC()->customer->set_shipping_phone( '555-0100' );
-		WC()->customer->set_shipping_address_1( '2 Shipping Avenue' );
-		WC()->customer->save();
-
+	public function test_update_order_review_copies_billing_into_the_shipping_address(): void {
 		$original_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Test cleanup restores the raw original request data.
-		$_POST         = array(
-			'security'    => wp_create_nonce( 'update-order-review' ),
-			'country'     => 'US',
-			'state'       => 'CA',
-			'postcode'    => '94103',
-			'city'        => 'San Francisco',
-			'address'     => '1 Billing Street',
-			'address_2'   => 'Apt 1',
-			's_country'   => 'US',
-			's_state'     => 'CA',
-			's_postcode'  => '94103',
-			's_city'      => 'San Francisco',
-			's_address'   => '1 Billing Street',
-			's_address_2' => 'Apt 1',
-		);
 
 		try {
+			$product = WC_Helper_Product::create_simple_product();
+			WC()->cart->add_to_cart( $product->get_id() );
+
+			WC()->customer->set_shipping_first_name( 'Saved' );
+			WC()->customer->set_shipping_company( 'Saved Company' );
+			WC()->customer->set_shipping_phone( '555-0100' );
+			WC()->customer->set_shipping_address_1( '2 Shipping Avenue' );
+			WC()->customer->save();
+
+			$_POST = array(
+				'security'    => wp_create_nonce( 'update-order-review' ),
+				'country'     => 'US',
+				'state'       => 'CA',
+				'postcode'    => '94103',
+				'city'        => 'San Francisco',
+				'address'     => '1 Billing Street',
+				'address_2'   => 'Apt 1',
+				's_country'   => 'US',
+				's_state'     => 'CA',
+				's_postcode'  => '94103',
+				's_city'      => 'San Francisco',
+				's_address'   => '1 Billing Street',
+				's_address_2' => 'Apt 1',
+			);
+
 			$this->do_ajax( 'woocommerce_update_order_review' );
+
+			$shipping = WC()->customer->get_shipping();
 		} finally {
+			// This class extends WP_Ajax_UnitTestCase, so nothing resets the WooCommerce singletons for us.
 			$_POST = $original_post;
 			WC()->cart->empty_cart();
+			WC()->session->set( 'customer', null );
+			WC()->customer = new WC_Customer( get_current_user_id(), true );
 		}
 
 		$expected_copied = array(
@@ -1405,14 +1413,14 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		foreach ( $expected_copied as $field => $expected ) {
 			$this->assertSame(
 				$expected,
-				WC()->customer->{"get_shipping_$field"}(),
+				$shipping[ $field ],
 				"Shipping {$field} should have been replaced with the billing value."
 			);
 		}
 
-		$this->assertSame( 'Saved', WC()->customer->get_shipping_first_name(), 'The shipping first name should be left alone.' );
-		$this->assertSame( 'Saved Company', WC()->customer->get_shipping_company(), 'The shipping company should be left alone.' );
-		$this->assertSame( '555-0100', WC()->customer->get_shipping_phone(), 'The shipping phone should be left alone.' );
+		$this->assertSame( 'Saved', $shipping['first_name'], 'The shipping first name should be left alone.' );
+		$this->assertSame( 'Saved Company', $shipping['company'], 'The shipping company should be left alone.' );
+		$this->assertSame( '555-0100', $shipping['phone'], 'The shipping phone should be left alone.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -1354,6 +1354,68 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * The classic checkout posts the billing address in the s_* fields while "Ship to a different
+	 * address?" is unticked, so that rates and taxes match where the order will really go. Which
+	 * shipping fields that copy covers decides which ones WC_Checkout::get_value() can't trust to
+	 * prefill from. @see issue #30258.
+	 */
+	public function test_update_order_review_copies_billing_into_the_shipping_address() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		WC()->customer->set_shipping_first_name( 'Saved' );
+		WC()->customer->set_shipping_company( 'Saved Company' );
+		WC()->customer->set_shipping_phone( '555-0100' );
+		WC()->customer->set_shipping_address_1( '2 Shipping Avenue' );
+		WC()->customer->save();
+
+		$original_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Test cleanup restores the raw original request data.
+		$_POST         = array(
+			'security'    => wp_create_nonce( 'update-order-review' ),
+			'country'     => 'US',
+			'state'       => 'CA',
+			'postcode'    => '94103',
+			'city'        => 'San Francisco',
+			'address'     => '1 Billing Street',
+			'address_2'   => 'Apt 1',
+			's_country'   => 'US',
+			's_state'     => 'CA',
+			's_postcode'  => '94103',
+			's_city'      => 'San Francisco',
+			's_address'   => '1 Billing Street',
+			's_address_2' => 'Apt 1',
+		);
+
+		try {
+			$this->do_ajax( 'woocommerce_update_order_review' );
+		} finally {
+			$_POST = $original_post;
+			WC()->cart->empty_cart();
+		}
+
+		$expected_copied = array(
+			'country'   => 'US',
+			'state'     => 'CA',
+			'postcode'  => '94103',
+			'city'      => 'San Francisco',
+			'address_1' => '1 Billing Street',
+			'address_2' => 'Apt 1',
+		);
+
+		foreach ( $expected_copied as $field => $expected ) {
+			$this->assertSame(
+				$expected,
+				WC()->customer->{"get_shipping_$field"}(),
+				"Shipping {$field} should have been replaced with the billing value."
+			);
+		}
+
+		$this->assertSame( 'Saved', WC()->customer->get_shipping_first_name(), 'The shipping first name should be left alone.' );
+		$this->assertSame( 'Saved Company', WC()->customer->get_shipping_company(), 'The shipping company should be left alone.' );
+		$this->assertSame( '555-0100', WC()->customer->get_shipping_phone(), 'The shipping phone should be left alone.' );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -724,7 +724,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'get_value' prefills shipping fields from the saved address when the session copy is the billing address.
 	 */
-	public function test_get_value_uses_the_saved_shipping_address_when_the_session_copy_matches_billing() {
+	public function test_get_value_uses_the_saved_shipping_address_when_the_session_copy_matches_billing(): void {
 		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
 		$this->create_logged_in_customer( $billing, $shipping );
 		$this->copy_billing_over_shipping_in_session();
@@ -751,7 +751,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'get_value' leaves logged out customers reading the session.
 	 */
-	public function test_get_value_keeps_the_session_shipping_address_for_logged_out_customers() {
+	public function test_get_value_keeps_the_session_shipping_address_for_logged_out_customers(): void {
 		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
 		$this->create_logged_in_customer( $billing, $shipping );
 		$this->copy_billing_over_shipping_in_session();
@@ -764,7 +764,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'get_value' keeps a shipping address the customer entered during the session.
 	 */
-	public function test_get_value_keeps_a_shipping_address_entered_during_the_session() {
+	public function test_get_value_keeps_a_shipping_address_entered_during_the_session(): void {
 		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
 		$this->create_logged_in_customer( $billing, $shipping );
 
@@ -780,7 +780,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'get_value' keeps the session shipping address when the saved one can't be used to calculate rates.
 	 */
-	public function test_get_value_keeps_the_session_shipping_address_when_the_saved_one_is_incomplete() {
+	public function test_get_value_keeps_the_session_shipping_address_when_the_saved_one_is_incomplete(): void {
 		list( $billing ) = $this->get_separate_saved_addresses();
 		$this->create_logged_in_customer( $billing, array( 'country' => 'US' ) );
 		$this->copy_billing_over_shipping_in_session();
@@ -792,7 +792,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'get_value' reads custom shipping fields from the session.
 	 */
-	public function test_get_value_reads_custom_shipping_fields_from_the_session() {
+	public function test_get_value_reads_custom_shipping_fields_from_the_session(): void {
 		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
 		$this->create_logged_in_customer( $billing, $shipping );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -59,7 +59,50 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 
 		$this->extra_field_filters = array();
 
+		wp_set_current_user( 0 );
+		WC()->session->set( 'customer', null );
+		WC()->customer = new WC_Customer( 0, true );
+
 		parent::tearDown();
+	}
+
+	/**
+	 * Create a customer with the given saved addresses, log them in, and make them the session customer.
+	 *
+	 * @param array $billing  Billing address fields, keyed without the 'billing_' prefix.
+	 * @param array $shipping Shipping address fields, keyed without the 'shipping_' prefix.
+	 * @return int The new customer's user ID.
+	 */
+	private function create_logged_in_customer( array $billing, array $shipping ) {
+		$user_id  = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$customer = new WC_Customer( $user_id );
+
+		foreach ( $billing as $field => $value ) {
+			$customer->{"set_billing_$field"}( $value );
+		}
+
+		foreach ( $shipping as $field => $value ) {
+			$customer->{"set_shipping_$field"}( $value );
+		}
+
+		$customer->save();
+
+		wp_set_current_user( $user_id );
+		WC()->customer = new WC_Customer( $user_id, true );
+
+		return $user_id;
+	}
+
+	/**
+	 * Copy the billing address over the shipping address in the customer session, the way
+	 * WC_AJAX::update_order_review does while "Ship to a different address?" is unticked.
+	 */
+	private function copy_billing_over_shipping_in_session() {
+		foreach ( array( 'country', 'state', 'postcode', 'city', 'address_1', 'address_2' ) as $field ) {
+			WC()->customer->{"set_shipping_$field"}( WC()->customer->{"get_billing_$field"}( 'edit' ) );
+		}
+
+		WC()->customer->save();
 	}
 
 	/**
@@ -650,6 +693,132 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->assertNull( $sut->get_value( 'billing_country' ) );
 
 		WC()->customer = $orig_customer;
+	}
+
+	/**
+	 * A saved billing address, and a saved shipping address that differs from it.
+	 *
+	 * @return array[] Billing fields and shipping fields, both keyed without their prefix.
+	 */
+	private function get_separate_saved_addresses() {
+		return array(
+			array(
+				'country'   => 'US',
+				'state'     => 'CA',
+				'postcode'  => '94103',
+				'city'      => 'San Francisco',
+				'address_1' => '1 Billing Street',
+				'address_2' => 'Apt 1',
+			),
+			array(
+				'country'   => 'US',
+				'state'     => 'NY',
+				'postcode'  => '11201',
+				'city'      => 'Brooklyn',
+				'address_1' => '2 Shipping Avenue',
+				'address_2' => 'Apt 2',
+			),
+		);
+	}
+
+	/**
+	 * @testdox 'get_value' prefills shipping fields from the saved address when the session copy is the billing address.
+	 */
+	public function test_get_value_uses_the_saved_shipping_address_when_the_session_copy_matches_billing() {
+		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
+		$this->create_logged_in_customer( $billing, $shipping );
+		$this->copy_billing_over_shipping_in_session();
+
+		// Only in the session, never saved to the account, so the assertion below can tell the two apart.
+		WC()->customer->set_billing_company( 'Session Company' );
+		WC()->customer->save();
+
+		foreach ( $shipping as $field => $expected ) {
+			$this->assertSame(
+				$expected,
+				$this->sut->get_value( 'shipping_' . $field ),
+				"Shipping {$field} should come from the saved address, not from the billing copy in the session."
+			);
+		}
+
+		$this->assertSame(
+			'Session Company',
+			$this->sut->get_value( 'billing_company' ),
+			'Billing fields should still be read from the session.'
+		);
+	}
+
+	/**
+	 * @testdox 'get_value' leaves logged out customers reading the session.
+	 */
+	public function test_get_value_keeps_the_session_shipping_address_for_logged_out_customers() {
+		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
+		$this->create_logged_in_customer( $billing, $shipping );
+		$this->copy_billing_over_shipping_in_session();
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame( '94103', $this->sut->get_value( 'shipping_postcode' ) );
+	}
+
+	/**
+	 * @testdox 'get_value' keeps a shipping address the customer entered during the session.
+	 */
+	public function test_get_value_keeps_a_shipping_address_entered_during_the_session() {
+		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
+		$this->create_logged_in_customer( $billing, $shipping );
+
+		// What the cart shipping calculator stores: a destination the customer typed, which blanks the street.
+		WC()->customer->set_shipping_location( 'US', 'WA', '98101', 'Seattle' );
+		WC()->customer->save();
+
+		$this->assertSame( '98101', $this->sut->get_value( 'shipping_postcode' ) );
+		$this->assertSame( 'Seattle', $this->sut->get_value( 'shipping_city' ) );
+		$this->assertNull( $this->sut->get_value( 'shipping_address_1' ) );
+	}
+
+	/**
+	 * @testdox 'get_value' keeps the session shipping address when the saved one can't be used to calculate rates.
+	 */
+	public function test_get_value_keeps_the_session_shipping_address_when_the_saved_one_is_incomplete() {
+		list( $billing ) = $this->get_separate_saved_addresses();
+		$this->create_logged_in_customer( $billing, array( 'country' => 'US' ) );
+		$this->copy_billing_over_shipping_in_session();
+
+		$this->assertSame( '94103', $this->sut->get_value( 'shipping_postcode' ) );
+		$this->assertSame( 'San Francisco', $this->sut->get_value( 'shipping_city' ) );
+	}
+
+	/**
+	 * @testdox 'get_value' reads custom shipping fields from the session.
+	 */
+	public function test_get_value_reads_custom_shipping_fields_from_the_session() {
+		list( $billing, $shipping ) = $this->get_separate_saved_addresses();
+		$this->create_logged_in_customer( $billing, $shipping );
+
+		add_filter( 'woocommerce_customer_allowed_session_meta_keys', array( $this, 'allow_shipping_custom_session_meta' ) );
+
+		try {
+			WC()->customer->update_meta_data( 'shipping_custom', 'session value' );
+			$this->copy_billing_over_shipping_in_session();
+
+			$this->assertSame( 'session value', $this->sut->get_value( 'shipping_custom' ) );
+		} finally {
+			remove_filter( 'woocommerce_customer_allowed_session_meta_keys', array( $this, 'allow_shipping_custom_session_meta' ) );
+		}
+	}
+
+	/**
+	 * Allow the custom shipping field used by test_get_value_reads_custom_shipping_fields_from_the_session
+	 * to round trip through the customer session.
+	 *
+	 * @param array $keys Allowed meta data keys.
+	 * @return array
+	 */
+	public function allow_shipping_custom_session_meta( $keys ) {
+		$keys[] = 'shipping_custom';
+
+		return $keys;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

On the classic checkout, while "Ship to a different address?" is unticked, the browser sends the billing address in the shipping fields of every background update. It has to — that is where the order will really go, so the rates and the tax have to match it.

The trouble is that the copy gets stored on the customer, and the next page load prefills the shipping form from it. A customer who saved a separate shipping address is shown their billing address instead, and can send an order to it without noticing.

Reading those six fields from the saved account address instead. Two conditions keep it narrow: the stored copy still has to match billing, so an address the customer typed themselves is never thrown away, and the saved address has to be complete enough to work out rates from.

This was fixed once in 3.6.0, then undone in 3.6.3 by a one-line change that was fixing something unrelated. Billing still reads from the session, so that other fix stays intact.

Fixing.

Closes #30258.

(For Bug Fixes) Bug introduced in PR #23528.

### How to test the changes in this Pull Request:

Use a store whose checkout page uses the `[woocommerce_checkout]` shortcode, and leave **WooCommerce → Settings → Shipping → Shipping settings → Shipping destination** on its default, "Default to customer billing address".

1. As a customer, go to `/my-account/edit-address/shipping/` and save a shipping address in a different city and state from the billing one.
2. Add a product to the cart and go to `/checkout/`.
3. Tick "Ship to a different address?". The fields show your saved shipping address. Untick it again.
4. Click into the browser's address bar and press Enter. Do not use the refresh button — a refresh restores the form values from the browser and hides the problem.
5. Tick "Ship to a different address?" once more.
    - On trunk: most of the shipping fields now hold the billing address.
    - On this branch: they still hold the saved shipping address.

Then check that an address typed during the session still wins:

1. On `/cart/`, use the shipping calculator to enter a postcode different from both addresses.
2. Go to `/checkout/` and tick "Ship to a different address?".
3. The calculator's values should be there, not the saved account address.

Worth a pass with **Shipping destination** set to "Force shipping to the customer billing address" too — the shipping fields should stay hidden and orders should still go to billing.

### Testing that has already taken place:

- New unit tests, run in `wp-env` on PHP 8.1. The one covering the report fails on trunk and passes here; the other four pin behaviour that must not change (an address entered during the session, an incomplete saved address, custom shipping fields, and logged-out shoppers).
- A new test for `WC_AJAX::update_order_review`, which had no coverage at all. It pins which shipping fields the billing copy covers, at both ends.
- 222 tests green across the checkout, ajax, customer, customer-session and cart suites. `phpcs` and PHPStan clean, nothing added to the baseline.
- No manual browser testing yet, and not tested on multisite.

Known limits, both stated deliberately:

- Guests are not covered. There is no saved address to fall back to.
- Customers whose saved address was already overwritten still see the overwritten value. No migration is possible: the only signal is the shipping address matching the billing one, which is legitimately true for most customers, so a migration keyed on it would destroy correct data.

### Considerations

The copy itself has to stay. Blanking the shipping fields when the box is unticked was tried in #21639 and rejected because an empty shipping address stops shipping zones matching, and `WC_Customer::get_taxable_address()` has no fallback to billing, so tax goes wrong silently. Suppressing the copy further down, in the customer session data store, prices the cart against an address the order will not go to — a display bug traded for a money bug. So the fix is on the read side only; no calculation path changes.

The billing comparison is deliberately not the checkbox inference that was reverted in 3.9.2 (#24271). That one changed what got priced and shipped. This one only picks where the prefill comes from. Its single false positive — a customer whose shipping address genuinely equals their billing address — resolves to their own saved account address, which is no worse.

### Backward compatibility

`WC_Checkout::get_value()` keeps its signature and return type. What changes:

- `default_checkout_shipping_{country,state,postcode,city,address_1,address_2}` callbacks receive a different value for affected logged-in customers. Same arguments, same order, same number of calls.
- `woocommerce_customer_loaded` fires once more per logged-in checkout render, and can now fire on the shortcode cart page.
- The shipping fieldset is built for the saved country rather than the billing one for affected customers, so per-country required and hidden flags follow the saved address. Skipped fieldsets are not validated, so this does not add validation failures.
- `WC_Customer::has_full_shipping_address()` is no longer Store API only, so `woocommerce_get_country_locale` now influences classic checkout prefill. Docblock updated.

Unchanged: the order's shipping address, the customer session, shipping rates, tax, `WC_Customer::get_shipping_*()`, `woocommerce_checkout_posted_data`, `woocommerce_cart_shipping_packages`, `woocommerce_customer_taxable_address`, and every write path. Nothing new is written to the session, to user meta or to orders, so there is no migration.

Store API note: classic and `wc/store/v1` already differ here. The Store API only falls back to billing when the cart needs no shipping or no shipping address was sent. This moves classic closer to that, on the read side.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entry added manually in `plugins/woocommerce/changelog/30258-fix-shipping-address-prefill`.

### Release Communication

<!-- release-communication-section -->
- [ ] **Feature Highlight**
- [x] **Developer Advisory** - see the Backward compatibility section above.

### Use of AI Tools

Written with Claude Code. The investigation, the fix and the tests were produced with AI assistance and reviewed by me; the git archaeology behind the "fixed in 3.6.0, undone in 3.6.3" note and the earlier reverted attempts referenced above were verified against the actual commits and PRs.
