### PR TITLE
fix: extensions sub-schema for Store API item

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-item-schema-extensions
+++ b/plugins/woocommerce/changelog/fix-store-api-item-schema-extensions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Store API: advertise the correct extensions sub-schema for cart item schemas, instead of the product endpoint's.
+Store API: the cart items endpoint now publishes and validates extensions registered against `cart-item`, rather than those registered against `product`.

--- a/plugins/woocommerce/changelog/fix-store-api-item-schema-extensions
+++ b/plugins/woocommerce/changelog/fix-store-api-item-schema-extensions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Store API: advertise the correct extensions sub-schema for cart item and order item schemas, instead of the product endpoint's.
+Store API: advertise the correct extensions sub-schema for cart item schemas, instead of the product endpoint's.

--- a/plugins/woocommerce/changelog/fix-store-api-item-schema-extensions
+++ b/plugins/woocommerce/changelog/fix-store-api-item-schema-extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: advertise the correct extensions sub-schema for cart item and order item schemas, instead of the product endpoint's.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ItemSchema.php
@@ -318,7 +318,7 @@ abstract class ItemSchema extends ProductSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			self::EXTENDING_KEY    => $this->get_extended_schema( self::IDENTIFIER ),
+			self::EXTENDING_KEY    => $this->get_extended_schema( static::IDENTIFIER ),
 		];
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ItemSchema.php
@@ -318,6 +318,8 @@ abstract class ItemSchema extends ProductSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
+			// static:: so each subclass advertises the extensions registered against its own
+			// endpoint. self:: here would resolve to the inherited ProductSchema identifier.
 			self::EXTENDING_KEY    => $this->get_extended_schema( static::IDENTIFIER ),
 		];
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartItems.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartItems.php
@@ -413,9 +413,8 @@ class CartItems extends ControllerTestCase {
 	}
 
 	/**
-	 * The published schema must advertise the extension schema registered against the cart-item
-	 * endpoint. ItemSchema is abstract, so an unqualified self:: there resolves to the inherited
-	 * ProductSchema identifier and advertises the product endpoint's extensions instead.
+	 * The cart item schema must advertise cart-item extensions. It inherits the property from
+	 * ItemSchema, which sits below ProductSchema and so can pick up the wrong identifier.
 	 */
 	public function test_get_item_schema_advertises_cart_item_extensions() {
 		$this->mock_extend->register_endpoint_data(

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartItems.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartItems.php
@@ -8,6 +8,8 @@ namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
 use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\ControllerTestCase;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\ValidateSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\CartItemSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema;
 use WC_Logger;
 use WC_Logger_Interface;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
@@ -408,6 +410,50 @@ class CartItems extends ControllerTestCase {
 		$this->assertEmpty( $diff, print_r( $diff, true ) );
 
 		wp_delete_attachment( $image_id, true );
+	}
+
+	/**
+	 * The published schema must advertise the extension schema registered against the cart-item
+	 * endpoint. ItemSchema is abstract, so an unqualified self:: there resolves to the inherited
+	 * ProductSchema identifier and advertises the product endpoint's extensions instead.
+	 */
+	public function test_get_item_schema_advertises_cart_item_extensions() {
+		$this->mock_extend->register_endpoint_data(
+			array(
+				'endpoint'        => CartItemSchema::IDENTIFIER,
+				'namespace'       => 'cart_item_extension_namespace',
+				'schema_callback' => function () {
+					return array(
+						'cart_item_extension_key' => array(
+							'description' => 'Test key',
+							'type'        => 'boolean',
+						),
+					);
+				},
+			)
+		);
+		$this->mock_extend->register_endpoint_data(
+			array(
+				'endpoint'        => ProductSchema::IDENTIFIER,
+				'namespace'       => 'product_extension_namespace',
+				'schema_callback' => function () {
+					return array(
+						'product_extension_key' => array(
+							'description' => 'Test key',
+							'type'        => 'boolean',
+						),
+					);
+				},
+			)
+		);
+
+		$routes     = new \Automattic\WooCommerce\StoreApi\RoutesController( new \Automattic\WooCommerce\StoreApi\SchemaController( $this->mock_extend ) );
+		$controller = $routes->get( 'cart-items', 'v1' );
+		$schema     = $controller->get_item_schema();
+		$extensions = (array) $schema['properties']['extensions']['properties'];
+
+		$this->assertArrayHasKey( 'cart_item_extension_namespace', $extensions, 'The cart item schema must advertise extensions registered against the cart-item endpoint.' );
+		$this->assertArrayNotHasKey( 'product_extension_namespace', $extensions, 'The cart item schema must not advertise extensions registered against the product endpoint.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The cart items endpoint publishes the wrong endpoint's extensions schema.

Extensions attach their own data to cart items, and the published schema tells them the shape to expect. `ItemSchema` is the shared parent for cart items and order items, and it asked for `self::IDENTIFIER`. `self::` resolves against the class the code is written in, not the one running — and `ItemSchema` defines no identifier of its own, so it fell through to its parent `ProductSchema` and always meant `product`. Cart items advertised the product endpoint's extensions while their responses carried cart-item data. `static::` resolves against the subclass instead.

Bug introduced in https://github.com/woocommerce/woocommerce-blocks/pull/8960, ported to core in https://github.com/woocommerce/woocommerce-blocks/pull/10199. That PR lifted `get_properties()` out of `CartItemSchema` into the new abstract `ItemSchema`. `self::` was correct in the concrete class and changed meaning on the way up, which is worth watching for whenever a method moves into a parent.

#### Backwards compatibility

The `extensions` sub-schema is not documentation only, so two public surfaces move.

**The published schema.** `OPTIONS /wc/store/v1/cart/items` and `?context=help` now list extensions registered against `cart-item` instead of `product`, which is what the responses have always carried. Nothing could have been validating real responses against the old schema successfully, since it never matched them.

**Request arguments.** `get_extended_schema()` also returns `arg_options`: `default`, `validate_callback` and `sanitize_callback`. `extensions` is not `readonly`, so `get_endpoint_args_for_item_schema()` registers those on `POST /cart/items` and `PUT /cart/items/{key}`. They are built from the same identifier, so they move too. An incoming `extensions` param on those two routes is now validated and sanitized against cart-item schemas rather than product ones.

Neither route reads `$request['extensions']`, so nothing depends on the result today. The visible effect is that a malformed payload aimed at a cart-item extension can now be rejected where it previously passed unchecked, which is the contract the endpoint was always meant to enforce. The injected default cannot fail a request on its own: every namespace is typed `['object', 'null']` in `ExtendSchema::format_extensions_properties()`, and the recursive validator skips empty values whose type allows null.

Responses are identical, before and after.

**Order items.** `ExtendSchema` only accepts `cart-item`, `cart`, `checkout` and `product`, so `order-item` extensions cannot be registered at all. That schema stops advertising product extensions its responses never returned and now advertises an empty object. The changelog claims only the cart item fix, which is what the test covers.

A subclass that defines no identifier still falls back exactly as it does today.

One note on the rest of `Schemas/`: `ProductSchema` uses the same `self::` pattern in `get_properties()` and `get_item_response()`, and it is subclassed. Every subclass overrides both methods, so no wrong identifier resolves today. I left them alone to keep this to the one broken call.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Register extension data against both endpoints:

```php
add_action( 'woocommerce_blocks_loaded', function () {
    woocommerce_store_api_register_endpoint_data( [
        'endpoint'        => \Automattic\WooCommerce\StoreApi\Schemas\V1\CartItemSchema::IDENTIFIER,
        'namespace'       => 'my_cart_item_ext',
        'schema_callback' => fn () => [ 'a' => [ 'description' => 'x', 'type' => 'boolean' ] ],
    ] );
    woocommerce_store_api_register_endpoint_data( [
        'endpoint'        => \Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema::IDENTIFIER,
        'namespace'       => 'my_product_ext',
        'schema_callback' => fn () => [ 'b' => [ 'description' => 'x', 'type' => 'boolean' ] ],
    ] );
} );
```

- Run `curl -X OPTIONS 'http://localhost:8888/wp-json/wc/store/v1/cart/items'`
- Look at `schema.properties.extensions.properties`
- On trunk you get `my_product_ext`. On this branch you get `my_cart_item_ext`
- Add something to the cart and run `curl 'http://localhost:8888/wp-json/wc/store/v1/cart/items'`
- The `extensions` on each item still has `my_cart_item_ext`, before and after — only the advertised schema moved

<!-- End testing instructions -->

### Testing that has already taken place:

- Added a test that registers extensions against both endpoints and checks the cart-item schema gets the right one. Confirmed it fails on trunk before writing the fix.
- Store API route suites pass: 144 tests, 618 assertions.
- Lint and PHPStan clean, no baseline changes. wp-env, PHP 8.1.
- Not tested on multisite. The change reads no site state.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Added manually in `plugins/woocommerce/changelog/fix-store-api-item-schema-extensions`.

