### PR TITLE
fix: type of Store API item_data hidden flag

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-item-data-hidden-type
+++ b/plugins/woocommerce/changelog/fix-store-api-item-data-hidden-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct the public TypeScript type for the Store API item_data `hidden` flag, which arrives as a string rather than a boolean.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/test/index.js
@@ -54,7 +54,7 @@ describe( 'ProductDetails', () => {
 
 	test( 'should not render hidden details', () => {
 		const details = [
-			{ name: 'Lorem', value: 'Ipsum', hidden: true },
+			{ name: 'Lorem', value: 'Ipsum', hidden: '1' },
 			{ name: 'LOREM', value: 'Ipsum', display: 'IPSUM' },
 			{ name: 'LOREM 2', value: 'Ipsum2', display: 'IPSUM 2' },
 		];
@@ -83,10 +83,24 @@ describe( 'ProductDetails', () => {
 		expect( screen.getByText( 'IPSUM 2' ) ).toBeInTheDocument();
 	} );
 
+	// The Store API runs every item_data value through wp_kses_post(), which
+	// string-coerces, so an extension's boolean arrives as '1' or ''.
+	test( 'should treat the string hidden flags the Store API actually sends', () => {
+		const details = [
+			{ name: 'Hidden', value: 'Ipsum', hidden: '1' },
+			{ name: 'Visible', value: 'Ipsum2', hidden: '' },
+		];
+
+		render( <ProductDetails details={ details } /> );
+
+		expect( screen.queryByText( 'Hidden:' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Visible:' ) ).toBeInTheDocument();
+	} );
+
 	test( 'should not render anything if all details are hidden', () => {
 		const details = [
-			{ name: 'Lorem', value: 'Ipsum', hidden: true },
-			{ name: 'LOREM', value: 'Ipsum', display: 'IPSUM', hidden: true },
+			{ name: 'Lorem', value: 'Ipsum', hidden: '1' },
+			{ name: 'LOREM', value: 'Ipsum', display: 'IPSUM', hidden: '1' },
 		];
 
 		const { container } = render( <ProductDetails details={ details } /> );

--- a/plugins/woocommerce/client/blocks/packages/public-api/types/type-defs/product-response.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/types/type-defs/product-response.ts
@@ -13,7 +13,13 @@ export interface ProductResponseItemPrices extends CurrencyResponse {
 export interface ProductResponseItemBaseData {
 	value: string;
 	display?: string;
-	hidden?: boolean;
+	/**
+	 * Truthy marks the entry hidden. Always a string: the Store API runs every
+	 * `item_data` value through `wp_kses_post()`, which string-coerces, so a
+	 * boolean set by an extension arrives as `"1"` or `""`. Test it for
+	 * truthiness — comparing against `true` or `1` can never match.
+	 */
+	hidden?: string;
 	className?: string;
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

I noticed the public type for the `hidden` flag on cart item data says `boolean`. It's never a boolean.

Everything in an `item_data` entry gets run through `wp_kses_post()` on the way out, `hidden` included. That's a string sanitizer, so it stringifies whatever it's handed — `true` leaves as `"1"` and `false` leaves as `""`. So extensions consuming this type are told to expect something that can't arrive.

Declaring it a string, which is the only thing that can arrive.

I considered the wider `boolean | string | number` the mini-cart uses, but then I thought it doesn't really fix anything.
A union that keeps `boolean` still lets you write `hidden === true`, which compiles fine and never matches at runtime.
That's the same trap this PR is about, so the narrow type turns it into a compile error.

No consumer needed changing.
The one place that reads this filters on truthiness, so it was already handling the real values, it just had a type claiming they were impossible.
The existing tests only ever passed a boolean, so the string path went untested.
They now use what actually arrives.

Fixing.

Type introduced in https://github.com/woocommerce/woocommerce-blocks/pull/4098.

#### Backwards compatibility

`ProductResponseItemBaseData` is exported from `@woocommerce/types`, so extensions consume it. Type-only change — nothing moves at runtime and no response changes.

This narrows the type, so it can fail an extension's build where the old one passed, if they construct `hidden: true` or compare against it.
That code was already broken at runtime, since neither can ever match a value coming from the API, so the build error surfaces a real bug rather than creating one.
Nothing in the repo relied on it: the only in-tree uses of a boolean here were three test fixtures using a value the API can't send, now corrected.

#### Two related things I left alone

Both are behaviour changes rather than type fixes, so they want their own PR:

- `__experimental_woocommerce_blocks_hidden` is never unset, so it ships alongside `hidden`. Dropping it changes the response shape.
- The cart and the mini-cart disagree on values like `'0'` and `'false'` — one hides them, the other shows them. Not reachable from the PHP path, which only ever produces `"1"` and `""`, but reachable if an extension sets those strings itself. Fixing it means picking which behaviour is right.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Add this snippet:

```php
add_filter( 'woocommerce_get_item_data', function ( $item_data ) {
    $item_data[] = [ 'key' => 'Hidden note', 'value' => 'nope', '__experimental_woocommerce_blocks_hidden' => true ];
    $item_data[] = [ 'key' => 'Visible note', 'value' => 'yep', '__experimental_woocommerce_blocks_hidden' => false ];
    return $item_data;
}, 10, 1 );
```

- Add a product to the cart, then run `curl 'http://localhost:8888/wp-json/wc/store/v1/cart'`
- Look at `items[0].item_data` — `hidden` is the string `"1"` / `""`, not a boolean. That's the existing behaviour, unchanged here
- Visit the Cart block. "Visible note" shows, "Hidden note" doesn't — same before and after
<img width="821" height="212" alt="Screenshot 2026-08-28 at 10 23 25 PM" src="https://github.com/user-attachments/assets/08453787-b480-488e-a44e-24513e78a219" />

<!-- End testing instructions -->

### Testing that has already taken place:

- Confirmed the stringification in PHP directly, and traced it through `wp_kses_post()` into `preg_replace()`.
- Added a test using the values the API actually sends instead of a boolean that can't happen.
- Jest: 63 tests pass across product-details and mini-cart utils.
- Ran `tsc --build --force` on this branch and on trunk under the same conditions and diffed — 4802 pre-existing errors on both, none added.
- ESLint clean. The other two copies of this file in the tree are gitignored build artifacts, so this is the only source to change.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Added manually in `plugins/woocommerce/changelog/fix-store-api-item-data-hidden-type`.


