### PR TITLE
Fix mis-scoped PHPCS output suppressions in dashboard, reviews widget, and loop templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-120-mis-scoped-output-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-120-mis-scoped-output-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Escape product titles in the dashboard top-seller report and correct output annotations.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -224,8 +224,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 						printf(
 							/* translators: %s: net sales */
 							esc_html__( 'Net sales this month %s', 'woocommerce' ),
-							'<strong>' . wc_price( $report_data->net_sales ) . '</strong>'
-						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+							'<strong>' . wc_price( $report_data->net_sales ) . '</strong>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wc_price() returns filterable price markup for the dashboard.
+						);
 					?>
 					</a>
 				</li>
@@ -244,9 +244,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 						printf(
 							/* translators: 1: top seller product title 2: top seller quantity sold */
 							esc_html( _n( 'Top seller this month %1$s (%2$d sale)', 'Top seller this month %1$s (%2$d sales)', $top_seller->qty, 'woocommerce' ) ),
-							'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
-							$top_seller->qty
-						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+							'<strong>' . esc_html( get_the_title( $top_seller->product_id ) ) . '</strong>',
+							(int) $top_seller->qty
+						);
 					?>
 					</a>
 				</li>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -243,7 +243,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					<?php
 						printf(
 							/* translators: 1: top seller product title 2: top seller quantity sold */
-							esc_html( _n( 'Top seller this month %1$s (%2$d sale)', 'Top seller this month %1$s (%2$d sales)', $top_seller->qty, 'woocommerce' ) ),
+							esc_html( _n( 'Top seller this month %1$s (%2$d sale)', 'Top seller this month %1$s (%2$d sales)', (int) $top_seller->qty, 'woocommerce' ) ),
 							'<strong>' . esc_html( get_the_title( $top_seller->product_id ) ) . '</strong>',
 							(int) $top_seller->qty
 						);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -243,7 +243,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					<?php
 						printf(
 							/* translators: 1: top seller product title 2: top seller quantity sold */
-							esc_html( _n( 'Top seller this month %1$s (%2$d sale)', 'Top seller this month %1$s (%2$d sales)', (int) $top_seller->qty, 'woocommerce' ) ),
+							esc_html( _n( 'Top seller this month %1$s (%2$d sale)', 'Top seller this month %1$s (%2$d sales)', $top_seller->qty, 'woocommerce' ) ),
 							'<strong>' . esc_html( get_the_title( $top_seller->product_id ) ) . '</strong>',
 							(int) $top_seller->qty
 						);

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-recent-reviews.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-recent-reviews.php
@@ -57,7 +57,7 @@ class WC_Widget_Recent_Reviews extends WC_Widget {
 		ob_start();
 
 		$number   = ! empty( $instance['number'] ) ? absint( $instance['number'] ) : $this->settings['number']['std'];
-		$comments = get_comments(
+		$comments = get_comments( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- The global is the legacy data contract consumed by review templates.
 			array(
 				'number'                    => $number,
 				'status'                    => 'approve',
@@ -66,14 +66,14 @@ class WC_Widget_Recent_Reviews extends WC_Widget {
 				'parent'                    => 0,
 				'update_comment_post_cache' => true,
 			)
-		); // WPCS: override ok.
+		);
 
 		if ( $comments ) {
 			$this->widget_start( $args, $instance );
 
 			echo wp_kses_post( apply_filters( 'woocommerce_before_widget_product_review_list', '<ul class="product_list_widget">' ) );
 
-			foreach ( (array) $comments as $comment ) {
+			foreach ( (array) $comments as $comment ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Each review template consumes the current comment through this WordPress global.
 				wc_get_template(
 					'content-widget-reviews.php',
 					array(

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -23,8 +23,17 @@ global $product;
 
 $aria_describedby = isset( $args['aria-describedby_text'] ) ? sprintf( 'aria-describedby="woocommerce_loop_add_to_cart_link_describedby_%s"', esc_attr( $product->get_id() ) ) : '';
 
-echo apply_filters(
-	'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
+/**
+ * Filters the loop add-to-cart link HTML.
+ *
+ * @param string     $link    The add-to-cart link HTML.
+ * @param WC_Product $product The product object.
+ * @param array      $args    Arguments used to build the link.
+ *
+ * @since 2.0.0
+ */
+echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The public filter intentionally allows extensions to return link markup.
+	'woocommerce_loop_add_to_cart_link',
 	sprintf(
 		'<a href="%s" %s data-quantity="%s" class="%s" %s>%s</a>',
 		esc_url( $product->add_to_cart_url() ),

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     11.2.0
+ * @version     9.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     9.2.0
+ * @version     11.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -30,10 +30,17 @@ if ( $total <= 1 ) {
 ?>
 <nav class="woocommerce-pagination" aria-label="<?php esc_attr_e( 'Product Pagination', 'woocommerce' ); ?>">
 	<?php
-	echo paginate_links(
+	echo paginate_links( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress generates the pagination markup after applying the public arguments filter.
+		/**
+		 * Filters the pagination arguments for the product loop.
+		 *
+		 * @param array $args Pagination arguments.
+		 *
+		 * @since 1.7.0
+		 */
 		apply_filters(
 			'woocommerce_pagination_args',
-			array( // WPCS: XSS ok.
+			array(
 				'base'      => $base,
 				'format'    => $format,
 				'add_args'  => false,

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 11.2.0
+ * @version 9.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -27,30 +27,32 @@ $format  = isset( $format ) ? $format : '';
 if ( $total <= 1 ) {
 	return;
 }
-
-/**
- * Filters the pagination arguments for the product loop.
- *
- * @param array $args Pagination arguments.
- *
- * @since 2.0.0
- */
-$pagination_args = apply_filters(
-	'woocommerce_pagination_args',
-	array(
-		'base'      => $base,
-		'format'    => $format,
-		'add_args'  => false,
-		'current'   => max( 1, $current ),
-		'total'     => $total,
-		'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
-		'next_text' => is_rtl() ? '&larr;' : '&rarr;',
-		'type'      => 'list',
-		'end_size'  => 3,
-		'mid_size'  => 3,
-	)
-);
 ?>
 <nav class="woocommerce-pagination" aria-label="<?php esc_attr_e( 'Product Pagination', 'woocommerce' ); ?>">
-	<?php echo paginate_links( $pagination_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress generates the pagination markup after applying the public arguments filter. ?>
+	<?php
+	echo paginate_links( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress generates the pagination markup after applying the public arguments filter.
+		/**
+		 * Filters the pagination arguments for the product loop.
+		 *
+		 * @param array $args Pagination arguments.
+		 *
+		 * @since 2.0.0
+		 */
+		apply_filters(
+			'woocommerce_pagination_args',
+			array(
+				'base'      => $base,
+				'format'    => $format,
+				'add_args'  => false,
+				'current'   => max( 1, $current ),
+				'total'     => $total,
+				'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
+				'next_text' => is_rtl() ? '&larr;' : '&rarr;',
+				'type'      => 'list',
+				'end_size'  => 3,
+				'mid_size'  => 3,
+			)
+		)
+	);
+	?>
 </nav>

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.3.0
+ * @version 11.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -27,32 +27,30 @@ $format  = isset( $format ) ? $format : '';
 if ( $total <= 1 ) {
 	return;
 }
+
+/**
+ * Filters the pagination arguments for the product loop.
+ *
+ * @param array $args Pagination arguments.
+ *
+ * @since 2.0.0
+ */
+$pagination_args = apply_filters(
+	'woocommerce_pagination_args',
+	array(
+		'base'      => $base,
+		'format'    => $format,
+		'add_args'  => false,
+		'current'   => max( 1, $current ),
+		'total'     => $total,
+		'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
+		'next_text' => is_rtl() ? '&larr;' : '&rarr;',
+		'type'      => 'list',
+		'end_size'  => 3,
+		'mid_size'  => 3,
+	)
+);
 ?>
 <nav class="woocommerce-pagination" aria-label="<?php esc_attr_e( 'Product Pagination', 'woocommerce' ); ?>">
-	<?php
-	echo paginate_links( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress generates the pagination markup after applying the public arguments filter.
-		/**
-		 * Filters the pagination arguments for the product loop.
-		 *
-		 * @param array $args Pagination arguments.
-		 *
-		 * @since 1.7.0
-		 */
-		apply_filters(
-			'woocommerce_pagination_args',
-			array(
-				'base'      => $base,
-				'format'    => $format,
-				'add_args'  => false,
-				'current'   => max( 1, $current ),
-				'total'     => $total,
-				'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
-				'next_text' => is_rtl() ? '&larr;' : '&rarr;',
-				'type'      => 'list',
-				'end_size'  => 3,
-				'mid_size'  => 3,
-			)
-		)
-	);
-	?>
+	<?php echo paginate_links( $pagination_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress generates the pagination markup after applying the public arguments filter. ?>
 </nav>

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 11.1.0
+ * @version 11.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -1,7 +1,11 @@
 <?php
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * Tests for the WC_Admin_Dashboard class.
@@ -13,6 +17,24 @@ use Automattic\WooCommerce\Enums\ProductStockStatus;
  * WC_Admin_Dashboard_Test
  */
 class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
+	use HPOSToggleTrait;
+
+	/**
+	 * Ensure the HPOS tables exist before per-test transactions start.
+	 */
+	public static function wpSetUpBeforeClass(): void {
+		$previous_hpos_state = OrderUtil::custom_orders_table_usage_is_enabled();
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+
+		try {
+			self::setup_cot_tables();
+			if ( OrderUtil::custom_orders_table_usage_is_enabled() !== $previous_hpos_state ) {
+				OrderHelper::toggle_cot_feature_and_usage( $previous_hpos_state );
+			}
+		} finally {
+			remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		}
+	}
 
 	/**
 	 * The system under test.
@@ -366,6 +388,76 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'Awaiting processing <strong>0 orders</strong>', $html );
 		$this->assertStringContainsString( 'On-hold <strong>0 orders</strong>', $html );
+	}
+
+	/**
+	 * @testdox The top-seller title is escaped without removing dashboard markup under legacy and HPOS storage.
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 */
+	public function test_status_widget_escapes_top_seller_title_for_each_order_storage( bool $hpos_enabled ): void {
+		$previous_hpos_state = OrderUtil::custom_orders_table_usage_is_enabled();
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$product = null;
+		$order   = null;
+
+		$reports_filter = static function ( array $reports ): array {
+			$reports['get_sales_sparkline'] = static fn() => array(
+				'total' => 0,
+				'data'  => array(),
+			);
+
+			return $reports;
+		};
+
+		try {
+			$this->toggle_cot_authoritative( $hpos_enabled );
+
+			$product = WC_Helper_Product::create_simple_product();
+			$order   = wc_create_order();
+			$order->add_product( $product, 2 );
+			$order->set_status( OrderStatus::COMPLETED );
+			$order->save();
+
+			$title_filter = static function ( string $title, int $post_id ) use ( $product ): string {
+				return $product->get_id() === $post_id ? 'Unsafe <script>alert("dashboard")</script> & title' : $title;
+			};
+
+			add_filter( 'woocommerce_admin_disabled', '__return_true' );
+			add_filter( 'woocommerce_dashboard_status_widget_reports', $reports_filter );
+			add_filter( 'the_title', $title_filter, 10, 2 );
+
+			ob_start();
+			$this->sut->status_widget_content();
+			$html = ob_get_clean();
+
+			$this->assertIsString( $html );
+			$this->assertStringContainsString( '<strong>Unsafe &lt;script&gt;alert(&quot;dashboard&quot;)&lt;/script&gt; &amp; title</strong> (2 sales)', $html );
+			$this->assertStringNotContainsString( '<script>', $html );
+		} finally {
+			remove_filter( 'woocommerce_admin_disabled', '__return_true' );
+			remove_filter( 'woocommerce_dashboard_status_widget_reports', $reports_filter );
+			if ( isset( $title_filter ) ) {
+				remove_filter( 'the_title', $title_filter, 10 );
+			}
+			if ( $order instanceof WC_Order ) {
+				$order->delete( true );
+			}
+			if ( $product instanceof WC_Product ) {
+				$product->delete( true );
+			}
+			if ( OrderUtil::custom_orders_table_usage_is_enabled() !== $previous_hpos_state ) {
+				$this->toggle_cot_authoritative( $previous_hpos_state );
+			}
+			add_filter( 'query', array( $this, '_create_temporary_tables' ) );
+			add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+			remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -436,7 +436,6 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 			$this->sut->status_widget_content();
 			$html = ob_get_clean();
 
-			$this->assertIsString( $html );
 			$this->assertStringContainsString( '<strong>Unsafe &lt;script&gt;alert(&quot;dashboard&quot;)&lt;/script&gt; &amp; title</strong> (2 sales)', $html );
 			$this->assertStringNotContainsString( '<script>', $html );
 		} finally {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -424,7 +424,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 			$order->set_status( OrderStatus::COMPLETED );
 			$order->save();
 
-			$title_filter = static function ( string $title, int $post_id ) use ( $product ): string {
+			$title_filter = static function ( string $title, int $post_id ) use ( $product ) {
 				return $product->get_id() === $post_id ? 'Unsafe <script>alert("dashboard")</script> & title' : $title;
 			};
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Several `phpcs:ignore` / legacy `// WPCS: ... ok.` annotations in these files were sitting on lines PHPCS never reports (closing `);` lines, or a line adjacent to the flagged expression), so they suppressed nothing and the real diagnostics were still being reported. The legacy `WPCS:` comment form is also no longer honored by WPCS 3.x. This PR moves each exception onto the exact expression PHPCS reports, names the current sniff, and documents why the exception exists.

- `includes/admin/class-wc-admin-dashboard.php`: the net-sales `wc_price()` markup keeps its exception, now on the correct line. The top-seller title is wrapped in `esc_html()` and the quantity cast to `(int)` so that suppression can simply be removed instead of relocated.
- `includes/widgets/class-wc-widget-recent-reviews.php`: the `$comments` / `$comment` WordPress-global assignments get a scoped `WordPress.WP.GlobalVariablesOverride.Prohibited` exception in place of the dead `// WPCS: override ok.` comment.
- `templates/loop/add-to-cart.php`: the `echo apply_filters(...)` keeps its `EscapeOutput` exception on the `echo` line and `woocommerce_loop_add_to_cart_link` gains the hook docblock the `WooCommerce.Commenting.CommentHooks` sniff asks for.
- `templates/loop/pagination.php`: `echo paginate_links(` keeps its `EscapeOutput` exception on the `echo` line and `woocommerce_pagination_args` gains a hook docblock. The docblock sits inside the `paginate_links(` argument list because the sniff requires it directly above `apply_filters()`; hoisting the call into a variable was considered and rejected so the filter keeps firing at exactly the same point in output.

Behavior notes:

- The only runtime change is in the dashboard top-seller label: the product title is now HTML-escaped before being placed inside the existing `<strong>` wrapper. Product titles are text, so safe titles render identically. Code that deliberately injects HTML into product titles via `the_title` will see it as text in this one admin slot.
- No hook contracts change: `woocommerce_loop_add_to_cart_link` and `woocommerce_pagination_args` keep the same arguments, timing, and raw-HTML behavior; the docblocks are documentation only.
- Template `@version` headers are intentionally **not** bumped. Both templates change only comments; their executable tokens are identical, so theme overrides cannot be affected, and a bump would only produce spurious "outdated template" warnings in System Status. The `Analyze Branch Changes` check has no comment-only exemption and will show red for this reason; it is not a required check.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`; confirm both pass.
2. Optionally run `plugins/woocommerce/vendor/bin/phpcs --ignore-annotations` on the four production files and confirm the only `EscapeOutput` / `GlobalVariablesOverride` findings on the changed lines are the ones now carrying an inline exception; the top-seller title and quantity report nothing.
3. Start the test env with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start` and run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Admin_Dashboard_Test`. The new parameterized case runs once with legacy order storage and once with HPOS, creates a completed two-item order, injects an HTML-bearing title through `the_title`, and asserts the dashboard keeps its `<strong>` markup, escapes the title, and renders `(2 sales)`.
4. Load WP Admin → Dashboard with at least one completed order this month and confirm the WooCommerce Status widget renders the net sales and top seller rows as before.
5. Load the shop page with enough products to paginate and confirm the pagination renders as before.

### Testing that has already taken place:

- `WC_Admin_Dashboard_Test`: 17 tests, 31 assertions passing on PHP 8.1.34, including the legacy and HPOS top-seller cases.
- `lint:php:changes` and `lint:changes:branch` pass. PHPCS with `--ignore-annotations` confirms every remaining exception sits on the line PHPCS actually reports.
- PHPStan passes for both modified class files (templates and the test file are outside the PHPStan bootstrap).
- No screenshot: safe product titles render identically.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-120-mis-scoped-output-suppressions`.

*\*left by Biff (AI agent) on behalf of Darren*
