### PR TITLE
Match block-based default pages by their WooCommerce block in wc_crea…

### DIFF
--- a/plugins/woocommerce/changelog/68099-create-page-block-content-match
+++ b/plugins/woocommerce/changelog/68099-create-page-block-content-match
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Match existing block-based default pages by their WooCommerce block instead of the full markup, so wc_create_page() adopts a customized Cart/Checkout page instead of creating a duplicate when the page option is empty.

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -114,9 +114,16 @@ function wc_create_page( $slug, $option = '', $page_title = '', $page_content = 
 	}
 
 	if ( strlen( $page_content ) > 0 ) {
-		// Search for an existing page with the specified page content (typically a shortcode).
-		$shortcode        = str_replace( array( '<!-- wp:shortcode -->', '<!-- /wp:shortcode -->' ), '', $page_content );
-		$valid_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status NOT IN ( 'pending', 'trash', 'future', 'auto-draft' ) AND post_content LIKE %s LIMIT 1;", "%{$shortcode}%" ) );
+		// Search for an existing page with the specified page content. For classic content the
+		// needle is the shortcode without its block wrappers. Full block markup is too fragile to
+		// match verbatim (any customization or markup update breaks it and a duplicate page would
+		// be created — see #68099), so the first WooCommerce block opener is used as the stable
+		// needle instead.
+		$content_needle = str_replace( array( '<!-- wp:shortcode -->', '<!-- /wp:shortcode -->' ), '', $page_content );
+		if ( preg_match( '#<!-- wp:woocommerce/[a-z0-9-]+#', $page_content, $matches ) ) {
+			$content_needle = $matches[0];
+		}
+		$valid_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status NOT IN ( 'pending', 'trash', 'future', 'auto-draft' ) AND post_content LIKE %s LIMIT 1;", "%{$content_needle}%" ) );
 	} else {
 		// Search for an existing page with the specified page slug.
 		$valid_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status NOT IN ( 'pending', 'trash', 'future', 'auto-draft' )  AND post_name = %s LIMIT 1;", $slug ) );
@@ -135,8 +142,8 @@ function wc_create_page( $slug, $option = '', $page_title = '', $page_content = 
 
 	// Search for a matching valid trashed page.
 	if ( strlen( $page_content ) > 0 ) {
-		// Search for an existing page with the specified page content (typically a shortcode).
-		$trashed_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status = 'trash' AND post_content LIKE %s LIMIT 1;", "%{$page_content}%" ) );
+		// Search for an existing trashed page using the same stable needle as above.
+		$trashed_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status = 'trash' AND post_content LIKE %s LIMIT 1;", "%{$content_needle}%" ) );
 	} else {
 		// Search for an existing page with the specified page slug.
 		$trashed_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status = 'trash' AND post_name = %s LIMIT 1;", $slug ) );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -666,7 +666,8 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 
 		$page_id = wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', $default_content );
 
-		$this->assertSame( $existing_page_id, $page_id, 'The existing customized Cart page must be adopted instead of creating a duplicate.' );
+		// wc_create_page() returns the adopted id as a string from $wpdb->get_var(), so compare loosely.
+		$this->assertEquals( $existing_page_id, $page_id, 'The existing customized Cart page must be adopted instead of creating a duplicate.' );
 		$this->assertEquals( $existing_page_id, get_option( 'woocommerce_cart_page_id' ), 'The page option must point at the adopted page.' );
 
 		wp_delete_post( $existing_page_id, true );
@@ -691,7 +692,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 
 		$page_id = wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->' );
 
-		$this->assertSame( $existing_page_id, $page_id, 'A page holding the shortcode must still be adopted.' );
+		$this->assertEquals( $existing_page_id, $page_id, 'A page holding the shortcode must still be adopted.' );
 
 		wp_delete_post( $existing_page_id, true );
 		delete_option( 'woocommerce_cart_page_id' );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -643,4 +643,74 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 			'Existing shipping lines named Shipping should not be replaced with the generic method title'
 		);
 	}
+	/**
+	 * A block-based default page must be matched by its WooCommerce block, not by the full
+	 * markup blob, so a customized existing page is adopted instead of duplicated.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/68099
+	 */
+	public function test_wc_create_page_adopts_customized_block_page(): void {
+		delete_option( 'woocommerce_cart_page_id' );
+
+		$existing_page_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_name'    => 'my-custom-cart',
+				'post_title'   => 'My custom cart',
+				'post_content' => '<!-- wp:paragraph --><p>Intro added by the merchant.</p><!-- /wp:paragraph --><!-- wp:woocommerce/cart --><div class="wp-block-woocommerce-cart">customized</div><!-- /wp:woocommerce/cart -->',
+			)
+		);
+
+		$default_content = '<!-- wp:woocommerce/cart --><div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block --><div class="wp-block-woocommerce-filled-cart-block">default markup</div><!-- /wp:woocommerce/filled-cart-block --></div><!-- /wp:woocommerce/cart -->';
+
+		$page_id = wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', $default_content );
+
+		$this->assertSame( $existing_page_id, $page_id, 'The existing customized Cart page must be adopted instead of creating a duplicate.' );
+		$this->assertEquals( $existing_page_id, get_option( 'woocommerce_cart_page_id' ), 'The page option must point at the adopted page.' );
+
+		wp_delete_post( $existing_page_id, true );
+		delete_option( 'woocommerce_cart_page_id' );
+	}
+
+	/**
+	 * The classic shortcode matching of wc_create_page() must keep working unchanged.
+	 */
+	public function test_wc_create_page_still_matches_shortcode_content(): void {
+		delete_option( 'woocommerce_cart_page_id' );
+
+		$existing_page_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_name'    => 'old-cart',
+				'post_title'   => 'Old cart',
+				'post_content' => 'Before [woocommerce_cart] after',
+			)
+		);
+
+		$page_id = wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->' );
+
+		$this->assertSame( $existing_page_id, $page_id, 'A page holding the shortcode must still be adopted.' );
+
+		wp_delete_post( $existing_page_id, true );
+		delete_option( 'woocommerce_cart_page_id' );
+	}
+
+	/**
+	 * Without any existing match, wc_create_page() must still create the page.
+	 */
+	public function test_wc_create_page_creates_page_when_no_match_exists(): void {
+		delete_option( 'woocommerce_cart_page_id' );
+
+		$default_content = '<!-- wp:woocommerce/cart --><div class="wp-block-woocommerce-cart">default</div><!-- /wp:woocommerce/cart -->';
+
+		$page_id = wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', $default_content );
+
+		$this->assertGreaterThan( 0, $page_id, 'A new Cart page must be created when nothing matches.' );
+		$this->assertSame( $default_content, get_post( $page_id )->post_content, 'The created page must carry the default content.' );
+
+		wp_delete_post( $page_id, true );
+		delete_option( 'woocommerce_cart_page_id' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The existing-page content search in `wc_create_page()` was written for the shortcode era: it strips the `wp:shortcode` wrappers and looks for the short, stable shortcode. For block-based pages nothing is stripped, so the needle is the entire default block markup — any customization of the existing page (or shipped markup changes, as with #67651) breaks the match. With an empty page option the function then creates a duplicate page and repoints the option at it, orphaning the merchant's customized page.

The content needle for block content is now the first WooCommerce block opener (e.g. `<!-- wp:woocommerce/cart`), which survives customization and markup updates — mirroring the original intent of matching a short, stable marker. The classic shortcode needle is unchanged, the trashed-page search uses the same needle, and the `woocommerce_create_page_id` filter keeps firing as before.

Includes regression tests for adopting a customized block page, the unchanged shortcode behavior, and page creation when nothing matches.

Closes #68099. Raised by @jorgeatorres while reviewing #67651.

### How to test the changes in this Pull Request:

1. On a store with a block-based Cart page, edit the page (add a paragraph above the Cart block) — or use any customized Cart page.
2. Clear the Cart page setting (WooCommerce → Settings → Advanced → Cart page).
3. Run WooCommerce → Status → Tools → "Create default WooCommerce pages".
4. The existing customized page is adopted and the option points at it again (before this fix a duplicate Cart page was created and the option repointed at the duplicate).

### Testing that has already taken place:

- Reproduced on a clean WordPress Playground instance running WooCommerce 11.0.1 (duplicate page created); verified the patched function adopts the customized page instead.
- `phpcs-changed` clean; changelog entry validates; three regression tests added (run in CI).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A changelog entry file (`plugins/woocommerce/changelog/68099-create-page-block-content-match`, Significance: patch, Type: fix) is included in this PR.

### Use of AI Tools

This fix was developed with AI assistance (Claude, by Anthropic). I reviewed the changes, reproduced the bug and verified the fix on a clean test instance, and take responsibility for the contribution.