### PR TITLE
Restore mobile zoom in the Core Profiler

### DIFF
--- a/plugins/woocommerce/changelog/fix-67834-core-profiler-mobile-zoom
+++ b/plugins/woocommerce/changelog/fix-67834-core-profiler-mobile-zoom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow mobile zoom in the Core Profiler without triggering automatic input zoom.

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -746,3 +746,20 @@
 		padding-top: 32px !important;
 	}
 }
+
+@include breakpoint("<782px") {
+	.woocommerce-profile-wizard__body #woocommerce-layout__primary {
+		input:not([type]),
+		input[type="email"],
+		input[type="number"],
+		input[type="password"],
+		input[type="search"],
+		input[type="tel"],
+		input[type="text"],
+		input[type="url"],
+		select,
+		textarea {
+			font-size: 16px;
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php
@@ -314,7 +314,7 @@ class OnboardingSetupWizard {
 			return $viewport_meta;
 		}
 
-		return 'width=device-width, initial-scale=1.0, maximum-scale=1.0';
+		return 'width=device-width, initial-scale=1.0';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/e2e/tests/onboarding/onboarding-wizard.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/onboarding/onboarding-wizard.spec.ts
@@ -41,6 +41,56 @@ test.describe(
 			}
 		} );
 
+		test( 'Allows mobile zoom without automatic input focus zoom', async ( {
+			page,
+		} ) => {
+			test.skip(
+				!! process.env.IS_MULTISITE,
+				'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55066'
+			);
+			await page.setViewportSize( { width: 390, height: 844 } );
+			await page.goto(
+				'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard'
+			);
+
+			await expect(
+				page.locator( 'meta[name="viewport"]' )
+			).toHaveAttribute(
+				'content',
+				'width=device-width, initial-scale=1.0'
+			);
+			await page
+				.getByRole( 'button', { name: 'Set up my store' } )
+				.click();
+			await page
+				.getByRole( 'radio' )
+				.filter( { hasText: 'just starting my business' } )
+				.click();
+			await page.getByRole( 'button', { name: 'Continue' } ).click();
+
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Tell us a bit about your store',
+				} )
+			).toBeVisible();
+			await expect(
+				page.getByPlaceholder( 'Ex. My awesome store' )
+			).toHaveCSS( 'font-size', '16px' );
+			await expect(
+				page.getByPlaceholder( 'wordpress@example.com' )
+			).toHaveCSS( 'font-size', '16px' );
+			await expect(
+				page.locator(
+					'.woocommerce-profiler-select-control__industry .woocommerce-select-control__control-input'
+				)
+			).toHaveCSS( 'font-size', '16px' );
+			await expect(
+				page.locator(
+					'.woocommerce-profiler-select-control__country .woocommerce-select-control__control-input'
+				)
+			).toHaveCSS( 'font-size', '16px' );
+		} );
+
 		test( 'Can complete the core profiler skipping extension install', async ( {
 			page,
 		} ) => {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Onboarding/OnboardingSetupWizardTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Onboarding/OnboardingSetupWizardTest.php
@@ -1,0 +1,82 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Onboarding;
+
+use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingSetupWizard;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the OnboardingSetupWizard class.
+ */
+class OnboardingSetupWizardTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var OnboardingSetupWizard
+	 */
+	private $sut;
+
+	/**
+	 * Original query parameters.
+	 *
+	 * @var array
+	 */
+	private array $original_get = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->sut          = new OnboardingSetupWizard();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should allow zooming on the setup wizard.
+	 */
+	public function test_set_viewport_meta_tag_allows_zoom_on_setup_wizard(): void {
+		$_GET = array(
+			'page' => 'wc-admin',
+			'path' => '/setup-wizard',
+		);
+
+		$result = $this->sut->set_viewport_meta_tag( 'original viewport value' );
+
+		$this->assertSame(
+			'width=device-width, initial-scale=1.0',
+			$result,
+			'The setup wizard viewport should not restrict zooming.'
+		);
+	}
+
+	/**
+	 * @testdox Should leave the viewport meta tag unchanged outside the setup wizard.
+	 */
+	public function test_set_viewport_meta_tag_leaves_other_admin_pages_unchanged(): void {
+		$_GET = array(
+			'page' => 'wc-admin',
+			'path' => '/analytics/overview',
+		);
+
+		$result = $this->sut->set_viewport_meta_tag( 'original viewport value' );
+
+		$this->assertSame(
+			'original viewport value',
+			$result,
+			'Other admin pages should retain their original viewport meta tag.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Mobile users cannot manually zoom the Core Profiler because its viewport declaration sets `maximum-scale=1.0`, which conflicts with WCAG 2.2 SC 1.4.4. This removes that restriction and sets text-entry controls to 16px below 782px so iPhone Safari does not automatically zoom them on focus. No PHP signatures, hooks, routes, or public APIs change.

Fixes #67834.

Bug introduced in PR #47400.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not included. This changes viewport behavior and computed mobile input styles rather than the visible desktop layout. Physical iOS and Android validation remains outstanding.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard` with a 390 x 844 mobile viewport.
2. Confirm `meta[name="viewport"]` has the exact content `width=device-width, initial-scale=1.0` and that pinch zoom is not restricted.
3. Continue through the user-profile step to Business Information.
4. Confirm the store name, email, industry, and country text-entry controls compute to `font-size: 16px`.
5. Confirm desktop profiler typography and layout are unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused PHPUnit: PHP 8.1.34 and PHPUnit 9.6.35; 2 tests and 2 assertions passed.
- Focused Playwright with install, authentication, and site-setup dependencies: 3 passed and 1 setup item skipped; the target ran at 390 x 844 in Chromium.
- WooCommerce Admin production Webpack build passed.
- Stylelint passed on the changed SCSS.
- ESLint completed with 0 errors and 11 pre-existing warnings in the existing onboarding spec.
- PHP coding standards passed for the changed lines and the new PHPUnit file.
- PHPStan passed on the changed production PHP file. The combined application-config run against the PHPUnit file cannot resolve `WC_Unit_Test_Case`; PHPUnit itself loads the test base class and passes.
- `git diff --check` passed.
- Physical iOS Safari and Android Chrome validation has not been performed.

Tested in a local Docker WordPress single-site environment with WooCommerce trunk, WordPress nightly 7.2-alpha-63397, PHP 8.1.34, and the Twenty Twenty-Two theme.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

A changelog entry was added manually in `plugins/woocommerce/changelog/fix-67834-core-profiler-mobile-zoom`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex assisted with implementation, test authoring, local debugging, validation, and drafting this pull request. I reviewed the changes and test results.

