### PR TITLE
Remove redundant Product Gallery viewer render E2E test

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-remove-redundant-product-gallery-viewer-test
+++ b/plugins/woocommerce/changelog/testops-234-remove-redundant-product-gallery-viewer-test
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Remove a redundant Product Gallery viewer E2E test covered by unit and PHP tests.

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -39,32 +39,6 @@ test.describe( `${ blockData.name }`, () => {
 		await editor.openDocumentSettingsSidebar();
 	} );
 
-	test( 'Renders Product Gallery Viewer block on the editor and frontend side', async ( {
-		page,
-		editor,
-		pageObject,
-	} ) => {
-		await pageObject.addProductGalleryBlock( { cleanContent: true } );
-
-		const viewerBlock = await pageObject.getViewerBlock( {
-			page: 'editor',
-		} );
-
-		await expect( viewerBlock ).toBeVisible();
-
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
-
-		await page.goto( blockData.productPage );
-
-		const viewerBlockFrontend = await pageObject.getViewerBlock( {
-			page: 'frontend',
-		} );
-
-		await expect( viewerBlockFrontend ).toBeVisible();
-	} );
-
 	test.describe( 'Zoom while hovering setting', () => {
 		test( 'should be enabled by default', async ( { pageObject } ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This removes one Playwright test, `Renders Product Gallery Viewer block on the editor and frontend side`, from `plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts`. It is part of a wider effort to move assertions that do not need a browser down the test pyramid.

The test did two things, and both are already asserted by cheaper tests.

**Editor half.** The test added the Product Gallery block in the site editor and asserted the viewer block was visible, resolving it through `editor.getBlockByName( 'woocommerce/product-gallery-large-image' )`, which is the selector `[data-type="woocommerce/product-gallery-large-image"]`.

Covered by the Jest integration test `plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/test/block.ts`, case `Product Gallery Block > should render the block in the editor with correct structure`, which mounts the same block tree in a real block editor and asserts:

```js
const viewerBlock = screen.getByRole( 'document', {
    name: /Block: Viewer/i,
} );
expect( viewerBlock ).toBeInTheDocument();
```

`Viewer` is the `title` in `inner-blocks/product-gallery-large-image/block.json`, so this is the same block the E2E test was locating by `data-type`. The Jest case goes further than the deleted test did, asserting the Product Image, On-Sale Badge and Next/Previous Buttons inner blocks and the resolved image `src` and `alt`.

**Frontend half.** The test saved the template, loaded `/product/hoodie/` and asserted the viewer block was present and visible.

Covered by the PHPUnit test `plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductGallery.php`, case `test_product_gallery_render_with_multiple_images`, which renders the same block markup through `do_blocks()` against a product with a featured image and three gallery images and asserts:

```php
$this->assertStringContainsString( 'wc-block-product-gallery-large-image', $markup );
```

along with `data-image-id="…"` for the main image and every gallery image. The assertion is on real server output, not on the input markup: `ProductGalleryLargeImage::render()` discards `$content` and emits the `wc-block-product-gallery-large-image` wrapper itself.

Two further points that made me comfortable deleting rather than rewriting:

- The remaining tests in the same spec file still exercise both halves incidentally. `Variable product gallery: featured → variation → cleared` asserts the viewer is visible in the editor, and the three `Zoom while hovering` tests and `Swipe to navigate` all resolve the viewer on the frontend through a `:visible` filter before interacting with its images.
- Nothing else in the spec file depended on the deleted test. Every import and every field of `blockData` is still used.

No production code changes.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable. This PR only deletes a test.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the Jest test that covers the editor half and confirm it passes: `pnpm --filter=@woocommerce/block-library test:js -- assets/js/blocks/product-gallery/test/block.ts`
2. Run the PHPUnit test that covers the frontend half and confirm it passes: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_product_gallery_render_with_multiple_images`
3. Confirm the rest of the Product Gallery E2E spec still collects and runs, one test fewer than before: `cd plugins/woocommerce && npx playwright test --config=tests/e2e/playwright.config.ts --project=blocks-chromium --list tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran the covering Jest test locally on this branch. Both cases in `assets/js/blocks/product-gallery/test/block.ts` pass.
- Compared Playwright collection for the spec file before and after. It goes from 7 tests to 6, and the six that remain are unchanged.
- Ran ESLint on the changed spec file before and after. Four warnings in both cases, the same four, with only line numbers shifted. No new warnings and no errors.
- Read `ProductGalleryLargeImage::render()` to confirm the PHPUnit assertion is on generated markup rather than on the fixture markup passed to `do_blocks()`.
- The PHPUnit case was not run locally because it needs a wp-env test environment. Its coverage was established by reading the test and the renderer.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to identify the redundant tests and draft this change. I verified the coverage claims and reviewed the diff.
