### PR TITLE
Restore plain-text product search responses

### DIFF
--- a/plugins/woocommerce/changelog/fix-plain-text-product-search-responses
+++ b/plugins/woocommerce/changelog/fix-plain-text-product-search-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore plain-text product names in AJAX search responses.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2137,7 +2137,7 @@ class WC_AJAX {
 				}
 			}//end if
 
-			$products[ $product_object->get_id() ] = esc_html( wp_strip_all_tags( $formatted_name ) );
+			$products[ $product_object->get_id() ] = wp_strip_all_tags( $formatted_name );
 		}
 
 		wp_send_json( apply_filters( 'woocommerce_json_search_found_products', $products ) );
@@ -2188,7 +2188,7 @@ class WC_AJAX {
 		$products        = array();
 
 		foreach ( $product_objects as $product_object ) {
-			$products[ $product_object->get_id() ] = esc_html( wp_strip_all_tags( $product_object->get_formatted_name() ) );
+			$products[ $product_object->get_id() ] = wp_strip_all_tags( $product_object->get_formatted_name() );
 		}
 
 		wp_send_json( $products );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2137,7 +2137,7 @@ class WC_AJAX {
 				}
 			}//end if
 
-			$products[ $product_object->get_id() ] = wp_strip_all_tags( $formatted_name );
+			$products[ $product_object->get_id() ] = wp_strip_all_tags( rawurldecode( $formatted_name ) );
 		}
 
 		wp_send_json( apply_filters( 'woocommerce_json_search_found_products', $products ) );
@@ -2188,7 +2188,7 @@ class WC_AJAX {
 		$products        = array();
 
 		foreach ( $product_objects as $product_object ) {
-			$products[ $product_object->get_id() ] = wp_strip_all_tags( $product_object->get_formatted_name() );
+			$products[ $product_object->get_id() ] = wp_strip_all_tags( rawurldecode( $product_object->get_formatted_name() ) );
 		}
 
 		wp_send_json( $products );

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -758,7 +758,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Product search returns plain text names without decoding URL-encoded characters.
+	 * @testdox Product search decodes URL-encoded characters before returning plain text names.
 	 * @dataProvider product_search_name_provider
 	 *
 	 * @param string $search_term          Product search term.
@@ -797,8 +797,8 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	public function product_search_name_provider(): array {
 		return array(
 			'plain punctuation'    => array( 'Ben', "Ben & Jerry's", "Ben & Jerry's" ),
-			'URL-encoded space'    => array( 'Coffee', 'Coffee%20Mug', 'Coffee%20Mug' ),
-			'URL-encoded HTML tag' => array( 'Text', 'Text %3Cspan%3Einside%3C/span%3E', 'Text %3Cspan%3Einside%3C/span%3E' ),
+			'URL-encoded space'    => array( 'Coffee', 'Coffee%20Mug', 'Coffee Mug' ),
+			'URL-encoded HTML tag' => array( 'Text', 'Text %3Cspan%3Einside%3C/span%3E', 'Text inside' ),
 			'HTML tag'             => array( 'Text', 'Text <span>inside</span>', 'Text inside' ),
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -758,6 +758,52 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Product search returns plain text names without decoding URL-encoded characters.
+	 * @dataProvider product_search_name_provider
+	 *
+	 * @param string $search_term          Product search term.
+	 * @param string $product_name         Product name.
+	 * @param string $expected_result_name Expected product name in the response.
+	 */
+	public function test_json_search_products_returns_plain_text_names( string $search_term, string $product_name, string $expected_result_name ): void {
+		$this->_setRole( 'administrator' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( $product_name );
+		$product->save();
+
+		$_GET['term']     = $search_term;
+		$_GET['include']  = array( $product->get_id() );
+		$_GET['security'] = wp_create_nonce( 'search-products' );
+
+		try {
+			$response = $this->do_ajax( 'woocommerce_json_search_products' );
+		} finally {
+			unset( $_GET['term'], $_GET['include'], $_GET['security'] );
+		}
+
+		$this->assertSame(
+			sprintf( '%s (%s)', $expected_result_name, $product->get_sku() ),
+			$response[ $product->get_id() ],
+			'Product search should return a stripped, plain text product name.'
+		);
+	}
+
+	/**
+	 * Product names used to verify AJAX search response formatting.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public function product_search_name_provider(): array {
+		return array(
+			'plain punctuation'    => array( 'Ben', "Ben & Jerry's", "Ben & Jerry's" ),
+			'URL-encoded space'    => array( 'Coffee', 'Coffee%20Mug', 'Coffee%20Mug' ),
+			'URL-encoded HTML tag' => array( 'Text', 'Text %3Cspan%3Einside%3C/span%3E', 'Text %3Cspan%3Einside%3C/span%3E' ),
+			'HTML tag'             => array( 'Text', 'Text <span>inside</span>', 'Text inside' ),
+		);
+	}
+
+	/**
 	 * Describe JSON search, particularly as it relates to handling searches for users in a
 	 * multisite context (it should generally not be possible to retrieve information about
 	 * users who have not been added to the current blog).


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Product names returned by the AJAX search endpoints are currently HTML-escaped, causing characters such as ampersands and apostrophes to be returned as entities.

This PR restores plain-text product names by URL-decoding formatted names before stripping tags. This retains the released URL-decoding behavior while ensuring tags introduced during decoding are removed.

This restores the released response and `woocommerce_json_search_found_products` filter contract for plain-text product names.

Bug introduced in PR #68173.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create products with the following names:
    - `Ben & Jerry's`
    - `Coffee%20Mug`
    - `Text <span>inside</span>`
    - `Text %3Cspan%3Einside%3C/span%3E`
2. Edit another product and search for each product under **Linked products → Upsells**.
3. Verify that the search results display:
    - `Ben & Jerry's`
    - `Coffee Mug`
    - `Text inside`
    - `Text inside`

<!-- End testing instructions -->

### Testing that has already taken place:

- `pnpm test:php:env -- --filter WC_AJAX_Test::test_json_search_products_returns_plain_text_names`
- PHP syntax checks for both changed PHP files.
- Changed-file and full branch PHP coding-standard checks.
- PHPStan analysis of `includes/class-wc-ajax.php`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A patch changelog entry is included in this PR.

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Codex was used to investigate the regression, draft the code and tests, and prepare the pull request description. The resulting changes were reviewed and verified by the author.
