### PR TITLE
Rename the default Payment method option from N/A to All methods available

### DIFF
--- a/plugins/woocommerce/changelog/31339-payment-method-all-methods-label
+++ b/plugins/woocommerce/changelog/31339-payment-method-all-methods-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Rename the default Payment method option on the order screen from "N/A" to "All methods available", so it says what the customer will actually be offered.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -610,7 +610,7 @@ class WC_Meta_Box_Order_Data {
 							<p class="form-field form-field-wide">
 								<label><?php esc_html_e( 'Payment method:', 'woocommerce' ); ?></label>
 								<select name="_payment_method" id="_payment_method" class="first">
-									<option value=""><?php esc_html_e( 'N/A', 'woocommerce' ); ?></option>
+									<option value=""><?php esc_html_e( 'All methods available', 'woocommerce' ); ?></option>
 									<?php
 									$found_method = false;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- @TODO Jana: rewrite this in your own words before marking ready. -->

- The Payment method dropdown on the order screen defaulted to "N/A".
- "N/A" names an absence. It doesn't tell the merchant what will happen.
- What actually happens: the customer gets offered every method the store has enabled.
- Renamed the option to "All methods available", so the label says that.
- Label only. The stored value is unchanged, so no order data moves and nothing breaks for existing stores.

Came out of feedback on a design post exploring payment methods on the Pay page. Split out from that larger proposal, which is still under discussion, so this stands alone.

Related to #31339. Not a fix for it.

### Screenshots or screen recordings:


| Before | After |
| ------ | ----- |
| <img alt="Payment method dropdown reading N/A" src="https://github.com/user-attachments/assets/6c32082d-73a3-4b12-b24f-e52f7926ca3d" /> | <img alt="Payment method dropdown reading All methods available" src="https://github.com/user-attachments/assets/e61c9ed1-621c-4b65-b7ea-3c9f96b486cc" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Orders > Add order.
2. Check the Payment method dropdown reads "All methods available" instead of "N/A".
3. Leave it as is, save, and confirm no payment method is stored on the order.
4. Pick a real gateway, save, and confirm it still saves as before.
5. Open an existing paid order and confirm its gateway still shows correctly.

<!-- End testing instructions -->

<details>
<summary>Milestone</summary>

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

</details>

<details>
<summary>Changelog entry</summary>

Changelog entry was added manually in this branch: `plugins/woocommerce/changelog/31339-payment-method-all-methods-label`

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [x] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Rename the default Payment method option on the order screen from "N/A" to "All methods available", so it says what the customer will actually be offered.

</details>

</details>

<details>
<summary>Release Communication</summary>

<!-- release-communication-section -->
- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

</details>

### Use of AI Tools

Claude Code was used to locate the string, run the lint and static analysis checks, and draft this description. The wording of the new label and the scope of the change were decided by the author. All changes have been reviewed by the author.

