### PR TITLE
Fix Featured Items image editor losing natural image dimensions

### DIFF
--- a/plugins/woocommerce/changelog/fix-featured-items-image-editor-natural-size
+++ b/plugins/woocommerce/changelog/fix-featured-items-image-editor-natural-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Restore the fallback image dimensions the Featured Product and Featured Category image editor lost when WordPress 6.2 merged the image editing provider into the editor component.
+Restore the real image dimensions in the Featured Product and Featured Category image editor, which opened at a square default after WordPress 6.2 merged the image editing provider into the editor component.

--- a/plugins/woocommerce/changelog/fix-featured-items-image-editor-natural-size
+++ b/plugins/woocommerce/changelog/fix-featured-items-image-editor-natural-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the fallback image dimensions the Featured Product and Featured Category image editor lost when WordPress 6.2 merged the image editing provider into the editor component.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx
@@ -21,7 +21,7 @@ type MediaSize = { height: number; width: number };
 
 interface WithImageEditorRequiredProps< T > {
 	attributes: MediaAttributes & EditorBlock< T >[ 'attributes' ];
-	backgroundImageSize: MediaSize;
+	backgroundImageSize: Partial< MediaSize >;
 	setAttributes: ( attrs: Partial< MediaAttributes > ) => void;
 	useEditingImage: [ boolean, Dispatch< SetStateAction< boolean > > ];
 }
@@ -45,9 +45,10 @@ type WithImageEditorProps< T extends EditorBlock< T > > =
 interface ImageEditorProps {
 	align: string;
 	backgroundImageId: number;
-	backgroundImageSize: MediaSize;
+	backgroundImageSize: Partial< MediaSize >;
 	backgroundImageSrc: string;
 	containerRef: RefObject< HTMLDivElement >;
+	originalImgDimension: MediaSize;
 	setAttributes: ( attrs: Partial< MediaAttributes > ) => void;
 	setIsEditingImage: ( value: boolean ) => void;
 }
@@ -96,23 +97,33 @@ export const ImageEditor = ( {
 	backgroundImageSize,
 	backgroundImageSrc,
 	containerRef,
+	originalImgDimension,
 	setAttributes,
 	setIsEditingImage,
 }: ImageEditorProps ) => {
 	const clientWidth = useClientWidth( containerRef, [ align ] );
 
+	// The rendered <img> only exists for plain backgrounds, so its measured
+	// size is missing for repeated/parallax ones and until it finishes
+	// loading. useBackgroundImage() measures the same file off-screen, which
+	// covers both cases; the constant is the last resort before either lands.
+	const editorHeight =
+		backgroundImageSize.height ||
+		originalImgDimension.height ||
+		DEFAULT_EDITOR_SIZE.height;
+	const editorWidth =
+		backgroundImageSize.width ||
+		originalImgDimension.width ||
+		DEFAULT_EDITOR_SIZE.width;
+
 	return (
 		<GutenbergImageEditor
 			id={ backgroundImageId }
 			url={ backgroundImageSrc }
-			height={ backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height }
-			width={ backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width }
-			naturalHeight={
-				backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height
-			}
-			naturalWidth={
-				backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width
-			}
+			height={ editorHeight }
+			width={ editorWidth }
+			naturalHeight={ editorHeight }
+			naturalWidth={ editorWidth }
 			onSaveImage={ ( { id, url }: { id: number; url: string } ) => {
 				setAttributes( { mediaId: id, mediaSrc: url } );
 			} }
@@ -136,12 +147,13 @@ export const withImageEditor =
 				? props.product
 				: props.category;
 
-		const { backgroundImageId, backgroundImageSrc } = useBackgroundImage( {
-			item,
-			mediaId,
-			mediaSrc,
-			blockName: name,
-		} );
+		const { backgroundImageId, backgroundImageSrc, originalImgDimension } =
+			useBackgroundImage( {
+				item,
+				mediaId,
+				mediaSrc,
+				blockName: name,
+			} );
 
 		if ( isEditingImage ) {
 			return (
@@ -152,6 +164,7 @@ export const withImageEditor =
 						backgroundImageSize={ backgroundImageSize }
 						backgroundImageSrc={ backgroundImageSrc }
 						containerRef={ ref }
+						originalImgDimension={ originalImgDimension }
 						setAttributes={ setAttributes }
 						setIsEditingImage={ setIsEditingImage }
 					/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx
@@ -48,7 +48,7 @@ interface ImageEditorProps {
 	backgroundImageSize: MediaSize;
 	backgroundImageSrc: string;
 	containerRef: RefObject< HTMLDivElement >;
-	setAttributes: ( attrs: MediaAttributes ) => void;
+	setAttributes: ( attrs: Partial< MediaAttributes > ) => void;
 	setIsEditingImage: ( value: boolean ) => void;
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx
@@ -6,11 +6,8 @@
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
 import { ProductResponseItem } from '@woocommerce/types';
-import {
-	__experimentalImageEditingProvider as ImageEditingProvider,
-	__experimentalImageEditor as GutenbergImageEditor,
-} from '@wordpress/block-editor';
-import type { ComponentType, Dispatch, SetStateAction } from 'react';
+import { __experimentalImageEditor as GutenbergImageEditor } from '@wordpress/block-editor';
+import type { ComponentType, Dispatch, RefObject, SetStateAction } from 'react';
 
 /**
  * Internal dependencies
@@ -50,8 +47,7 @@ interface ImageEditorProps {
 	backgroundImageId: number;
 	backgroundImageSize: MediaSize;
 	backgroundImageSrc: string;
-	containerRef: React.RefObject< HTMLDivElement >;
-	isEditingImage: boolean;
+	containerRef: RefObject< HTMLDivElement >;
 	setAttributes: ( attrs: MediaAttributes ) => void;
 	setIsEditingImage: ( value: boolean ) => void;
 }
@@ -59,7 +55,7 @@ interface ImageEditorProps {
 // Adapted from:
 // https://github.com/WordPress/gutenberg/blob/v15.6.1/packages/block-library/src/image/use-client-width.js
 function useClientWidth(
-	ref: React.RefObject< HTMLDivElement >,
+	ref: RefObject< HTMLDivElement >,
 	dependencies: string[]
 ) {
 	const [ clientWidth, setClientWidth ]: [
@@ -100,43 +96,10 @@ export const ImageEditor = ( {
 	backgroundImageSize,
 	backgroundImageSrc,
 	containerRef,
-	isEditingImage,
 	setAttributes,
 	setIsEditingImage,
 }: ImageEditorProps ) => {
 	const clientWidth = useClientWidth( containerRef, [ align ] );
-
-	// Fallback for WP 6.1 or lower. In WP 6.2. ImageEditingProvider was merged
-	// with ImageEditor, see: https://github.com/WordPress/gutenberg/pull/47171
-	if ( typeof ImageEditingProvider === 'function' ) {
-		return (
-			<ImageEditingProvider
-				id={ backgroundImageId }
-				url={ backgroundImageSrc }
-				naturalHeight={
-					backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height
-				}
-				naturalWidth={
-					backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width
-				}
-				onSaveImage={ ( { id, url }: { id: number; url: string } ) => {
-					setAttributes( { mediaId: id, mediaSrc: url } );
-				} }
-				isEditing={ isEditingImage }
-				onFinishEditing={ () => setIsEditingImage( false ) }
-			>
-				<GutenbergImageEditor
-					url={ backgroundImageSrc }
-					height={
-						backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height
-					}
-					width={
-						backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width
-					}
-				/>
-			</ImageEditingProvider>
-		);
-	}
 
 	return (
 		<GutenbergImageEditor
@@ -144,8 +107,12 @@ export const ImageEditor = ( {
 			url={ backgroundImageSrc }
 			height={ backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height }
 			width={ backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width }
-			naturalHeight={ backgroundImageSize.height }
-			naturalWidth={ backgroundImageSize.width }
+			naturalHeight={
+				backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height
+			}
+			naturalWidth={
+				backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width
+			}
 			onSaveImage={ ( { id, url }: { id: number; url: string } ) => {
 				setAttributes( { mediaId: id, mediaSrc: url } );
 			} }
@@ -185,7 +152,6 @@ export const withImageEditor =
 						backgroundImageSize={ backgroundImageSize }
 						backgroundImageSrc={ backgroundImageSrc }
 						containerRef={ ref }
-						isEditingImage={ isEditingImage }
 						setAttributes={ setAttributes }
 						setIsEditingImage={ setIsEditingImage }
 					/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/test/image-editor.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/test/image-editor.tsx
@@ -43,6 +43,7 @@ describe( 'Featured Items image editor', () => {
 				backgroundImageSize={ { height: 640, width: 960 } }
 				backgroundImageSrc="https://example.com/product.jpg"
 				containerRef={ { current: container } }
+				originalImgDimension={ { height: 100, width: 200 } }
 				setAttributes={ setAttributes }
 				setIsEditingImage={ setIsEditingImage }
 			/>
@@ -77,7 +78,36 @@ describe( 'Featured Items image editor', () => {
 		expect( setIsEditingImage ).toHaveBeenCalledWith( false );
 	} );
 
-	it( 'uses the editor fallback for missing natural image dimensions', () => {
+	// Repeated and parallax backgrounds render a <div>, never an <img>, so the
+	// measured size stays empty for as long as the block keeps that setting.
+	it( 'falls back to the off-screen measurement when no image was measured', () => {
+		render(
+			<ImageEditor
+				align="center"
+				backgroundImageId={ 42 }
+				backgroundImageSize={ {} }
+				backgroundImageSrc="https://example.com/product.jpg"
+				containerRef={ {
+					current: document.createElement( 'div' ),
+				} }
+				originalImgDimension={ { height: 640, width: 960 } }
+				setAttributes={ jest.fn() }
+				setIsEditingImage={ jest.fn() }
+			/>
+		);
+
+		const editorProps = mockGutenbergImageEditor.mock.lastCall?.[ 0 ];
+		expect( editorProps ).toEqual(
+			expect.objectContaining( {
+				height: 640,
+				width: 960,
+				naturalHeight: 640,
+				naturalWidth: 960,
+			} )
+		);
+	} );
+
+	it( 'uses the editor default only when no size has been measured yet', () => {
 		render(
 			<ImageEditor
 				align="center"
@@ -87,6 +117,7 @@ describe( 'Featured Items image editor', () => {
 				containerRef={ {
 					current: document.createElement( 'div' ),
 				} }
+				originalImgDimension={ { height: 0, width: 0 } }
 				setAttributes={ jest.fn() }
 				setIsEditingImage={ jest.fn() }
 			/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/test/image-editor.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/test/image-editor.tsx
@@ -1,0 +1,105 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import {
+	__experimentalImageEditor as GutenbergImageEditor,
+	__experimentalImageEditingProvider as LegacyImageEditingProvider,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ImageEditor } from '../image-editor';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	__experimentalImageEditor: jest.fn( () => null ),
+	__experimentalImageEditingProvider: jest.fn(
+		( { children }: { children: ReactNode } ) => children
+	),
+} ) );
+
+const mockGutenbergImageEditor = GutenbergImageEditor as jest.Mock;
+const mockLegacyImageEditingProvider = LegacyImageEditingProvider as jest.Mock;
+
+describe( 'Featured Items image editor', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'passes the complete editing contract to the merged image editor', () => {
+		const setAttributes = jest.fn();
+		const setIsEditingImage = jest.fn();
+		const container = document.createElement( 'div' );
+
+		render(
+			<ImageEditor
+				align="center"
+				backgroundImageId={ 42 }
+				backgroundImageSize={ { height: 640, width: 960 } }
+				backgroundImageSrc="https://example.com/product.jpg"
+				containerRef={ { current: container } }
+				setAttributes={ setAttributes }
+				setIsEditingImage={ setIsEditingImage }
+			/>
+		);
+
+		expect( mockLegacyImageEditingProvider ).not.toHaveBeenCalled();
+		expect( mockGutenbergImageEditor ).toHaveBeenCalled();
+		const editorProps = mockGutenbergImageEditor.mock.lastCall?.[ 0 ];
+		expect( editorProps ).toEqual(
+			expect.objectContaining( {
+				id: 42,
+				url: 'https://example.com/product.jpg',
+				height: 640,
+				width: 960,
+				naturalHeight: 640,
+				naturalWidth: 960,
+				onSaveImage: expect.any( Function ),
+				onFinishEditing: expect.any( Function ),
+			} )
+		);
+
+		editorProps.onSaveImage( {
+			id: 84,
+			url: 'https://example.com/product-edited.jpg',
+		} );
+		editorProps.onFinishEditing();
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			mediaId: 84,
+			mediaSrc: 'https://example.com/product-edited.jpg',
+		} );
+		expect( setIsEditingImage ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'uses the editor fallback for missing natural image dimensions', () => {
+		render(
+			<ImageEditor
+				align="center"
+				backgroundImageId={ 42 }
+				backgroundImageSize={ { height: 0, width: 0 } }
+				backgroundImageSrc="https://example.com/product.jpg"
+				containerRef={ {
+					current: document.createElement( 'div' ),
+				} }
+				setAttributes={ jest.fn() }
+				setIsEditingImage={ jest.fn() }
+			/>
+		);
+
+		const editorProps = mockGutenbergImageEditor.mock.lastCall?.[ 0 ];
+		expect( editorProps ).toEqual(
+			expect.objectContaining( {
+				height: 500,
+				width: 500,
+				naturalHeight: 500,
+				naturalWidth: 500,
+			} )
+		);
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The Featured Product and Featured Category image editor carried a compatibility branch for WordPress 6.1 and lower that wrapped the editor in `__experimentalImageEditingProvider`. WordPress 6.2 merged that provider into `__experimentalImageEditor` ([Gutenberg #47171](https://github.com/WordPress/gutenberg/pull/47171)), so the `typeof ImageEditingProvider === 'function'` guard has been false ever since — the symbol is not exported by the bundled `@wordpress/block-editor` at all.

The two branches were not equivalent, which is the actual bug. The provider branch passed `naturalHeight`/`naturalWidth` with a `DEFAULT_EDITOR_SIZE` fallback, while the branch that silently became live passed the raw values. `backgroundImageSize` is initialised as an empty object in `with-featured-item.tsx`, so opening the crop UI before the image dimensions resolve handed the editor `undefined` for both, leaving it without the values it uses to compute crop ratio and zoom.

This drops the unreachable branch and gives the merged editor the complete contract, including the natural-dimension fallback the old path had. The `isEditingImage` prop goes with it — `withImageEditor` only renders this component inside `if ( isEditingImage )`, so the prop was always `true` at the call site. `ImageEditor` is consumed only through that HOC by `featured-product/block.tsx` and `featured-category/block.tsx`, and is not part of any published package surface, so there is no external contract to preserve.

Both halves predate the Blocks library merge (#54911), so there is no single WooCommerce PR that introduced this; the natural-size regression became live behavior when sites moved to WordPress 6.2.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable. The change restores dimension values passed to the WordPress image editor; there is no WooCommerce-authored UI in this path.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the focused unit tests and confirm they pass:

    ```sh
    pnpm --filter='@woocommerce/block-library' test:js -- --runInBand featured-items/test/image-editor
    ```

2. Confirm the coverage is real rather than incidental: in `plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/image-editor.tsx`, replace the `naturalHeight`/`naturalWidth` expressions with the bare `backgroundImageSize.height` / `backgroundImageSize.width`, re-run the command above, and check that `uses the editor fallback for missing natural image dimensions` fails with `naturalHeight: 500` expected against `0` received. Restore the fallback afterwards.

3. Exercise the editor itself. Build Blocks (`pnpm --filter='@woocommerce/block-library' build`), add a Featured Product or Featured Category block to a page, give it a background image, and choose **Crop** in the block toolbar. Confirm the crop UI opens with a correctly proportioned image, that zoom and aspect-ratio controls behave, and that saving writes the new image back to the block.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- `pnpm --filter='@woocommerce/block-library' test:js -- --runInBand featured-items/test/image-editor` passes: 1 suite, 2 tests.
- The natural-dimension test was mutation-checked. Removing the `DEFAULT_EDITOR_SIZE` fallback makes `uses the editor fallback for missing natural image dimensions` fail with `naturalHeight: 500` expected against `0` received; restoring it returns the suite to green.
- The dead branch was confirmed against the bundled dependency rather than inferred from a version number: `__experimentalImageEditingProvider` has no occurrence anywhere in the build output of the installed `@wordpress/block-editor@12.26.0`, so the removed guard could only ever evaluate to `false`. The first test asserts this directly by mocking the legacy provider and requiring it is never called.
- `wp-scripts lint-js` reports no errors and no warnings on both changed files.
- Step 3 above (the interactive crop UI) has **not** been exercised in a browser for this PR; the evidence here is the unit tests and the dependency check.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to trace the divergence between the two compatibility branches, confirm against the bundled `@wordpress/block-editor` build that the legacy provider no longer exists, write the fix and its tests, run the mutation check, and prepare this description. The result was verified through the test, lint, and dependency checks listed above.
