### PR TITLE
[tests] Allow disabling the PHPUnit code hacker with an environment variable

### DIFF
--- a/plugins/woocommerce/changelog/dev-test-bootstrap-disable-code-hacker
+++ b/plugins/woocommerce/changelog/dev-test-bootstrap-disable-code-hacker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Allow running the PHPUnit suite without the code hacker by setting the WC_TEST_DISABLE_CODE_HACKER environment variable, for tools such as mutation testers that need to own the file stream wrapper.

--- a/plugins/woocommerce/tests/Tools/CodeHacking/README.md
+++ b/plugins/woocommerce/tests/Tools/CodeHacking/README.md
@@ -151,6 +151,16 @@ In a few rare cases the code hacker will cause problems with tests that do write
 
 One of these cases is the usage of the `copy` command to copy files. Since this function is used in a few tests, a convenience `file_copy` method is defined in `WC_Unit_Test_Case`; it just temporarily disables the hacker, does the copy, and reenables the hacker.
 
+## Disabling the code hacker for a whole run
+
+The code hacker owns PHP's `file` stream wrapper while it is enabled, so it cannot coexist with other tools that need that wrapper for themselves, such as mutation testing frameworks that swap mutated files in at include time. Set the `WC_TEST_DISABLE_CODE_HACKER` environment variable to any non-empty value to skip the code hacker for the whole run:
+
+```sh
+pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli env WC_TEST_DISABLE_CODE_HACKER=1 tests/php/bin/run-phpunit.sh -c phpunit.xml --filter SomeTest
+```
+
+The bootstrap prints a notice when it does this. Tests that mock functions or static methods, or that subclass `final` classes, fail without the code hacker, so narrow the run to test classes that do not rely on it.
+
 ## An important note
 
 The code hacker is intended to be a **last resort** mechanism to test stuff that it's **really** difficult or impossible to test otherwise - the mechanisms already in place to help testing (e.g. the PHPUnit's mocks or the Woo helpers) should still be used whenever possible. And of course, the code hacker should not be an excuse to write code that's difficult to test.

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -42,7 +42,7 @@ class WC_Unit_Tests_Bootstrap {
 
 		$this->register_autoloader_for_testing_tools();
 
-		$this->initialize_code_hacker();
+		$this->maybe_initialize_code_hacker();
 
 		ini_set( 'display_errors', 'on' ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Blacklisted
 		error_reporting( E_ALL ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
@@ -149,7 +149,23 @@ class WC_Unit_Tests_Bootstrap {
 	}
 
 	/**
-	 * Initialize the code hacker.
+	 * Initialize the code hacker unless the WC_TEST_DISABLE_CODE_HACKER environment variable is set.
+	 *
+	 * The code hacker owns PHP's file stream wrapper, so tools that need that wrapper
+	 * themselves (for example mutation testers, which swap mutated files in at include
+	 * time) cannot run alongside it.
+	 */
+	private function maybe_initialize_code_hacker() {
+		if ( empty( getenv( 'WC_TEST_DISABLE_CODE_HACKER' ) ) ) {
+			$this->initialize_code_hacker();
+			return;
+		}
+
+		echo 'Not enabling the code hacker (WC_TEST_DISABLE_CODE_HACKER is set). Tests that mock functions or static methods, or that subclass final classes, will fail.' . PHP_EOL;
+	}
+
+	/**
+	 * Initialize the code hacker and register the hacks.
 	 *
 	 * @throws Exception Error when initializing one of the hacks.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The PHPUnit bootstrap always enables the code hacker (`tests/legacy/bootstrap.php` → `CodeHacker::enable()`), which takes over PHP's `file` stream wrapper for the whole run and, whenever it needs a native file operation, calls `stream_wrapper_restore()` — i.e. brings back PHP's built-in wrapper, not whatever was registered before it. Any tool that needs to own that wrapper itself cannot run alongside it. The concrete case: mutation testers such as Infection swap mutated files in at include time through their own stream wrapper; the code hacker silently drops it, every mutant loads the original code, and the run reports a false 0% mutation score.

This PR adds an opt-out: when the `WC_TEST_DISABLE_CODE_HACKER` environment variable is set to a non-empty value, the bootstrap skips the code hacker and prints a notice, mirroring how `DISABLE_HPOS` is read. `initialize_code_hacker()` itself is unchanged; a new `maybe_initialize_code_hacker()` wraps it. The trade-off is documented in `tests/Tools/CodeHacking/README.md`: tests that mock functions or static methods, or subclass `final` classes, fail loudly without the hacker (`Error: Call to a member function register_function_mocks() on null`), so runs using the switch need to be narrowed to test classes that do not rely on it. There is no silent-pass path.

No runtime code is touched; the default run (variable unset) is byte-for-byte the same behaviour as before.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Start the PHPUnit environment from `plugins/woocommerce`: `pnpm env:test:start`.
2. Run a test class that depends on function mocks, with the code hacker enabled (default): `pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli tests/php/bin/run-phpunit.sh -c phpunit.xml --filter 'test_wc_get_price_including_tax'`
   - [ ] Verify the output does not mention the code hacker and ends with `OK (4 tests, 12 assertions)`.
3. Run the same test with the switch: `pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli env WC_TEST_DISABLE_CODE_HACKER=1 tests/php/bin/run-phpunit.sh -c phpunit.xml --filter 'test_wc_get_price_including_tax'`
   - [ ] Verify the output starts with `Not enabling the code hacker (WC_TEST_DISABLE_CODE_HACKER is set). …` and the four data sets fail with `Error: Call to a member function register_function_mocks() on null` — the failure is loud, not a silent pass.
4. Run a test class that does not use the hacks, with the switch: `pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli env WC_TEST_DISABLE_CODE_HACKER=1 tests/php/bin/run-phpunit.sh -c phpunit.xml --filter 'WC_Cart_Test'`
   - [ ] Verify the notice is printed and the run ends with `OK (39 tests, 211 assertions)`.
5. Run `markdownlint plugins/woocommerce/tests/Tools/CodeHacking/README.md` from the repository root.
   - [ ] Verify it reports nothing.

<!-- End testing instructions -->

### Testing that has already taken place:

Steps 2–4 above were run in wp-env (PHP 8.1.34, PHPUnit 9.6.35, HPOS on) with exactly the outputs listed. `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` are clean; `markdownlint` on the README is clean. The motivating scenario was an Infection run against a WooCommerce branch in which every mutant escaped because the interceptor was displaced by the code hacker; with the code hacker skipped, Infection owns the wrapper again.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Created manually: `plugins/woocommerce/changelog/dev-test-bootstrap-disable-code-hacker` (Significance: patch, Type: dev).

### Release Communication

<!-- release-communication-section -->
- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Drafted with Claude Code (Claude Fable 5); the change, the probes and this description were reviewed and verified by me.

---
🤖 Generated with [Claude Code](https://claude.ai/code)
