### PR TITLE
Document when PRs need an independent human review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 -   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 -   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
 -   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
+-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
 -   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,8 @@ This is part of the WooCommerce monorepo:
 
 For code review standards and critical violations to flag, use the **`woocommerce-code-review` skill**.
 
+Automated reviews complement the [Review Requirements](#review-requirements); they never satisfy the human review requirement.
+
 ## Notes for AI Agents
 
 - This doc provides context; skills provide procedures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ For bug fixes, always reference the PR that introduced the bug using: `Bug intro
 
 ### Review Requirements
 
-PRs against `trunk` require an approving review by default. `docs/contribution/contributing/deciding-pr-high-impact.md` defines when that requirement may be bypassed (clearly low-impact changes: docs, typos, tests, tooling outside the release package) and when an independent human review is always required (anything on the High-Impact list, plus security, privacy, data integrity, backward compatibility, and performance-sensitive paths).
+PRs against `trunk` require an approving review from a human by default. `docs/contribution/contributing/deciding-pr-high-impact.md` defines when that requirement may be bypassed (clearly low-impact changes: docs, typos, tests, tooling outside the release package) and when an independent human review is always required (anything on the High-Impact list, plus security, privacy, data integrity, backward compatibility, and performance-sensitive paths).
 
 Two rules matter for agents:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,15 @@ When creating PRs, **always use the template** from `.github/PULL_REQUEST_TEMPLA
 
 For bug fixes, always reference the PR that introduced the bug using: `Bug introduced in PR #XXXXX.`
 
+### Review Requirements
+
+PRs against `trunk` require an approving review by default. `docs/contribution/contributing/deciding-pr-high-impact.md` defines when that requirement may be bypassed (clearly low-impact changes: docs, typos, tests, tooling outside the release package) and when an independent human review is always required (anything on the High-Impact list, plus security, privacy, data integrity, backward compatibility, and performance-sensitive paths).
+
+Two rules matter for agents:
+
+- Never present an AI review, whether your own or another agent's, as satisfying the human review requirement. The author and their agents are a single workflow, not independent reviewers.
+- When a PR qualifies as High-Impact, say so and recommend requesting an independent human review; never suggest merging it without one.
+
 ## Testing Environment
 
 - PHP tests run in Docker via `wp-env`

--- a/docs/contribution/contributing/community-contributions.md
+++ b/docs/contribution/contributing/community-contributions.md
@@ -38,7 +38,7 @@ After you submit a PR that meets these requirements:
 
 1. A maintainer will triage your PR
 2. You may receive additional feedback or change requests
-3. Once approved, your PR will be merged into an upcoming release
+3. Once approved by a maintainer (see [review requirements](/docs/contribution/contributing/deciding-pr-high-impact#review-requirements)), your PR will be merged into an upcoming release
 
 If your PR needs changes, we'll add a `needs: author feedback` label. Please respond to feedback promptly to keep your contribution moving forward, as stale PRs with that label are automatically closed after a period of time.
 

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -16,9 +16,12 @@ On this page, we will share some guidelines to help you assess the impact degree
 - Modifies **critical functionality** that shoppers or merchants rely on to run a store.
 - It fixes a **high-priority bug** (this includes Blocks fix releases core version bumps).
 - It contains a **security fix**.
+- Changes affecting **privacy** (how personal or store data is collected, stored, or shared).
 - Updates **SQL queries**.
 - Touches any of the **$_REQUEST** family of variables.
-- Any kind of **data migration/update**.
+- Any kind of **data migration/update**, or other changes affecting **data integrity**.
+- Changes affecting **backward compatibility** (public APIs, hook signatures or timing, templates, or anything third-party code consumes).
+- Changes to **performance-sensitive paths**.
 - Changes to **emails** sent from WooCommerce.
 - Changes to WooCommerce **hooks/actions/filters**.
 - Changes to **REST API endpoints**.
@@ -52,7 +55,7 @@ Bypassing the requirement is an exception for low-risk changes, not an alternati
 
 ### When an independent human review is always required
 
-A PR matching anything in the High-Impact list above must receive an independent human review before merge, no matter who (or what) authored it. The same applies to any change affecting security, privacy, data integrity, backward compatibility, or performance-sensitive paths.
+A PR matching anything in the High-Impact list above must receive an independent human review before merge, no matter who (or what) authored it.
 
 Two things do not count as an independent human review:
 

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -59,4 +59,4 @@ Two things do not count as an independent human review:
 - **The author's own review of AI-generated code.** The author drives the agent, provides its context, and shapes its solution. The author and the agent are a single workflow, not two reviewers. A single workflow can produce a convincing implementation of the wrong approach and not notice.
 - **An AI review, automated or requested by anyone.** AI reviews are encouraged as an additional safety net, but they complement an independent human review rather than replace it.
 
-Community PRs always require a review and should only be merged with an approval.
+Community PRs always require a review and should only be merged with approval from a human.

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -37,3 +37,26 @@ On this page, we will share some guidelines to help you assess the impact degree
 ## My PR is High-Impact. What's next?
 
 If your PR is High-Impact, be sure to label it with `impact: high` and the WooCommerce Core team will keep special considerations for testing it.
+
+## Review requirements
+
+Pull requests against `trunk` require an approving review before merge. That is the default for every change, because an independent reviewer brings experience, product knowledge, and assumptions that the author does not have. AI tooling working from the author's context does not add that independence.
+
+The impact assessment above is also the reference for when that requirement can be relaxed and when it must not be.
+
+### When a PR may be merged without a formal approval
+
+Contributors with permission to bypass the review requirement may use their judgment to merge a PR without a formal approval when it clearly fits the "should not mark as High-Impact" list above: documentation, changelog, or typo changes; updates to automated tests; and tooling or infrastructure changes not shipped in the release package.
+
+Bypassing the requirement is an exception for low-risk changes, not an alternative default. If you are unsure whether your change qualifies, request a review.
+
+### When an independent human review is always required
+
+A PR matching anything in the High-Impact list above must receive an independent human review before merge, no matter who (or what) authored it. The same applies to any change affecting security, privacy, data integrity, backward compatibility, or performance-sensitive paths.
+
+Two things do not count as an independent human review:
+
+- **The author's own review of AI-generated code.** The author drives the agent, provides its context, and shapes its solution. The author and the agent are a single workflow, not two reviewers. A single workflow can produce a convincing implementation of the wrong approach and not notice.
+- **An AI review requested by the author.** AI reviews are encouraged as an additional safety net, but they complement an independent human review rather than replace it.
+
+Community PRs always require a review and should only be merged with an approval.

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -62,4 +62,4 @@ Two things do not count as an independent human review:
 - **The author's own review of AI-generated code.** The author drives the agent, provides its context, and shapes its solution. The author and the agent are a single workflow, not two reviewers. A single workflow can produce a convincing implementation of the wrong approach and not notice.
 - **An AI review, automated or requested by anyone.** AI reviews are encouraged as an additional safety net, but they complement an independent human review rather than replace it.
 
-Community PRs always require a review and should only be merged with approval from a human.
+[Community PRs](/docs/contribution/contributing/community-contributions) always require a review and should only be merged with approval from a human.

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -48,7 +48,7 @@ The impact assessment above is also the reference for when that requirement can 
 
 Contributors with permission to bypass the review requirement may use their judgment to merge a PR without a formal approval when it clearly fits the "should not mark as High-Impact" list above: documentation, changelog, or typo changes; updates to automated tests; and tooling or infrastructure changes not shipped in the release package.
 
-Bypassing the requirement is an exception for low-risk changes, not an alternative default. If you are unsure whether your change qualifies, request a review.
+Bypassing the requirement is an exception for low-risk changes, not an alternative default. If you are unsure whether your change qualifies, request a review from a human.
 
 ### When an independent human review is always required
 

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -57,6 +57,6 @@ A PR matching anything in the High-Impact list above must receive an independent
 Two things do not count as an independent human review:
 
 - **The author's own review of AI-generated code.** The author drives the agent, provides its context, and shapes its solution. The author and the agent are a single workflow, not two reviewers. A single workflow can produce a convincing implementation of the wrong approach and not notice.
-- **An AI review requested by the author.** AI reviews are encouraged as an additional safety net, but they complement an independent human review rather than replace it.
+- **An AI review, automated or requested by anyone.** AI reviews are encouraged as an additional safety net, but they complement an independent human review rather than replace it.
 
 Community PRs always require a review and should only be merged with an approval.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

## What it does

The rules for when a `trunk` PR needs an approving review, and when that requirement may be bypassed, were not written down in the repo.

Add a "Review requirements" section to `docs/contribution/contributing/deciding-pr-high-impact.md`.

## Rationale

Reusing the High-Impact lists keeps one definition of risk in one file instead of adding a second taxonomy that can drift.

This PR does not touch CODEOWNERS or branch protection settings. Which paths always require a second review is a separate decision.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Read the "Review requirements" section in `docs/contribution/contributing/deciding-pr-high-impact.md` and check it against the High-Impact definitions above it.
2. Check the new line in `.github/PULL_REQUEST_TEMPLATE.md` points at the section's `#review-requirements` anchor (resolves once merged).
3. Check the `AGENTS.md` "Review Requirements" subsection matches the doc.

<!-- End testing instructions -->

### Testing that has already taken place:

- `markdownlint` with the repo config passes on the three changed files. The CI `validate-markdown` job excludes `.github/**`, so the template's pre-existing lint errors don't block this change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation and contributor tooling only; nothing in this PR ships in the WooCommerce release package.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Drafted with Claude Code (Claude Fable 5); reviewed and revised by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
