### PR TITLE
Revoke downloadable permissions when deleting an order while HPOS sync is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-sync-disabled-downloadable-permissions
+++ b/plugins/woocommerce/changelog/fix-hpos-sync-disabled-downloadable-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Delete downloadable file permissions immediately when an order is deleted with HPOS authoritative and sync disabled.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -19,6 +19,7 @@ use Exception;
 use WC_Abstract_Order;
 use WC_Data;
 use WC_Order;
+use WC_Post_Data;
 use Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentUtils;
 
 defined( 'ABSPATH' ) || exit;
@@ -2634,6 +2635,13 @@ FROM $order_meta_table
 				do_action( 'woocommerce_before_delete_order', $order_id, $order );
 			}
 
+			$orders_table_is_authoritative = $order->get_data_store()->get_current_class_name() === self::class;
+
+			if ( $orders_table_is_authoritative ) {
+				// Must run before delete_order_data_from_custom_order_tables() removes the row is_order() checks.
+				WC_Post_Data::delete_order_downloadable_permissions( $order_id );
+			}
+
 			$this->upshift_or_delete_child_orders( $order );
 			$this->delete_order_data_from_custom_order_tables( $order_id );
 			$this->delete_items( $order );
@@ -2646,8 +2654,6 @@ FROM $order_meta_table
 			 *
 			 * In other words, we do not delete the post record when HPOS table is authoritative and synchronization is disabled but post record is a full record and not just a placeholder, because it implies that the order was created before HPOS was enabled.
 			 */
-			$orders_table_is_authoritative = $order->get_data_store()->get_current_class_name() === self::class;
-
 			if ( $orders_table_is_authoritative ) {
 				$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
 				if ( $data_synchronizer->data_sync_is_enabled() ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -18,6 +18,8 @@ use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use DateTime;
 use DateTimeZone;
+use WC_Customer_Download;
+use WC_Data_Store;
 use WC_Helper_Order;
 use WC_Helper_Payment_Token;
 use WC_Helper_Product;
@@ -2691,6 +2693,50 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$order->delete( true );
 
 		$this->assert_no_order_records_or_deletion_records_exist( $order_id, $refund_id, false );
+	}
+
+	/**
+	 * @testdox When the orders table is authoritative and a non-placeholder order is deleted, its downloadable product permissions are deleted immediately, regardless of whether sync is enabled or disabled.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $sync_enabled_at_deletion True to delete the order with sync enabled, false to delete it with sync disabled.
+	 */
+	public function test_downloadable_permissions_deleted_when_non_placeholder_order_deleted( bool $sync_enabled_at_deletion ) {
+		$this->allow_current_user_to_delete_posts();
+		$this->toggle_cot_feature_and_usage( true );
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
+
+		$order    = OrderHelper::create_order();
+		$order_id = $order->get_id();
+
+		$this->assertNotEquals( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE, get_post_type( $order_id ) );
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $order->get_customer_id() );
+		$download->set_user_email( $order->get_billing_email() );
+		$download->set_order_id( $order_id );
+		$download->set_download_id( 'test-download' );
+		$download->set_access_granted( time() );
+		$download->save();
+
+		if ( ! $sync_enabled_at_deletion ) {
+			$this->disable_cot_sync();
+		}
+
+		$order->delete( true );
+
+		$download_data_store = WC_Data_Store::load( 'customer-download' );
+		$this->assertEmpty( $download_data_store->get_downloads( array( 'order_id' => $order_id ) ), 'Downloadable permission should have been deleted.' );
+
+		if ( $sync_enabled_at_deletion ) {
+			$this->assertNull( get_post( $order_id ), 'Backup post record should have been deleted immediately.' );
+		} else {
+			$this->assertNotNull( get_post( $order_id ), 'Backup post record should still exist, pending sync.' );
+			$this->assert_deletion_record_existence( $order_id, true, true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When HPOS is authoritative and sync is disabled, permanently deleting an order didn't revoke the customer's downloadable-product permissions for that order. This does happen when HPOS is off, so that's actually the desired behavior.

This PR ensures downloadable permissions are deleted unconditionally.

Closes #68178.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to **Products > Add new** and create a virtual downloadable product. Ensure it has at least a downloadable file attached.
2. Ensure HPOS is enabled and compatibility mode is disabled in **WC > Settings > Advanced > Features** or via CLI (`wp wc hpos enable && wp wc hpos compatibility-mode disable`).
3. Create an order with the product from step 1, set its status to **Processing**.
4. Go to **My Account > Downloads** on the frontend and copy the download link related to the new order.
5. Confirm the link works and the download is served.
6. Go back to the admin and fully delete the order (trash first and then delete permanently from Trash) in **WC > Orders**.
7. Visit the download link again. It should show "Invalid download link".
8. Optional: repeat with other HPOS/compat. mode combinations to confirm the same result holds.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.