### PR TITLE
Restore order notes when an HPOS order is untrashed

### DIFF
--- a/plugins/woocommerce/changelog/fix-68177-hpos-order-notes-hidden-after-untrash
+++ b/plugins/woocommerce/changelog/fix-68177-hpos-order-notes-hidden-after-untrash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore order notes when an HPOS order is untrashed, instead of leaving them permanently hidden.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -1076,7 +1076,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$keys_to_delete = array_diff(
 			array_keys( $existing_meta_data ),
 			$this->internal_meta_keys,
-			array_keys( $this->get_internal_data_store_key_getters() )
+			array_keys( $this->get_internal_data_store_key_getters() ),
+			array(
+				// WordPress writes and manages this directly on the post while trashing.
+				'_wp_trash_meta_comments_status',
+			)
 		);
 
 		foreach ( $keys_to_delete as $meta_key ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2931,6 +2931,31 @@ FROM $order_meta_table
 
 		// Was the status successfully restored? Let's clean up the meta and indicate success...
 		if ( 'wc-' . $order->get_status() === $previous_status ) {
+			wp_untrash_post_comments( $id );
+
+			// Order notes are always restored. Other comment types are left alone.
+			global $wpdb;
+			$order_note_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT comment_ID FROM {$wpdb->comments} WHERE comment_post_ID = %d AND comment_approved = %s AND comment_type = %s",
+					$id,
+					'post-trashed',
+					'order_note'
+				)
+			);
+			if ( $order_note_ids ) {
+				$wpdb->update(
+					$wpdb->comments,
+					array( 'comment_approved' => '1' ),
+					array(
+						'comment_post_ID'  => $id,
+						'comment_approved' => 'post-trashed',
+						'comment_type'     => 'order_note',
+					)
+				);
+				clean_comment_cache( $order_note_ids );
+			}
+
 			$order->delete_meta_data( '_wp_trash_meta_status' );
 			$order->delete_meta_data( '_wp_trash_meta_time' );
 			$order->delete_meta_data( '_wp_trash_meta_comments_status' );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -570,7 +570,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	}
 
 	/**
-	 * @testdox Test the trash-untrash cycle with sync enabled.
+	 * @testdox Test the trash-untrash cycle with sync enabled, including order note visibility.
 	 */
 	public function test_cot_datastore_untrash() {
 		global $wpdb;
@@ -583,6 +583,17 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order->save();
 		$order_id = $order->get_id();
+		$note_id  = $order->add_order_note( 'Test note' );
+
+		// A non-order-note comment type, so restore can't be relying on the notes-only fallback.
+		$third_party_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $order_id,
+				'comment_content'  => 'Third-party comment',
+				'comment_type'     => 'wc-messaging',
+				'comment_approved' => 1,
+			)
+		);
 
 		$this->sut->trash_order( $order );
 
@@ -591,6 +602,8 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$this->assertEquals( OrderStatus::TRASH, $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$orders_table} WHERE id = %d", $order_id ) ) );
 		$this->assertEquals( OrderStatus::TRASH, $wpdb->get_var( $wpdb->prepare( "SELECT post_status FROM {$wpdb->posts} WHERE id = %d", $order_id ) ) );
 		$this->assertNotEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$this->sut->get_meta_table_name()} WHERE order_id = %d AND meta_key LIKE %s", $order_id, '_wp_trash_meta_%' ) ) );
+		$this->assertSame( 'post-trashed', get_comment( $note_id )->comment_approved, 'Order note should be hidden while the order is in the trash' );
+		$this->assertSame( 'post-trashed', get_comment( $third_party_comment_id )->comment_approved, 'Third-party comment should be hidden while the order is in the trash' );
 
 		$this->sut->read( $order );
 		$this->sut->untrash_order( $order );
@@ -600,6 +613,70 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$this->sut->get_meta_table_name()} WHERE order_id = %d AND meta_key LIKE %s", $order_id, '_wp_trash_meta_%' ) ) );
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key LIKE '_wp_trash_meta_%'", $order_id ) ) );
+		$this->assertSame( '1', get_comment( $note_id )->comment_approved, 'Order note should be restored when the order is untrashed' );
+		$this->assertSame( '1', get_comment( $third_party_comment_id )->comment_approved, 'Third-party comment should be restored when the order is untrashed' );
+		//phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
+	}
+
+	/**
+	 * @testdox Notes are still restored on untrash even without a comment-status record.
+	 */
+	public function test_cot_datastore_untrash_restores_notes_with_no_trash_meta_record() {
+		$this->enable_cot_sync();
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = $this->create_complex_cot_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->save();
+		$order_id = $order->get_id();
+		$note_id  = $order->add_order_note( 'Test note' );
+
+		$this->sut->trash_order( $order );
+		$this->assertSame( 'post-trashed', get_comment( $note_id )->comment_approved );
+
+		// No comment-status record, as if this order predates the fix.
+		delete_post_meta( $order_id, '_wp_trash_meta_comments_status' );
+
+		$this->sut->read( $order );
+		$this->sut->untrash_order( $order );
+
+		$this->assertSame( '1', get_comment( $note_id )->comment_approved, 'Order note should still be restored even with no trash-meta record' );
+	}
+
+	/**
+	 * @testdox A leaked wc_orders_meta row for the trash comment-status is removed on untrash.
+	 */
+	public function test_cot_datastore_untrash_removes_leaked_trash_comments_meta() {
+		global $wpdb;
+
+		$this->enable_cot_sync();
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = $this->create_complex_cot_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->save();
+		$order_id = $order->get_id();
+
+		$this->sut->trash_order( $order );
+
+		// Simulate a copy that leaked into wc_orders_meta from a prior CPT-to-HPOS sync.
+		$wpdb->insert(
+			$this->sut->get_meta_table_name(),
+			array(
+				'order_id'   => $order_id,
+				'meta_key'   => '_wp_trash_meta_comments_status', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => 'leaked', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		$this->sut->read( $order );
+		$this->sut->untrash_order( $order );
+
+		//phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
+		$this->assertEmpty(
+			$wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$this->sut->get_meta_table_name()} WHERE order_id = %d AND meta_key = %s", $order_id, '_wp_trash_meta_comments_status' ) ),
+			'A leaked _wp_trash_meta_comments_status row should not survive untrash'
+		);
 		//phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
 	}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When an HPOS order is trashed while sync is enabled, WordPress core hides its notes (comments) as a side effect of trashing the backup post. `OrdersTableDataStore::untrash_order()` never undid that, so notes stayed permanently hidden even after the order itself was restored.

This PR ensures comments are untrashed as well so order notes become visible again.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #68177.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable HPOS with sync enabled: `wp wc hpos enable --with-sync`.
2. Go to **WC > Orders**, create an order and add a note to it.
3. Trash the order.
4. Go to **WC > Orders > Trash** and restore the order.
5. Open the order again and confirm the note from step 2 is visible.
6. (Optional) Repeat the above on `trunk` and confirm the note doesn't get restored with the order.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.