### PR TITLE
Fix cross-resource post-action webhook deliveries

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2191-post-action-webhook-validation
+++ b/plugins/woocommerce/changelog/wooplug-2191-post-action-webhook-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Validate post-action webhooks using the affected post ID instead of request-global post type state.

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -210,6 +210,10 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * @return bool       True if validation passes.
 	 */
 	private function is_valid_post_action( $arg ) {
+		if ( ( ! is_int( $arg ) && ! ( is_string( $arg ) && ctype_digit( $arg ) ) ) || 0 >= (int) $arg ) {
+			return false;
+		}
+
 		$post_id = absint( $arg );
 		if ( ! $post_id ) {
 			return false;

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -210,16 +210,14 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * @return bool       True if validation passes.
 	 */
 	private function is_valid_post_action( $arg ) {
-		// Only deliver deleted/restored event for coupons, orders, and products.
-		if ( isset( $GLOBALS['post_type'] ) && ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product' ), true ) ) {
-			return false;
-		}
+		$post_type_to_resource = array(
+			'product'     => 'product',
+			'shop_coupon' => 'coupon',
+			'shop_order'  => 'order',
+		);
+		$post_type             = get_post_type( absint( $arg ) );
 
-		// Check if is delivering for the correct resource.
-		if ( isset( $GLOBALS['post_type'] ) && str_replace( 'shop_', '', $GLOBALS['post_type'] ) !== $this->get_resource() ) {
-			return false;
-		}
-		return true;
+		return isset( $post_type_to_resource[ $post_type ] ) && $post_type_to_resource[ $post_type ] === $this->get_resource();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -210,12 +210,20 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * @return bool       True if validation passes.
 	 */
 	private function is_valid_post_action( $arg ) {
-		$post_type_to_resource = array(
-			'product'     => 'product',
-			'shop_coupon' => 'coupon',
-			'shop_order'  => 'order',
+		$post_id = absint( $arg );
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		$post_type_to_resource = array_merge(
+			array(
+				'product'           => 'product',
+				'product_variation' => 'product',
+				'shop_coupon'       => 'coupon',
+			),
+			array_fill_keys( wc_get_order_types( 'order-webhooks' ), 'order' )
 		);
-		$post_type             = get_post_type( absint( $arg ) );
+		$post_type             = get_post_type( $post_id );
 
 		return isset( $post_type_to_resource[ $post_type ] ) && $post_type_to_resource[ $post_type ] === $this->get_resource();
 	}

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -214,11 +214,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			return false;
 		}
 
-		$post_id = absint( $arg );
-		if ( ! $post_id ) {
-			return false;
-		}
-
+		$post_id               = absint( $arg );
 		$post_type_to_resource = array_merge(
 			array(
 				'product'           => 'product',

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -83,6 +83,143 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Post-action validation rejects a falsy ID even when a global product exists.
+	 */
+	public function test_is_valid_post_action_rejects_falsy_id_with_global_post(): void {
+		$had_global_post = array_key_exists( 'post', $GLOBALS );
+		$original_post   = $GLOBALS['post'] ?? null;
+		$product_id      = $this->factory->post->create(
+			array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+		$webhook         = new WC_Webhook();
+		$webhook->set_topic( 'product.deleted' );
+
+		try {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test isolates arbitrary global request state.
+			$GLOBALS['post'] = get_post( $product_id );
+			$this->assertFalse( $this->call_is_valid_post_action( $webhook, 0 ) );
+		} finally {
+			if ( $had_global_post ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the global request state changed for this test.
+				$GLOBALS['post'] = $original_post;
+			} else {
+				unset( $GLOBALS['post'] );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Post-action validation accepts extension order types registered for webhooks.
+	 */
+	public function test_is_valid_post_action_accepts_registered_order_webhook_type(): void {
+		global $wc_order_types;
+
+		$order_type = 'shop_webhook_test';
+		$registered = wc_register_order_type(
+			$order_type,
+			array(
+				'exclude_from_order_webhooks' => false,
+			)
+		);
+
+		try {
+			$this->assertTrue( $registered, 'The test order type should be registered.' );
+			$post_id = $this->factory->post->create(
+				array(
+					'post_type'   => $order_type,
+					'post_status' => 'publish',
+				)
+			);
+			$webhook = new WC_Webhook();
+			$webhook->set_topic( 'order.deleted' );
+
+			$this->assertTrue( $this->call_is_valid_post_action( $webhook, $post_id ) );
+		} finally {
+			if ( post_type_exists( $order_type ) ) {
+				unregister_post_type( $order_type );
+			}
+			unset( $wc_order_types[ $order_type ] );
+		}
+	}
+
+	/**
+	 * @testdox Product deletion webhooks are delivered for a variable product and all of its variations.
+	 */
+	public function test_product_deletion_webhook_delivers_for_variable_product_variations(): void {
+		$product       = WC_Helper_Product::create_variation_product();
+		$expected_ids  = array_merge( array( $product->get_id() ), $product->get_children() );
+		$delivered_ids = array();
+		$webhook       = $this->create_active_webhook( 'product.deleted' );
+
+		remove_action( 'woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10 );
+		add_action(
+			'woocommerce_webhook_process_delivery',
+			function ( $delivering_webhook, $arg ) use ( $webhook, &$delivered_ids ) {
+				if ( $webhook === $delivering_webhook ) {
+					$delivered_ids[] = $arg;
+				}
+			},
+			10,
+			2
+		);
+		$webhook->enqueue();
+
+		wp_trash_post( $product->get_id() );
+
+		sort( $expected_ids );
+		sort( $delivered_ids );
+		$this->assertSame( $expected_ids, $delivered_ids );
+	}
+
+	/**
+	 * @testdox Product restoration webhooks are delivered for a variable product and all of its variations.
+	 */
+	public function test_product_restoration_webhook_delivers_for_variable_product_variations(): void {
+		$product       = WC_Helper_Product::create_variation_product();
+		$expected_ids  = array_merge( array( $product->get_id() ), $product->get_children() );
+		$delivered_ids = array();
+		wp_trash_post( $product->get_id() );
+
+		$webhook = $this->create_active_webhook( 'product.restored' );
+		remove_action( 'woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10 );
+		add_action(
+			'woocommerce_webhook_process_delivery',
+			function ( $delivering_webhook, $arg ) use ( $webhook, &$delivered_ids ) {
+				if ( $webhook === $delivering_webhook ) {
+					$delivered_ids[] = $arg;
+				}
+			},
+			10,
+			2
+		);
+		$webhook->enqueue();
+
+		wp_untrash_post( $product->get_id() );
+
+		sort( $expected_ids );
+		sort( $delivered_ids );
+		$this->assertSame( $expected_ids, $delivered_ids );
+	}
+
+	/**
+	 * Create an active webhook for integration tests.
+	 *
+	 * @param string $topic Webhook topic.
+	 * @return WC_Webhook
+	 */
+	private function create_active_webhook( string $topic ): WC_Webhook {
+		$webhook = new WC_Webhook();
+		$webhook->set_status( 'active' );
+		$webhook->set_topic( $topic );
+		$webhook->set_delivery_url( 'https://example.com/webhook' );
+
+		return $webhook;
+	}
+
+	/**
 	 * @testDox Check if valid resource is true when both arg and topic are valid.
 	 */
 	public function test_is_valid_resource() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -112,36 +112,52 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Post-action validation accepts extension order types registered for webhooks.
+	 * @testdox Post-action validation honors the order-webhooks registry.
 	 */
-	public function test_is_valid_post_action_accepts_registered_order_webhook_type(): void {
+	public function test_is_valid_post_action_honors_order_webhook_registry(): void {
 		global $wc_order_types;
 
-		$order_type = 'shop_webhook_test';
-		$registered = wc_register_order_type(
+		$order_type          = 'shop_webhook_test';
+		$excluded_order_type = 'shop_no_webhook';
+		$registered          = wc_register_order_type(
 			$order_type,
 			array(
 				'exclude_from_order_webhooks' => false,
 			)
 		);
+		$excluded_registered = wc_register_order_type(
+			$excluded_order_type,
+			array(
+				'exclude_from_order_webhooks' => true,
+			)
+		);
 
 		try {
-			$this->assertTrue( $registered, 'The test order type should be registered.' );
-			$post_id = $this->factory->post->create(
+			$this->assertSame( array( true, true ), array( $registered, $excluded_registered ), 'The test order types should be registered.' );
+			$post_id          = $this->factory->post->create(
 				array(
 					'post_type'   => $order_type,
 					'post_status' => 'publish',
 				)
 			);
-			$webhook = new WC_Webhook();
+			$excluded_post_id = $this->factory->post->create(
+				array(
+					'post_type'   => $excluded_order_type,
+					'post_status' => 'publish',
+				)
+			);
+			$webhook          = new WC_Webhook();
 			$webhook->set_topic( 'order.deleted' );
 
 			$this->assertTrue( $this->call_is_valid_post_action( $webhook, $post_id ) );
+			$this->assertFalse( $this->call_is_valid_post_action( $webhook, $excluded_post_id ) );
 		} finally {
-			if ( post_type_exists( $order_type ) ) {
-				unregister_post_type( $order_type );
+			foreach ( array( $order_type, $excluded_order_type ) as $test_order_type ) {
+				if ( post_type_exists( $test_order_type ) ) {
+					unregister_post_type( $test_order_type );
+				}
+				unset( $wc_order_types[ $test_order_type ] );
 			}
-			unset( $wc_order_types[ $order_type ] );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -112,6 +112,50 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Post-action validation rejects non-ID values before coercion.
+	 */
+	public function test_is_valid_post_action_rejects_non_id_values_before_coercion(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+		$webhook = new WC_Webhook();
+		$webhook->set_topic( 'product.deleted' );
+
+		$cached_post_at_one = wp_cache_get( 1, 'posts', false, $had_cached_post_at_one );
+		$post_at_one        = clone get_post( $post_id );
+		$post_at_one->ID    = 1;
+		wp_cache_set( 1, $post_at_one, 'posts' );
+
+		try {
+			$this->assertTrue( $this->call_is_valid_post_action( $webhook, (string) $post_id ) );
+
+			$invalid_ids = array(
+				'boolean'             => true,
+				'array'               => array( $post_id ),
+				'float'               => (float) $post_id,
+				'negative integer'    => -$post_id,
+				'decimal-like string' => $post_id . '.5',
+			);
+
+			foreach ( $invalid_ids as $description => $invalid_id ) {
+				$this->assertFalse(
+					$this->call_is_valid_post_action( $webhook, $invalid_id ),
+					"A {$description} should not be treated as a post ID."
+				);
+			}
+		} finally {
+			if ( $had_cached_post_at_one ) {
+				wp_cache_set( 1, $cached_post_at_one, 'posts' );
+			} else {
+				wp_cache_delete( 1, 'posts' );
+			}
+		}
+	}
+
+	/**
 	 * @testdox Post-action validation honors the order-webhooks registry.
 	 */
 	public function test_is_valid_post_action_honors_order_webhook_registry(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -9,6 +9,80 @@
 class WC_Webhook_Test extends WC_Unit_Test_Case {
 
 	/**
+	 * @testdox Check that post-action validation uses the affected post ID.
+	 *
+	 * @dataProvider post_action_validation_provider
+	 *
+	 * @param string|null $post_type       Post type to create, or null for ID 0.
+	 * @param string      $topic           Webhook topic.
+	 * @param string|null $global_post_type Existing global post type, or null to unset it.
+	 * @param bool        $expected        Expected validation result.
+	 */
+	public function test_is_valid_post_action_uses_post_id( $post_type, $topic, $global_post_type, $expected ): void {
+		$had_global_post_type = array_key_exists( 'post_type', $GLOBALS );
+		$original_post_type   = $GLOBALS['post_type'] ?? null;
+		if ( null === $global_post_type ) {
+			unset( $GLOBALS['post_type'] );
+		} else {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test isolates arbitrary global request state.
+			$GLOBALS['post_type'] = $global_post_type;
+		}
+
+		try {
+			$post_id = null === $post_type ? 0 : $this->factory->post->create(
+				array(
+					'post_type'   => $post_type,
+					'post_status' => 'publish',
+				)
+			);
+			$webhook = new WC_Webhook();
+			$webhook->set_topic( $topic );
+			$this->assertSame( $expected, $this->call_is_valid_post_action( $webhook, $post_id ) );
+		} finally {
+			if ( $had_global_post_type ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the global request state changed for this test.
+				$GLOBALS['post_type'] = $original_post_type;
+			} else {
+				unset( $GLOBALS['post_type'] );
+			}
+		}
+	}
+
+	/**
+	 * Call the private post-action validator.
+	 *
+	 * @param WC_Webhook $webhook Webhook to validate.
+	 * @param mixed      $arg     Hook argument.
+	 * @return bool Validation result.
+	 */
+	private function call_is_valid_post_action( WC_Webhook $webhook, $arg ): bool {
+		$call_is_valid_function = function ( $arg ) {
+			return $this->is_valid_post_action( $arg );
+		};
+
+		return $call_is_valid_function->call( $webhook, $arg );
+	}
+
+	/**
+	 * Data provider for test_is_valid_post_action_uses_post_id().
+	 *
+	 * @return array<string, array{string|null, string, string|null, bool}> Test cases.
+	 */
+	public function post_action_validation_provider() {
+		return array(
+			'matching product without global'         => array( 'product', 'product.deleted', null, true ),
+			'matching coupon without global'          => array( 'shop_coupon', 'coupon.deleted', null, true ),
+			'matching order without global'           => array( 'shop_order', 'order.deleted', null, true ),
+			'product resource with coupon ID'         => array( 'shop_coupon', 'product.deleted', null, false ),
+			'coupon resource with product ID'         => array( 'product', 'coupon.deleted', null, false ),
+			'product resource with unrelated post ID' => array( 'post', 'product.deleted', null, false ),
+			'product resource with missing ID'        => array( null, 'product.deleted', null, false ),
+			'matching product with stale global'      => array( 'product', 'product.deleted', 'page', true ),
+			'product resource with stale global'      => array( 'shop_coupon', 'product.deleted', 'product', false ),
+		);
+	}
+
+	/**
 	 * @testDox Check if valid resource is true when both arg and topic are valid.
 	 */
 	public function test_is_valid_resource() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Generic post hooks do not reliably populate global post type state, so post-action webhook validation could fail open and queue a delivery for the wrong WooCommerce resource. Resolve the affected post type from the hook's post ID, accept only positive integer IDs or digit-only ID strings before coercion, reject IDs that normalize to zero before WordPress can fall back to the global post, map product variations to the product resource, and build order mappings from `wc_get_order_types( 'order-webhooks' )`.

Invalid cross-resource deliveries are now rejected. Matching IDs continue to be accepted when global post type state is missing and are now accepted when it is empty or stale. This repairs first-party `product.deleted`, `coupon.deleted`, and CPT-backed `order.deleted` deliveries on front-end requests where WordPress publishes an empty `post_type` query variable; the old global-based guard rejected those matching IDs. Variable-product trash and restore actions now deliver `product.deleted` and `product.restored` for the parent plus every variation, matching the variation behavior already used by product-created and product-updated topics.

Compatibility impact: no webhook/filter names, timing, arguments, or override behavior change. The initial boolean passed to `woocommerce_webhook_should_deliver` changes for affected post-action calls. Core post actions continue to pass positive integer IDs, and positive digit-only ID strings remain accepted; booleans, arrays, floats, negative integers, strings with leading whitespace or a leading plus sign, and other coercible non-ID values are now rejected. Deleted events remain ID-only; restored variation deliveries use variation-shaped REST payloads (`type: variation`) while the parent uses `type: variable`. Post-action validation now accepts every post type registered for `order-webhooks`, including extension-registered order types, while honoring the `exclude_from_order_webhooks` opt-out; actual delivery still depends on the topic's registered hooks. Filtered custom resource names outside product, coupon, and order that previously delivered when global post type state was absent—which can occur in REST, WP-CLI, cron, and admin AJAX contexts—are now rejected by default; integrations can override this through `woocommerce_webhook_should_deliver`. Multisite behavior was not separately tested.

Bug introduced in PR #13057.

### Screenshots or screen recordings

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; this is a backend-only webhook validation change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From the repository root, run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Webhook_Test`.
2. Confirm all 19 tests and 36 assertions pass, including the nine-case post-action provider, falsy-ID global-post regression, malformed-ID coercion regression, order-webhooks registry and opt-out regression, and variable-product trash/restore delivery tests.
3. In a local WooCommerce site, create a variable product with multiple variations and active `Product deleted` and `Product restored` webhooks that deliver to inspectable endpoints.
4. Move the variable product to the trash, process the queued webhook actions, and confirm the deleted endpoint receives one request for the parent ID plus one for every variation ID.
5. Restore the variable product, process the queued webhook actions, and confirm the restored endpoint receives the parent object plus every variation object.
6. Confirm restored variation payloads have `type: variation` and the restored parent payload has `type: variable`.
7. Create separate active `Product deleted` and `Coupon deleted` webhooks, trash one product and one coupon, and confirm each endpoint receives only its matching resource.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The complete `WC_Webhook_Test` class passed: 19 tests and 36 assertions.
- Targeted mutation checks confirmed that the falsy-ID and malformed-ID regressions fail when the pre-coercion positive-ID validation guard is removed; the order-type registry test fails with either the old hardcoded `shop_order` map or an unfiltered `wc_get_order_types()` lookup that ignores webhook opt-outs.
- The variable-product integration tests exercise `wp_trash_post()`, `wp_untrash_post()`, and `woocommerce_webhook_process_delivery` for the parent plus all six variations.
- `lint:php:changes` ran while both PHP files were unstaged, and `lint:changes:branch` passed again after the final follow-up commit.
- PHPStan passed for the modified production file. The production PHPStan configuration does not bootstrap the legacy PHPUnit test harness, so directly adding the test file reports its existing undiscovered-framework errors.
- Local end-to-end validation on a Docker-backed WordPress/WooCommerce site confirmed product and coupon deletions each delivered only their matching webhook topic and endpoint.
- The branch received task-level and whole-diff reviews with no findings.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to implement, test, locally validate, review, and draft this pull request.

