### PR TITLE
Escape settings attributes and report currency symbols

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-119-context-specific-output-escaping
+++ b/plugins/woocommerce/changelog/fix-woo6-119-context-specific-output-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Escape settings field attributes and currency symbols in legacy report scripts.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -709,7 +709,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 								<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Sanitized, filterable help-tip markup from get_field_description(). ?></label>
 							</th>
 							<td class="forminp">
-								<?php echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'woocommerce' ) . "' style='" . $value['css'] . "' class='" . $value['class'] . "' id=", wp_dropdown_pages( $args ) ); // WPCS: XSS ok. ?> <?php echo $description; // WPCS: XSS ok. ?>
+								<?php
+								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_dropdown_pages() and get_field_description() return intentional, sanitized markup; injected attributes are escaped here.
+								echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'woocommerce' ) . "' style='" . esc_attr( $value['css'] ) . "' class='" . esc_attr( $value['class'] ) . "' id=", wp_dropdown_pages( $args ) ) . ' ' . $description;
+								?>
 							</td>
 						</tr>
 						<?php

--- a/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
@@ -774,19 +774,21 @@ class WC_Admin_Report {
 	 * @return string
 	 */
 	public function get_currency_tooltip() {
+		$currency_symbol = get_woocommerce_currency_symbol();
+
 		switch ( get_option( 'woocommerce_currency_pos' ) ) {
 			case 'right':
-				$currency_tooltip = 'append_tooltip: "' . get_woocommerce_currency_symbol() . '"';
+				$currency_tooltip = 'append_tooltip: ' . wp_json_encode( $currency_symbol, JSON_UNESCAPED_UNICODE );
 				break;
 			case 'right_space':
-				$currency_tooltip = 'append_tooltip: "&nbsp;' . get_woocommerce_currency_symbol() . '"';
+				$currency_tooltip = 'append_tooltip: ' . wp_json_encode( '&nbsp;' . $currency_symbol, JSON_UNESCAPED_UNICODE );
 				break;
 			case 'left':
-				$currency_tooltip = 'prepend_tooltip: "' . get_woocommerce_currency_symbol() . '"';
+				$currency_tooltip = 'prepend_tooltip: ' . wp_json_encode( $currency_symbol, JSON_UNESCAPED_UNICODE );
 				break;
 			case 'left_space':
 			default:
-				$currency_tooltip = 'prepend_tooltip: "' . get_woocommerce_currency_symbol() . '&nbsp;"';
+				$currency_tooltip = 'prepend_tooltip: ' . wp_json_encode( $currency_symbol . '&nbsp;', JSON_UNESCAPED_UNICODE );
 				break;
 		}
 

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -747,7 +747,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip();  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Returns a fixed JavaScript property with a JSON-encoded currency symbol. ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Shipping amount', 'woocommerce' ) ); ?>",
@@ -757,7 +757,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
+							prepend_tooltip: <?php echo wp_json_encode( get_woocommerce_currency_symbol(), JSON_UNESCAPED_UNICODE ); ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Gross sales amount', 'woocommerce' ) ); ?>",
@@ -767,7 +767,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Returns a fixed JavaScript property with a JSON-encoded currency symbol. ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Net sales amount', 'woocommerce' ) ); ?>",
@@ -777,7 +777,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 6, lineWidth: 4, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 5, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Returns a fixed JavaScript property with a JSON-encoded currency symbol. ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Refund amount', 'woocommerce' ) ); ?>",
@@ -787,7 +787,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
+							prepend_tooltip: <?php echo wp_json_encode( get_woocommerce_currency_symbol(), JSON_UNESCAPED_UNICODE ); ?>
 						},
 					];
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -168,4 +168,41 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $product->get_name(), $data->name );
 	}
+
+	/**
+	 * @testdox Currency tooltip fragments preserve filtered symbols as valid JavaScript strings.
+	 */
+	public function test_get_currency_tooltip_encodes_filtered_symbol(): void {
+		$currency_symbol = "'\"\\</script>€雪";
+		$currency_pos    = get_option( 'woocommerce_currency_pos', null );
+		$positions       = array(
+			'right'       => array( 'append_tooltip', $currency_symbol ),
+			'right_space' => array( 'append_tooltip', '&nbsp;' . $currency_symbol ),
+			'left'        => array( 'prepend_tooltip', $currency_symbol ),
+			'left_space'  => array( 'prepend_tooltip', $currency_symbol . '&nbsp;' ),
+		);
+		$report          = new WC_Admin_Report();
+		$filter          = static function () use ( $currency_symbol ): string {
+			return $currency_symbol;
+		};
+
+		add_filter( 'woocommerce_currency_symbol', $filter );
+		try {
+			foreach ( $positions as $position => $expected ) {
+				update_option( 'woocommerce_currency_pos', $position );
+				$fragment = $report->get_currency_tooltip();
+
+				$this->assertSame( 1, preg_match( '/^(append_tooltip|prepend_tooltip): (.+)$/s', $fragment, $matches ) );
+				$this->assertSame( $expected[0], $matches[1] );
+				$this->assertSame( $expected[1], json_decode( $matches[2], true, 512, JSON_THROW_ON_ERROR ) );
+			}
+		} finally {
+			remove_filter( 'woocommerce_currency_symbol', $filter );
+			if ( null === $currency_pos ) {
+				delete_option( 'woocommerce_currency_pos' );
+			} else {
+				update_option( 'woocommerce_currency_pos', $currency_pos );
+			}
+		}
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -267,4 +267,51 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 		return $data;
 	}
+
+	/**
+	 * @testdox The rendered sales chart preserves filtered currency symbols in valid JavaScript strings.
+	 */
+	public function test_main_chart_encodes_filtered_currency_symbols(): void {
+		$currency_symbol = "'\"\\</script>€雪";
+		$currency_pos    = get_option( 'woocommerce_currency_pos', null );
+		$filter          = static function () use ( $currency_symbol ): string {
+			return $currency_symbol;
+		};
+		$report          = new WC_Report_Sales_By_Date();
+		$report->calculate_current_range( '7day' );
+		$report->get_report_data();
+		$report->chart_colours = array(
+			'sales_amount'     => '#b1d4ea',
+			'net_sales_amount' => '#3498db',
+			'average'          => '#b1d4ea',
+			'net_average'      => '#3498db',
+			'order_count'      => '#dbe1e3',
+			'item_count'       => '#ecf0f1',
+			'shipping_amount'  => '#5cc488',
+			'coupon_amount'    => '#f1c40f',
+			'refund_amount'    => '#e74c3c',
+		);
+
+		update_option( 'woocommerce_currency_pos', 'left' );
+		add_filter( 'woocommerce_currency_symbol', $filter );
+		ob_start();
+		try {
+			$report->get_main_chart();
+			$output = (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+			remove_filter( 'woocommerce_currency_symbol', $filter );
+			if ( null === $currency_pos ) {
+				delete_option( 'woocommerce_currency_pos' );
+			} else {
+				update_option( 'woocommerce_currency_pos', $currency_pos );
+			}
+		}
+
+		$this->assertSame( 1, substr_count( $output, '</script>' ) );
+		$this->assertSame( 5, preg_match_all( '/prepend_tooltip:\s*("(?:\\\\.|[^"\\\\])*")/', $output, $matches ) );
+		foreach ( $matches[1] as $encoded_symbol ) {
+			$this->assertSame( $currency_symbol, json_decode( $encoded_symbol, true, 512, JSON_THROW_ON_ERROR ) );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -381,6 +381,53 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should keep single-page-select attributes inside their rendered contexts.
+	 */
+	public function test_output_fields_escapes_single_select_page_attributes(): void {
+		$css   = "width: 12px;' onfocus='alert(1)";
+		$class = "safe-class' data-pwned='1";
+		$this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$options = array(
+			array(
+				'id'    => 'test_page_setting',
+				'title' => 'Page setting',
+				'type'  => 'single_select_page',
+				'value' => 0,
+				'css'   => $css,
+				'class' => $class,
+			),
+		);
+
+		ob_start();
+		try {
+			WC_Admin_Settings::output_fields( $options );
+			$output = (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+
+		$document       = new DOMDocument();
+		$previous_state = libxml_use_internal_errors( true );
+		$loaded         = $document->loadHTML( '<table>' . $output . '</table>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_state );
+
+		$this->assertTrue( $loaded, 'The setting output should remain valid enough for DOM parsing.' );
+
+		$select = ( new DOMXPath( $document ) )->query( '//select[@id="test_page_setting"]' )->item( 0 );
+		$this->assertInstanceOf( DOMElement::class, $select );
+		$this->assertSame( $css, $select->getAttribute( 'style' ) );
+		$this->assertSame( $class, $select->getAttribute( 'class' ) );
+		$this->assertFalse( $select->hasAttribute( 'onfocus' ) );
+		$this->assertFalse( $select->hasAttribute( 'data-pwned' ) );
+	}
+
+	/**
 	 * @testdox Should not emit a shared "-title" ID for radio settings that have no ID.
 	 */
 	public function test_output_fields_does_not_cross_label_id_less_radio_settings(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Apply context-appropriate encoding to attributes in the legacy single-page settings field and to currency symbols inserted into legacy report JavaScript. This replaces broad legacy PHPCS suppressions with precise handling while preserving the visible settings and report behavior for existing values.

`WC_Admin_Report::get_currency_tooltip()` retains its public signature, `prepend_tooltip`/`append_tooltip` fragment shape, currency-position behavior, spacing, and single `woocommerce_currency_symbol` filter invocation. Public compatibility checks found external consumers that echo or concatenate this fragment; the returned contract remains the same, while edge-case currency symbols are now represented correctly in the JavaScript context. A bounded WP Beacon search covered 26,674 active WordPress.org plugin mirrors and found eight external call sites across six plugins; WP Beacon does not cover themes, so this is supporting evidence rather than an exhaustive consumer inventory.

No queries, writes, caches, collections, hooks, global-state dependencies, order-storage assumptions, or install-path assumptions are changed. The focused tests exercise rendered output rather than implementation details.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not applicable. Valid settings and report values render identically before and after this change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the PHP test environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start`.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter '/(test_output_fields_escapes_single_select_page_attributes|test_get_currency_tooltip_encodes_filtered_symbol|test_main_chart_encodes_filtered_currency_symbols)/'`.
3. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env:hpos-off -- --filter '/(test_output_fields_escapes_single_select_page_attributes|test_get_currency_tooltip_encodes_filtered_symbol|test_main_chart_encodes_filtered_currency_symbols)/'`.
4. Confirm all three tests pass in both runs and that the rendered attribute and report values round-trip unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused PHP behavior suite passed with HPOS enabled: 3 tests, 25 assertions.
- The same focused suite passed with HPOS disabled: 3 tests, 25 assertions.
- Both required changed-file and full-branch lint checks passed.
- PHPStan passed for all three modified production files.
- PHP syntax and `git diff --check` passed.
- Compatibility review covered current Core consumers, public GitHub results, and the bounded WP Beacon plugin corpus described above.
- The rebased branch was reviewed for signature, hook/filter, multisite, global-state, install-layout, performance, and normal-output compatibility; no new compatibility issue was found.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex assisted with the compatibility review, focused testing, current-trunk port, and pull-request preparation.

*\*left by Biff (AI agent) on behalf of Darren*
