### PR TITLE
Fix stale attribute taxonomy state after deletion

### DIFF
--- a/plugins/woocommerce/changelog/fix-38919-unregister-deleted-attribute-taxonomy
+++ b/plugins/woocommerce/changelog/fix-38919-unregister-deleted-attribute-taxonomy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Unregister a global product attribute's runtime taxonomy when the attribute is deleted so its slug can be reused in the same request.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -761,13 +761,10 @@ function wc_delete_attribute( $id ) {
 	do_action( 'woocommerce_before_attribute_delete', $id, $name, $taxonomy );
 
 	if ( $name && $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = %d", $id ) ) ) {
-		$deleted_terms = false;
-
 		if ( taxonomy_exists( $taxonomy ) ) {
 			$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
 			foreach ( $terms as $term ) {
 				wp_delete_term( $term->term_id, $taxonomy );
-				$deleted_terms = true;
 			}
 		}
 
@@ -781,10 +778,10 @@ function wc_delete_attribute( $id ) {
 		do_action( 'woocommerce_attribute_deleted', $id, $name, $taxonomy );
 
 		if ( taxonomy_exists( $taxonomy ) ) {
-			// Deleting terms queues their counts when the caller defers counting, and those
-			// resolve the taxonomy by name later, once it is gone. Flush while it still exists.
-			// WordPress drains its whole queue at once, so only do this when we queued something.
-			if ( $deleted_terms && wp_defer_term_counting() ) {
+			// When the caller defers term counting, any count queued for this taxonomy (by the
+			// deletions above or by the caller itself) resolves the taxonomy by name later, once
+			// it is gone. Flush while it still exists. WordPress drains its whole queue at once.
+			if ( wp_defer_term_counting() ) {
 				wp_update_term_count( array(), '', true );
 			}
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -761,10 +761,13 @@ function wc_delete_attribute( $id ) {
 	do_action( 'woocommerce_before_attribute_delete', $id, $name, $taxonomy );
 
 	if ( $name && $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = %d", $id ) ) ) {
+		$deleted_terms = false;
+
 		if ( taxonomy_exists( $taxonomy ) ) {
 			$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
 			foreach ( $terms as $term ) {
 				wp_delete_term( $term->term_id, $taxonomy );
+				$deleted_terms = true;
 			}
 		}
 
@@ -778,10 +781,10 @@ function wc_delete_attribute( $id ) {
 		do_action( 'woocommerce_attribute_deleted', $id, $name, $taxonomy );
 
 		if ( taxonomy_exists( $taxonomy ) ) {
-			// Deleting the terms above queues term counts when the caller defers counting.
-			// Those resolve the taxonomy by name, so flush them while it still exists.
-			// WordPress keeps one shared queue, so this flushes every pending taxonomy.
-			if ( wp_defer_term_counting() ) {
+			// Deleting terms queues their counts when the caller defers counting, and those
+			// resolve the taxonomy by name later, once it is gone. Flush while it still exists.
+			// WordPress drains its whole queue at once, so only do this when we queued something.
+			if ( $deleted_terms && wp_defer_term_counting() ) {
 				wp_update_term_count( array(), '', true );
 			}
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -736,7 +736,7 @@ function wc_update_attribute( $id, $args ) {
  * @return bool
  */
 function wc_delete_attribute( $id ) {
-	global $wpdb;
+	global $wpdb, $wc_product_attributes;
 
 	$name = $wpdb->get_var(
 		$wpdb->prepare(
@@ -776,6 +776,20 @@ function wc_delete_attribute( $id ) {
 		 * @param string $taxonomy Attribute taxonomy name.
 		 */
 		do_action( 'woocommerce_attribute_deleted', $id, $name, $taxonomy );
+
+		if ( taxonomy_exists( $taxonomy ) ) {
+			// Deleting the terms above queues term counts when the caller defers counting.
+			// Those resolve the taxonomy by name, so flush them while it still exists.
+			// WordPress keeps one shared queue, so this flushes every pending taxonomy.
+			if ( wp_defer_term_counting() ) {
+				wp_update_term_count( array(), '', true );
+			}
+
+			unregister_taxonomy( $taxonomy );
+		}
+
+		unset( $wc_product_attributes[ $taxonomy ] );
+
 		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 		WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -342,64 +342,68 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertIsInt( $product_id, 'The fixture product should be created.' );
 		wp_set_object_terms( $product_id, array( (int) $term['term_id'] ), $attribute['taxonomy'] );
 
+		// Record whether the queued count for this taxonomy resolves while it is still registered.
+		$counted_while_registered = false;
+		$count_callback           = static function ( $tt_id, $taxonomy_name ) use ( $attribute, &$counted_while_registered ): void {
+			if ( $taxonomy_name === $attribute['taxonomy'] && taxonomy_exists( $taxonomy_name ) ) {
+				$counted_while_registered = true;
+			}
+		};
+		add_action( 'edited_term_taxonomy', $count_callback, 10, 2 );
+
 		wp_defer_term_counting( true );
 
 		try {
 			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should be deleted successfully.' );
+			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The deleted attribute taxonomy should be unregistered.' );
+			$this->assertTrue( $counted_while_registered, 'The queued term count should be resolved before the taxonomy is unregistered.' );
 
-			// Flushing the queue must not reach for the now-unregistered taxonomy.
-			wp_defer_term_counting( false );
+			$this->assertSame( array(), $this->drain_deferred_term_counts(), 'Draining the queue must not resolve the unregistered taxonomy.' );
 		} finally {
-			if ( ! taxonomy_exists( $attribute['taxonomy'] ) ) {
-				register_taxonomy( $attribute['taxonomy'], array( 'product' ) );
-			}
-			wp_defer_term_counting( false );
+			remove_action( 'edited_term_taxonomy', $count_callback, 10 );
+			$this->drain_deferred_term_counts();
 			wp_delete_post( $product_id, true );
 			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
 		}
 	}
+
 	/**
-	 * @testdox Should leave an unrelated taxonomy's deferred counts queued when no terms were deleted.
+	 * @testdox Should flush counts the caller already queued for the taxonomy before unregistering it.
 	 */
-	public function test_wc_delete_attribute_without_terms_leaves_other_deferred_counts_queued(): void {
-		$slug      = $this->get_unique_attribute_slug( 'no-terms' );
+	public function test_wc_delete_attribute_flushes_counts_queued_by_the_caller(): void {
+		$slug      = $this->get_unique_attribute_slug( 'caller-queue' );
 		$attribute = $this->create_registered_attribute( $slug );
 
-		$category = wp_insert_term( 'Deferred category ' . $slug, 'product_cat' );
-		$this->assertIsArray( $category, 'The fixture category should be created.' );
+		$term = wp_insert_term( 'Caller deleted term', $attribute['taxonomy'] );
+		$this->assertIsArray( $term, 'The fixture term should be created.' );
 
 		$product_id = wp_insert_post(
 			array(
 				'post_type'   => 'product',
-				'post_title'  => 'Unrelated taxonomy product',
+				'post_title'  => 'Caller queued counting product',
 				'post_status' => 'publish',
 			)
 		);
 		$this->assertIsInt( $product_id, 'The fixture product should be created.' );
+		wp_set_object_terms( $product_id, array( (int) $term['term_id'] ), $attribute['taxonomy'] );
 
 		wp_defer_term_counting( true );
 
 		try {
-			// Queue a count for a taxonomy this deletion has nothing to do with.
-			wp_set_object_terms( $product_id, array( (int) $category['term_id'] ), 'product_cat' );
-			$this->assertSame( 0, $this->get_term_count( (int) $category['term_id'] ), 'The unrelated count should start deferred.' );
+			// The caller removes the term itself, which queues a count for the taxonomy.
+			// The attribute then has no terms left for wc_delete_attribute() to remove.
+			$this->assertTrue( wp_delete_term( (int) $term['term_id'], $attribute['taxonomy'] ), 'The fixture term should be deleted by the caller.' );
 
-			// The attribute has no terms, so nothing of ours is queued and nothing needs flushing.
 			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should be deleted successfully.' );
-			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The deleted attribute taxonomy should still be unregistered.' );
-			$this->assertSame( 0, $this->get_term_count( (int) $category['term_id'] ), 'The unrelated taxonomy should still be deferred.' );
+			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The deleted attribute taxonomy should be unregistered.' );
 
-			wp_defer_term_counting( false );
-			$this->assertSame( 1, $this->get_term_count( (int) $category['term_id'] ), "The caller's own flush should resolve the unrelated count." );
+			$this->assertSame( array(), $this->drain_deferred_term_counts(), 'Draining the queue must not resolve the unregistered taxonomy.' );
 		} finally {
-			wp_defer_term_counting( false );
+			$this->drain_deferred_term_counts();
 			wp_delete_post( $product_id, true );
-			wp_delete_term( (int) $category['term_id'], 'product_cat' );
 			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
 		}
 	}
-
-
 
 	/**
 	 * Describes the behavior of the wc_update_attribute() function.
@@ -570,15 +574,32 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Reads a term's stored count straight from the database, bypassing caches.
+	 * Stops deferring term counts, which drains WordPress's queue, and captures any PHP warnings raised while doing so.
 	 *
-	 * @param int $term_id Term ID.
-	 * @return int
+	 * The queue resolves each taxonomy by name, so a queued taxonomy that was unregistered
+	 * in the meantime surfaces as a warning. Capturing it keeps the assertion independent
+	 * of PHPUnit converting warnings to exceptions.
+	 *
+	 * @return string[] Warning messages raised during the drain.
 	 */
-	private function get_term_count( int $term_id ): int {
-		global $wpdb;
+	private function drain_deferred_term_counts(): array {
+		$warnings = array();
 
-		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT count FROM {$wpdb->term_taxonomy} WHERE term_id = %d", $term_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The test must observe the stored count, not a cached one.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception, and PHPUnit 10 stops doing that.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				$warnings[] = $errstr;
+				return true;
+			}
+		);
+
+		try {
+			wp_defer_term_counting( false );
+		} finally {
+			restore_error_handler();
+		}
+
+		return $warnings;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -358,6 +358,47 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
 		}
 	}
+	/**
+	 * @testdox Should leave an unrelated taxonomy's deferred counts queued when no terms were deleted.
+	 */
+	public function test_wc_delete_attribute_without_terms_leaves_other_deferred_counts_queued(): void {
+		$slug      = $this->get_unique_attribute_slug( 'no-terms' );
+		$attribute = $this->create_registered_attribute( $slug );
+
+		$category = wp_insert_term( 'Deferred category ' . $slug, 'product_cat' );
+		$this->assertIsArray( $category, 'The fixture category should be created.' );
+
+		$product_id = wp_insert_post(
+			array(
+				'post_type'   => 'product',
+				'post_title'  => 'Unrelated taxonomy product',
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertIsInt( $product_id, 'The fixture product should be created.' );
+
+		wp_defer_term_counting( true );
+
+		try {
+			// Queue a count for a taxonomy this deletion has nothing to do with.
+			wp_set_object_terms( $product_id, array( (int) $category['term_id'] ), 'product_cat' );
+			$this->assertSame( 0, $this->get_term_count( (int) $category['term_id'] ), 'The unrelated count should start deferred.' );
+
+			// The attribute has no terms, so nothing of ours is queued and nothing needs flushing.
+			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should be deleted successfully.' );
+			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The deleted attribute taxonomy should still be unregistered.' );
+			$this->assertSame( 0, $this->get_term_count( (int) $category['term_id'] ), 'The unrelated taxonomy should still be deferred.' );
+
+			wp_defer_term_counting( false );
+			$this->assertSame( 1, $this->get_term_count( (int) $category['term_id'] ), "The caller's own flush should resolve the unrelated count." );
+		} finally {
+			wp_defer_term_counting( false );
+			wp_delete_post( $product_id, true );
+			wp_delete_term( (int) $category['term_id'], 'product_cat' );
+			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
+		}
+	}
+
 
 
 	/**
@@ -526,6 +567,18 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			'wp_taxonomy'  => $wp_taxonomy,
 			'wc_attribute' => $wc_attribute,
 		);
+	}
+
+	/**
+	 * Reads a term's stored count straight from the database, bypassing caches.
+	 *
+	 * @param int $term_id Term ID.
+	 * @return int
+	 */
+	private function get_term_count( int $term_id ): int {
+		global $wpdb;
+
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT count FROM {$wpdb->term_taxonomy} WHERE term_id = %d", $term_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The test must observe the stored count, not a cached one.
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -248,6 +248,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			$this->assertSame( $attribute['wc_attribute'], $hook_wc_attribute, 'The deletion hook should observe the original WooCommerce attribute entry.' );
 			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The deleted attribute taxonomy should be unregistered after the deletion hook.' );
 			$this->assertArrayNotHasKey( $attribute['taxonomy'], $wc_product_attributes, 'The deleted WooCommerce attribute entry should be removed after the deletion hook.' );
+			$this->assertFalse( taxonomy_is_product_attribute( $attribute['taxonomy'] ), 'The deleted taxonomy should no longer be reported as a product attribute.' );
 
 			$replacement_attribute_id = wc_create_attribute(
 				array(
@@ -284,6 +285,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should still be deleted after its taxonomy is unregistered by a callback.' );
 			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The pre-unregistered taxonomy should remain absent.' );
 			$this->assertArrayNotHasKey( $attribute['taxonomy'], $wc_product_attributes, 'The original WooCommerce attribute entry should still be removed.' );
+			$this->assertFalse( taxonomy_is_product_attribute( $attribute['taxonomy'] ), 'The deleted taxonomy should no longer be reported as a product attribute.' );
 		} finally {
 			remove_action( 'woocommerce_before_attribute_delete', $unregister_callback, 10 );
 			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
@@ -317,11 +319,13 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			$this->assertFalse( wc_delete_attribute( $attribute['id'] ), 'The outer deletion should fail after the callback removes the database row.' );
 			$this->assertTrue( taxonomy_exists( $attribute['taxonomy'] ), 'A failed deletion should leave the taxonomy registered.' );
 			$this->assertArrayHasKey( $attribute['taxonomy'], $wc_product_attributes, 'A failed deletion should leave the WooCommerce attribute entry in place.' );
+			$this->assertTrue( taxonomy_is_product_attribute( $attribute['taxonomy'] ), 'A failed deletion should leave the taxonomy reported as a product attribute.' );
 		} finally {
 			remove_action( 'woocommerce_before_attribute_delete', $before_delete_callback, 10 );
 			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
 		}
 	}
+
 	/**
 	 * @testdox Should flush deferred term counts before unregistering the taxonomy.
 	 */

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -225,6 +225,142 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should unregister a deleted attribute after its deletion hook and allow recreating the slug.
+	 */
+	public function test_wc_delete_attribute_unregisters_runtime_entries_and_allows_recreation(): void {
+		global $wc_product_attributes;
+
+		$slug                     = $this->get_unique_attribute_slug( 'normal' );
+		$attribute                = $this->create_registered_attribute( $slug );
+		$replacement_attribute_id = null;
+		$hook_taxonomy            = null;
+		$hook_wc_attribute        = null;
+		$deleted_callback         = static function ( $id, $name, $taxonomy ) use ( &$hook_taxonomy, &$hook_wc_attribute, &$wc_product_attributes ): void {
+			$hook_taxonomy     = get_taxonomy( $taxonomy );
+			$hook_wc_attribute = $wc_product_attributes[ $taxonomy ] ?? null;
+		};
+
+		add_action( 'woocommerce_attribute_deleted', $deleted_callback, 10, 3 );
+
+		try {
+			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should be deleted successfully.' );
+			$this->assertSame( $attribute['wp_taxonomy'], $hook_taxonomy, 'The deletion hook should observe the original WordPress taxonomy.' );
+			$this->assertSame( $attribute['wc_attribute'], $hook_wc_attribute, 'The deletion hook should observe the original WooCommerce attribute entry.' );
+			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The deleted attribute taxonomy should be unregistered after the deletion hook.' );
+			$this->assertArrayNotHasKey( $attribute['taxonomy'], $wc_product_attributes, 'The deleted WooCommerce attribute entry should be removed after the deletion hook.' );
+
+			$replacement_attribute_id = wc_create_attribute(
+				array(
+					'name' => 'Recreated attribute',
+					'slug' => $slug,
+				)
+			);
+
+			$this->assertIsInt( $replacement_attribute_id, 'The deleted attribute slug should be reusable in the same request.' );
+		} finally {
+			remove_action( 'woocommerce_attribute_deleted', $deleted_callback, 10 );
+			$this->clean_up_attribute_test_state(
+				array( $attribute['id'], $replacement_attribute_id ),
+				$attribute['taxonomy']
+			);
+		}
+	}
+
+	/**
+	 * @testdox Should tolerate a deletion callback unregistering the original taxonomy first.
+	 */
+	public function test_wc_delete_attribute_is_idempotent_when_taxonomy_is_pre_unregistered(): void {
+		global $wc_product_attributes;
+
+		$slug                = $this->get_unique_attribute_slug( 'pre-unreg' );
+		$attribute           = $this->create_registered_attribute( $slug );
+		$unregister_callback = static function ( $id, $name, $taxonomy ): void {
+			unregister_taxonomy( $taxonomy );
+		};
+
+		add_action( 'woocommerce_before_attribute_delete', $unregister_callback, 10, 3 );
+
+		try {
+			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should still be deleted after its taxonomy is unregistered by a callback.' );
+			$this->assertFalse( taxonomy_exists( $attribute['taxonomy'] ), 'The pre-unregistered taxonomy should remain absent.' );
+			$this->assertArrayNotHasKey( $attribute['taxonomy'], $wc_product_attributes, 'The original WooCommerce attribute entry should still be removed.' );
+		} finally {
+			remove_action( 'woocommerce_before_attribute_delete', $unregister_callback, 10 );
+			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
+		}
+	}
+
+	/**
+	 * @testdox Should leave the attribute taxonomy registered when the database deletion fails.
+	 */
+	public function test_wc_delete_attribute_failed_delete_leaves_taxonomy_registered(): void {
+		global $wpdb, $wc_product_attributes;
+
+		$slug                   = $this->get_unique_attribute_slug( 'failure' );
+		$attribute              = $this->create_registered_attribute( $slug );
+		$before_delete_callback = static function ( $id ) use ( $attribute, $wpdb ): void {
+			if ( $attribute['id'] !== $id ) {
+				return;
+			}
+
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = %d",
+					$id
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The test needs the outer deletion query to affect no rows.
+		};
+
+		add_action( 'woocommerce_before_attribute_delete', $before_delete_callback, 10, 3 );
+
+		try {
+			$this->assertFalse( wc_delete_attribute( $attribute['id'] ), 'The outer deletion should fail after the callback removes the database row.' );
+			$this->assertTrue( taxonomy_exists( $attribute['taxonomy'] ), 'A failed deletion should leave the taxonomy registered.' );
+			$this->assertArrayHasKey( $attribute['taxonomy'], $wc_product_attributes, 'A failed deletion should leave the WooCommerce attribute entry in place.' );
+		} finally {
+			remove_action( 'woocommerce_before_attribute_delete', $before_delete_callback, 10 );
+			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
+		}
+	}
+	/**
+	 * @testdox Should flush deferred term counts before unregistering the taxonomy.
+	 */
+	public function test_wc_delete_attribute_flushes_deferred_term_counts(): void {
+		$slug      = $this->get_unique_attribute_slug( 'deferred' );
+		$attribute = $this->create_registered_attribute( $slug );
+
+		$term = wp_insert_term( 'Deferred term', $attribute['taxonomy'] );
+		$this->assertIsArray( $term, 'The fixture term should be created.' );
+
+		$product_id = wp_insert_post(
+			array(
+				'post_type'   => 'product',
+				'post_title'  => 'Deferred counting product',
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertIsInt( $product_id, 'The fixture product should be created.' );
+		wp_set_object_terms( $product_id, array( (int) $term['term_id'] ), $attribute['taxonomy'] );
+
+		wp_defer_term_counting( true );
+
+		try {
+			$this->assertTrue( wc_delete_attribute( $attribute['id'] ), 'The attribute should be deleted successfully.' );
+
+			// Flushing the queue must not reach for the now-unregistered taxonomy.
+			wp_defer_term_counting( false );
+		} finally {
+			if ( ! taxonomy_exists( $attribute['taxonomy'] ) ) {
+				register_taxonomy( $attribute['taxonomy'], array( 'product' ) );
+			}
+			wp_defer_term_counting( false );
+			wp_delete_post( $product_id, true );
+			$this->clean_up_attribute_test_state( array( $attribute['id'] ), $attribute['taxonomy'] );
+		}
+	}
+
+
+	/**
 	 * Describes the behavior of the wc_update_attribute() function.
 	 *
 	 * @return void
@@ -357,5 +493,70 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			array( 'pa_SubStr', 'substr' ),
 			array( 'ĂnîC°Dę', 'anicde' ),
 		);
+	}
+
+	/**
+	 * Creates a uniquely named attribute with entries in both runtime registries.
+	 *
+	 * @param string $slug Attribute slug.
+	 * @return array{id: int, taxonomy: string, wp_taxonomy: WP_Taxonomy, wc_attribute: object}
+	 */
+	private function create_registered_attribute( string $slug ): array {
+		global $wc_product_attributes;
+
+		$attribute_id = wc_create_attribute(
+			array(
+				'name' => 'Runtime attribute',
+				'slug' => $slug,
+			)
+		);
+		$this->assertIsInt( $attribute_id, 'The runtime attribute fixture should be created.' );
+
+		$taxonomy = wc_attribute_taxonomy_name( $slug );
+		register_taxonomy( $taxonomy, array( 'product' ) );
+		$wp_taxonomy = get_taxonomy( $taxonomy );
+		$this->assertInstanceOf( WP_Taxonomy::class, $wp_taxonomy, 'The runtime attribute fixture should have a registered taxonomy.' );
+
+		$wc_attribute                       = (object) array( 'attribute_id' => $attribute_id );
+		$wc_product_attributes[ $taxonomy ] = $wc_attribute;
+
+		return array(
+			'id'           => $attribute_id,
+			'taxonomy'     => $taxonomy,
+			'wp_taxonomy'  => $wp_taxonomy,
+			'wc_attribute' => $wc_attribute,
+		);
+	}
+
+	/**
+	 * Returns a unique attribute slug within WordPress's taxonomy byte limit.
+	 *
+	 * @param string $context Slug context.
+	 * @return string
+	 */
+	private function get_unique_attribute_slug( string $context ): string {
+		return 'runtime-' . $context . '-' . strtolower( wp_generate_password( 5, false, false ) );
+	}
+
+	/**
+	 * Removes database and runtime state created by an attribute deletion test.
+	 *
+	 * @param array<int|null> $attribute_ids Attribute IDs to remove.
+	 * @param string          $taxonomy      Attribute taxonomy name.
+	 * @return void
+	 */
+	private function clean_up_attribute_test_state( array $attribute_ids, string $taxonomy ): void {
+		global $wc_product_attributes;
+
+		if ( taxonomy_exists( $taxonomy ) ) {
+			unregister_taxonomy( $taxonomy );
+		}
+		unset( $wc_product_attributes[ $taxonomy ] );
+
+		foreach ( $attribute_ids as $attribute_id ) {
+			if ( is_int( $attribute_id ) ) {
+				wc_delete_attribute( $attribute_id );
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

#### Why

`wc_create_attribute()` decides whether a global attribute slug is free by asking `taxonomy_exists()`. But `wc_delete_attribute()` only removes the database row, the terms, and the caches — it leaves the taxonomy registered in `$wp_taxonomies` and the entry sitting in `$wc_product_attributes`.

For the rest of that request, both registries still describe an attribute that no longer exists, so recreating the same slug fails with `invalid_product_attribute_slug_already_exists`. The next request is fine, because `init` rebuilds both registries from the database.

That narrow same-request window is what makes the bug easy to miss and annoying to hit:

- Import and sync routines that reset a global attribute — the case reported in #38919
- WP-CLI commands that delete and recreate attributes in a single run
- WooCommerce's own PHPUnit suite, which runs in one process, where several tests already hand-roll this cleanup after calling `wc_delete_attribute()`

#### How

Once the deletion succeeds, unregister the taxonomy and drop the runtime entry:

```php
if ( taxonomy_exists( $taxonomy ) ) {
	if ( wp_defer_term_counting() ) {
		wp_update_term_count( array(), '', true );
	}

	unregister_taxonomy( $taxonomy );
}

unset( $wc_product_attributes[ $taxonomy ] );
```

Three details worth calling out:

**Both registries are cleared.** `taxonomy_is_product_attribute()` reads both, so clearing only one would leave it answering inconsistently.

**Deferred term counts are flushed first.** Deleting the terms queues count updates whenever the caller has `wp_defer_term_counting( true )` active — WooCommerce's own products REST batch endpoint does this, and so do bulk importers. Those counts resolve the taxonomy by name when the queue is later flushed, so they have to be drained while it still exists. WordPress keeps a single shared queue with no per-taxonomy drain, so the flush necessarily covers every pending taxonomy, and it runs whenever counting is deferred rather than only when this call deleted terms: the caller may already have queued counts for this taxonomy by deleting or detaching its terms earlier in the same window. An extra drain is bounded recompute work that leaves the persisted counts identical, since `wp_update_term_count_now()` recomputes from the database and later changes are re-queued; a missed drain is a live PHP warning. The caller's deferral flag is never touched.

**Cleanup runs after `woocommerce_attribute_deleted`, and only on success.** Existing callbacks still observe the same pre-cleanup state they always have, and a failed deletion leaves both registries untouched.

One boundary worth stating: this makes the deleted slug *eligible* for reuse in the same request, not the recreated attribute *usable* in it. `wc_create_attribute()` never registers the taxonomy, so terms can only be inserted against the recreated attribute once the next request's `init` registers it, or after the caller registers it itself the way the CSV importer does.

#### Compatibility

- Hook names, arguments, and firing order are unchanged.
- A successful deletion now also fires WordPress' standard `unregistered_taxonomy` action, as a consequence of calling `unregister_taxonomy()`.
- No schema, stored-data, URL, path, session, or admin-context dependency.
- **Direct callers:** once `wc_delete_attribute()` returns `true`, the deleted attribute's taxonomy is gone for the rest of that request, as it already was on every later request. `taxonomy_exists()` and `taxonomy_is_product_attribute()` return `false`, and `get_terms()` for it returns a `WP_Error` (`invalid_taxonomy`) instead of an empty array. Product objects loaded before the call keep the attribute, but its `WC_Product_Attribute::get_terms()` and `get_taxonomy_object()` now return `null`. Code that needs the old taxonomy should read it before the call, or in `woocommerce_attribute_deleted`, which still fires first. Variation summaries for up to 50 affected variations are rebuilt at `shutdown`, after the cleanup, so they now store `pa_<slug>: <term-slug>`. That is what the Action Scheduler path already stored for larger catalogs, so the "No stored-data dependency" bullet above needs this one exception.
- On multisite, both registries are per-process and `switch_to_blog()` does not rebuild them. A network-wide routine that deletes an attribute on a switched site therefore also unregisters the current site's `pa_*` taxonomy of the same slug for the rest of that request, where before nothing was unregistered mid-request. Such routines should re-register after switching back. This was not exercised on a multisite runtime.
- Not addressed here: `WC_Product_Attribute::get_taxonomy_object()` reads `$wc_product_attributes` without a guard, and the REST v2 products controller, `wc_display_product_attributes()`, and the Product Specifications block dereference its result without a null check. That gap is pre-existing, since the CSV importer already rebuilds the global mid-request, but this change makes a same-request read of a just-deleted attribute more likely to hit it. It is left as a follow-up to keep this PR's scope tight.

Closes #38919.

### Screenshots or screen recordings:

Not applicable — this is request-local registry cleanup with no UI surface.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Both manual scenarios need **two separate requests**: `wc_create_attribute()` writes the database row but does not register the taxonomy, so the stale state only appears once `init` has registered it from the database.

#### Automated

```bash
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Attribute_Functions_Test
```

Expect 15 passing tests. To see the failures this PR fixes, remove the `if ( taxonomy_exists( ... ) ) { ... }` block and the `unset()` beneath it from `wc_delete_attribute()` and re-run — four tests fail.

#### Scenario 1: delete and recreate the same slug in one request

1. Create the attribute:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '
   var_dump( wc_create_attribute( array( "name" => "WC 38919 manual", "slug" => "wc-38919-manual" ) ) );'
   ```

2. In a **fresh** request, delete it and immediately recreate the same slug:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '
   $slug = "wc-38919-manual";
   $tax  = wc_attribute_taxonomy_name( $slug );
   var_dump( taxonomy_exists( $tax ) );                                  // true  — registered on init
   var_dump( wc_delete_attribute( wc_attribute_taxonomy_id_by_name( $slug ) ) );  // true
   var_dump( taxonomy_exists( $tax ) );                                  // false — this PR
   $new = wc_create_attribute( array( "name" => "WC 38919 recreated", "slug" => $slug ) );
   var_dump( $new );                                                     // int   — this PR
   if ( is_int( $new ) ) { wc_delete_attribute( $new ); }'
   ```

   On `trunk`, the third `var_dump()` prints `true` and the fourth returns a `WP_Error` with code `invalid_product_attribute_slug_already_exists`.

#### Scenario 2: deleting inside a deferred term-counting window

1. Create the attribute:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '
   var_dump( wc_create_attribute( array( "name" => "WC 38919 defer", "slug" => "wc-38919-defer" ) ) );'
   ```

2. In a **fresh** request, attach a term to a product, delete the attribute with counting deferred, then flush:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '
   $slug = "wc-38919-defer";
   $tax  = wc_attribute_taxonomy_name( $slug );
   $term = wp_insert_term( "Deferred", $tax );
   $post = wp_insert_post( array( "post_type" => "product", "post_title" => "38919 defer", "post_status" => "publish" ) );
   wp_set_object_terms( $post, array( (int) $term["term_id"] ), $tax );
   wp_defer_term_counting( true );
   wc_delete_attribute( wc_attribute_taxonomy_id_by_name( $slug ) );
   wp_defer_term_counting( false );
   echo "flushed cleanly\n";
   wp_delete_post( $post, true );'
   ```

   Expect `flushed cleanly` with no PHP notice. Without the flush, the queued counts resolve a taxonomy that no longer exists and WordPress warns `Attempt to read property "object_type" on bool` from `_update_post_term_count()`.

#### Cleanup

If either scenario is interrupted before its own cleanup runs:

```bash
pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '
foreach ( array( "wc-38919-manual", "wc-38919-defer" ) as $slug ) {
    $id = wc_attribute_taxonomy_id_by_name( $slug );
    if ( $id ) { wc_delete_attribute( $id ); }
}'
```

<!-- End testing instructions -->

### Testing that has already taken place:

**Automated** — PHP 8.1.34 / PHPUnit 9.6.35, wp-env:

- `WC_Attribute_Functions_Test`: 15 tests, 91 assertions, passing.
- Broader `--filter Attribute` sweep: 491 tests, 1343 assertions. One failure (`OrderItemSchemaTest::test_get_item_response_any_variation_with_mixed_attributes`) and one skip (`FilterDataTest::test_get_attribute_counts_with_query_type_and`, known — see #44825). Both reproduce identically on `trunk` with this PR's change reverted, so neither is caused by it.
- Negative check: reverting the cleanup block fails exactly the two tests that assert the fixed behavior, confirming they pin it rather than passing incidentally.

**Static analysis** — PHPStan (production file) and `lint:changes:branch` both clean, with no baseline entries added.

**Review** — the deferred term-counting interaction was found by an independent review pass and confirmed by reproducing the PHP warning in the test suite before fixing it. A later pass showed that gating the flush on whether this call had deleted terms reintroduced that warning for callers that queue counts for the taxonomy themselves; the gate was removed and the scenario is now a regression test. Removing the flush fails both deferred-counting tests on their own named assertions.

**Not covered** — no multisite runtime was exercised.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually in this branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

Claude Code and OpenAI Codex were both used on this pull request: to investigate the root cause, write the implementation and tests, run an independent multi-round review that surfaced the deferred term-counting interaction, and draft this description. The author reviewed the resulting code and evidence and remains responsible for the contribution.




