### PR TITLE
Fix keyboard support in the add tax modal

### DIFF
--- a/plugins/woocommerce/changelog/fix-tax-modal-accessibility
+++ b/plugins/woocommerce/changelog/fix-tax-modal-accessibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve keyboard support in the Add tax modal on the admin order screen, including page navigation and keeping the selected tax visible when moving through results.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1379,7 +1379,28 @@ jQuery( function ( $ ) {
 					wc_meta_boxes_order_items.backbone.update_tax_rate_add_button( modal );
 				} );
 
+				results.on( 'keydown', 'input[type="radio"][name="add_order_tax"]', function( event ) {
+					wc_meta_boxes_order_items.backbone.handle_tax_rate_result_tab_navigation( modal, event );
+				} );
+
 				load_tax_rates( 1 );
+			},
+
+			handle_tax_rate_result_tab_navigation: function( modal, event ) {
+				if ( 9 !== event.which || event.altKey || event.ctrlKey || event.metaKey ) {
+					return;
+				}
+
+				var radios = modal[ 0 ].querySelectorAll( 'input[type="radio"][name="add_order_tax"]' ),
+					current_index = Array.prototype.indexOf.call( radios, event.target ),
+					next_index = current_index + ( event.shiftKey ? -1 : 1 );
+
+				if ( -1 === current_index || next_index < 0 || next_index >= radios.length ) {
+					return;
+				}
+
+				event.preventDefault();
+				radios[ next_index ].focus();
 			},
 
 			search_tax_rates: function( modal, page, is_search ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1376,6 +1376,7 @@ jQuery( function ( $ ) {
 
 				// Rows are re-rendered on every search, so delegate from the results table.
 				results.on( 'change', 'input[type="radio"][name="add_order_tax"]', function() {
+					modal.data( 'wc-selected-tax-rate-id', $( this ).val() );
 					wc_meta_boxes_order_items.backbone.update_tax_rate_add_button( modal );
 				} );
 
@@ -1417,8 +1418,8 @@ jQuery( function ( $ ) {
 				modal.data( 'wc-tax-rate-request-id', request_id );
 				table_body.css( 'height', table_body.height() );
 
-				// Replacing the rows drops any selected rate, so re-evaluate the Add button
-				// before the request starts rather than leaving it enabled with no selection.
+				// Replacing the rows drops any visible selection, so re-evaluate the Add button
+				// before the request starts rather than leaving it enabled with no checked input.
 				table_body.html( wc_meta_boxes_order_items.backbone.tax_rate_status_row( status ) );
 				wc_meta_boxes_order_items.backbone.update_tax_rate_add_button( modal );
 				pagination.find( '.button, .current-page' ).prop( 'disabled', true );
@@ -1515,13 +1516,13 @@ jQuery( function ( $ ) {
 						.replace( '%1$s', rate.tax_class || '' )
 						.replace( '%2$s', rate.rate_code || '' )
 						.replace( '%3$s', rate.rate_percent || '' ),
-					radio          = $( '<input />', {
-						type:               'radio',
-						id:                 input_id,
-						name:               'add_order_tax',
-						value:              rate.id,
-						'aria-describedby': description_id
-					} );
+						radio          = $( '<input />', {
+							type:               'radio',
+							id:                 input_id,
+							name:               'add_order_tax',
+							value:              rate.id,
+							'aria-describedby': description_id
+						} );
 
 				return $( '<tr></tr>' ).append(
 					$( '<td></td>' ).append(
@@ -1536,6 +1537,22 @@ jQuery( function ( $ ) {
 					$( '<td></td>' ).text( rate.rate_code ),
 					$( '<td></td>' ).text( rate.rate_percent )
 				);
+			},
+
+			restore_selected_tax_rate: function( modal ) {
+				var selected_rate_id = modal.data( 'wc-selected-tax-rate-id' ),
+					selected_input;
+
+				if ( ! selected_rate_id ) {
+					return;
+				}
+
+				selected_input = modal.find( 'input[name="add_order_tax"][value="' + selected_rate_id + '"]' );
+
+				if ( selected_input.length ) {
+					selected_input.prop( 'checked', true );
+					wc_meta_boxes_order_items.backbone.update_tax_rate_add_button( modal );
+				}
 			},
 
 			update_tax_rate_search_summary: function( modal, search_term ) {
@@ -1599,6 +1616,7 @@ jQuery( function ( $ ) {
 					$.each( results, function( index, rate ) {
 						table_body.append( wc_meta_boxes_order_items.backbone.tax_rate_result_row( rate ) );
 					} );
+					wc_meta_boxes_order_items.backbone.restore_selected_tax_rate( modal );
 					announcement = meta.displaying_num || '';
 				}
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1314,6 +1314,14 @@ jQuery( function ( $ ) {
 					pagination = modal.find( '[data-wc-tax-rate-pagination]' ),
 					load_tax_rates;
 
+				modal.data( 'wc-existing-tax-rate-ids', $( '.order-tax-id' ).map( function() {
+					return String( $( this ).val() );
+				} ).get() );
+
+				if ( ! modal.data( 'wc-selected-tax-rate-id' ) ) {
+					modal.data( 'wc-selected-tax-rate-id', modal.data( 'wc-existing-tax-rate-ids' )[ 0 ] || '' );
+				}
+
 				// The modal template is filterable, so only wire the controls up when the
 				// elements this code depends on are actually present.
 				if ( ! form.length || ! search.length || ! results.length || ! pagination.length ) {
@@ -1480,9 +1488,12 @@ jQuery( function ( $ ) {
 			},
 
 			update_tax_rate_add_button: function( modal ) {
+				var checked_rate_id = modal.find( 'input[name="add_order_tax"]:checked' ).val(),
+					existing_tax_rate_ids = modal.data( 'wc-existing-tax-rate-ids' ) || [];
+
 				modal.find( '#btn-ok' ).prop(
 					'disabled',
-					! modal.find( 'input[name="add_order_tax"]:checked' ).length
+					! checked_rate_id || -1 !== $.inArray( String( checked_rate_id ), existing_tax_rate_ids )
 				);
 			},
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1346,6 +1346,16 @@ jQuery( function ( $ ) {
 					load_tax_rates( 1 );
 				} );
 
+				pagination.on( 'keydown', '.first-page, .prev-page, .next-page, .last-page', function( event ) {
+					if ( 13 !== event.which ) {
+						return;
+					}
+
+					event.preventDefault();
+					event.stopPropagation();
+					$( this ).trigger( 'click' );
+				} );
+
 				pagination.on( 'click', '.prev-page', function() {
 					var current_page = parseInt( pagination.data( 'page' ), 10 ) || 1;
 					load_tax_rates( Math.max( 1, current_page - 1 ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes some accessibility issues which were introduced in https://github.com/woocommerce/woocommerce/pull/66039

- Retaining the selected tax rate when closing/reopening the modal
- Retaining the selected tax rate when navigating pages
- Enables users to tab through each option instead of skipping from selected option straight to next page button
- Enter of next page now triggers next page instead of submitting the form and closing the modal

Closes [WOOAIRR-183](https://linear.app/a8c/issue/WOOAIRR-183/ai-regression-reviewtrunk-pressing-enter-on-the-new-tax-modal)

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not included. This changes keyboard behavior in an existing modal.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open an order in wp-admin and click **Add tax**.
2. Use the keyboard only: tab through the tax options, move between result pages, and press Enter on the page buttons.
3. Confirm the modal does not submit when paging, the selected tax is kept when you leave and return to a page, and an already applied tax is pre-selected when the modal opens.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
Code review only. I did not run the browser flow locally.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Used OpenCode to help draft and implement the change. I reviewed the final result before opening this PR.