### PR TITLE
[Email Editor] Restore Personalization Tags on the Button block

### DIFF
--- a/packages/js/email-editor/changelog/fix-button-block-personalization-tags-toolbar
+++ b/packages/js/email-editor/changelog/fix-button-block-personalization-tags-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the Personalization Tags toolbar button on the Button block by registering the shortcode format as non-interactive

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -214,7 +214,10 @@ function extendRichTextFormats() {
 		className: 'woocommerce-email-editor-personalization-tags',
 		tagName: 'span',
 		attributes: {},
-		interactive: true,
+		// Must stay non-interactive: blocks using `withoutInteractiveFormatting`
+		// (e.g. the Button block) drop interactive formats entirely, which would
+		// hide the Personalization Tags toolbar button there.
+		interactive: false,
 		edit: PersonalizationTagsButton,
 	} );
 

--- a/packages/js/email-editor/src/blocks/core/test/rich-text.spec.tsx
+++ b/packages/js/email-editor/src/blocks/core/test/rich-text.spec.tsx
@@ -1,0 +1,82 @@
+import '../../../components/test/__mocks__/setup-shared-mocks';
+
+/**
+ * External dependencies
+ */
+import { registerFormatType } from '@wordpress/rich-text';
+
+/**
+ * Internal dependencies
+ */
+import { extendRichTextFormats } from '../rich-text';
+
+jest.mock( '@wordpress/rich-text', () => ( {
+	registerFormatType: jest.fn(),
+	unregisterFormatType: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	ToolbarButton: () => null,
+	ToolbarGroup: () => null,
+} ) );
+
+jest.mock( '../../../store', () => ( {
+	storeName: 'email-editor',
+} ) );
+
+jest.mock( '../../../events', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock(
+	'../../../components/personalization-tags/personalization-tags-modal',
+	() => ( {
+		PersonalizationTagsModal: () => null,
+	} )
+);
+
+jest.mock(
+	'../../../components/personalization-tags/personalization-tags-popover',
+	() => ( {
+		PersonalizationTagsPopover: () => null,
+	} )
+);
+
+jest.mock(
+	'../../../components/personalization-tags/personalization-tags-link-popover',
+	() => ( {
+		PersonalizationTagsLinkPopover: () => null,
+	} )
+);
+
+const registerFormatTypeMock = registerFormatType as jest.Mock;
+
+describe( 'extendRichTextFormats', () => {
+	beforeEach( () => {
+		registerFormatTypeMock.mockClear();
+		extendRichTextFormats();
+	} );
+
+	it( 'registers the personalization tags format as non-interactive', () => {
+		// Blocks using `withoutInteractiveFormatting` (e.g. the Button block)
+		// drop interactive formats entirely, which would hide the
+		// Personalization Tags toolbar button there.
+		expect( registerFormatTypeMock ).toHaveBeenCalledWith(
+			'woocommerce-email-editor/shortcode',
+			expect.objectContaining( {
+				interactive: false,
+				edit: expect.any( Function ),
+			} )
+		);
+	} );
+
+	it( 'registers the link format as interactive', () => {
+		// The link format renders a real `a` element and is applied
+		// programmatically via `applyFormat`, so unlike the shortcode format it
+		// has no toolbar `edit` component that the interactive flag could hide.
+		expect( registerFormatTypeMock ).toHaveBeenCalledWith(
+			'woocommerce-email-editor/link-shortcode',
+			expect.objectContaining( { interactive: true, edit: null } )
+		);
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e/tests/email-editor/email-editor-loads.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email-editor/email-editor-loads.spec.ts
@@ -3,7 +3,10 @@
  */
 import { expect, test } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
-import { disableEmailEditor } from './helpers/enable-email-editor-feature';
+import {
+	disableEmailEditor,
+	enableEmailEditor,
+} from './helpers/enable-email-editor-feature';
 import { accessTheEmailEditor } from '../../utils/email';
 
 test.describe( 'WooCommerce Email Editor Core', () => {
@@ -76,7 +79,7 @@ test.describe( 'WooCommerce Email Editor Core', () => {
 		// eslint-disable-next-line playwright/no-wait-for-selector -- wait for the tab to be loaded.
 		await newPage.waitForSelector( '.wp-block-heading' );
 		await page.close(); // close the original tab.
-		await expect( newPage.url() ).toContain( 'preview=true' );
+		expect( newPage.url() ).toContain( 'preview=true' );
 		await expect( newPage.locator( 'body' ) ).toContainText(
 			'New order: #12345'
 		);
@@ -145,5 +148,71 @@ test.describe( 'WooCommerce Email Editor Core', () => {
 		await expect( page1.locator( 'body' ) ).toContainText(
 			'Hello world from Woo plugin'
 		);
+	} );
+
+	test( 'Can use personalization tags in the Button block', async ( {
+		page,
+		baseURL,
+	} ) => {
+		// Enable via API so the test does not depend on the enable test having
+		// run in the same worker (a worker restart runs afterAll, which
+		// disables the feature).
+		await enableEmailEditor( baseURL );
+		await accessTheEmailEditor( page, 'New order' );
+		const canvas = page
+			.locator( 'iframe[name="editor-canvas"]' )
+			.contentFrame();
+
+		// Set the insertion point inside the email content. The heading is not
+		// touched by the other tests in this suite, unlike the first paragraph.
+		await canvas.getByLabel( 'Block: Heading' ).click();
+
+		// Insert a Button block.
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Buttons' );
+		await page
+			.getByRole( 'option', { name: 'Buttons', exact: true } )
+			.click();
+
+		// Focus the button text. The Personalization Tags toolbar button must be
+		// available there — the button text field uses
+		// `withoutInteractiveFormatting`, which hides the button when the
+		// personalization tags format is registered as interactive.
+		await canvas
+			.getByRole( 'document', { name: 'Block: Button', exact: true } )
+			.click();
+		const personalizationTagsButton = page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Personalization Tags' } );
+		await expect( personalizationTagsButton ).toBeVisible();
+
+		// Set a URL personalization tag as the button link.
+		await personalizationTagsButton.click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Personalization Tags' } )
+		).toBeVisible();
+		await page
+			.locator(
+				'.woocommerce-personalization-tags-modal-category-group-item'
+			)
+			.filter( { hasText: 'Payment URL' } )
+			.getByRole( 'button', { name: 'Set as URL' } )
+			.click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Personalization Tags' } )
+		).toBeHidden();
+
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlock()?.attributes?.url
+				)
+			)
+			.toBe( '[woocommerce/order-payment-url]' );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Personalization Tags toolbar button disappeared from the Button block, so the tags modal and its "Set as URL" action became unreachable there. 

PR #60741 registered the `woocommerce-email-editor/shortcode` format with `interactive: true` as part of a type cleanup, and the Button block's text field uses `withoutInteractiveFormatting`, which drops interactive formats together with their toolbar UI. The format only renders a plain `span` placeholder, so this PR registers it as non-interactive again, restoring the toolbar button, the modal, and "Set as URL" on the Button block.

Closes #67735.

(For Bug Fixes) Bug introduced in PR #60741.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="624" height="661" alt="Screenshot 2026-09-01 at 13 31 16" src="https://github.com/user-attachments/assets/780c4ec3-86d2-4741-9895-621d3527d974" /> | <img width="693" height="719" alt="Screenshot 2026-09-01 at 13 24 46" src="https://github.com/user-attachments/assets/bcda5675-6e50-4031-8b7d-45c7a05eeabc" /> <img width="823" height="1027" alt="Screenshot 2026-09-01 at 13 25 35" src="https://github.com/user-attachments/assets/3314091c-5e31-4717-9d96-ea786e392d62" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block email editor: WooCommerce → Settings → Advanced → Features → **Block Email Editor**.
2. Go to WooCommerce → Settings → Emails, open any email via **Actions → Edit**.
3. Insert a **Button** block and place the cursor in the button text.
4. Confirm the **Personalization Tags** button (`[/]` icon) appears in the block toolbar.
5. Open the modal and confirm **Insert** adds a tag as button text.
6. On a URL tag (e.g. Payment URL under Order), confirm **Set as URL** sets the button link to the tag (the link popover shows `[woocommerce/order-payment-url]`).
7. Confirm the toolbar button still works in Paragraph, Heading, and List blocks.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally on wp-env (WordPress with WooCommerce trunk): inserted a Button block into the "Order failed" email, confirmed the Personalization Tags toolbar button renders, "Insert" adds a tag as button text, and "Set as URL" sets the button `url` attribute to `[woocommerce/order-payment-url]`. Added a jest spec guarding the format registration flags; ran the `@woocommerce/email-editor` jest suite for the new spec, eslint, and prettier.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

Developed with Claude Code (investigation, fix, tests, and local verification); reviewed and validated by the author.