### PR TITLE
Do not rely on `FeaturesUtil` for analytics check in `Features::is_enabled()`

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -332,7 +332,7 @@ class Features {
 
 		if (
 			in_array( 'analytics', $features, true ) &&
-			! FeaturesUtil::feature_is_enabled( 'analytics' )
+			! self::is_analytics_enabled()
 		) {
 			$unavailable_features[] = 'analytics';
 		}
@@ -489,7 +489,7 @@ class Features {
 		$compatibility_values = array_merge(
 			array_fill_keys( array_keys( self::$retired_feature_compatibility_versions ), true ),
 			array(
-				'analytics'                  => FeaturesUtil::feature_is_enabled( 'analytics' ),
+				'analytics'                  => self::is_analytics_enabled(),
 				'remote-inbox-notifications' => 'yes' === get_option( RemoteInboxNotifications::TOGGLE_OPTION_NAME, 'yes' ),
 			)
 		);
@@ -547,6 +547,20 @@ class Features {
 		}
 
 		return ! in_array( 'analytics', self::get_features_with_legacy_compatibility_defaults(), true );
+	}
+
+	/**
+	 * Checks if analytics is enabled, without building the (translated) feature definitions.
+	 *
+	 * Mirrors FeaturesController::feature_is_enabled( 'analytics' ), since going through
+	 * FeaturesUtil/FeaturesController here can trigger a too-early textdomain load for
+	 * callers that check this before init.
+	 *
+	 * @return bool
+	 */
+	private static function is_analytics_enabled() {
+		return ! self::is_analytics_disabled_by_legacy_filters()
+			&& 'yes' === get_option( Analytics::TOGGLE_OPTION_NAME, 'yes' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -550,11 +550,7 @@ class Features {
 	}
 
 	/**
-	 * Checks if analytics is enabled, without building the (translated) feature definitions.
-	 *
-	 * Mirrors FeaturesController::feature_is_enabled( 'analytics' ), since going through
-	 * FeaturesUtil/FeaturesController here can trigger a too-early textdomain load for
-	 * callers that check this before init.
+	 * Checks if analytics is enabled, without going through FeaturesController.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`Features::is_enabled()` and `Features::get_available_features()` checked whether analytics is enabled via `FeaturesUtil::feature_is_enabled( 'analytics' )`, which can trigger the "early translation" WordPress notice if called before `init` (`wc-calypso-bridge` seems to be doing this).

Until we land a proper fix for that, it'd be best not to rely on it.

This PR restores behavior to a plain `get_option()` plus the existing `is_analytics_disabled_by_legacy_filters()` check, with no `FeaturesController` involvement. Other `FeaturesUtil`/`FeaturesController` calls left in this file are hooked to `init` so remain ok.

Closes #68211.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. With `WP_DEBUG` and `WP_DEBUG_DISPLAY` enabled, drop this into `wp-content/mu-plugins/repro.php` or enable the snippet some other way:

    ```php
    <?php
    add_action( 'plugins_loaded', function () {
        \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'analytics' );
    }, 20 );
    ```

2. Load any front-end or admin page.
3. Confirm no "Function _load_textdomain_just_in_time was called incorrectly" message is logged.
   You will still get a deprecation warning about using direct behavior checks. That's expected.
4. In **WC > Settings > Advanced > Features** confirm the analytics setting still controls whether the feature is on or off: unchecking should hide the "Analytics" menu for example. Restore it to enabled.
5. Simulate a plugin stripping just analytics out of the wc admin feature list, then reload:

    ```php
    add_filter( 'woocommerce_admin_features', function ( $features ) {
        return array_diff( $features, array( 'analytics' ) );
    } );
    ```

    Confirm the "Analytics" menu is not shown in the admin.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Fixes a regression in #65472, not yet shipped.

</details>
