### PR TITLE
Add filter for failed order confirmation text

### DIFF
--- a/plugins/woocommerce/changelog/52517-failed-order-text-filter
+++ b/plugins/woocommerce/changelog/52517-failed-order-text-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add an order-aware filter for failed order confirmation messages in classic and block renderers.

--- a/plugins/woocommerce/changelog/52517-failed-order-text-filter
+++ b/plugins/woocommerce/changelog/52517-failed-order-text-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Add an order-aware filter for failed order confirmation messages in classic and block renderers. `__return_false` on the legacy block filter now falls back to the default message; `__return_empty_string` remains a valid suppression value. Filtered output is restricted by `wp_kses_post()`.
+Add an order-aware filter for failed order confirmation messages in classic and block renderers.

--- a/plugins/woocommerce/changelog/52517-failed-order-text-filter
+++ b/plugins/woocommerce/changelog/52517-failed-order-text-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Add an order-aware filter for failed order confirmation messages in classic and block renderers.
+Add an order-aware filter for failed order confirmation messages in classic and block renderers. `__return_false` on the legacy block filter now falls back to the default message; `__return_empty_string` remains a valid suppression value. Filtered output is restricted by `wp_kses_post()`.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -139,9 +139,30 @@ class Status extends AbstractOrderConfirmationBlock {
 				) . '</p>';
 				break;
 			case 'failed':
-				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-				$order_received_text = apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' ), null );
-				$actions             = '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woocommerce' ) . '</a> ';
+				$default_order_failed_text = esc_html__( 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' );
+
+				/**
+				 * Filters the message shown when an order has failed.
+				 *
+				 * @param string    $message The failed order message.
+				 * @param \WC_Order $order   The failed order.
+				 *
+				 * @since 11.2.0
+				 */
+				$order_failed_text = apply_filters( 'woocommerce_thankyou_order_failed_text', $default_order_failed_text, $order );
+				$order_failed_text = is_string( $order_failed_text ) ? $order_failed_text : $default_order_failed_text;
+
+				/**
+				 * Filters the message shown after checkout is complete.
+				 *
+				 * @param string $message The message, including failure-specific customization.
+				 * @param null   $order   Null to preserve existing failed-order callback behavior.
+				 *
+				 * @since 2.2.0
+				 */
+				$filtered_order_failed_text = apply_filters( 'woocommerce_thankyou_order_received_text', $order_failed_text, null );
+				$order_failed_text          = is_string( $filtered_order_failed_text ) ? $filtered_order_failed_text : $order_failed_text;
+				$actions                    = '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woocommerce' ) . '</a> ';
 
 				if ( wc_get_page_permalink( 'myaccount' ) ) {
 					$actions .= '<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="button">' . esc_html__( 'My account', 'woocommerce' ) . '</a> ';
@@ -155,7 +176,7 @@ class Status extends AbstractOrderConfirmationBlock {
 					)
 				) . '</h1>';
 				$content .= '
-				<p>' . $order_received_text . '</p>
+				<p>' . wp_kses_post( $order_failed_text ) . '</p>
 				<p class="wc-block-order-confirmation-status__actions">' . $actions . '</p>
 			';
 				break;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -141,26 +141,24 @@ class Status extends AbstractOrderConfirmationBlock {
 			case 'failed':
 				$default_order_failed_text = esc_html__( 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' );
 
+				// Null, not $order: passing the real order would let WC_Gateway_Paypal::order_received_text()
+				// overwrite this failure message with PayPal success copy, since that callback checks the
+				// payment method but not the order status.
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$legacy_order_failed_text = apply_filters( 'woocommerce_thankyou_order_received_text', $default_order_failed_text, null );
+				$order_failed_text        = is_string( $legacy_order_failed_text ) ? $legacy_order_failed_text : $default_order_failed_text;
+
 				/**
 				 * Filters the message shown when an order has failed.
+				 *
+				 * Runs after the legacy order-received filter so callbacks can customize the final failed-order message.
 				 *
 				 * @param string    $message The failed order message.
 				 * @param \WC_Order $order   The failed order.
 				 *
 				 * @since 11.2.0
 				 */
-				$order_failed_text = apply_filters( 'woocommerce_thankyou_order_failed_text', $default_order_failed_text, $order );
-				$order_failed_text = is_string( $order_failed_text ) ? $order_failed_text : $default_order_failed_text;
-
-				/**
-				 * Filters the message shown after checkout is complete.
-				 *
-				 * @param string $message The message, including failure-specific customization.
-				 * @param null   $order   Null to preserve existing failed-order callback behavior.
-				 *
-				 * @since 2.2.0
-				 */
-				$filtered_order_failed_text = apply_filters( 'woocommerce_thankyou_order_received_text', $order_failed_text, null );
+				$filtered_order_failed_text = apply_filters( 'woocommerce_thankyou_order_failed_text', $order_failed_text, $order );
 				$order_failed_text          = is_string( $filtered_order_failed_text ) ? $filtered_order_failed_text : $order_failed_text;
 				$actions                    = '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woocommerce' ) . '</a> ';
 

--- a/plugins/woocommerce/templates/checkout/thankyou.php
+++ b/plugins/woocommerce/templates/checkout/thankyou.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.1.0
+ * @version 11.2.0
  *
  * @var WC_Order $order
  */
@@ -30,7 +30,22 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php if ( $order->has_status( 'failed' ) ) : ?>
 
-			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed"><?php esc_html_e( 'Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' ); ?></p>
+			<?php
+			$default_order_failed_text = esc_html__( 'Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' );
+
+			/**
+			 * Filters the message shown when an order has failed.
+			 *
+			 * @param string   $message The failed order message.
+			 * @param WC_Order $order   The failed order.
+			 *
+			 * @since 11.2.0
+			 */
+			$order_failed_text = apply_filters( 'woocommerce_thankyou_order_failed_text', $default_order_failed_text, $order );
+			$order_failed_text = is_string( $order_failed_text ) ? $order_failed_text : $default_order_failed_text;
+			?>
+
+			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed"><?php echo wp_kses_post( $order_failed_text ); ?></p>
 
 			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed-actions">
 				<a href="<?php echo esc_url( $order->get_checkout_payment_url() ); ?>" class="button pay"><?php esc_html_e( 'Pay', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
@@ -27,7 +27,7 @@ class StatusTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The block filter pipeline preserves order context, legacy arguments, and legacy precedence.
+	 * @testdox The block filter pipeline preserves order context, legacy arguments, and new-filter precedence.
 	 */
 	public function test_filter_pipeline_preserves_context_arguments_and_precedence(): void {
 		$order                   = $this->create_failed_order();
@@ -59,21 +59,19 @@ class StatusTest extends WC_Unit_Test_Case {
 
 		$html = $this->render_failed_order( $order );
 
-		$this->assertSame( self::BLOCK_FAILED_MESSAGE, $new_filter_message, 'The new filter should receive the exact block default.' );
-		$this->assertSame( $order, $new_filter_order, 'The new filter should receive the exact failed order.' );
 		$this->assertCount( 2, $legacy_filter_arguments, 'The legacy filter should continue receiving two arguments.' );
-		$this->assertSame( $new_filter_result, $legacy_filter_arguments[0], 'The legacy filter should receive the validated new-filter result.' );
+		$this->assertSame( self::BLOCK_FAILED_MESSAGE, $legacy_filter_arguments[0], 'The legacy filter should receive the untouched block default.' );
 		$this->assertNull( $legacy_filter_arguments[1], 'The legacy filter second argument should remain null.' );
-		$this->assertStringContainsString( $legacy_filter_result, $html, 'The legacy filter should retain final output control.' );
-		$this->assertStringNotContainsString( $new_filter_result, $html, 'The legacy replacement should win final precedence.' );
+		$this->assertSame( $legacy_filter_result, $new_filter_message, 'The new filter should receive the validated legacy-filter result.' );
+		$this->assertSame( $order, $new_filter_order, 'The new filter should receive the exact failed order.' );
+		$this->assertStringContainsString( $new_filter_result, $html, 'The new filter should retain final output control.' );
+		$this->assertStringNotContainsString( $legacy_filter_result, $html, 'The new-filter replacement should win final precedence.' );
 	}
 
 	/**
-	 * @testdox An empty new block-filter result is passed unchanged to the legacy filter.
+	 * @testdox An empty new block-filter result is the final message.
 	 */
-	public function test_empty_new_filter_result_is_passed_to_legacy_filter(): void {
-		$legacy_filter_message = null;
-
+	public function test_empty_new_filter_result_is_final(): void {
 		add_filter(
 			'woocommerce_thankyou_order_failed_text',
 			static function () {
@@ -82,42 +80,47 @@ class StatusTest extends WC_Unit_Test_Case {
 		);
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
-			static function ( $message ) use ( &$legacy_filter_message ) {
-				$legacy_filter_message = $message;
+			static function () {
 				return '<strong>Legacy replacement</strong>';
 			}
 		);
 
 		$html = $this->render_failed_order( $this->create_failed_order() );
 
-		$this->assertSame( '', $legacy_filter_message, 'The legacy filter should receive the empty new-filter result.' );
-		$this->assertStringContainsString( '<strong>Legacy replacement</strong>', $html, 'The legacy filter should retain final control after an empty new-filter result.' );
+		$this->assertStringNotContainsString( '<strong>Legacy replacement</strong>', $html, 'An empty new-filter result should override the legacy replacement.' );
+		$this->assertMatchesRegularExpression(
+			'/<p><\/p>\s*<p class="wc-block-order-confirmation-status__actions">/',
+			$html,
+			'The failed-message paragraph should be empty.'
+		);
 	}
 
 	/**
-	 * @testdox An invalid new block-filter result falls back before the legacy filter runs.
+	 * @testdox An invalid new block-filter result preserves the valid legacy-filter result.
 	 */
-	public function test_invalid_new_filter_return_falls_back_to_block_default(): void {
-		$legacy_filter_message = null;
+	public function test_invalid_new_filter_return_preserves_legacy_filter_result(): void {
+		$new_filter_message   = null;
+		$legacy_filter_result = '<a href="https://example.com/legacy">Legacy replacement</a>';
 
 		add_filter(
 			'woocommerce_thankyou_order_failed_text',
-			static function () {
+			static function ( $message ) use ( &$new_filter_message ) {
+				$new_filter_message = $message;
 				return array( 'invalid' );
 			}
 		);
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
-			static function ( $message ) use ( &$legacy_filter_message ) {
-				$legacy_filter_message = $message;
-				return $message;
+			static function () use ( $legacy_filter_result ) {
+				return $legacy_filter_result;
 			}
 		);
 
 		$html = $this->render_failed_order( $this->create_failed_order() );
 
-		$this->assertSame( self::BLOCK_FAILED_MESSAGE, $legacy_filter_message, 'The legacy filter should receive the block default after new-filter fallback.' );
-		$this->assertStringContainsString( self::BLOCK_FAILED_MESSAGE, $html, 'The block default should render after new-filter fallback.' );
+		$this->assertSame( $legacy_filter_result, $new_filter_message, 'The new filter should receive the validated legacy-filter result.' );
+		$this->assertStringContainsString( $legacy_filter_result, $html, 'An invalid new-filter return should preserve the legacy-filter result, not the block default.' );
+		$this->assertStringNotContainsString( self::BLOCK_FAILED_MESSAGE, $html, 'An invalid new-filter return should not discard valid legacy text for the block default.' );
 	}
 
 	/**
@@ -145,17 +148,9 @@ class StatusTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox An empty legacy block-filter result remains the final message.
+	 * @testdox An empty legacy block-filter result remains the final message when no new-filter callback runs.
 	 */
 	public function test_empty_legacy_filter_result_remains_empty(): void {
-		$new_filter_result = '<strong>New failure context</strong>';
-
-		add_filter(
-			'woocommerce_thankyou_order_failed_text',
-			static function () use ( $new_filter_result ) {
-				return $new_filter_result;
-			}
-		);
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
 			static function () {
@@ -170,6 +165,37 @@ class StatusTest extends WC_Unit_Test_Case {
 			$html,
 			'The failed-message paragraph should remain empty.'
 		);
+	}
+
+	/**
+	 * @testdox The new filter overrides a single-argument legacy callback that replaces the message unconditionally.
+	 */
+	public function test_single_argument_legacy_replacer_is_overridden_by_new_filter(): void {
+		$new_filter_result    = '<strong>Merchant failure context</strong>';
+		$legacy_filter_result = '<strong>Unconditional legacy replacement</strong>';
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () use ( $new_filter_result ) {
+				return $new_filter_result;
+			}
+		);
+		// Shaped like gateway callbacks that declare a single $text parameter (so they never receive
+		// the $order argument) and replace the message unconditionally at a later priority.
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function ( $text ) use ( $legacy_filter_result ) {
+				// Avoid parameter not used PHPCS errors.
+				unset( $text );
+				return $legacy_filter_result;
+			},
+			11
+		);
+
+		$html = $this->render_failed_order( $this->create_failed_order() );
+
+		$this->assertStringContainsString( $new_filter_result, $html, 'The new filter should override an unconditional single-argument legacy replacer.' );
+		$this->assertStringNotContainsString( $legacy_filter_result, $html, 'The unconditional legacy replacement should not survive the new filter.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
@@ -1,0 +1,252 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\Status as StatusBlock;
+use Automattic\WooCommerce\Enums\OrderStatus;
+use WC_Gateway_Paypal;
+use WC_Order;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Order Confirmation Status block.
+ */
+class StatusTest extends WC_Unit_Test_Case {
+
+	private const BLOCK_FAILED_MESSAGE = 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.';
+
+	/**
+	 * Reset message filters before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		remove_all_filters( 'woocommerce_thankyou_order_failed_text' );
+		remove_all_filters( 'woocommerce_thankyou_order_received_text' );
+	}
+
+	/**
+	 * @testdox The block filter pipeline preserves order context, legacy arguments, and legacy precedence.
+	 */
+	public function test_filter_pipeline_preserves_context_arguments_and_precedence(): void {
+		$order                   = $this->create_failed_order();
+		$new_filter_message      = null;
+		$new_filter_order        = null;
+		$legacy_filter_arguments = array();
+		$new_filter_result       = '<strong>New failure context</strong>';
+		$legacy_filter_result    = '<a href="https://example.com/legacy">Legacy replacement</a>';
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function ( $message, $filtered_order ) use ( &$new_filter_message, &$new_filter_order, $new_filter_result ) {
+				$new_filter_message = $message;
+				$new_filter_order   = $filtered_order;
+				return $new_filter_result;
+			},
+			10,
+			2
+		);
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function ( ...$arguments ) use ( &$legacy_filter_arguments, $legacy_filter_result ) {
+				$legacy_filter_arguments = $arguments;
+				return $legacy_filter_result;
+			},
+			10,
+			2
+		);
+
+		$html = $this->render_failed_order( $order );
+
+		$this->assertSame( self::BLOCK_FAILED_MESSAGE, $new_filter_message, 'The new filter should receive the exact block default.' );
+		$this->assertSame( $order, $new_filter_order, 'The new filter should receive the exact failed order.' );
+		$this->assertCount( 2, $legacy_filter_arguments, 'The legacy filter should continue receiving two arguments.' );
+		$this->assertSame( $new_filter_result, $legacy_filter_arguments[0], 'The legacy filter should receive the validated new-filter result.' );
+		$this->assertNull( $legacy_filter_arguments[1], 'The legacy filter second argument should remain null.' );
+		$this->assertStringContainsString( $legacy_filter_result, $html, 'The legacy filter should retain final output control.' );
+		$this->assertStringNotContainsString( $new_filter_result, $html, 'The legacy replacement should win final precedence.' );
+	}
+
+	/**
+	 * @testdox An empty new block-filter result is passed unchanged to the legacy filter.
+	 */
+	public function test_empty_new_filter_result_is_passed_to_legacy_filter(): void {
+		$legacy_filter_message = null;
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () {
+				return '';
+			}
+		);
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function ( $message ) use ( &$legacy_filter_message ) {
+				$legacy_filter_message = $message;
+				return '<strong>Legacy replacement</strong>';
+			}
+		);
+
+		$html = $this->render_failed_order( $this->create_failed_order() );
+
+		$this->assertSame( '', $legacy_filter_message, 'The legacy filter should receive the empty new-filter result.' );
+		$this->assertStringContainsString( '<strong>Legacy replacement</strong>', $html, 'The legacy filter should retain final control after an empty new-filter result.' );
+	}
+
+	/**
+	 * @testdox An invalid new block-filter result falls back before the legacy filter runs.
+	 */
+	public function test_invalid_new_filter_return_falls_back_to_block_default(): void {
+		$legacy_filter_message = null;
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () {
+				return array( 'invalid' );
+			}
+		);
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function ( $message ) use ( &$legacy_filter_message ) {
+				$legacy_filter_message = $message;
+				return $message;
+			}
+		);
+
+		$html = $this->render_failed_order( $this->create_failed_order() );
+
+		$this->assertSame( self::BLOCK_FAILED_MESSAGE, $legacy_filter_message, 'The legacy filter should receive the block default after new-filter fallback.' );
+		$this->assertStringContainsString( self::BLOCK_FAILED_MESSAGE, $html, 'The block default should render after new-filter fallback.' );
+	}
+
+	/**
+	 * @testdox An invalid legacy block-filter result falls back to the valid new-filter result.
+	 */
+	public function test_invalid_legacy_filter_return_falls_back_to_new_filter_result(): void {
+		$new_filter_result = '<strong>New failure context</strong>';
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () use ( $new_filter_result ) {
+				return $new_filter_result;
+			}
+		);
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function () {
+				return new \stdClass();
+			}
+		);
+
+		$html = $this->render_failed_order( $this->create_failed_order() );
+
+		$this->assertStringContainsString( $new_filter_result, $html, 'An invalid legacy return should restore the valid new-filter result.' );
+	}
+
+	/**
+	 * @testdox An empty legacy block-filter result remains the final message.
+	 */
+	public function test_empty_legacy_filter_result_remains_empty(): void {
+		$new_filter_result = '<strong>New failure context</strong>';
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () use ( $new_filter_result ) {
+				return $new_filter_result;
+			}
+		);
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function () {
+				return '';
+			}
+		);
+
+		$html = $this->render_failed_order( $this->create_failed_order() );
+
+		$this->assertMatchesRegularExpression(
+			'/<p><\/p>\s*<p class="wc-block-order-confirmation-status__actions">/',
+			$html,
+			'The failed-message paragraph should remain empty.'
+		);
+	}
+
+	/**
+	 * @testdox The final block message keeps safe post HTML and removes unsafe markup.
+	 */
+	public function test_final_message_preserves_safe_post_html_and_removes_unsafe_markup(): void {
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function () {
+				return '<strong>Retry</strong> or <a href="https://example.com/help" onclick="alert(1)">contact support</a><script>alert(1)</script>';
+			}
+		);
+
+		$html = $this->render_failed_order( $this->create_failed_order() );
+
+		$this->assertStringContainsString( '<strong>Retry</strong>', $html, 'Safe emphasis should remain.' );
+		$this->assertStringContainsString( '<a href="https://example.com/help">contact support</a>', $html, 'A safe inline link should remain.' );
+		$this->assertStringNotContainsString( 'onclick=', $html, 'Event handler attributes should be removed.' );
+		$this->assertStringNotContainsString( '<script', $html, 'Script elements should be removed.' );
+	}
+
+	/**
+	 * @testdox The PayPal success callback preserves the new failed-order result in the block pipeline.
+	 */
+	public function test_paypal_success_callback_does_not_replace_block_failed_message(): void {
+		$new_filter_result = '<strong>Payment failed</strong>';
+		$paypal_gateway    = new WC_Gateway_Paypal();
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () use ( $new_filter_result ) {
+				return $new_filter_result;
+			}
+		);
+		add_filter( 'woocommerce_thankyou_order_received_text', array( $paypal_gateway, 'order_received_text' ), 10, 2 );
+
+		$html = $this->render_failed_order( $this->create_failed_order( WC_Gateway_Paypal::ID ) );
+
+		$this->assertStringContainsString( $new_filter_result, $html, 'The PayPal callback should pass through the failure-specific result when its order argument is null.' );
+	}
+
+	/**
+	 * Create a failed order for a block test.
+	 *
+	 * @param string $payment_method Payment method ID.
+	 * @return WC_Order
+	 */
+	private function create_failed_order( string $payment_method = '' ): WC_Order {
+		$order = new WC_Order();
+		$order->set_status( OrderStatus::FAILED );
+
+		if ( '' !== $payment_method ) {
+			$order->set_payment_method( $payment_method );
+		}
+
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Render a failed order with full permissions.
+	 *
+	 * @param WC_Order $order Order to render.
+	 * @return string
+	 */
+	private function render_failed_order( WC_Order $order ): string {
+		$sut = new class() extends StatusBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission ) {
+				return $this->render_content( $order, $permission );
+			}
+		};
+
+		return $sut->render_content_proxy( $order, 'full' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
@@ -180,8 +180,6 @@ class StatusTest extends WC_Unit_Test_Case {
 				return $new_filter_result;
 			}
 		);
-		// Shaped like gateway callbacks that declare a single $text parameter (so they never receive
-		// the $order argument) and replace the message unconditionally at a later priority.
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
 			static function ( $text ) use ( $legacy_filter_result ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
@@ -183,7 +183,6 @@ class StatusTest extends WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
 			static function ( $text ) use ( $legacy_filter_result ) {
-				// Avoid parameter not used PHPCS errors.
 				unset( $text );
 				return $legacy_filter_result;
 			},

--- a/plugins/woocommerce/tests/php/templates/checkout/ThankyouTemplateTest.php
+++ b/plugins/woocommerce/tests/php/templates/checkout/ThankyouTemplateTest.php
@@ -1,0 +1,141 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Templates\Checkout;
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use WC_Order;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the checkout thankyou template.
+ */
+class ThankyouTemplateTest extends WC_Unit_Test_Case {
+
+	private const CLASSIC_FAILED_MESSAGE = 'Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.';
+
+	/**
+	 * @testdox The classic failure filter receives the exact default and order, then replaces the message.
+	 */
+	public function test_failed_message_filter_replaces_text_and_receives_order(): void {
+		$order            = $this->create_failed_order();
+		$received_message = null;
+		$received_order   = null;
+
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function ( $message, $filtered_order ) use ( &$received_message, &$received_order ) {
+				$received_message = $message;
+				$received_order   = $filtered_order;
+				return '<strong>Use another payment method.</strong>';
+			},
+			10,
+			2
+		);
+
+		$html = $this->render_thankyou_template( $order );
+
+		$this->assertSame( self::CLASSIC_FAILED_MESSAGE, $received_message, 'The failure filter should receive the exact classic default.' );
+		$this->assertSame( $order, $received_order, 'The failure filter should receive the exact order instance.' );
+		$this->assertStringContainsString( '<strong>Use another payment method.</strong>', $html, 'The filtered message should render.' );
+		$this->assertStringNotContainsString( self::CLASSIC_FAILED_MESSAGE, $html, 'The filtered message should replace the default.' );
+	}
+
+	/**
+	 * @testdox An empty classic failure-filter result remains empty.
+	 */
+	public function test_empty_failed_message_filter_return_remains_empty(): void {
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () {
+				return '';
+			}
+		);
+
+		$html = $this->render_thankyou_template( $this->create_failed_order() );
+
+		$this->assertStringContainsString(
+			'<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed"></p>',
+			$html,
+			'The failed-message element should remain empty.'
+		);
+	}
+
+	/**
+	 * @testdox A non-string classic failure-filter result falls back to the default message.
+	 */
+	public function test_invalid_failed_message_filter_return_falls_back_to_default(): void {
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () {
+				return array( 'invalid' );
+			}
+		);
+
+		$html = $this->render_thankyou_template( $this->create_failed_order() );
+
+		$this->assertStringContainsString( self::CLASSIC_FAILED_MESSAGE, $html, 'An invalid filter return should restore the classic default.' );
+	}
+
+	/**
+	 * @testdox The classic failed message keeps safe post HTML and removes unsafe markup.
+	 */
+	public function test_failed_message_preserves_safe_post_html_and_removes_unsafe_markup(): void {
+		add_filter(
+			'woocommerce_thankyou_order_failed_text',
+			static function () {
+				return '<strong>Retry</strong> or <a href="https://example.com/help" onclick="alert(1)">contact support</a><script>alert(1)</script>';
+			}
+		);
+
+		$html = $this->render_thankyou_template( $this->create_failed_order() );
+
+		$this->assertStringContainsString( '<strong>Retry</strong>', $html, 'Safe emphasis should remain.' );
+		$this->assertStringContainsString( '<a href="https://example.com/help">contact support</a>', $html, 'A safe inline link should remain.' );
+		$this->assertStringNotContainsString( 'onclick=', $html, 'Event handler attributes should be removed.' );
+		$this->assertStringNotContainsString( '<script', $html, 'Script elements should be removed.' );
+	}
+
+	/**
+	 * @testdox The classic failed template never invokes the legacy success-oriented message filter.
+	 */
+	public function test_failed_template_does_not_invoke_legacy_received_text_filter(): void {
+		$legacy_filter_calls = 0;
+
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function () use ( &$legacy_filter_calls ) {
+				++$legacy_filter_calls;
+				return 'Unexpected success copy';
+			},
+			10,
+			2
+		);
+
+		$this->render_thankyou_template( $this->create_failed_order() );
+
+		$this->assertSame( 0, $legacy_filter_calls, 'The legacy filter should not run in the classic failed branch.' );
+	}
+
+	/**
+	 * Create a failed order for a template test.
+	 *
+	 * @return WC_Order
+	 */
+	private function create_failed_order(): WC_Order {
+		$order = new WC_Order();
+		$order->set_status( OrderStatus::FAILED );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Render the classic thankyou template.
+	 *
+	 * @param WC_Order $order Order to render.
+	 * @return string
+	 */
+	private function render_thankyou_template( WC_Order $order ): string {
+		return wc_get_template_html( 'checkout/thankyou.php', array( 'order' => $order ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Failed-order confirmation messages are not consistently extensible: the classic renderer has no filter, while the block renderer's legacy filter receives `null` instead of the order. This adds the public `woocommerce_thankyou_order_failed_text` filter to both renderers, passing the failed message and `WC_Order` object.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #52517.

#### Backward compatibility

`woocommerce_thankyou_order_failed_text` is additive. In the block renderer, `woocommerce_thankyou_order_received_text` runs first on the default message with two arguments and keeps `null` as its second argument; the new failed-order filter then runs with the real order and has final control. The classic failed branch continues not to call the legacy success-oriented filter.

Both renderers fall back to the previous valid string when a filter returns a non-string and sanitize the final output with `wp_kses_post()`; callbacks should return text or safe inline markup. `checkout/thankyou.php` is versioned to 11.2.0, so older theme overrides will not receive the classic filter until updated.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start the development environment with `pnpm wc:env` and sign in to WordPress admin.
2. Add and activate the following code through a temporary test plugin or snippet runner:

    ```php
    add_filter(
        'woocommerce_thankyou_order_failed_text',
        function ( $message, $order ) {
            return sprintf(
                '<strong>Custom failed message for order #%s.</strong> <a href="https://example.com/support">Contact support</a>',
                esc_html( $order->get_order_number() )
            );
        },
        10,
        2
    );

    // Shaped like gateway callbacks that declare a single $text parameter
    // and replace the message unconditionally at a later priority.
    add_filter(
        'woocommerce_thankyou_order_received_text',
        function ( $text ) {
            return '<strong>Legacy filter replacement</strong>';
        },
        11
    );
    ```

3. In the browser, place an order while signed in using an offline payment method. Copy the order-received URL.
4. In **WooCommerce > Orders**, open the order, change its status to **Failed**, and save it.
5. Activate Storefront, revisit the saved order-received URL, and confirm:
    - The custom failed message is shown.
    - Its order number matches the order.
    - The bold text and support link render.
    - The **Pay** and **My account** actions remain available.
    - **Legacy filter replacement** is not shown; the classic failed template does not invoke the legacy filter.
6. Activate a block theme such as Twenty Twenty-Five. In **Appearance > Editor**, open the Order Confirmation template, transform it into blocks, and save it. If it is already blockified, confirm it contains the Order Confirmation blocks. Revisit the same URL and confirm:
    - The custom failed message and matching order number are shown instead of **Legacy filter replacement**, confirming that the new failed-order filter takes precedence.
    - The **Try again** and **My account** actions remain available.
7. Deactivate the test snippet and confirm that both renderers return to their unchanged default failed-order messages.
8. Start the PHP test environment and run the focused edge-case coverage:

    ```bash
    pnpm --filter=@woocommerce/plugin-woocommerce env:test:start
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'ThankyouTemplateTest|StatusTest'
    ```

9. Confirm all 13 tests pass, covering classic and block replacement, order context, empty and invalid returns, sanitization, one-argument legacy-filter precedence, and PayPal compatibility.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Browser testing with Storefront and Twenty Twenty-Five confirmed the order-aware custom message, safe markup, and expected actions in both renderers. With a one-argument priority-11 legacy replacer registered, the block renderer displayed the new-filter result instead of the legacy replacement. Disabling the snippet restored both default messages, with no console errors.
- This browser check reproduces the WooPayments callback shape, not a full WooPayments transaction; WooPayments itself and its order-key, `needs_payment()`, and payment-method-prefix checks were not exercised.
- Focused PHPUnit on PHP 8.1: 13 tests and 32 assertions passed.
- `lint:php:changes` and `lint:changes:branch` passed.
- PHPStan passed for the modified block renderer. The combined production-file check also reports the pre-existing nullable return from `$order->get_date_created()` at `thankyou.php:70`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/52517-failed-order-text-filter`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex assisted with implementation, tests, local verification, and PR drafting. I reviewed and validated the generated code and text.
