### PR TITLE
Remove the duplicated Variant SKU entry in the Shopify importer mapping

### DIFF
--- a/plugins/woocommerce/changelog/fix-duplicate-shopify-variant-sku-mapping
+++ b/plugins/woocommerce/changelog/fix-duplicate-shopify-variant-sku-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove the duplicated Variant SKU entry from the Shopify importer column mapping.

--- a/plugins/woocommerce/includes/admin/importers/mappings/shopify.php
+++ b/plugins/woocommerce/includes/admin/importers/mappings/shopify.php
@@ -30,7 +30,6 @@ function wc_importer_shopify_mappings( $mappings, $raw_headers ) {
 		'Variant Inventory Qty'     => 'stock_quantity',
 		'Image Src'                 => 'images',
 		'Variant Image'             => 'images',
-		'Variant SKU'               => 'sku',
 		'Variant Price'             => 'sale_price',
 		'Variant Compare At Price'  => 'regular_price',
 		'Type'                      => 'category_ids',

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -4231,12 +4231,6 @@ parameters:
 			path: includes/admin/importers/class-wc-tax-rate-importer.php
 
 		-
-			message: '#^Array has 2 duplicate keys with value ''Variant SKU'' \(''Variant SKU'', ''Variant SKU''\)\.$#'
-			identifier: array.duplicateKey
-			count: 1
-			path: includes/admin/importers/mappings/shopify.php
-
-		-
 			message: '#^Variable \$errors might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`'Variant SKU' => 'sku'` is listed twice in the Shopify importer mapping, once at the top of the array and once seven lines down. PHP keeps the first position and the last value for a repeated key, and both values here are the same, so the mapping the importer ends up with does not change. It is just a line that reads as if a second column were being mapped.

### How to test the changes in this Pull Request:

There is nothing observable to test. The array `wc_importer_shopify_mappings()` returns is identical before and after, both in values and in key order, because the removed line was the losing duplicate of one that stays.

1. Import a Shopify product CSV as before and confirm the SKU column still maps to `sku`.

### Testing that has already taken place:

None beyond reading the array. The change removes a line that PHP was already discarding.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added by hand as `plugins/woocommerce/changelog/fix-duplicate-shopify-variant-sku-mapping`, patch significance and dev type, since the automatic job cannot push into a fork branch.
