### PR TITLE
Fix grouped product quantity selector widths

### DIFF
--- a/plugins/woocommerce/changelog/67157-grouped-product-quantity-widths
+++ b/plugins/woocommerce/changelog/67157-grouped-product-quantity-widths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix inconsistent quantity selector widths for grouped products.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -78,11 +78,12 @@
 }
 
 // Keep grouped steppers equal when child products have different `max` attributes.
-// The repeated component class overrides theme quantity input widths.
+// The repeated component class overrides theme quantity input widths. `2.9em` matches
+// the component's 40px floor at its default 14px font size and grows with larger text.
 .wc-block-add-to-cart-with-options-grouped-product-item-selector
 	.wc-block-components-quantity-selector.wc-block-components-quantity-selector
 	input.wc-block-components-quantity-selector__input {
-	width: 40px;
+	width: 2.9em;
 }
 
 // `cursor` needs to override some styles from WordPress core, that's why we

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -77,6 +77,14 @@
 	}
 }
 
+// Keep grouped steppers equal when child products have different `max` attributes.
+// The repeated component class overrides theme quantity input widths.
+.wc-block-add-to-cart-with-options-grouped-product-item-selector
+	.wc-block-components-quantity-selector.wc-block-components-quantity-selector
+	input.wc-block-components-quantity-selector__input {
+	width: 40px;
+}
+
 // `cursor` needs to override some styles from WordPress core, that's why we
 // need extra specificity.
 :where(.wc-block-add-to-cart-with-options.is-invalid) .wp-block-woocommerce-product-button .wc-block-components-product-button__button {


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Grouped product Add to Cart with Options forms currently rely on the legacy `.woocommerce .quantity .qty` rule from `woocommerce-general` to keep quantity selectors the same width. Fresh Product blocks include the `woocommerce` class, so the issue does not reproduce out of the box with Twenty Twenty-Four or Twenty Twenty-Five when that stylesheet is present.

The original #67157 case still applies: themes such as the earlier Purple version override the legacy width with `width: auto`, and sites can dequeue `woocommerce-general`. Without the legacy rule, the inputs size themselves from the optional `max` attribute, so children with mixed stock settings render uneven quantity steppers.

This change gives only grouped item-selector inputs an explicit `2.9em` width. It matches the component's existing 40px `min-width` at its default 14px font size, scales with larger text, and uses enough specificity to survive generic theme `input.qty` rules. Standalone and outer Add to Cart with Options contexts remain unchanged.

Backward compatibility: no markup or public PHP/JS contract changes. Generic theme `input.qty` width rules no longer control grouped steppers, which is the intended fix; non-grouped contexts are unchanged.

Closes #67157.

Bug introduced in PR #66261.

### Screenshots or screen recordings

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Purple at `d966384c00`, before its theme-side grouped-width workaround:

![Grouped product quantity selectors before and after the fix in Purple](https://github.com/user-attachments/assets/fa92b472-f26a-4a21-a2e2-fdb78192d3d9)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run `pnpm wc:build:classic-assets` and `pnpm wc:build:blocks`.
2. Activate [Purple at `d966384c00`](https://github.com/woocommerce/woo-themes/tree/d966384c00/purple), before its theme-side grouped-width workaround.
3. Create two published simple products. Enable stock management with a quantity of `2` or higher for one product, and leave stock management disabled for the other. At a stock quantity of `1`, the stepper is intentionally not rendered, so the comparison needs `2` or more.
4. Create a grouped product containing both children and view it on the frontend.
5. Confirm both quantity steppers have equal widths and both increment buttons update their inputs.
6. View the unmanaged simple product and confirm its standalone quantity selector retains its existing non-grouped sizing.
7. Open the **Grouped Product Add to Cart with Options** template part in the Site Editor. Confirm the quantity controls remain ordered minus/input/plus and fit within the item-selector wrapper.
8. Raise the theme's `small` font size preset, or use the browser's text-only zoom, and confirm the grouped steppers grow with the text rather than clipping. A three- or four-digit quantity should still fit inside the input.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Tested on a local Docker WordPress site with WooCommerce 11.2.0-dev and Chromium against Purple 1.0.0 at `d966384c00`, Twenty Twenty-Five, and Twenty Twenty-Four.
- Confirmed that Purple at `d966384c00` renders different widths before the fix and equal widths after it.
- Retested Twenty Twenty-Four and Twenty Twenty-Five with `assets/css/woocommerce.css` loaded. Fresh Product blocks save with the `woocommerce` class, and the legacy `.woocommerce .quantity .qty` rule keeps the grouped steppers equal without this change.
- Confirmed that the earlier Twenty Twenty-Four and Twenty Twenty-Five mismatch was a local build artifact. `pnpm wc:build:blocks` does not generate the gitignored `assets/css/woocommerce.css`; without that stylesheet, the inputs fall back to intrinsic sizing and reproduce the previously reported measurements.
- Confirmed both grouped increment buttons changed their input values from `0` to `1`.
- Confirmed the non-grouped simple-product selector retained its existing sizing.
- Confirmed the grouped template-part editor preview remained `inline-flex`, retained minus/input/plus DOM order, and had `0px` overflow. All editor REST requests returned HTTP 200.
- `pnpm wc:build:blocks`
- `pnpm --filter=@woocommerce/block-library lint:css`
- `pnpm --filter=@woocommerce/plugin-woocommerce changelog validate changelog/67157-grouped-product-quantity-widths`
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g., for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the regression, implement the scoped CSS change, run verification, and draft this PR description. Claude Code was used to retest the reported behavior after review, identify the missing classic stylesheet in the earlier test environment, confirm the original Purple theme reproduction, and correct the PR's scope and testing notes. The resulting code and test evidence were reviewed before submission.
