### PR TITLE
Fix WooPayments onboarding profile data handling

### DIFF
--- a/plugins/woocommerce/changelog/fix-woopayments-profile-data-handling
+++ b/plugins/woocommerce/changelog/fix-woopayments-profile-data-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve WooPayments onboarding profile data handling.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -2493,10 +2493,8 @@ class WooPaymentsService {
 	private function get_nox_profile(): array {
 		$nox_profile = $this->proxy->call_function( 'get_option', self::NOX_PROFILE_OPTION_KEY, array() );
 
-		if ( empty( $nox_profile ) ) {
-			$nox_profile = array();
-		} else {
-			$nox_profile = maybe_unserialize( $nox_profile );
+		if ( ! is_array( $nox_profile ) ) {
+			return array();
 		}
 
 		return $nox_profile;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/NoxProfileObjectInstantiationProbe.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/NoxProfileObjectInstantiationProbe.php
@@ -1,0 +1,24 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings\PaymentsProviders\WooPayments;
+
+/**
+ * Probe for detecting NOX profile object instantiation.
+ */
+final class NoxProfileObjectInstantiationProbe {
+
+	/**
+	 * Whether the probe was instantiated from a serialized value.
+	 *
+	 * @var bool
+	 */
+	public static bool $was_unserialized = false;
+
+	/**
+	 * Record object instantiation from a serialized value.
+	 */
+	public function __wakeup(): void {
+		self::$was_unserialized = true;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -2456,6 +2456,36 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Serialized NOX profile strings are ignored without instantiating objects.
+	 */
+	public function test_get_onboarding_step_status_ignores_serialized_profile_string(): void {
+		NoxProfileObjectInstantiationProbe::$was_unserialized = false;
+
+		$serialized_profile = maybe_serialize(
+			array(
+				'probe' => new NoxProfileObjectInstantiationProbe(),
+			)
+		);
+
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) use ( $serialized_profile ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						return $serialized_profile;
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		$status = $this->sut->get_onboarding_step_status( WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS, 'US' );
+
+		$this->assertSame( WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED, $status );
+		$this->assertFalse( NoxProfileObjectInstantiationProbe::$was_unserialized, 'Serialized NOX profile strings must not instantiate objects.' );
+	}
+
+	/**
 	 * Data provider for test_get_onboarding_step_status.
 	 *
 	 * @return array[]


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooPayments expects its stored onboarding profile to be an array. This change validates the retrieved value before use and treats unexpected values as an empty profile, preserving existing behavior for valid profiles while preventing malformed stored data from affecting onboarding state.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR #56229.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start the WooCommerce test environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start`.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env --filter 'WooPaymentsServiceTest'`.
3. Confirm the test suite passes.
4. Stop the environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:stop`.

<!-- End testing instructions -->

### Testing that has already taken place:

- `WooPaymentsServiceTest`: 330 tests and 738 assertions passed using the local test environment with PHP 8.1.34.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- Focused PHPStan analysis of `WooPaymentsService.php`
- Focused Semgrep analysis of `WooPaymentsService.php`
- `git diff --check origin/trunk...HEAD`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-woopayments-profile-data-handling`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to implement the change, add regression coverage, run verification, and draft this description. The author reviewed the resulting diff and test output.
