### PR TITLE
[tests] Keep Blocks snapshot setup out of the specialized E2E environment configs

### DIFF
--- a/plugins/woocommerce/tests/e2e/envs/default-hpos-disabled/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/default-hpos-disabled/playwright.config.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import defaultConfig, { setupProjects } from '../../playwright.config';
+import defaultConfig, { coreSetupProjects } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
 
 process.env.USE_WP_ENV = 'true';
@@ -10,7 +10,7 @@ process.env.DISABLE_HPOS = '1';
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'e2e-hpos-disabled',
 			grep: new RegExp( tags.HPOS ),

--- a/plugins/woocommerce/tests/e2e/envs/default-pressable/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/default-pressable/playwright.config.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import defaultConfig, {
-	setupProjects,
+	coreSetupProjects,
 	TESTS_ROOT_PATH,
 } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
@@ -17,7 +17,7 @@ const grepInvert = new RegExp(
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'reset',
 			testDir: `${ TESTS_ROOT_PATH }/fixtures`,

--- a/plugins/woocommerce/tests/e2e/envs/default-wpcom/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/default-wpcom/playwright.config.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import defaultConfig, {
-	setupProjects,
+	coreSetupProjects,
 	TESTS_ROOT_PATH,
 } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
@@ -17,7 +17,7 @@ const grepInvert = new RegExp(
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'reset',
 			testDir: `${ TESTS_ROOT_PATH }/fixtures`,

--- a/plugins/woocommerce/tests/e2e/envs/gutenberg-stable/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/gutenberg-stable/playwright.config.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import defaultConfig, { setupProjects } from '../../playwright.config';
+import defaultConfig, { coreSetupProjects } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
 
 process.env.USE_WP_ENV = 'true';
@@ -9,7 +9,7 @@ process.env.USE_WP_ENV = 'true';
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'Gutenberg',
 			grep: new RegExp( tags.GUTENBERG ),

--- a/plugins/woocommerce/tests/e2e/envs/woocommerce-payments/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/woocommerce-payments/playwright.config.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import defaultConfig, { setupProjects } from '../../playwright.config';
+import defaultConfig, { coreSetupProjects } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
 
 process.env.USE_WP_ENV = 'true';
@@ -9,7 +9,7 @@ process.env.USE_WP_ENV = 'true';
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'WooPayments',
 			grep: new RegExp( tags.PAYMENTS ),

--- a/plugins/woocommerce/tests/e2e/envs/woocommerce-paypal-payments/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/woocommerce-paypal-payments/playwright.config.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import defaultConfig, { setupProjects } from '../../playwright.config';
+import defaultConfig, { coreSetupProjects } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
 
 process.env.USE_WP_ENV = 'true';
@@ -9,7 +9,7 @@ process.env.USE_WP_ENV = 'true';
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'WooCommerce PayPal Payments',
 			grep: new RegExp( tags.PAYMENTS ),

--- a/plugins/woocommerce/tests/e2e/envs/woocommerce-services/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/envs/woocommerce-services/playwright.config.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import defaultConfig, { setupProjects } from '../../playwright.config';
+import defaultConfig, { coreSetupProjects } from '../../playwright.config';
 import { tags } from '../../fixtures/fixtures';
 
 process.env.USE_WP_ENV = 'true';
@@ -9,7 +9,7 @@ process.env.USE_WP_ENV = 'true';
 const config = {
 	...defaultConfig,
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
 		{
 			name: 'WooCommerce Shipping & Tax',
 			grep: new RegExp( tags.SERVICES ),

--- a/plugins/woocommerce/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/playwright.config.ts
@@ -89,7 +89,7 @@ if ( process.env.CI ) {
 	] );
 }
 
-export const setupProjects = [
+export const coreSetupProjects = [
 	{
 		name: 'install wc',
 		testDir: `${ TESTS_ROOT_PATH }/fixtures`,
@@ -107,12 +107,13 @@ export const setupProjects = [
 		testMatch: `site.setup.ts`,
 		dependencies: [ 'global authentication' ],
 	},
-	{
-		name: 'blocks setup',
-		testDir: `${ TESTS_ROOT_PATH }/fixtures`,
-		testMatch: 'blocks-setup.ts',
-	},
 ];
+
+const blocksSetupProject = {
+	name: 'blocks setup',
+	testDir: `${ TESTS_ROOT_PATH }/fixtures`,
+	testMatch: 'blocks-setup.ts',
+};
 
 /**
  * Spec folders that must run serially in `core-serial` (they mutate global
@@ -234,7 +235,8 @@ export default defineConfig( {
 	snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}',
 
 	projects: [
-		...setupProjects,
+		...coreSetupProjects,
+		blocksSetupProject,
 		{
 			name: 'core-serial',
 			testMatch: serialRunSpecs,


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Refs [TESTOPS-234](https://linear.app/a8c/issue/TESTOPS-234)

The seven specialized E2E environments under `tests/e2e/envs/` (`default-hpos-disabled`, `default-pressable`, `default-wpcom`, `gutenberg-stable`, `woocommerce-payments`, `woocommerce-paypal-payments`, `woocommerce-services`) build their Playwright project graph from a list exported by the default `playwright.config.ts`. That list included the Blocks snapshot setup project alongside the Core install, authentication, and site-setup chain. A specialized run that did not filter projects would therefore execute Blocks setup against a Core-profile database, and once the Blocks fixture gains a request lock that Core environments do not provision, that path fails outright.

This PR makes the boundary explicit:

- `playwright.config.ts` exports only the Core setup chain (`install`, `auth`, `site setup`) to the specialized configs.
- The `blocks setup` project stays private to the default config's Blocks project graph, which is the only place that provisions the snapshot it depends on.
- The seven `envs/*/playwright.config.ts` files consume the narrowed export; their own project lists are otherwise unchanged.

No test titles change. `--list` on `gutenberg-stable` now resolves to `site setup` plus its 28 tests, with no Blocks setup; `--list --project='blocks setup'` on the default config still resolves the Blocks setup project.

Split out of #68046, where the stricter Blocks fixture made this inherited leak visible. It is a prerequisite for the Blocks database-determinism PR that follows.

### Backward compatibility

Test configuration only. No test names, projects run by CI, or runtime code change.

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, run `WP_ENV_PORT=8089 npx playwright test --config tests/e2e/envs/gutenberg-stable/playwright.config.ts --list` and confirm the output lists `[site setup]` and no `[blocks setup]` project.
2. Run `WP_ENV_PORT=8089 npx playwright test --config tests/e2e/playwright.config.ts --list --project='blocks setup'` and confirm `[blocks setup] › ../fixtures/blocks-setup.ts` is still listed.
3. Confirm the **Gutenberg stable** and **HPOS disabled** E2E jobs on this PR pass.

### Testing that has already taken place:

- Both `--list` checks above run locally on this branch with the expected results.
- On #68046 every specialized E2E job (Gutenberg stable, HPOS disabled, WPCOM, Pressable, WooPayments, PayPal Payments, Services) passed with this config in place.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

E2E test configuration only; nothing shipped.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

The leak was found and the fix written during an AI-assisted test-system repair on #68046; this PR was extracted from that branch and its description assembled with Claude Code. I reviewed the diff and take responsibility for it.

---
🤖 Generated with [Claude Code](https://claude.ai/code)
