### PR TITLE
Use the REST route resolved by WordPress for API-key authentication

### DIFF
--- a/plugins/woocommerce/changelog/fix-rest-api-key-rewritten-routes
+++ b/plugins/woocommerce/changelog/fix-rest-api-key-rewritten-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve REST API key authentication for WooCommerce routes reached through custom URLs.

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -91,8 +91,6 @@ class WC_REST_Authentication {
 	 *
 	 * 'wc/' is WooCommerce; 'wc-' lets third party plugins use our authentication methods.
 	 *
-	 * @since 11.1.0
-	 *
 	 * @param string $route Route without the REST prefix or surrounding slashes.
 	 * @return bool
 	 */
@@ -104,8 +102,6 @@ class WC_REST_Authentication {
 	 * The route WordPress resolved for this request, trimmed of surrounding slashes.
 	 *
 	 * Null when WordPress has not parsed the request yet, which is not the same as an empty route.
-	 *
-	 * @since 11.1.0
 	 *
 	 * @return string|null
 	 */

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -72,9 +72,9 @@ class WC_REST_Authentication {
 			return false;
 		}
 
-		// 'wc/' is WooCommerce; 'wc-' lets third party plugins use our authentication methods.
-		$route       = $this->route_from_request_uri();
-		$is_wc_route = str_starts_with( $route, 'wc/' ) || str_starts_with( $route, 'wc-' );
+		$resolved_route = $this->resolved_route();
+		$is_wc_route    = $this->is_wc_namespace( $this->route_from_request_uri() )
+			|| ( null !== $resolved_route && $this->is_wc_namespace( $resolved_route ) );
 
 		/**
 		 * Filters whether the current request is a request to the WooCommerce REST API.
@@ -84,6 +84,39 @@ class WC_REST_Authentication {
 		 * @param bool $is_request_to_rest_api Whether the request is to a WooCommerce REST API endpoint.
 		 */
 		return apply_filters( 'woocommerce_rest_is_request_to_rest_api', $is_wc_route );
+	}
+
+	/**
+	 * Whether a route is in a namespace a WooCommerce API key may authenticate.
+	 *
+	 * 'wc/' is WooCommerce; 'wc-' lets third party plugins use our authentication methods.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param string $route Route without the REST prefix or surrounding slashes.
+	 * @return bool
+	 */
+	private function is_wc_namespace( string $route ): bool {
+		return str_starts_with( $route, 'wc/' ) || str_starts_with( $route, 'wc-' );
+	}
+
+	/**
+	 * The route WordPress resolved for this request, trimmed of surrounding slashes.
+	 *
+	 * Null when WordPress has not parsed the request yet, which is not the same as an empty route.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @return string|null
+	 */
+	private function resolved_route(): ?string {
+		global $wp;
+
+		if ( ! $wp instanceof WP || ! isset( $wp->query_vars['rest_route'] ) || ! is_string( $wp->query_vars['rest_route'] ) ) {
+			return null;
+		}
+
+		return trim( $wp->query_vars['rest_route'], '/' );
 	}
 
 	/**
@@ -264,19 +297,16 @@ class WC_REST_Authentication {
 	 * @return bool False only when the resolved route is not ours and the request URI never named it.
 	 */
 	private function is_resolved_route_in_scope() {
-		global $wp;
-
 		// Has WordPress picked a route yet? If not, there is nothing to compare.
-		if ( ! $wp instanceof WP || ! isset( $wp->query_vars['rest_route'] ) || ! is_string( $wp->query_vars['rest_route'] ) ) {
+		$resolved_route = $this->resolved_route();
+
+		if ( null === $resolved_route ) {
 			return true;
 		}
 
-		// Our own namespaces are always in scope for a WooCommerce key: 'wc/' is WooCommerce, 'wc-'
-		// is a third party using our auth. The read/write permission check in check_user_permissions()
-		// still bounds what the key can do there.
-		$resolved_route = trim( $wp->query_vars['rest_route'], '/' );
-
-		if ( str_starts_with( $resolved_route, 'wc/' ) || str_starts_with( $resolved_route, 'wc-' ) ) {
+		// Our own namespaces are always in scope for a WooCommerce key. The read/write permission
+		// check in check_user_permissions() still bounds what the key can do there.
+		if ( $this->is_wc_namespace( $resolved_route ) ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -179,6 +179,38 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should identify a WooCommerce REST request by the route WordPress resolved.
+	 *
+	 * @dataProvider provider_resolved_routes_for_rest_api_detection
+	 *
+	 * @param string $request_uri    Request URI.
+	 * @param string $resolved_route Route WordPress resolved for the request.
+	 * @param bool   $expected       Expected result.
+	 */
+	public function test_is_request_to_rest_api_checks_resolved_route( string $request_uri, string $resolved_route, bool $expected ): void {
+		global $wp;
+
+		$_SERVER['REQUEST_URI']       = $request_uri;
+		$wp->query_vars['rest_route'] = $resolved_route;
+
+		$this->assertSame( $expected, $this->is_request_to_rest_api() );
+	}
+
+	/**
+	 * Data provider for resolved REST routes.
+	 *
+	 * @return array[]
+	 */
+	public static function provider_resolved_routes_for_rest_api_detection(): array {
+		return array(
+			'language-prefixed woocommerce route' => array( '/en/wp-json/wc/v3/products', '/wc/v3/products', true ),
+			'route differs from resolved route'   => array( '/en/wp-json/wc/v3/products', '/wp/v2/users', false ),
+			'custom rewrite without REST prefix'  => array( '/shop-api/products', '/wc/v3/products', true ),
+			'resolved route overrides URI route'  => array( '/wp-json/wp/v2/users', '/wc/v3/products', true ),
+		);
+	}
+
+	/**
 	 * @testdox Should detect WooCommerce routes on a subdirectory install, matching how WordPress strips the home path.
 	 *
 	 * @dataProvider provider_subdirectory_request_uris
@@ -465,9 +497,15 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should let the authentication fallback through for a WooCommerce route.
+	 * @testdox Should let the authentication fallback through for an in-scope WooCommerce route.
+	 *
+	 * @testWith ["/wp-json/wc/v3/products"]
+	 *           ["/ja/wp-json/wc/v3/products"]
+	 *           ["/shop-api/products"]
+	 *
+	 * @param string $request_uri Request URI.
 	 */
-	public function test_rest_authentication_errors_allows_in_scope_route_from_fallback(): void {
+	public function test_rest_authentication_errors_allows_in_scope_route_from_fallback( string $request_uri ): void {
 		global $wp, $wpdb;
 
 		$consumer_key    = 'ck_' . wp_generate_password( 32, false );
@@ -488,7 +526,7 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$_SERVER['HTTPS']             = 'on';
 		$_SERVER['PHP_AUTH_USER']     = $consumer_key;
 		$_SERVER['PHP_AUTH_PW']       = $consumer_secret;
-		$_SERVER['REQUEST_URI']       = '/wp-json/wc/v3/products';
+		$_SERVER['REQUEST_URI']       = $request_uri;
 		$wp->query_vars['rest_route'] = '/wc/v3/products';
 
 		wp_set_current_user( 0 );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Use the REST route resolved by WordPress as an additional signal when deciding whether to apply WooCommerce API-key authentication. This allows valid API keys to work when custom URLs resolve to `wc/` or `wc-*` routes, while preserving the final route checks.

Closes WOOAIRR-188.

### How to test the changes in this Pull Request:

Basic auth requires HTTPS, so use a store served over TLS, with pretty permalinks and a REST API key with **read** permissions.

1. Add this as an mu-plugin — it puts a prefix in front of the REST API, the same way the [Bogo](https://wordpress.org/plugins/bogo/) translation plugin does for language prefixes. The `+ $rules` matters: these must come before core's `^wp-json/` rules.

   ```php
   <?php
   add_filter(
       'rewrite_rules_array',
       function ( $rules ) {
           global $wp_rewrite;

           $prefix = rest_get_url_prefix();
           $lang   = '(en|ja)';

           return array(
               "{$lang}/{$prefix}/?$"                         => 'index.php?lang=$matches[1]&rest_route=/',
               "{$lang}/{$prefix}/(.*)?"                      => 'index.php?lang=$matches[1]&rest_route=/$matches[2]',
               "{$wp_rewrite->index}/{$lang}/{$prefix}/?$"    => 'index.php?lang=$matches[1]&rest_route=/',
               "{$wp_rewrite->index}/{$lang}/{$prefix}/(.*)?" => 'index.php?lang=$matches[1]&rest_route=/$matches[2]',
           ) + $rules;
       }
   );
   ```

2. Re-save permalinks to flush the rewrite rules.
3. Call the same endpoint both ways. On trunk the prefixed one returns `401 woocommerce_rest_cannot_view`; on this branch both return products.
   ```
   curl -u ck_...:cs_... 'https://<store>/wp-json/wc/v3/products'
   curl -u ck_...:cs_... 'https://<store>/ja/wp-json/wc/v3/products'
   ```
4. Run the unit tests:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_REST_Authentication_Tests
   ```

Installing Bogo with a second locale enabled works instead of the snippet — it registers the same rules.

### Testing that has already taken place:

Verified against a local store with a read-only key, using both the snippet above and Bogo 3.9.3 with `en` + `ja` enabled.

Exercised each REST URL shape over HTTP on plain and pretty permalinks, on a subdirectory install, and on a subdirectory multisite network including cross-site key scoping.

`WC_REST_Authentication_Tests` passes (53 tests, 63 assertions); the wider REST suite is unaffected (918 tests, 5119 assertions, 0 failures) on PHP 8.1 / WordPress latest. PHPStan clean.

**Backward compatibility:** The `woocommerce_rest_is_request_to_rest_api` filter may now receive true for custom URLs that WordPress resolves to a WooCommerce REST route. This is an intentional widening that allows REST API key authentication on those URLs. No filter signature or arguments have changed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually in the branch, Patch / Fix.

### Use of AI Tools

Written with Claude Code. I reviewed the diff and the testing above myself.
