### PR TITLE
[tests] Make the Blocks E2E seed reset the shipping zones and tax settings it relies on

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-blocks-seed-convergence
+++ b/plugins/woocommerce/changelog/testops-234-blocks-seed-convergence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Make the Blocks E2E seed reset the shipping zones, tax classes, and tax settings it depends on, and document switching between the Core and Blocks E2E profiles. Test infrastructure only.
+

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -43,6 +43,8 @@ To re-create the environment for a fresh state:
 
 `pnpm env:e2e:restart` (resets and restarts the E2E test environment)
 
+Core and Blocks tests share the same E2E `wp-env` database but expect different fixture profiles. `pnpm env:start:blocks` seeds the Blocks profile on top of whatever the database already holds, and `pnpm test:e2e:*` runs against the environment's current state. The Blocks seed resets the shipping zones, tax classes, and tax settings it relies on, so running it after Core tests is safe for those. Other state a Core run leaves behind can still leak into the Blocks profile. If Blocks tests fail after Core tests ran on the same environment, run `pnpm env:e2e:restart` and then `pnpm env:start:blocks`. To go back to Core tests after Blocks, run `pnpm env:e2e:restart`.
+
 You can refer to the pnpm scripts in the `package.json` file for more commands. Check out the `env:some-command` scripts
 for managing the `wp-env` environment.
 

--- a/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/shipping.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/shipping.sh
@@ -2,16 +2,28 @@
 
 set -euo pipefail
 
-# `wp site empty` does not remove shipping zone methods: they are rows in the
-# woocommerce_shipping_zone_methods table rather than posts or terms, so they
-# survive it. Creating them again on a re-seed leaves zone 0 with four methods
-# instead of two, at exit 0, and the specs that rely on the seeded shape then
-# fail somewhere far from the seed. Clear the zone first so this is re-runnable.
+# `wp site empty` does not remove shipping zones or methods. Converge the full
+# topology so this profile always uses only its zone 0 Flat/Free pair, even
+# after another profile creates a named smart-default zone.
 wp eval "$(cat <<'PHP'
+foreach ( WC_Shipping_Zones::get_zones() as $zone_data ) {
+	WC_Shipping_Zones::delete_zone( $zone_data['zone_id'] );
+}
+
+$remaining_zones = WC_Shipping_Zones::get_zones();
+if ( ! empty( $remaining_zones ) ) {
+	WP_CLI::error( sprintf( 'Unable to delete %d named shipping zone(s).', count( $remaining_zones ) ) );
+}
+
 $zone = WC_Shipping_Zones::get_zone( 0 );
 
 foreach ( $zone->get_shipping_methods() as $method ) {
 	$zone->delete_shipping_method( $method->instance_id );
+}
+
+update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+if ( 'yes' !== get_option( 'woocommerce_admin_created_default_shipping_zones' ) ) {
+	WP_CLI::error( 'Unable to persist the smart-default shipping zone marker.' );
 }
 PHP
 )"

--- a/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/tax.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/tax.sh
@@ -17,6 +17,22 @@ $rate_ids = $wpdb->get_col( "SELECT tax_rate_id FROM {$wpdb->prefix}woocommerce_
 foreach ( $rate_ids as $rate_id ) {
 	WC_Tax::_delete_tax_rate( $rate_id );
 }
+
+$required_tax_classes = array(
+	'reduced-rate' => 'Reduced rate',
+	'zero-rate'    => 'Zero rate',
+);
+
+foreach ( $required_tax_classes as $slug => $name ) {
+	if ( WC_Tax::get_tax_class_by( 'slug', $slug ) ) {
+		continue;
+	}
+
+	$result = WC_Tax::create_tax_class( $name, $slug );
+	if ( is_wp_error( $result ) ) {
+		WP_CLI::error( sprintf( 'Could not create tax class "%1$s": %2$s', $slug, $result->get_error_message() ) );
+	}
+}
 PHP
 )"
 

--- a/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/tax.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/tax.sh
@@ -33,6 +33,26 @@ foreach ( $required_tax_classes as $slug => $name ) {
 		WP_CLI::error( sprintf( 'Could not create tax class "%1$s": %2$s', $slug, $result->get_error_message() ) );
 	}
 }
+
+// Core's tax settings spec changes these and restores only
+// woocommerce_calc_taxes. Blocks specs expect WooCommerce's defaults.
+$tax_option_defaults = array(
+	'woocommerce_prices_include_tax'    => 'no',
+	'woocommerce_tax_based_on'          => 'shipping',
+	'woocommerce_shipping_tax_class'    => 'inherit',
+	'woocommerce_tax_round_at_subtotal' => 'no',
+	'woocommerce_tax_display_shop'      => 'excl',
+	'woocommerce_tax_display_cart'      => 'excl',
+	'woocommerce_price_display_suffix'  => '',
+	'woocommerce_tax_total_display'     => 'itemized',
+);
+
+foreach ( $tax_option_defaults as $option => $value ) {
+	update_option( $option, $value );
+	if ( get_option( $option ) !== $value ) {
+		WP_CLI::error( sprintf( 'Could not reset %s.', $option ) );
+	}
+}
 PHP
 )"
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Refs [TESTOPS-234](https://linear.app/a8c/issue/TESTOPS-234)

The Blocks E2E seed now resets the shipping zones, tax classes, and tax settings it relies on. That lets `pnpm env:start:blocks` work on a local environment that just ran Core tests. This PR no longer adds the request lock around snapshot restores; the review thread explains why.

**What changed**

- `parallel/tax.sh` creates the `reduced-rate` and `zero-rate` tax classes when they are missing. Trunk's `settings-tax.spec.ts` deletes them, and the seed then stops with `class is not standard`.
- `parallel/tax.sh` also resets the tax display and calculation settings to WooCommerce's defaults. The same Core spec leaves the cart showing prices including tax, so the Blocks checkout shows Flat rate as $12.00 instead of $10.00.
- `parallel/shipping.sh` deletes named shipping zones and sets the smart-default marker. A named US zone left by Core matches US addresses before zone 0, so the Blocks checkout offers only Free shipping.
- The E2E README says that Core and Blocks share one database, what the seed resets, and when to run `pnpm env:e2e:restart`.

**Limits**

- CI is unaffected, because every job starts from a fresh environment.
- This covers the leaks we know about, not every one. The README points to `pnpm env:e2e:restart` for anything else a Core run leaves behind.

**If you ran an earlier version of this PR locally**

- Its Blocks seed added an `.htaccess` block that loads `request-lock.php`. Without that file, every request fails with a fatal error. Run `pnpm env:e2e:restart`, or delete the `# BEGIN WooCommerce Blocks E2E DB Lock` block from the site's `.htaccess`.

### Backward compatibility

E2E test infrastructure only. Nothing under `src/` or `includes/` changes, and no shipped asset changes.

### How to test the changes in this Pull Request:

From `plugins/woocommerce`, with `<port>` set to your E2E port:

1. Start the E2E environment with `pnpm env:e2e`.
2. Run the Core tax settings spec: `WP_ENV_PORT=<port> bash ./tests/e2e/run-tests-with-env.sh -x default --project=core-serial --retries=0 tests/e2e/tests/settings/settings-tax.spec.ts`.
3. Confirm it removed the tax classes: `pnpm wp-env:e2e run cli wp eval 'print_r( WC_Tax::get_tax_class_slugs() );'` prints an empty array.
4. Run `pnpm env:start:blocks` and confirm it finishes. On trunk it stops at `class is not standard`.
5. Run the checkout shipping test: `WP_ENV_PORT=<port> pnpm test:e2e:blocks --retries=0 tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts --grep 'free shipping, flat rate shipping'`. Confirm it passes and that Flat rate shows $10.00.
6. Run `WP_ENV_PORT=<port> pnpm test:e2e:blocks --retries=0 tests/e2e/tests/blocks/cart/cart-checkout-block-shipping.block_theme.spec.ts` and confirm it passes.

### Testing that has already taken place:

- **Trunk seed compared with the branch seed, on the same leaked state** (tax classes deleted, a named US zone added). Trunk's `tax.sh` exits 1 with `class is not standard`, and its `shipping.sh` leaves the named zone in place. The branch restores both classes and all three rates, and removes the named zone. A second run gives the same result.
- **Tax settings, on the state the Core spec leaves** (cart showing prices including tax, a single tax total, a changed shipping tax class). The branch's `tax.sh` resets all eight options to WooCommerce's defaults, and a second run gives the same result.
- **The full sequence on a local environment, at `--retries=0`.** `settings-tax.spec.ts` passed 7 of 7, then `env:start:blocks` succeeded. After that, the checkout shopper test for free and flat rate shipping passed, and so did all 10 tests in `cart-checkout-block-shipping`. Before the tax-settings reset, that checkout test failed on the $12.00 price.
- `bash -n` passes on both scripts, and `markdownlint` is clean on the README.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually: `plugins/woocommerce/changelog/testops-234-blocks-seed-convergence`

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

The seed defects were found during an AI-assisted test-system repair on #68046. This PR was trimmed after review, re-verified locally, and its description written with Claude Code. I reviewed the diff and take responsibility for it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
