### PR TITLE
Normalize coupon spend amounts before minimum/maximum validation

### DIFF
--- a/plugins/woocommerce/changelog/fix-67704-normalize-coupon-spend-amounts
+++ b/plugins/woocommerce/changelog/fix-67704-normalize-coupon-spend-amounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize locale-formatted coupon minimum/maximum spend amounts before validating and storing them in WC_Coupon::set_minimum_amount() and WC_Coupon::set_maximum_amount().

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -803,10 +803,11 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return void
 	 */
 	public function set_minimum_amount( $amount ) {
+		$amount = wc_format_decimal( $amount );
 		if ( (float) $this->get_maximum_amount() && (float) $amount > (float) $this->get_maximum_amount() ) {
 			$this->error( 'coupon_invalid_minimum_amount', __( 'Invalid minimum spend value.', 'woocommerce' ) );
 		}
-		$this->set_prop( 'minimum_amount', wc_format_decimal( $amount ) );
+		$this->set_prop( 'minimum_amount', $amount );
 	}
 
 	/**
@@ -817,11 +818,12 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return void
 	 */
 	public function set_maximum_amount( $amount ) {
+		$amount = wc_format_decimal( $amount );
 		if ( (float) $amount && (float) $this->get_minimum_amount() > (float) $amount ) {
 			$this->error( 'coupon_invalid_maximum_amount', __( 'Invalid maximum spend value.', 'woocommerce' ) );
 		}
 
-		$this->set_prop( 'maximum_amount', wc_format_decimal( $amount ) );
+		$this->set_prop( 'maximum_amount', $amount );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -360,6 +360,51 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 	}
 
 	// -------------------------------------------------------------------------
+	// Locale-formatted amounts (comma decimal separator).
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox set_minimum_amount throws exception when a comma-decimal minimum exceeds existing maximum.
+	 */
+	public function test_set_minimum_amount_throws_when_comma_decimal_exceeds_maximum(): void {
+		$original_decimal_separator = get_option( 'woocommerce_price_decimal_sep' );
+		update_option( 'woocommerce_price_decimal_sep', ',' );
+
+		try {
+			$coupon = new WC_Coupon();
+			$coupon->set_maximum_amount( '100,00' );
+
+			try {
+				$coupon->set_minimum_amount( '100,50' );
+				$this->fail( 'Expected WC_Data_Exception was not thrown.' );
+			} catch ( \WC_Data_Exception $e ) {
+				$this->assertSame( 'coupon_invalid_minimum_amount', $e->getErrorCode() );
+			}
+		} finally {
+			update_option( 'woocommerce_price_decimal_sep', $original_decimal_separator );
+		}
+	}
+
+	/**
+	 * @testdox set_maximum_amount succeeds and stores the normalized value when a comma-decimal maximum satisfies the existing minimum.
+	 */
+	public function test_set_maximum_amount_succeeds_when_comma_decimal_satisfies_minimum(): void {
+		$original_decimal_separator = get_option( 'woocommerce_price_decimal_sep' );
+		update_option( 'woocommerce_price_decimal_sep', ',' );
+
+		try {
+			$coupon = new WC_Coupon();
+			$coupon->set_minimum_amount( '100.50' );
+
+			$coupon->set_maximum_amount( '100,75' );
+
+			$this->assertSame( '100.75', $coupon->get_maximum_amount() );
+		} finally {
+			update_option( 'woocommerce_price_decimal_sep', $original_decimal_separator );
+		}
+	}
+
+	// -------------------------------------------------------------------------
 	// Atomic set_props() validation (both amounts supplied together).
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Coupon::set_minimum_amount()` and `set_maximum_amount()` validated the incoming amount with a raw `(float)` cast before storing it through `wc_format_decimal()`. On a store whose price decimal separator is a comma, `(float)` stops parsing at the first non-numeric character, so `(float) '100,50'` evaluates to `100.0`, silently dropping the fractional part for the comparison while the stored value is correctly normalized to `100.50`. Depending on which setter runs first, this either lets an invalid minimum/maximum pair through or wrongly rejects a valid one.

This was called out as out-of-scope follow-up work in #67703, which fixed the same validation gap for the atomic `set_props()` path but left the two individual setters unaddressed. The fix here normalizes the amount with `wc_format_decimal()` first, then both validates and stores the same normalized value.

Closes #67704.

(For Bug Fixes) Bug introduced in PR #67703.

### How to test the changes in this Pull Request:

1. Set **WooCommerce > Settings > General > Currency options > Decimal separator** to `,`.
2. In PHP (e.g. via a quick REPL/mu-plugin, or the new unit tests below):
   ```php
   $coupon = new WC_Coupon();
   $coupon->set_maximum_amount( '100,00' );
   $coupon->set_minimum_amount( '100,50' ); // should throw coupon_invalid_minimum_amount
   ```
   Before this fix, no exception is thrown because `(float) '100,50'` is read as `100.0`.
3. Also verify the mirror case does not falsely reject a valid amount:
   ```php
   $coupon = new WC_Coupon();
   $coupon->set_minimum_amount( '100.50' );
   $coupon->set_maximum_amount( '100,75' ); // should succeed, not throw
   ```
   Before this fix, this incorrectly throws `coupon_invalid_maximum_amount` because `(float) '100,75'` is read as `100.0`, which appears below the minimum.
4. Run `vendor/bin/phpunit --filter WC_Coupon_Tests` — all tests pass, including two new tests covering the two scenarios above.

### Testing that has already taken place:

- Ran `phpcs-changed --git --git-base origin/trunk` on the two changed files: clean, no violations.
- Ran the full `WC_Coupon_Tests` class (35 tests, 61 assertions): all pass.
- Ran the broader legacy coupon test suite (154 tests, 578 assertions) as a regression check: all pass.
- Verified both new tests actually catch the bug: temporarily reverted only the source fix (keeping the new tests) and confirmed both failed against the pre-fix code with the expected symptoms (a real minimum/maximum violation going undetected, and a valid maximum being wrongly rejected), then restored the fix and confirmed both pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry was created manually at `plugins/woocommerce/changelog/fix-67704-normalize-coupon-spend-amounts`.

### Use of AI Tools

Claude Code (Anthropic) was used to investigate the issue, implement the fix, write and verify the unit tests (including confirming each new test fails against the pre-fix code and passes against the fix), and run phpcs/PHPUnit locally. I directed the investigation, reviewed the resulting diff, and take responsibility for the change.
