### PR TITLE
Document failed order message customization

### DIFF
--- a/docs/code-snippets/customize-failed-order-message.md
+++ b/docs/code-snippets/customize-failed-order-message.md
@@ -9,6 +9,8 @@ WooCommerce displays a message on the order confirmation page when an order fail
 
 The filter receives the current message and the failed order, so the message can include order details:
 
+When packaging this snippet in a plugin or theme, replace `your-text-domain` with the plugin or theme's text domain so its translation catalog can include the message.
+
 ```php
 /**
  * Customize the message shown for failed orders.
@@ -19,7 +21,8 @@ The filter receives the current message and the failed order, so the message can
  */
 function your_prefix_customize_failed_order_message( $message, $order ) {
 	return sprintf(
-		'We could not process order #%s. Please try again or contact us for help.',
+		/* translators: %s: Order number. */
+		__( 'We could not process order #%s. Please try again or contact us for help.', 'your-text-domain' ),
 		esc_html( $order->get_order_number() )
 	);
 }

--- a/docs/code-snippets/customize-failed-order-message.md
+++ b/docs/code-snippets/customize-failed-order-message.md
@@ -1,0 +1,29 @@
+---
+post_title: Customize the failed order message
+sidebar_label: Customize the failed order message
+---
+
+# Customize the failed order message
+
+WooCommerce displays a message on the order confirmation page when an order fails. In WooCommerce 11.2 and later, use the `woocommerce_thankyou_order_failed_text` filter to customize this message in both the classic and block-based order confirmation pages.
+
+The filter receives the current message and the failed order, so the message can include order details:
+
+```php
+/**
+ * Customize the message shown for failed orders.
+ *
+ * @param string   $message Current failed order message.
+ * @param WC_Order $order   Failed order.
+ * @return string
+ */
+function your_prefix_customize_failed_order_message( $message, $order ) {
+	return sprintf(
+		'We could not process order #%s. Please try again or contact us for help.',
+		esc_html( $order->get_order_number() )
+	);
+}
+add_filter( 'woocommerce_thankyou_order_failed_text', 'your_prefix_customize_failed_order_message', 10, 2 );
+```
+
+The callback must return a string. Safe inline HTML is allowed and is sanitized before WooCommerce displays it.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The failed-order message filter added in #68221 is otherwise easy to miss unless developers inspect the source. This adds a focused snippet showing how to customize the message with order context on both classic and block-based confirmation pages. Follow-up to #68221.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open `docs/code-snippets/customize-failed-order-message.md` in a Markdown preview.
2. Confirm the page renders its heading, explanation, and PHP snippet correctly.
3. Confirm the snippet registers `woocommerce_thankyou_order_failed_text` with two accepted arguments and uses the failed order number in the replacement message.
4. From the repository root, run `pnpm dlx markdownlint-cli docs/code-snippets/customize-failed-order-message.md` and confirm it reports no findings.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `markdownlint --fix` and the final Markdown lint check passed with no findings.
- The documented hook name, arguments, renderer coverage, and WooCommerce 11.2 availability were compared with the merged classic and block implementations.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation-only change; no plugin code is shipped to merchants.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex assisted with documentation drafting, verification, and PR preparation. I reviewed and validated the generated content.