### PR TITLE
Fix visual attribute term column TypeError

### DIFF
--- a/plugins/woocommerce/changelog/wc-slack-1788330585798149-investigation
+++ b/plugins/woocommerce/changelog/wc-slack-1788330585798149-investigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a critical error when adding terms to Color/Image product attributes.

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
@@ -387,7 +387,7 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 	 *
 	 * @internal
 	 *
-	 * @param string $content  Column output so far.
+	 * @param mixed  $content  Column output so far.
 	 * @param string $column   Current column key.
 	 * @param int    $term_id  Term ID.
 	 * @param string $taxonomy Taxonomy slug.
@@ -395,7 +395,7 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 	 */
 	public function render_term_visual_column( $content, $column, $term_id, $taxonomy ): string {
 		if ( 'visual' !== $column || ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
-			return $content;
+			return is_string( $content ) ? $content : '';
 		}
 
 		$image_id = absint( get_term_meta( $term_id, 'image', true ) );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
@@ -237,6 +237,37 @@ class VisualAttributeTermAdminTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should preserve string content and normalize non-string content when passing through another column.
+	 * @dataProvider column_content_provider
+	 *
+	 * @param mixed  $content Column content.
+	 * @param string $expected Expected content.
+	 */
+	public function test_normalizes_column_content( $content, string $expected ): void {
+		$instance = wc_get_container()->get( VisualAttributeTermAdmin::class );
+
+		$this->assertSame(
+			$expected,
+			$instance->render_term_visual_column( $content, 'another-column', 1, 'pa_color' ),
+			'Column content should remain a string.'
+		);
+	}
+
+	/**
+	 * Data provider for column content normalization.
+	 *
+	 * @return array
+	 */
+	public function column_content_provider(): array {
+		return array(
+			'string content' => array( 'existing content', 'existing content' ),
+			'null content'   => array( null, '' ),
+			'array content'  => array( array(), '' ),
+			'object content' => array( new \stdClass(), '' ),
+		);
+	}
+
+	/**
 	 * @testdox Should not throw a TypeError when the current screen has a non-string id.
 	 *
 	 * Reproduces issue #66528: Visual Composer calls do_action('admin_enqueue_scripts', NULL),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR ensures the return type of `VisualAttributeTermAdmin::render_term_visual_column()` is string to prevent type error like reported in https://developer.woocommerce.com/2026/06/03/introducing-color-swatches-in-woocommerce-core/#comment-214843

Bug introduced in PR #65347.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use a block theme. Go to **WooCommerce > Settings > Advanced > Features**, enable **Color swatches for attributes**, and save.
2. Go to **Products > Attributes** and create a Color/Image product attribute with the slug `color`.
3. Add this temporary test code to the site:

    ```php
    add_filter(
    	'manage_edit-pa_color_columns',
    	static function ( $columns ) {
    		$columns['test-column'] = 'Test column';
    		return $columns;
    	}
    );

    add_filter(
    	'manage_pa_color_custom_column',
    	static function ( $content, $column ) {
    		return 'test-column' === $column ? null : $content;
    	},
    	9,
    	2
    );
    ```

4. Select **Configure terms** for the Color/Image attribute and add a term named `Purple`.
5. Confirm `Purple` is created, no critical-error message appears, and the new row renders normally.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `VisualAttributeTermAdminTest`: 8 tests and 36 assertions passed with PHP 8.1.34 in the WooCommerce wp-env test environment.
- File-scoped PHPCS passed for both changed PHP files.
- PHP syntax and Git diff checks passed.
- Source and history analysis confirmed that WordPress initializes the filter with an empty string, while earlier extension callbacks can replace the value before WooCommerce receives it.
- No browser or video testing was performed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex (`gpt-5.6-sol`) was used to investigate the report and relevant history, implement the defensive normalization and regression coverage, run focused checks, and draft this pull request. 