### PR TITLE
Loosen render_term_visual_column return type

### DIFF
--- a/plugins/woocommerce/changelog/loosen-render-term-visual-column-type
+++ b/plugins/woocommerce/changelog/loosen-render-term-visual-column-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow product attribute term columns to preserve non-string content.

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
@@ -387,13 +387,13 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 	 *
 	 * @internal
 	 *
-	 * @param string $content  Column output so far.
+	 * @param mixed  $content  Column output so far.
 	 * @param string $column   Current column key.
 	 * @param int    $term_id  Term ID.
 	 * @param string $taxonomy Taxonomy slug.
-	 * @return string
+	 * @return mixed
 	 */
-	public function render_term_visual_column( $content, $column, $term_id, $taxonomy ): string {
+	public function render_term_visual_column( $content, $column, $term_id, $taxonomy ) {
 		if ( 'visual' !== $column || ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			return $content;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`render_term_visual_column()` returned the incoming column content unchanged for columns it does not handle, but its native `string` return type caused a `TypeError` when another filter supplied a non-string value. Remove the native return type and document the parameter and return value as `mixed`, preserving runtime behavior while accurately describing the WordPress filter contract.

Although this changes a public method signature on an `@internal` class, it only loosens the return constraint. Existing callers and subclasses returning strings remain compatible, while callbacks can now preserve arbitrary incoming content without a type error.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

See https://developer.woocommerce.com/2026/06/03/introducing-color-swatches-in-woocommerce-core/#comment-214843

Bug introduced in PR #65347.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run:
   ```sh
   php -r 'require "vendor/autoload.php"; $value = array( "existing" ); $instance = new Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermAdmin(); var_export( $instance->render_term_visual_column( $value, "name", 1, "product_cat" ) );'
   ```
2. Confirm the command returns `array ( 0 => 'existing', )` without throwing a `TypeError`.
3. Run `composer exec -- phpstan analyse src/Internal/ProductAttributes/VisualAttributeTermAdmin.php --memory-limit=2G` and confirm it reports no errors.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Direct PHP regression check with array content: passed.
- PHP syntax check: passed.
- PHPStan on the modified file: passed.
- PHPCS on the modified file: passed.
- Branch PHP lint: passed.
- Focused PHPUnit was not run because the local wp-env `cli` service was unavailable.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to implement the type correction, run checks, and draft this pull request description.
