### PR TITLE
Fix PHP error on malformed download links and correct WPCS annotations

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-114-download-authorization-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-114-download-authorization-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Treat product download links whose query arguments arrive as arrays as invalid links instead of letting them raise a PHP error.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -34,7 +34,7 @@ class WC_Download_Handler {
 	 * Hook in methods.
 	 */
 	public static function init() {
-		if ( isset( $_GET['download_file'], $_GET['order'] ) && ( isset( $_GET['email'] ) || isset( $_GET['uid'] ) ) ) { // WPCS: input var ok, CSRF ok.
+		if ( isset( $_GET['download_file'], $_GET['order'] ) && ( isset( $_GET['email'] ) || isset( $_GET['uid'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Emailed download links are bearer URLs; download_product() verifies the order key and email hash.
 			add_action( 'init', array( __CLASS__, 'download_product' ) );
 		}
 		add_action( 'woocommerce_download_file_redirect', array( __CLASS__, 'download_file_redirect' ), 10, 2 );
@@ -47,7 +47,15 @@ class WC_Download_Handler {
 	 * Check if we need to download a file and check validity.
 	 */
 	public static function download_product() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Emailed download links are bearer URLs: authorization is the order key plus the billing email or its hash, both verified below, so no nonce can be issued for them.
+
+		// Download links only ever carry scalar values, so reject array input instead of passing it to the string handling below.
+		foreach ( array( 'download_file', 'order', 'key', 'email', 'uid' ) as $download_arg ) {
+			if ( isset( $_GET[ $download_arg ] ) && ! is_scalar( $_GET[ $download_arg ] ) ) {
+				self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
+			}
+		}
+
 		$product_id = absint( $_GET['download_file'] ); // phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.VIP.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$product    = wc_get_product( $product_id );
 		$downloads  = $product ? $product->get_downloads() : array();
@@ -66,16 +74,15 @@ class WC_Download_Handler {
 		}
 
 		// Fallback, accept email address if it's passed.
-		if ( empty( $_GET['email'] ) && empty( $_GET['uid'] ) ) { // WPCS: input var ok, CSRF ok.
+		if ( empty( $_GET['email'] ) && empty( $_GET['uid'] ) ) {
 			self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		$order_id = wc_get_order_id_by_order_key( wc_clean( wp_unslash( $_GET['order'] ) ) ); // WPCS: input var ok, CSRF ok.
+		$order_id = wc_get_order_id_by_order_key( wc_clean( wp_unslash( $_GET['order'] ) ) );
 		$order    = wc_get_order( $order_id );
 
-		if ( isset( $_GET['email'] ) ) { // WPCS: input var ok, CSRF ok.
-			$email_address = wp_unslash( $_GET['email'] ); // WPCS: input var ok, CSRF ok, sanitization ok.
+		if ( isset( $_GET['email'] ) ) {
+			$email_address = wp_unslash( $_GET['email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- The raw value is needed so spaces can be restored to "+" below; sanitize_email() is applied before the lookup.
 		} else {
 			// Get email address from order to verify hash.
 			$email_address = is_a( $order, 'WC_Order' ) ? $order->get_billing_email() : null;
@@ -83,7 +90,7 @@ class WC_Download_Handler {
 			// Prepare email address hash.
 			$email_hash = function_exists( 'hash' ) ? hash( 'sha256', $email_address ) : sha1( $email_address );
 
-			if ( is_null( $email_address ) || ! hash_equals( wp_unslash( $_GET['uid'] ), $email_hash ) ) { // WPCS: input var ok, CSRF ok, sanitization ok.
+			if ( is_null( $email_address ) || ! hash_equals( wp_unslash( $_GET['uid'] ), $email_hash ) ) {
 				self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 			}
 		}
@@ -91,15 +98,16 @@ class WC_Download_Handler {
 		$download_ids = $data_store->get_downloads(
 			array(
 				'user_email'  => sanitize_email( str_replace( ' ', '+', $email_address ) ),
-				'order_key'   => wc_clean( wp_unslash( $_GET['order'] ) ), // WPCS: input var ok, CSRF ok.
+				'order_key'   => wc_clean( wp_unslash( $_GET['order'] ) ),
 				'product_id'  => $product_id,
-				'download_id' => wc_clean( preg_replace( '/\s+/', ' ', wp_unslash( $_GET['key'] ) ) ), // WPCS: input var ok, CSRF ok, sanitization ok.
+				'download_id' => wc_clean( preg_replace( '/\s+/', ' ', wp_unslash( $_GET['key'] ) ) ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- The key is matched against the product's download list above and wc_clean() normalizes it before the lookup.
 				'orderby'     => 'downloads_remaining',
 				'order'       => 'DESC',
 				'limit'       => 1,
 				'return'      => 'ids',
 			)
 		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( empty( $download_ids ) ) {
 			self::download_error( __( 'Invalid download link.', 'woocommerce' ) );

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -179,11 +179,11 @@ class ReportExporter {
 		if (
 			isset( $_GET['action'] ) &&
 			! empty( $_GET['filename'] ) &&
-			self::DOWNLOAD_EXPORT_ACTION === wp_unslash( $_GET['action'] ) && // WPCS: input var ok, sanitization ok.
+			self::DOWNLOAD_EXPORT_ACTION === wp_unslash( $_GET['action'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only export download reached from an emailed admin link and gated on the view_woocommerce_reports capability; the value is only compared verbatim against a fixed action name.
 			current_user_can( 'view_woocommerce_reports' )
 		) {
 			$exporter = new ReportCSVExporter();
-			$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // WPCS: input var ok, sanitization ok.
+			$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only export download reached from an emailed admin link and gated on the view_woocommerce_reports capability; set_filename() applies sanitize_file_name(), which keeps the read inside the reports directory.
 			$exporter->export();
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -662,6 +662,14 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 			'email'         => 'a@example.org',
 		);
 
+		$product_was_looked_up = false;
+		$lookup_watcher        = function ( $type ) use ( &$product_was_looked_up ) {
+			$product_was_looked_up = true;
+			return $type;
+		};
+
+		add_filter( 'woocommerce_product_type_query', $lookup_watcher );
+
 		try {
 			foreach ( array( 'download_file', 'order', 'key', 'email', 'uid' ) as $arg ) {
 				$_GET = $string_args;
@@ -671,8 +679,9 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 					unset( $_GET['email'] );
 				}
 
-				$_GET[ $arg ]   = array( 'x' );
-				$wp_die_message = '';
+				$_GET[ $arg ]          = array( 'x' );
+				$wp_die_message        = '';
+				$product_was_looked_up = false;
 
 				// We do not use expectException() here because every argument is checked in turn.
 				try {
@@ -686,8 +695,14 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 					$wp_die_message,
 					"An array value for the \"$arg\" query argument should render the invalid download link error."
 				);
+
+				$this->assertFalse(
+					$product_was_looked_up,
+					"Array query arguments are rejected before any product lookup, but the \"$arg\" case reached one."
+				);
 			}
 		} finally {
+			remove_filter( 'woocommerce_product_type_query', $lookup_watcher );
 			$_GET = array();
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -652,6 +652,78 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox download_product() should treat array query args as an invalid download link.
+	 */
+	public function test_download_product_rejects_array_query_args(): void {
+		self::remove_download_handlers();
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Ok for unit tests.
+		file_put_contents( WP_CONTENT_DIR . '/uploads/woocommerce_uploads/array-args-123.ods', str_pad( '', 100 ) );
+
+		list( $product, $order ) = $this->build_downloadable_product_and_order_one(
+			array(
+				array(
+					'name' => 'Array args 123',
+					'file' => content_url( 'uploads/woocommerce_uploads/array-args-123.ods' ),
+				),
+			)
+		);
+
+		$email         = 'admin@example.org';
+		$download_keys = array_keys( $product->get_downloads() );
+		$valid_args    = array(
+			'download_file' => $product->get_id(),
+			'order'         => $order->get_order_key(),
+			'email'         => $email,
+			'uid'           => hash( 'sha256', $email ),
+			'key'           => $download_keys[0],
+		);
+
+		$downloads_served = 0;
+		$download_counter = function () use ( &$downloads_served ) {
+			++$downloads_served;
+		};
+
+		add_action( 'woocommerce_download_file_force', $download_counter );
+
+		foreach ( array( 'download_file', 'order', 'key', 'email', 'uid' ) as $arg ) {
+			$_GET = $valid_args;
+
+			if ( 'uid' === $arg ) {
+				// The UID is only consulted when no email address is supplied.
+				unset( $_GET['email'] );
+			}
+
+			$_GET[ $arg ]   = array( 'x' );
+			$wp_die_message = '';
+
+			// We do not use expectException() here because every argument is checked in turn.
+			try {
+				WC_Download_Handler::download_product();
+			} catch ( WPDieException $e ) {
+				$wp_die_message = $e->getMessage();
+			}
+
+			$this->assertStringContainsString(
+				'Invalid download link',
+				$wp_die_message,
+				"An array value for the \"$arg\" query argument should render the invalid download link error."
+			);
+		}
+
+		$this->assertSame( 0, $downloads_served, 'No file is served for a download link carrying array query arguments.' );
+
+		// The same link with scalar values is unaffected.
+		$_GET = $valid_args;
+		WC_Download_Handler::download_product();
+		$this->assertSame( 1, $downloads_served, 'A valid download link still serves the file.' );
+
+		$_GET = array();
+		remove_action( 'woocommerce_download_file_force', $download_counter );
+		self::restore_download_handlers();
+	}
+
+	/**
 	 * Creates a downloadable product, and then places (and completes) an order for that
 	 * object.
 	 *

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -655,69 +655,41 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	 * @testdox download_product() should treat array query args as an invalid download link.
 	 */
 	public function test_download_product_rejects_array_query_args(): void {
-		self::remove_download_handlers();
-
-		list( $product, $order ) = $this->build_downloadable_product_and_order_one(
-			array(
-				array(
-					'name' => 'Array args 123',
-					'file' => content_url( 'uploads/woocommerce_uploads/array-args-123.ods' ),
-				),
-			)
+		$string_args = array(
+			'download_file' => '1',
+			'order'         => 'wc_order_x',
+			'key'           => 'k',
+			'email'         => 'a@example.org',
 		);
 
-		$email         = 'admin@example.org';
-		$download_keys = array_keys( $product->get_downloads() );
-		$valid_args    = array(
-			'download_file' => $product->get_id(),
-			'order'         => $order->get_order_key(),
-			'email'         => $email,
-			'uid'           => hash( 'sha256', $email ),
-			'key'           => $download_keys[0],
-		);
+		try {
+			foreach ( array( 'download_file', 'order', 'key', 'email', 'uid' ) as $arg ) {
+				$_GET = $string_args;
 
-		$downloads_served = 0;
-		$download_counter = function () use ( &$downloads_served ) {
-			++$downloads_served;
-		};
+				if ( 'uid' === $arg ) {
+					// The UID is only consulted when no email address is supplied.
+					unset( $_GET['email'] );
+				}
 
-		add_action( 'woocommerce_download_file_force', $download_counter );
+				$_GET[ $arg ]   = array( 'x' );
+				$wp_die_message = '';
 
-		foreach ( array( 'download_file', 'order', 'key', 'email', 'uid' ) as $arg ) {
-			$_GET = $valid_args;
+				// We do not use expectException() here because every argument is checked in turn.
+				try {
+					WC_Download_Handler::download_product();
+				} catch ( WPDieException $e ) {
+					$wp_die_message = $e->getMessage();
+				}
 
-			if ( 'uid' === $arg ) {
-				// The UID is only consulted when no email address is supplied.
-				unset( $_GET['email'] );
+				$this->assertStringContainsString(
+					'Invalid download link',
+					$wp_die_message,
+					"An array value for the \"$arg\" query argument should render the invalid download link error."
+				);
 			}
-
-			$_GET[ $arg ]   = array( 'x' );
-			$wp_die_message = '';
-
-			// We do not use expectException() here because every argument is checked in turn.
-			try {
-				WC_Download_Handler::download_product();
-			} catch ( WPDieException $e ) {
-				$wp_die_message = $e->getMessage();
-			}
-
-			$this->assertStringContainsString(
-				'Invalid download link',
-				$wp_die_message,
-				"An array value for the \"$arg\" query argument should render the invalid download link error."
-			);
+		} finally {
+			$_GET = array();
 		}
-
-		$this->assertSame( 0, $downloads_served, 'No file is served for a download link carrying array query arguments.' );
-
-		// The same link with scalar values is unaffected.
-		$_GET = $valid_args;
-		WC_Download_Handler::download_product();
-		$this->assertSame( 1, $downloads_served, 'A valid download link still serves the file.' );
-
-		$_GET = array();
-		remove_action( 'woocommerce_download_file_force', $download_counter );
-		self::restore_download_handlers();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -657,9 +657,6 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	public function test_download_product_rejects_array_query_args(): void {
 		self::remove_download_handlers();
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Ok for unit tests.
-		file_put_contents( WP_CONTENT_DIR . '/uploads/woocommerce_uploads/array-args-123.ods', str_pad( '', 100 ) );
-
 		list( $product, $order ) = $this->build_downloadable_product_and_order_one(
 			array(
 				array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The download handler and the report exporter carry legacy `// WPCS: input var ok, CSRF ok.` comments. WPCS 3.x does not honor that form, so those lines were reporting their diagnostics anyway while looking suppressed. This PR replaces each one with the exact sniff PHPCS reports plus a reason, and fixes a PHP error that the dead annotations were hiding.

- `includes/class-wc-download-handler.php`: `download_product()` reads `download_file`, `order`, `key`, `email` and `uid` from the query string and hands them to string-only functions. When `email` or `uid` arrives as an array, `sanitize_email()` and `hash_equals()` raise a PHP 8 `TypeError` and the request dies with a fatal error instead of the usual error page. The method now rejects non-scalar values for those five arguments up front and renders the existing "Invalid download link." message. Array values for `download_file`, `order` and `key` already ended up on that path, so only the two fatal cases change.
- `includes/class-wc-download-handler.php`: the file already had a `phpcs:disable WordPress.Security.NonceVerification.Recommended` block covering part of `download_product()`. It now spans the whole section that reads the request, which is what it describes, and carries a reason. Two lines that also need a sanitization exception get an inline `phpcs:ignore` naming that sniff.
- `src/Admin/ReportExporter.php`: `download_export_file()` gets exact annotations on the two lines that had legacy comments. No executable change; the file's tokens are identical to trunk.

Behavior notes:

- A download link built the normal way is unaffected. Query arguments are strings over HTTP, and the check accepts any scalar, so callers that pass an integer product ID to the public `download_product()` keep working.
- Authorization is unchanged. Download links are bearer URLs sent by email, so there is no nonce to verify; the order key plus the billing email or its SHA-256 hash remain the check, in the same order as before.
- The report export download is unchanged. It stays gated on `view_woocommerce_reports`, and `set_filename()` still applies `sanitize_file_name()`, which keeps the read inside the reports directory.
- No public signature, hook, option, REST field or output contract changes.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`; confirm both pass.
2. Optionally run `plugins/woocommerce/vendor/bin/phpcs --ignore-annotations` on the two production files and confirm every diagnostic on a changed line is one that now carries an inline exception or sits inside the nonce block.
3. Start the test env with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start` and run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Download_Handler_Tests`, then the same with `test:php:env:hpos-off`.
4. Buy a downloadable product, open the download link from the order email, and confirm the file downloads as before.
5. Append `&email[]=x` to that same link and confirm you get the "Invalid download link." page rather than a fatal error. Repeat with `&uid[]=x` after removing the `email` argument.
6. As a shop manager, run a report export from Analytics and download the emailed CSV link; confirm it still serves the file.

### Testing that has already taken place:

- `WC_Download_Handler_Tests`: 31 tests, 62 assertions passing on PHP 8.1.34, run once with HPOS enabled and once with legacy order storage. The new case sets plain string query arguments, swaps one of `download_file`, `order`, `key`, `email` and `uid` for an array in turn, and for each asserts both that the invalid download link error is rendered and, by watching `woocommerce_product_type_query`, that no product lookup happened. The second assertion is what distinguishes the new check from the pre-existing invalid link paths: with the check removed the test fails for all five arguments. It creates no product or order, and it does not assert that a valid link serves a file; the first test in that file already covers that.
- Against the unpatched code, a download link carrying a real product and download key reproduces `TypeError: strlen(): Argument #1 ($string) must be of type string, array given` from `sanitize_email()` for the `email` case and `TypeError: hash_equals(): Argument #1 ($known_string) must be of type string, array given` for the `uid` case.
- `lint:php:changes` and `lint:changes:branch` pass. PHPCS with `--ignore-annotations` confirms every remaining exception sits on the line PHPCS actually reports.
- PHPStan passes for both modified class files.
- `src/Admin/ReportExporter.php` was checked token by token against trunk after dropping comments and whitespace: 602 tokens, identical.

### Use of AI Tools

This change was authored with AI assistance (Claude Code) and reviewed by the author.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-114-download-authorization-suppressions`.

*\*left by Biff (AI agent) on behalf of Darren*
