### PR TITLE
Replace mixed WPCS suppressions with exact PHPCS annotations

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-116-mixed-request-validation-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-116-mixed-request-validation-suppressions
@@ -1,4 +1,4 @@
 Significance: patch
-Type: dev
+Type: fix
 
-Replace legacy WPCS suppression comments in the settings save handler, thanks page, conditional tag helpers and terms template with exact PHPCS annotations, and document the hooks on those lines.
+Fix a fatal error on the order received page when the order key is passed as an array, and replace legacy WPCS suppression comments in the settings save handler, thanks page, conditional tag helpers and terms template with exact PHPCS annotations.

--- a/plugins/woocommerce/changelog/fix-woo6-116-mixed-request-validation-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-116-mixed-request-validation-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace legacy WPCS suppression comments in the settings save handler, thanks page, conditional tag helpers and terms template with exact PHPCS annotations, and document the hooks on those lines.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -186,9 +186,31 @@ class WC_Admin_Menus {
 		$current_section = empty( $_REQUEST['section'] ) ? '' : sanitize_title( wp_unslash( $_REQUEST['section'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only selector; settings mutations verify capability and nonce.
 
 		// Save settings if data has been posted.
-		if ( '' !== $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}_{$current_section}", ! empty( $_POST['save'] ) ) ) { // WPCS: input var okay, CSRF ok.
+		/**
+		 * Filters whether the posted data for a settings section should be saved.
+		 *
+		 * The dynamic portions of the hook name, `$current_tab` and `$current_section`, are the
+		 * sanitized `tab` and `section` request values of the settings screen being viewed.
+		 *
+		 * @since 3.3.0
+		 * @param bool $save Whether to save. Defaults to true when the settings form was submitted.
+		 */
+		if ( '' !== $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}_{$current_section}", ! empty( $_POST['save'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Presence check only; WC_Admin_Settings::save() verifies the manage_woocommerce capability and the woocommerce-settings nonce before anything is written.
 			WC_Admin_Settings::save();
-		} elseif ( '' === $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}", ! empty( $_POST['save'] ) ) ) { // WPCS: input var okay, CSRF ok.
+		} elseif (
+			'' === $current_section
+			/**
+			 * Filters whether the posted data for a settings tab should be saved.
+			 *
+			 * The dynamic portion of the hook name, `$current_tab`, is the sanitized `tab` request
+			 * value of the settings screen being viewed. This variant fires only when no section is
+			 * selected.
+			 *
+			 * @since 3.3.0
+			 * @param bool $save Whether to save. Defaults to true when the settings form was submitted.
+			 */
+			&& apply_filters( "woocommerce_save_settings_{$current_tab}", ! empty( $_POST['save'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Presence check only; WC_Admin_Settings::save() verifies the manage_woocommerce capability and the woocommerce-settings nonce before anything is written.
+		) {
 			WC_Admin_Settings::save();
 		}
 	}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -278,7 +278,7 @@ class WC_Shortcode_Checkout {
 		 * @since 2.0.0
 		 * @param string $order_key The order key read from the request, or an empty string.
 		 */
-		$order_key = apply_filters( 'woocommerce_thankyou_order_key', empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Bearer-style order-key lookup; the value is compared with hash_equals() below and a nonce cannot apply to links emailed to the customer.
+		$order_key = apply_filters( 'woocommerce_thankyou_order_key', ( empty( $_GET['key'] ) || ! is_string( $_GET['key'] ) ) ? '' : sanitize_text_field( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Bearer-style order-key lookup; the value is compared with hash_equals() below and a nonce cannot apply to links emailed to the customer.
 
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -265,8 +265,20 @@ class WC_Shortcode_Checkout {
 		$order = false;
 
 		// Get the order.
-		$order_id  = apply_filters( 'woocommerce_thankyou_order_id', absint( $order_id ) );
-		$order_key = apply_filters( 'woocommerce_thankyou_order_key', empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) ) ); // WPCS: input var ok, CSRF ok.
+		/**
+		 * Filters the ID of the order shown on the thanks page.
+		 *
+		 * @since 2.0.0
+		 * @param int $order_id The order ID resolved from the request.
+		 */
+		$order_id = apply_filters( 'woocommerce_thankyou_order_id', absint( $order_id ) );
+		/**
+		 * Filters the order key used to validate the order shown on the thanks page.
+		 *
+		 * @since 2.0.0
+		 * @param string $order_key The order key read from the request, or an empty string.
+		 */
+		$order_key = apply_filters( 'woocommerce_thankyou_order_key', empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Bearer-style order-key lookup; the value is compared with hash_equals() below and a nonce cannot apply to links emailed to the customer.
 
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -245,6 +245,12 @@ if ( ! function_exists( 'is_order_received_page' ) ) {
 
 		$page_id = wc_get_page_id( 'checkout' );
 
+		/**
+		 * Filters whether the order received (thanks) page is being viewed.
+		 *
+		 * @since 3.0.0
+		 * @param bool $is_order_received_page Whether the order received page is being viewed.
+		 */
 		return apply_filters( 'woocommerce_is_order_received_page', ( $page_id && is_page( $page_id ) && isset( $wp->query_vars['order-received'] ) ) );
 	}
 }
@@ -343,7 +349,13 @@ if ( ! function_exists( 'is_filtered' ) ) {
 	 * @return bool
 	 */
 	function is_filtered() {
-		return apply_filters( 'woocommerce_is_filtered', ( count( WC_Query::get_layered_nav_chosen_attributes() ) > 0 || isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) || isset( $_GET['rating_filter'] ) ) ); // WPCS: CSRF ok.
+		/**
+		 * Filters whether products are currently being filtered by layered nav, price or rating.
+		 *
+		 * @since 2.1.0
+		 * @param bool $is_filtered Whether a product filter is active.
+		 */
+		return apply_filters( 'woocommerce_is_filtered', ( count( WC_Query::get_layered_nav_chosen_attributes() ) > 0 || isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) || isset( $_GET['rating_filter'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only presence checks on public catalog filter parameters; nothing is written.
 	}
 }
 
@@ -399,6 +411,12 @@ if ( ! function_exists( 'wc_tax_enabled' ) ) {
 	 * @return bool
 	 */
 	function wc_tax_enabled() {
+		/**
+		 * Filters whether store-wide taxes are enabled.
+		 *
+		 * @since 2.4.0
+		 * @param bool $tax_enabled Whether taxes are enabled.
+		 */
 		return apply_filters( 'wc_tax_enabled', get_option( 'woocommerce_calc_taxes' ) === 'yes' );
 	}
 }
@@ -411,6 +429,12 @@ if ( ! function_exists( 'wc_shipping_enabled' ) ) {
 	 * @return bool
 	 */
 	function wc_shipping_enabled() {
+		/**
+		 * Filters whether shipping is enabled.
+		 *
+		 * @since 2.6.0
+		 * @param bool $shipping_enabled Whether shipping is enabled.
+		 */
 		return apply_filters( 'wc_shipping_enabled', get_option( 'woocommerce_ship_to_countries' ) !== 'disabled' );
 	}
 }

--- a/plugins/woocommerce/templates/checkout/terms.php
+++ b/plugins/woocommerce/templates/checkout/terms.php
@@ -27,7 +27,7 @@ if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists
 		<?php if ( wc_terms_and_conditions_checkbox_enabled() ) : ?>
 			<p class="form-row validate-required">
 				<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">
-				<input type="checkbox" class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" name="terms" <?php checked( apply_filters( 'woocommerce_terms_is_checked_default', isset( $_POST['terms'] ) ), true ); // WPCS: input var ok, csrf ok. ?> id="terms" />
+				<input type="checkbox" class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" name="terms" <?php checked( apply_filters( 'woocommerce_terms_is_checked_default', isset( $_POST['terms'] ) ), true ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WooCommerce.Commenting.CommentHooks.MissingHookComment -- Presence check only, used to re-render the checkbox; WC_Checkout::process_checkout() verifies the checkout nonce. A docblock cannot precede this inline call without changing the rendered markup. ?> id="terms" />
 					<span class="woocommerce-terms-and-conditions-checkbox-text"><?php wc_terms_and_conditions_checkbox_text(); ?></span>&nbsp;<abbr class="required" title="<?php esc_attr_e( 'required', 'woocommerce' ); ?>">*</abbr>
 				</label>
 				<input type="hidden" name="terms-field" value="1" />

--- a/plugins/woocommerce/tests/php/includes/shortcodes/class-wc-shortcode-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/shortcodes/class-wc-shortcode-checkout-test.php
@@ -1,0 +1,68 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Shortcode_Checkout.
+ *
+ * @package WooCommerce\Tests\Shortcodes
+ */
+
+/**
+ * Class WC_Shortcode_Checkout_Test.
+ */
+class WC_Shortcode_Checkout_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Restore the request and query state touched by these tests.
+	 */
+	public function tearDown(): void {
+		global $wp;
+
+		unset( $_GET['key'] );
+		unset( $wp->query_vars['order-received'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the order received page for an order with the supplied `key` request value.
+	 *
+	 * @param int   $order_id  Order to request.
+	 * @param mixed $order_key Value to place in `$_GET['key']`.
+	 * @return string The rendered markup.
+	 */
+	private function render_order_received( int $order_id, $order_key ): string {
+		global $wp;
+
+		$wp->query_vars['order-received'] = $order_id;
+		$_GET['key']                      = $order_key;
+
+		ob_start();
+		WC_Shortcode_Checkout::output( array() );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * An array `key` must be treated as absent rather than reaching hash_equals().
+	 */
+	public function test_order_received_treats_array_order_key_as_absent() {
+		$order = WC_Helper_Order::create_order( 0 );
+
+		$output = $this->render_order_received( $order->get_id(), array( $order->get_order_key() ) );
+
+		$this->assertStringNotContainsString( 'woocommerce-thankyou-order-details', $output );
+		$this->assertStringNotContainsString( (string) $order->get_order_number(), $output );
+	}
+
+	/**
+	 * A valid string `key` still renders the order details.
+	 */
+	public function test_order_received_renders_order_for_valid_key() {
+		$order = WC_Helper_Order::create_order( 0 );
+
+		$output = $this->render_order_received( $order->get_id(), $order->get_order_key() );
+
+		$this->assertStringContainsString( 'woocommerce-thankyou-order-details', $output );
+		$this->assertStringContainsString( (string) $order->get_order_number(), $output );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/shortcodes/class-wc-shortcode-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/shortcodes/class-wc-shortcode-checkout-test.php
@@ -13,7 +13,7 @@ declare( strict_types = 1 );
 class WC_Shortcode_Checkout_Test extends WC_Unit_Test_Case {
 
 	/**
-	 * Restore the request and query state touched by these tests.
+	 * Restore the request and query state touched by this test.
 	 */
 	public function tearDown(): void {
 		global $wp;
@@ -25,44 +25,21 @@ class WC_Shortcode_Checkout_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Render the order received page for an order with the supplied `key` request value.
-	 *
-	 * @param int   $order_id  Order to request.
-	 * @param mixed $order_key Value to place in `$_GET['key']`.
-	 * @return string The rendered markup.
-	 */
-	private function render_order_received( int $order_id, $order_key ): string {
-		global $wp;
-
-		$wp->query_vars['order-received'] = $order_id;
-		$_GET['key']                      = $order_key;
-
-		ob_start();
-		WC_Shortcode_Checkout::output( array() );
-		return (string) ob_get_clean();
-	}
-
-	/**
 	 * An array `key` must be treated as absent rather than reaching hash_equals().
 	 */
 	public function test_order_received_treats_array_order_key_as_absent() {
+		global $wp;
+
 		$order = WC_Helper_Order::create_order( 0 );
 
-		$output = $this->render_order_received( $order->get_id(), array( $order->get_order_key() ) );
+		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = array( $order->get_order_key() );
+
+		ob_start();
+		WC_Shortcode_Checkout::output( array() );
+		$output = (string) ob_get_clean();
 
 		$this->assertStringNotContainsString( 'woocommerce-thankyou-order-details', $output );
 		$this->assertStringNotContainsString( (string) $order->get_order_number(), $output );
-	}
-
-	/**
-	 * A valid string `key` still renders the order details.
-	 */
-	public function test_order_received_renders_order_for_valid_key() {
-		$order = WC_Helper_Order::create_order( 0 );
-
-		$output = $this->render_order_received( $order->get_id(), $order->get_order_key() );
-
-		$this->assertStringContainsString( 'woocommerce-thankyou-order-details', $output );
-		$this->assertStringContainsString( (string) $order->get_order_number(), $output );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Each line touched here carried a legacy `// WPCS: ... ok.` comment sitting on a line PHPCS reports for two unrelated reasons: a request-state finding and an undocumented hook. The legacy comment form is no longer honored by WPCS 3.x, so both findings were live, and a single vague comment gave no way to tell which concern it was meant to cover. This PR names the exact codes PHPCS emits on each line, gives each a reason, and adds the hook docblocks the `WooCommerce.Commenting.CommentHooks` sniff asks for.

Documenting the order received page's order key made an existing bug visible, so a fix for it is included in a second commit.

- `includes/admin/class-wc-admin-menus.php`: both `woocommerce_save_settings_*` filters gain hook docblocks and the `$_POST['save']` presence checks get a scoped `WordPress.Security.NonceVerification.Missing` exception. The `elseif` condition is split across lines because the sniff requires the docblock directly above the `apply_filters()` call; the short-circuit order is unchanged, so each filter still fires exactly when it did before.
- `includes/shortcodes/class-wc-shortcode-checkout.php`: `woocommerce_thankyou_order_id` and `woocommerce_thankyou_order_key` gain hook docblocks, and the order-key read keeps a scoped `NonceVerification.Recommended` exception. The key is compared with `hash_equals()` immediately below, and a nonce cannot apply to a link emailed to the customer. **This file also carries the runtime fix described below.**
- `includes/wc-conditional-functions.php`: `woocommerce_is_order_received_page`, `woocommerce_is_filtered`, `wc_tax_enabled` and `wc_shipping_enabled` gain hook docblocks. `is_filtered()` keeps a scoped `NonceVerification.Recommended` exception for its read-only presence checks on the public catalog filter parameters. `is_cart()` and `is_checkout()` already carry docblocks and report nothing, so they are untouched.
- `templates/checkout/terms.php`: the checkbox line names both codes it emits. The hook sniff needs a docblock on the line directly above the call, which is impossible for a filter embedded mid-attribute without splitting the opening tag and changing the rendered markup, so the documentation finding is suppressed explicitly rather than hidden behind a broad comment.

### The runtime fix

`WC_Shortcode_Checkout::order_received()` read `$_GET['key']` through `wc_clean( wp_unslash( ... ) )`, which returns an array unchanged when the request supplies one. A URL such as `/checkout/order-received/123/?key[]=x` therefore reached `hash_equals( $order->get_order_key(), $order_key )` with an array and raised `TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, array given`, producing a fatal error page instead of the order received page.

A non-string `key` is now treated the same as an absent one, so the generic order received page renders, which is already what happens for a wrong key. For a string value nothing changes: the guarded branch calls `sanitize_text_field()`, which is exactly what `wc_clean()` delegates to for scalars, so the sanitization is identical and the array branch of `wc_clean()` is now unreachable from this call site.

Attacker prerequisites are low (any visitor can craft the URL) but impact is limited to a fatal error on that one request. No data is exposed: an order still renders only when the supplied key matches the stored order key.

Behavior notes:

- The only runtime change is the guard above. Requests with a valid, missing, or wrong string key behave exactly as before; requests with an array or other non-string key now render the generic order received page instead of erroring.
- The other three files change only comments and whitespace. Their token streams are identical to `trunk` once comments and whitespace are dropped.
- No hook contracts change. All eight documented filters keep the same names, arguments and firing points; the docblocks are documentation only. Each `@since` is the release that first shipped the hook, taken from the introducing commit and the earliest tag containing it. `woocommerce_thankyou_order_key` still receives a string and still fires at the same point.
- The template `@version` header is intentionally **not** bumped. `templates/checkout/terms.php` changes only a comment; its emitted bytes are identical, so theme overrides cannot be affected, and a bump would only produce spurious "outdated template" warnings in System Status. The `Analyze Branch Changes` check has no comment-only exemption and will show red for this reason; it is not a required check.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`; confirm both pass.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Shortcode_Checkout_Test` and the same with `test:php:env:hpos-off`; confirm both pass.
3. Place an order, then load its order received URL with `&key[]=x` appended. Before this change that produced a fatal error; it should now render the generic "order received" page with no order details.
4. Load the same order received URL with the correct `key` and confirm the order number, date and totals still render, then with a wrong string key and confirm the generic page renders.
5. Optionally run `plugins/woocommerce/vendor/bin/phpcs -s --ignore-annotations` on the four production files and confirm each changed line reports only the codes now named in its inline exception, and that lines 108 and 126 of `wc-conditional-functions.php` report nothing.
6. Visit WooCommerce → Settings, change a value on a tab with no section (General) and on a tab with a section (Products → Inventory), and confirm both save.
7. Enable the terms and conditions checkbox in checkout settings, submit checkout with a validation error, and confirm the checkbox keeps the state you left it in.
8. Load a shop page with a layered nav or price filter applied and confirm filtered results still render.

### Testing that has already taken place:

- New `WC_Shortcode_Checkout_Test`: 1 test, 2 assertions passing on PHP 8.1.34, run with HPOS enabled and again with `DISABLE_HPOS=1`. It asserts that an array `key` renders the order received page without the order details and without a fatal. Reverting the guard makes it fail with `TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, array given`, so it genuinely covers the fix.
- `lint:php:changes` and `lint:changes:branch` pass.
- `php -l` clean on all changed files.
- PHPStan passes on `class-wc-shortcode-checkout.php` at the project's level 8; the `@param string $order_key` docblock is now accurate rather than being weakened to `string|array`.
- PHPCS with `--ignore-annotations` confirms every remaining exception names exactly the codes emitted on its line, no more and no fewer, and that the hook docblock findings on those lines are gone.
- Token equivalence against `trunk` verified for `class-wc-admin-menus.php`, `wc-conditional-functions.php` and `templates/checkout/terms.php`, which also proves the template's rendered output is byte for byte unchanged. `class-wc-shortcode-checkout.php` is deliberately excluded because it carries the runtime fix.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-116-mixed-request-validation-suppressions`.

### Use of AI Tools

Biff, an AI coding agent, assisted with the suppression audit, implementation, focused test, validation, compatibility and security review, and PR preparation. The author reviewed the result.

*\*left by Biff (AI agent) on behalf of Darren*
