### PR TITLE
Scope product review and raw referer input suppressions to real diagnostics

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-115-public-interaction-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-115-public-interaction-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product review ratings posted as a fraction below one, such as 0.5, are no longer stored as a rating of 0.

--- a/plugins/woocommerce/includes/class-wc-background-emailer.php
+++ b/plugins/woocommerce/includes/class-wc-background-emailer.php
@@ -119,7 +119,7 @@ class WC_Background_Emailer extends WC_Background_Process {
 		// Pass cookies through with the request so nonces function.
 		$cookies = array();
 
-		foreach ( $_COOKIE as $name => $value ) { // WPCS: input var ok.
+		foreach ( $_COOKIE as $name => $value ) {
 			if ( 'PHPSESSID' === $name ) {
 				continue;
 			}

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -240,8 +240,9 @@ class WC_Comments {
 		if ( isset( $_POST['rating'], $_POST['comment_post_ID'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the post ID is read through absint().
 			$raw_rating = is_scalar( $_POST['rating'] ) ? wp_unslash( $_POST['rating'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the value is range checked and cast to an integer below.
 
-			// Ratings are whole numbers from 1 to 5. Numeric input is range checked before it is
-			// truncated, so that both 0.5 and 5.9 are rejected rather than stored as 0 and 5.
+			// Stored ratings are whole numbers from 1 to 5. Numeric input is range checked before it
+			// is truncated, so 0.5 and 5.9 are rejected rather than stored as 0 and 5, while 4.7
+			// still stores 4 as before.
 			if ( is_numeric( $raw_rating ) && ( $raw_rating < 1 || $raw_rating > 5 ) ) {
 				return;
 			}

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -224,7 +224,7 @@ class WC_Comments {
 	 */
 	public static function check_comment_rating( $comment_data ) {
 		// If posting a comment (not trackback etc) and not logged in.
-		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && wc_review_ratings_enabled() && wc_review_ratings_required() ) { // WPCS: input var ok, CSRF ok.
+		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && wc_review_ratings_enabled() && wc_review_ratings_required() ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the post ID is read through absint() and the rating is only tested for emptiness.
 			wp_die( esc_html__( 'Please rate the product.', 'woocommerce' ) );
 			exit;
 		}
@@ -237,13 +237,24 @@ class WC_Comments {
 	 * @param int $comment_id Comment ID.
 	 */
 	public static function add_comment_rating( $comment_id ) {
-		if ( isset( $_POST['rating'], $_POST['comment_post_ID'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // WPCS: input var ok, CSRF ok.
-			if ( ! $_POST['rating'] || $_POST['rating'] > 5 || $_POST['rating'] < 0 ) { // WPCS: input var ok, CSRF ok, sanitization ok.
+		if ( isset( $_POST['rating'], $_POST['comment_post_ID'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the post ID is read through absint().
+			$raw_rating = is_scalar( $_POST['rating'] ) ? wp_unslash( $_POST['rating'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the value is range checked and cast to an integer below.
+
+			// Ratings are whole numbers from 1 to 5. Numeric input is range checked before it is
+			// truncated, so that both 0.5 and 5.9 are rejected rather than stored as 0 and 5.
+			if ( is_numeric( $raw_rating ) && ( $raw_rating < 1 || $raw_rating > 5 ) ) {
 				return;
 			}
-			add_comment_meta( $comment_id, 'rating', intval( $_POST['rating'] ), true ); // WPCS: input var ok, CSRF ok.
 
-			$post_id = isset( $_POST['comment_post_ID'] ) ? absint( $_POST['comment_post_ID'] ) : 0; // WPCS: input var ok, CSRF ok.
+			$rating = intval( $raw_rating );
+
+			if ( $rating < 1 || $rating > 5 ) {
+				return;
+			}
+
+			add_comment_meta( $comment_id, 'rating', $rating, true );
+
+			$post_id = isset( $_POST['comment_post_ID'] ) ? absint( $_POST['comment_post_ID'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the post ID is read through absint().
 			if ( $post_id ) {
 				self::clear_transients( $post_id );
 			}
@@ -642,7 +653,7 @@ class WC_Comments {
 	 * @return array
 	 */
 	public static function update_comment_type( $comment_data ) {
-		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $comment_data['comment_type'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // WPCS: input var ok, CSRF ok.
+		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $comment_data['comment_type'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Anonymous product reviews are submitted through the core comment form, which carries no WooCommerce nonce; the post ID is read through absint().
 			$comment_data['comment_type'] = 'review';
 		}
 

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -55,10 +55,10 @@ function wc_get_raw_referer() {
 		return wp_get_raw_referer();
 	}
 
-	if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) { // WPCS: input var ok, CSRF ok.
-		return wp_unslash( $_REQUEST['_wp_http_referer'] ); // WPCS: input var ok, CSRF ok, sanitization ok.
-	} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) { // WPCS: input var ok, CSRF ok.
-		return wp_unslash( $_SERVER['HTTP_REFERER'] ); // WPCS: input var ok, CSRF ok, sanitization ok.
+	if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only fallback that only reports where the request came from; no state changes here.
+		return wp_unslash( $_REQUEST['_wp_http_referer'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This function is documented to return the referer unvalidated; every caller passes the result through wp_validate_redirect().
+	} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
+		return wp_unslash( $_SERVER['HTTP_REFERER'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This function is documented to return the referer unvalidated; every caller passes the result through wp_validate_redirect().
 	}
 
 	return false;

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -225,4 +225,74 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 		wp_delete_comment( $comment_id, true );
 		wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * @testdox add_comment_rating() stores a rating only for whole numbers from 1 to 5.
+	 *
+	 * @testWith ["1", 1]
+	 *           ["3", 3]
+	 *           ["5", 5]
+	 *           ["05", 5]
+	 *           ["5.0", 5]
+	 *           ["4.7", 4]
+	 *           ["3abc", 3]
+	 *           ["", null]
+	 *           ["0", null]
+	 *           ["6", null]
+	 *           ["-1", null]
+	 *           ["-0.5", null]
+	 *           ["0.5", null]
+	 *           ["0.9", null]
+	 *           ["5.9", null]
+	 *           ["abc", null]
+	 *
+	 * @param string   $posted_rating   Raw value posted in the rating field.
+	 * @param int|null $expected_rating Rating expected in comment meta, or null when nothing should be stored.
+	 */
+	public function test_add_comment_rating_stores_only_whole_ratings_in_range( string $posted_rating, ?int $expected_rating ): void {
+		$this->assert_posted_rating_is_stored_as( $posted_rating, $expected_rating );
+	}
+
+	/**
+	 * @testdox add_comment_rating() stores nothing when the rating field is posted as an array.
+	 */
+	public function test_add_comment_rating_ignores_an_array_rating(): void {
+		$this->assert_posted_rating_is_stored_as( array( '5' ), null );
+	}
+
+	/**
+	 * Post a rating for a fresh product review and assert what ends up in comment meta.
+	 *
+	 * @param mixed    $posted_rating   Raw value to place in $_POST['rating'].
+	 * @param int|null $expected_rating Rating expected in comment meta, or null when nothing should be stored.
+	 */
+	private function assert_posted_rating_is_stored_as( $posted_rating, ?int $expected_rating ): void {
+		$product    = WC_Helper_Product::create_simple_product();
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $product->get_id(),
+				'comment_type'     => 'review',
+				'comment_approved' => '1',
+			)
+		);
+
+		$_POST['comment_post_ID'] = (string) $product->get_id();
+		$_POST['rating']          = $posted_rating;
+
+		try {
+			WC_Comments::add_comment_rating( $comment_id );
+
+			$stored = get_comment_meta( $comment_id, 'rating', true );
+
+			if ( null === $expected_rating ) {
+				$this->assertSame( '', $stored, 'No rating should have been stored.' );
+			} else {
+				$this->assertSame( $expected_rating, (int) $stored, 'The stored rating does not match.' );
+			}
+		} finally {
+			unset( $_POST['comment_post_ID'], $_POST['rating'] );
+			wp_delete_comment( $comment_id, true );
+			$product->delete( true );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The legacy `// WPCS: input var ok, CSRF ok.` comment form is no longer honored by WPCS 3.x, so eleven of these comments in the product review and raw referer paths were suppressing nothing while the real diagnostics were still being reported. This PR puts each exception on the exact expression PHPCS reports, names the current sniff, and gives a reason describing the workflow. Both paths are anonymous by design, so a WooCommerce nonce cannot apply to either.

- `includes/class-wc-comments.php`: the four review callbacks that read `$_POST['comment_post_ID']` and `$_POST['rating']` get `WordPress.Security.NonceVerification.Missing` exceptions. Standard product reviews are submitted through the core comment form, which anonymous visitors can use, so there is no WooCommerce nonce to verify. The post ID is read only through `absint()`.
- `includes/wc-cart-functions.php`: the `wc_get_raw_referer()` fallback keeps `NonceVerification.Recommended` and `ValidatedSanitizedInput.InputNotSanitized` exceptions where PHPCS reports them. The function is documented to return the referer unvalidated, and all three callers pass the result through `wp_validate_redirect()` before redirecting. Note that this fallback only runs when `wp_get_raw_referer()` is missing, which has not been the case since WordPress 4.5, so it is unreachable on every supported version. The body is left intact rather than removed.
- `includes/class-wc-background-emailer.php`: the `foreach ( $_COOKIE ... )` comment is removed. PHPCS reports nothing on that line, so the comment suppressed nothing. Cookies are still forwarded as `WP_Http_Cookie` objects to the internal loopback request so that nonces keep working there.

Behavior change:

`add_comment_rating()` now normalizes the posted rating once instead of relying on PHP's comparison rules. A fractional value below one, such as `0.5`, is truthy, is not above five and is not below zero, so it passed the old guard and `intval()` then stored a rating of `0`. Ratings are now range checked before truncation, so those inputs store nothing at all.

Whole ratings from 1 to 5 are unchanged, and so is the existing lenient handling of values like `4.7` and `3abc`, which still store 4 and 3. Values that were already rejected, including `5.9`, `abc`, `6` and array input, are still rejected. The only inputs that behave differently are the ones that previously wrote a rating of `0`, and both rating aggregation queries already filtered on `meta_value > 0` while the structured data output already treated `0` as no rating, so no displayed average, count or schema value changes. The REST reviews controllers write rating meta directly and do not go through this callback.

No public signatures, hook names, arguments, timing, options, REST fields or output contracts change.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`; confirm both pass.
2. Run `plugins/woocommerce/vendor/bin/phpcs --ignore-annotations` on the three production files and confirm the only nonce and sanitization findings on the changed lines are the ones now carrying an inline exception. Confirm the normal run reports none of them.
3. Start the test env and run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Comments_Tests`, then the same with `test:php:env:hpos-off`.
4. On a store with reviews enabled, submit a product review with each star rating from 1 to 5 and confirm the review, the star display, the average and the rating counts are all as before.
5. Enable "Star ratings should be required" under Products, then submit a review with no rating and confirm "Please rate the product." still appears.
6. Post a review with the rating field forced to `0.5` using browser devtools and confirm no `rating` comment meta row is created for it. On trunk this stores a rating of `0`.

### Testing that has already taken place:

- `WC_Comments_Tests`: 29 tests, 35 assertions passing on PHP 8.1.34, run with HPOS on and with HPOS off. The 17 new cases cover the whole accepted and rejected rating range plus array input.
- The new tests were mutation checked. Reverting only `class-wc-comments.php` to trunk makes exactly the `0.5` and `0.9` cases fail, each finding a stored `'0'`. The other 27 cases pass identically against both versions, so the tests target this defect and nothing else.
- All 34 input shapes considered were compared old against new in isolation. Six diverge, and all six are inputs that previously stored a rating of `0`.
- `lint:php:changes` and `lint:changes:branch` both pass. PHPCS with `--ignore-annotations` confirms every remaining exception sits on the line PHPCS actually reports, with exactly the codes it emits there.
- PHPStan reports no errors for the three modified production files.
- Non-comment PHP tokens for `class-wc-background-emailer.php` and `wc-cart-functions.php` are identical to `trunk`; only `class-wc-comments.php` carries executable changes.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-115-public-interaction-suppressions`.

### Use of AI Tools

This change was authored with AI assistance (Claude Code) and reviewed by the author.

*\*left by Biff (AI agent) on behalf of Darren*
