### PR TITLE
Reject array wc-auth parameters and replace legacy WPCS suppressions

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-113-auth-callback-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-113-auth-callback-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reject array values for the wc-auth handshake parameters so they no longer cause a fatal error, and replace legacy WPCS suppression comments in the auth, REST authentication and PayPal IPN handlers with exact PHPCS annotations.

--- a/plugins/woocommerce/includes/class-wc-auth.php
+++ b/plugins/woocommerce/includes/class-wc-auth.php
@@ -172,13 +172,13 @@ class WC_Auth {
 				throw new Exception( sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param ) );
 			}
 
-			// Every handshake parameter is a single string; array input is rejected here so that it cannot reach the string-only functions used below.
-			if ( ! is_scalar( $_REQUEST[ $param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Values are required for handshake validation; key creation verifies capability and nonce.
+			// Every handshake parameter is a single string; anything else, an array in particular, is rejected here so that it cannot reach the string-only functions used below.
+			if ( ! is_string( $_REQUEST[ $param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Values are required for handshake validation; key creation verifies capability and nonce.
 				/* translators: %s: parameter */
 				throw new Exception( sprintf( __( 'Invalid parameter %s', 'woocommerce' ), $param ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The caught message is escaped by esc_html() where it is rendered; escaping here would double-encode translated text.
 			}
 
-			$data[ $param ] = (string) wp_unslash( $_REQUEST[ $param ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Raw values are needed to validate the submitted URLs and scope; each value is sanitized or escaped where it is used, and key creation verifies capability and nonce.
+			$data[ $param ] = wp_unslash( $_REQUEST[ $param ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Raw values are needed to validate the submitted URLs and scope; each value is sanitized or escaped where it is used, and key creation verifies capability and nonce.
 		}
 
 		if ( ! in_array( $data['scope'], array( 'read', 'write', 'read_write' ), true ) ) {

--- a/plugins/woocommerce/includes/class-wc-auth.php
+++ b/plugins/woocommerce/includes/class-wc-auth.php
@@ -167,10 +167,15 @@ class WC_Auth {
 		);
 
 		foreach ( $params as $param ) {
-			// Every handshake parameter is a single string; array input is rejected here so that it cannot reach the string-only functions used below.
-			if ( empty( $_REQUEST[ $param ] ) || ! is_scalar( $_REQUEST[ $param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Values are required for handshake validation; key creation verifies capability and nonce.
+			if ( empty( $_REQUEST[ $param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Values are required for handshake validation; key creation verifies capability and nonce.
 				/* translators: %s: parameter */
 				throw new Exception( sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param ) );
+			}
+
+			// Every handshake parameter is a single string; array input is rejected here so that it cannot reach the string-only functions used below.
+			if ( ! is_scalar( $_REQUEST[ $param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Values are required for handshake validation; key creation verifies capability and nonce.
+				/* translators: %s: parameter */
+				throw new Exception( sprintf( __( 'Invalid parameter %s', 'woocommerce' ), $param ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The caught message is escaped by esc_html() where it is rendered; escaping here would double-encode translated text.
 			}
 
 			$data[ $param ] = (string) wp_unslash( $_REQUEST[ $param ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Raw values are needed to validate the submitted URLs and scope; each value is sanitized or escaped where it is used, and key creation verifies capability and nonce.

--- a/plugins/woocommerce/includes/class-wc-auth.php
+++ b/plugins/woocommerce/includes/class-wc-auth.php
@@ -167,12 +167,13 @@ class WC_Auth {
 		);
 
 		foreach ( $params as $param ) {
-			if ( empty( $_REQUEST[ $param ] ) ) { // WPCS: input var ok, CSRF ok.
+			// Every handshake parameter is a single string; array input is rejected here so that it cannot reach the string-only functions used below.
+			if ( empty( $_REQUEST[ $param ] ) || ! is_scalar( $_REQUEST[ $param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Values are required for handshake validation; key creation verifies capability and nonce.
 				/* translators: %s: parameter */
 				throw new Exception( sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param ) );
 			}
 
-			$data[ $param ] = wp_unslash( $_REQUEST[ $param ] ); // WPCS: input var ok, CSRF ok, sanitization ok.
+			$data[ $param ] = (string) wp_unslash( $_REQUEST[ $param ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Raw values are needed to validate the submitted URLs and scope; each value is sanitized or escaped where it is used, and key creation verifies capability and nonce.
 		}
 
 		if ( ! in_array( $data['scope'], array( 'read', 'write', 'read_write' ), true ) ) {
@@ -320,7 +321,8 @@ class WC_Auth {
 			$route = strtolower( wc_clean( $route ) );
 			$this->make_validation();
 
-			$data = wp_unslash( $_REQUEST ); // WPCS: input var ok, CSRF ok.
+			// Validated by make_validation() above. Values are cleaned or escaped where they are rendered or stored; create_keys() sanitizes what it persists.
+			$data = wp_unslash( $_REQUEST );
 
 			// Login endpoint.
 			if ( 'login' === $route && ! is_user_logged_in() ) {

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -428,7 +428,7 @@ class WC_REST_Authentication {
 	 * @return array|WP_Error
 	 */
 	public function get_oauth_parameters() {
-		$params = array_merge( $_GET, $_POST ); // WPCS: CSRF ok.
+		$params = array_merge( $_GET, $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- Raw credentials and request data are required for OAuth signature verification.
 		$params = wp_unslash( $params );
 		$header = $this->get_authorization_header();
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -45,8 +45,8 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	 * Check for PayPal IPN Response.
 	 */
 	public function check_response() {
-		if ( ! empty( $_POST ) && $this->validate_ipn() ) { // WPCS: CSRF ok.
-			$posted = wp_unslash( $_POST ); // WPCS: CSRF ok, input var ok.
+		if ( ! empty( $_POST ) && $this->validate_ipn() ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- PayPal posts the IPN from its own servers, so no site nonce exists; validate_ipn() echoes the payload back to PayPal and only a VERIFIED response allows processing to continue.
+			$posted = wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- PayPal posts the IPN from its own servers, so no site nonce exists; the payload is only read after validate_ipn() confirms it, and each value is sanitized where it is consumed.
 
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			do_action( 'valid-paypal-standard-ipn-request', $posted );
@@ -85,7 +85,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 		WC_Gateway_Paypal::log( 'Checking IPN response is valid' );
 
 		// Get received values from post data.
-		$validate_ipn        = wp_unslash( $_POST ); // WPCS: CSRF ok, input var ok.
+		$validate_ipn        = wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- The unmodified payload must be echoed back to PayPal for verification, so no site nonce applies and the values cannot be altered here.
 		$validate_ipn['cmd'] = '_notify-validate';
 
 		// Send back post vars to paypal.

--- a/plugins/woocommerce/tests/php/includes/class-wc-auth-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-auth-test.php
@@ -35,4 +35,59 @@ class WC_Auth_Test extends \WC_Unit_Test_Case {
 		$maybe_delete_key->setAccessible( true );
 		$maybe_delete_key->invoke( $wc_auth, $key_data );
 	}
+
+	/**
+	 * Get the protected WC_Auth::make_validation() method.
+	 *
+	 * @return ReflectionMethod
+	 */
+	private function get_make_validation_method() {
+		$make_validation = ( new ReflectionClass( WC_Auth::class ) )->getMethod( 'make_validation' );
+		$make_validation->setAccessible( true );
+
+		return $make_validation;
+	}
+
+	/**
+	 * A well formed set of handshake parameters passes validation.
+	 */
+	public function test_make_validation_accepts_string_parameters() {
+		$request_backup = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Saved and restored so the test can drive make_validation() with a known request.
+		$_REQUEST       = array(
+			'app_name'     => 'Test app',
+			'user_id'      => '123',
+			'return_url'   => 'https://example.com/return',
+			'callback_url' => 'https://example.com/callback',
+			'scope'        => 'read',
+		);
+
+		try {
+			$this->assertNull( $this->get_make_validation_method()->invoke( new WC_Auth() ) );
+		} finally {
+			$_REQUEST = $request_backup;
+		}
+	}
+
+	/**
+	 * An array submitted for a handshake parameter is rejected instead of reaching a string-only function.
+	 */
+	public function test_make_validation_rejects_array_parameters() {
+		$request_backup = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Saved and restored so the test can drive make_validation() with a known request.
+		$_REQUEST       = array(
+			'app_name'     => 'Test app',
+			'user_id'      => '123',
+			'return_url'   => array( 'https://example.com/return' ),
+			'callback_url' => 'https://example.com/callback',
+			'scope'        => 'read',
+		);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Missing parameter return_url' );
+
+		try {
+			$this->get_make_validation_method()->invoke( new WC_Auth() );
+		} finally {
+			$_REQUEST = $request_backup;
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-auth-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-auth-test.php
@@ -49,26 +49,6 @@ class WC_Auth_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A well formed set of handshake parameters passes validation.
-	 */
-	public function test_make_validation_accepts_string_parameters() {
-		$request_backup = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Saved and restored so the test can drive make_validation() with a known request.
-		$_REQUEST       = array(
-			'app_name'     => 'Test app',
-			'user_id'      => '123',
-			'return_url'   => 'https://example.com/return',
-			'callback_url' => 'https://example.com/callback',
-			'scope'        => 'read',
-		);
-
-		try {
-			$this->assertNull( $this->get_make_validation_method()->invoke( new WC_Auth() ) );
-		} finally {
-			$_REQUEST = $request_backup;
-		}
-	}
-
-	/**
 	 * An array submitted for a handshake parameter is reported as invalid rather than missing, and never
 	 * reaches a string-only function.
 	 */

--- a/plugins/woocommerce/tests/php/includes/class-wc-auth-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-auth-test.php
@@ -69,7 +69,8 @@ class WC_Auth_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * An array submitted for a handshake parameter is rejected instead of reaching a string-only function.
+	 * An array submitted for a handshake parameter is reported as invalid rather than missing, and never
+	 * reaches a string-only function.
 	 */
 	public function test_make_validation_rejects_array_parameters() {
 		$request_backup = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Saved and restored so the test can drive make_validation() with a known request.
@@ -82,7 +83,7 @@ class WC_Auth_Test extends \WC_Unit_Test_Case {
 		);
 
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Missing parameter return_url' );
+		$this->expectExceptionMessage( 'Invalid parameter return_url' );
 
 		try {
 			$this->get_make_validation_method()->invoke( new WC_Auth() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Three files still carried the legacy `// WPCS: ... ok.` comment form, which WPCS 3.x no longer honors, so the diagnostics on those lines were never actually suppressed. Each one is replaced with the exact sniff code PHPCS reports on that line plus a reason naming the boundary that stands in for a nonce. Working through `class-wc-auth.php` also turned up a real defect, fixed here.

- `includes/class-wc-auth.php`: `WC_Auth::make_validation()` only checked `empty()` on the five handshake parameters. An array value such as `?return_url[]=x` passed that check and reached `urldecode()` inside `get_formatted_url()`, raising a `TypeError`. Because `TypeError` extends `Error` rather than `Exception`, the surrounding `catch ( Exception $e )` never ran and the request died as an uncaught fatal instead of the intended "Access denied" page. `app_name[]=x` hit the same wall one step later in `esc_html()`. Each parameter is now checked separately: a missing one still reports `Missing parameter <name>`, and one that is present but not a string reports `Invalid parameter <name>`. Two suppressions in the same loop are rewritten with their real codes, and the one on `$data = wp_unslash( $_REQUEST )` is removed outright because PHPCS reports no security diagnostic there at all.
- `includes/class-wc-rest-authentication.php`: `get_oauth_parameters()` merges `$_GET` and `$_POST` unmodified, because OAuth 1.0a signatures are computed over the request exactly as sent. The line now names both `NonceVerification` codes it emits, matching the annotations already used elsewhere in the file.
- `includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php`: the IPN payload arrives from PayPal's servers, so no site nonce can exist, and the raw payload has to be echoed back verbatim for PayPal to verify it. The three suppressions now say so and name the real code.

Behavior notes:

- The only runtime change is the parameter validation in `make_validation()`. Valid requests are unaffected: the five parameters are single strings by contract, and PHP only ever puts strings or arrays in `$_REQUEST`. Requests that previously produced a fatal now produce the normal 401 page reading `Invalid parameter <name>`. A `scope[]=x` request, which already threw, now reports `Invalid parameter scope` instead of `Invalid scope Array`.
- The new `throw` carries a `WordPress.Security.EscapeOutput.ExceptionNotEscaped` exception. The caught message is already escaped by `esc_html()` where `wp_die()` renders it, so escaping at the throw would double-encode translated text in locales whose translation contains `&`, `'`, `"`, `<` or `>`.
- No public signature, hook, option, REST field or output contract changes. The REST authentication and PayPal IPN files are comment-only; their executable tokens are byte-identical to trunk.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`; confirm both pass.
2. Optionally run `plugins/woocommerce/vendor/bin/phpcs -s --ignore-annotations` on the three production files and confirm the only findings on the changed lines are the codes now named in the inline exceptions.
3. Start the test env with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start` and run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Auth_Test`. Repeat with `test:php:env:hpos-off`.
4. On a store with pretty permalinks, request `/wc-auth/v1/login?app_name=Test&user_id=1&scope=read&callback_url=https://example.com/cb&return_url[]=https://example.com/r`. Before this change that returns a blank page or HTTP 500; after it, the "Access denied" page reading `Error: Invalid parameter return_url.`
5. Drop `return_url` from that request entirely and confirm it still reads `Error: Missing parameter return_url.`
6. Repeat the request with a normal string `return_url` and confirm the login form still renders and the approve/deny flow still issues an API key.

### Testing that has already taken place:

- `WC_Auth_Test`: 2 tests, 3 assertions passing on PHP 8.1.34, run once with HPOS enabled and once with legacy order storage. `WC_Gateway_Paypal_Test` was also run alongside it earlier in the branch and passed in both storage modes.
- The new `test_make_validation_rejects_array_parameters` case was confirmed to fail against the unguarded version with `TypeError: urldecode(): Argument #1 ($string) must be of type string, array given`, so it genuinely covers the defect. It asserts the `Invalid parameter return_url` message specifically.
- `lint:php:changes` and `lint:changes:branch` pass. PHPCS with `--ignore-annotations` confirms every exception sits on the line PHPCS actually reports and names exactly the codes emitted there.
- PHPStan passes for `class-wc-auth.php`.
- Token-level comparison against trunk confirms `class-wc-rest-authentication.php` (2718 tokens) and the PayPal IPN handler (1586 tokens) are unchanged apart from comments.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-113-auth-callback-suppressions`.

### Use of AI Tools

This change was authored with AI assistance (Claude Code) and reviewed by the author.

*\*left by Biff (AI agent) on behalf of Darren*
