### PR TITLE
Restore createElement import in CustomerEffortScoreTracksContainer for the published package build

### DIFF
--- a/packages/js/customer-effort-score/changelog/fix-wooairr-204-ces-container-createelement-import
+++ b/packages/js/customer-effort-score/changelog/fix-wooairr-204-ces-container-createelement-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the createElement/Fragment import in CustomerEffortScoreTracksContainer so the published esbuild artifact no longer references unbound identifiers.

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-tracks-container/index.js
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-tracks-container/index.js
@@ -4,6 +4,7 @@
 import { useEffect } from 'react';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { createElement, Fragment } from '@wordpress/element';
 import { optionsStore } from '@woocommerce/data';
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Restores the `createElement`/`Fragment` import from `@wordpress/element` in `CustomerEffortScoreTracksContainer` (`packages/js/customer-effort-score/src/components/customer-effort-score-tracks-container/index.js`).

The `@woocommerce/customer-effort-score` package is published through esbuild with the classic JSX transform (`jsx: 'transform'`, `jsxFactory: 'createElement'`, `jsxFragment: 'Fragment'`, `bundle: false`, see `packages/js/internal-build/src/esbuild/options.ts`). With that transform, every JSX source file has to import the factory itself. PR #68222 removed the import from the container while the component still renders a fragment and a child component, so both the `build-module/` (ESM) and `build/` (CJS) artifacts emit `createElement(Fragment, …)` with no binding for either identifier. Any consumer rendering the container from the published npm package throws `ReferenceError: createElement is not defined` as soon as a survey is queued for the page.

The in-tree admin webpack build resolves the package through the `wc-source` export condition and uses the automatic JSX runtime, and Jest does the same via Babel, so unit tests and the shipped WooCommerce plugin were never affected. That is what masked the regression. Every other JSX file in the package still imports `createElement`; this fix brings the container back in line with them.

Flagged by the AI regression review pipeline (Linear issue WOOAIRR-204).

Bug introduced in PR #68222.

**Backward compatibility:** no public API changes. The fix only restores an import in an internal component file so the published artifact is valid again.

### How to test the changes in this Pull Request:

1. Check out this branch and run the package publish build:
   ```sh
   cd packages/js/customer-effort-score
   node build.mjs
   node build.mjs --commonjs
   ```
2. Open `packages/js/customer-effort-score/build-module/components/customer-effort-score-tracks-container/index.js`.
   - [ ] Verify it contains `import { createElement, Fragment } from "@wordpress/element";` near the top, and that the `createElement(Fragment, …)` call below it is therefore bound.
3. Open `packages/js/customer-effort-score/build/components/customer-effort-score-tracks-container/index.js`.
   - [ ] Verify it contains `require("@wordpress/element")` and the `createElement(` calls reference that import.
4. For comparison, check out `trunk`, re-run step 1, and reopen the same two files.
   - [ ] Confirm the `@wordpress/element` import is missing there while `createElement(Fragment, …)` is still emitted, which is the bug this PR fixes.
5. Back on this branch, run the package unit tests and lint:
   ```sh
   cd packages/js/customer-effort-score
   npx jest src/components/customer-effort-score-tracks-container
   npx eslint src/components/customer-effort-score-tracks-container/index.js
   ```
   - [ ] Confirm the test passes and ESLint reports no errors (three pre-existing warnings are expected and unrelated).
6. Optionally, in a WooCommerce admin with a queued CES tracks survey (for example after saving a product), confirm the survey still renders. This path uses the automatic runtime and was never broken, so this only guards against regressions.

### Testing that has already taken place:

- Reproduced the bug on `trunk` at `434650beab`: both `node build.mjs` and `node build.mjs --commonjs` succeed but emit `createElement(Fragment, …)` in the container module with no `@wordpress/element` import.
- With this fix, both builds emit the `@wordpress/element` import and the calls are bound.
- `npx jest src/components/customer-effort-score-tracks-container` passes (1 test).
- `npx eslint` on the changed file: 0 errors, 3 pre-existing warnings unchanged.
- Analysis was performed with an AI coding assistant (Claude Code) and verified by running the builds above.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually at `packages/js/customer-effort-score/changelog/fix-wooairr-204-ces-container-createelement-import` (patch, fix).

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Use of AI Tools

The regression was flagged by the WooCommerce AI regression review pipeline. The investigation, the fix, and this PR description were produced with Claude Code and reviewed by me; the builds and tests listed above were run locally to verify the change.

---
🤖 Generated with [Claude Code](https://claude.ai/code)
