### PR TITLE
[tests] Add REST tax class and tax rate lifecycle coverage

### DIFF
--- a/plugins/woocommerce/changelog/test-rest-api-taxes
+++ b/plugins/woocommerce/changelog/test-rest-api-taxes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add REST taxes controller tests covering tax class and tax rate CRUD and batch lifecycles against persisted state.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
@@ -84,6 +84,7 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 				'class'     => $class_slug,
 			)
 		);
+		$this->assertSame( 201, $response->get_status() );
 		$data     = $response->get_data();
 		$rate_id  = $data['id'];
 		$expected = array(
@@ -102,7 +103,6 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 			'postcodes' => array( '90001' ),
 			'cities'    => array( 'LOS ANGELES' ),
 		);
-		$this->assertSame( 201, $response->get_status() );
 		$this->assertIsInt( $rate_id );
 		$this->assertSame( $expected, array_intersect_key( $data, $expected ) );
 
@@ -189,9 +189,9 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 				),
 			)
 		);
+		$this->assertSame( 200, $response->get_status() );
 		$created  = $response->get_data()['create'];
 		$rate_ids = wp_list_pluck( $created, 'id' );
-		$this->assertSame( 200, $response->get_status() );
 		$this->assertCount( 2, array_unique( $rate_ids ) );
 		$this->assertContainsOnly( 'int', $rate_ids );
 		$this->assertSame( array( 'Batch One', 'Batch Two' ), wp_list_pluck( $created, 'name' ) );
@@ -218,8 +218,8 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 				),
 			)
 		);
-		$updated  = $response->get_data()['update'];
 		$this->assertSame( 200, $response->get_status() );
+		$updated = $response->get_data()['update'];
 		$this->assertSame( $rate_ids, wp_list_pluck( $updated, 'id' ) );
 		$this->assertSame( array( '4.1111', '6.2222' ), wp_list_pluck( $updated, 'rate' ) );
 		$this->assertSame( array( 'Batch One Updated', 'Batch Two Updated' ), wp_list_pluck( $updated, 'name' ) );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
@@ -63,6 +63,8 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @testdox A tax rate completes its V3 CRUD lifecycle and every read reflects the persisted rate.
 	 */
 	public function test_tax_rate_crud_lifecycle(): void {
+		global $wpdb;
+
 		wp_set_current_user( $this->user );
 
 		$class_slug = WC_Tax::create_tax_class( 'Lifecycle Rate Class' )['slug'];
@@ -145,6 +147,10 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( $rate_id, $response->get_data()['id'] );
 		$this->assertNull( WC_Tax::_get_tax_rate( $rate_id ) );
+		$remaining_locations = $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d", $rate_id )
+		);
+		$this->assertSame( '0', $remaining_locations );
 
 		$response = $this->do_rest_get_request( 'taxes/' . $rate_id );
 		$this->assertSame( 404, $response->get_status() );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
@@ -19,6 +19,225 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A tax class completes its V3 create, read, list, unsupported update, and delete lifecycle.
+	 */
+	public function test_tax_class_crud_lifecycle(): void {
+		wp_set_current_user( $this->user );
+
+		$class_name = 'Lifecycle Class';
+		$class_slug = sanitize_title( $class_name );
+		$expected   = array(
+			'name' => $class_name,
+			'slug' => $class_slug,
+		);
+
+		$response = $this->do_rest_request( 'taxes/classes', 'POST', array( 'name' => $class_name ) );
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( $expected, $response->get_data() );
+		$this->assertSame( $expected, WC_Tax::get_tax_class_by( 'slug', $class_slug ) );
+
+		$response = $this->do_rest_get_request( 'taxes/classes/' . $class_slug );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertSame( $expected, array_intersect_key( $response->get_data()[0], $expected ) );
+
+		$response = $this->do_rest_get_request( 'taxes/classes' );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertContains( $class_slug, wp_list_pluck( $response->get_data(), 'slug' ) );
+
+		$response = $this->do_rest_request( 'taxes/classes/' . $class_slug, 'PUT', array( 'name' => 'Unsupported update' ) );
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'rest_no_route', $response->get_data()['code'] );
+
+		$response = $this->do_rest_request( 'taxes/classes/' . $class_slug, 'DELETE', array( 'force' => true ) );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $class_slug, $response->get_data()['slug'] );
+		$this->assertFalse( WC_Tax::get_tax_class_by( 'slug', $class_slug ) );
+
+		$response = $this->do_rest_get_request( 'taxes/classes/' . $class_slug );
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'woocommerce_rest_tax_class_invalid_slug', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @testdox A tax rate completes its V3 CRUD lifecycle and every read reflects the persisted rate.
+	 */
+	public function test_tax_rate_crud_lifecycle(): void {
+		wp_set_current_user( $this->user );
+
+		$class_slug = WC_Tax::create_tax_class( 'Lifecycle Rate Class' )['slug'];
+
+		$response = $this->do_rest_request(
+			'taxes',
+			'POST',
+			array(
+				'country'   => 'US',
+				'state'     => 'CA',
+				'cities'    => array( 'Los Angeles' ),
+				'postcodes' => array( '90001' ),
+				'rate'      => '4.25',
+				'name'      => 'State Tax',
+				'shipping'  => false,
+				'order'     => 3,
+				'class'     => $class_slug,
+			)
+		);
+		$data     = $response->get_data();
+		$rate_id  = $data['id'];
+		$expected = array(
+			'id'        => $rate_id,
+			'country'   => 'US',
+			'state'     => 'CA',
+			'postcode'  => '90001',
+			'city'      => 'LOS ANGELES',
+			'rate'      => '4.2500',
+			'name'      => 'State Tax',
+			'priority'  => 1,
+			'compound'  => false,
+			'shipping'  => false,
+			'order'     => 3,
+			'class'     => $class_slug,
+			'postcodes' => array( '90001' ),
+			'cities'    => array( 'LOS ANGELES' ),
+		);
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertIsInt( $rate_id );
+		$this->assertSame( $expected, array_intersect_key( $data, $expected ) );
+
+		$response = $this->do_rest_get_request( 'taxes/' . $rate_id );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $expected, array_intersect_key( $response->get_data(), $expected ) );
+
+		$response = $this->do_rest_get_request( 'taxes' );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertContains( $rate_id, wp_list_pluck( $response->get_data(), 'id' ) );
+
+		$response = $this->do_rest_request(
+			'taxes/' . $rate_id,
+			'PUT',
+			array(
+				'rate'     => '5.5',
+				'name'     => 'Updated Tax',
+				'priority' => 2,
+				'compound' => true,
+				'shipping' => true,
+				'order'    => 8,
+			)
+		);
+		$expected = array(
+			'id'       => $rate_id,
+			'rate'     => '5.5000',
+			'name'     => 'Updated Tax',
+			'priority' => 2,
+			'compound' => true,
+			'shipping' => true,
+			'order'    => 8,
+			'class'    => $class_slug,
+		);
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $expected, array_intersect_key( $response->get_data(), $expected ) );
+
+		$response = $this->do_rest_get_request( 'taxes/' . $rate_id );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $expected, array_intersect_key( $response->get_data(), $expected ) );
+
+		$response = $this->do_rest_request( 'taxes/' . $rate_id, 'DELETE', array( 'force' => true ) );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $rate_id, $response->get_data()['id'] );
+		$this->assertNull( WC_Tax::_get_tax_rate( $rate_id ) );
+
+		$response = $this->do_rest_get_request( 'taxes/' . $rate_id );
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'woocommerce_rest_invalid_id', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @testdox Two tax rates complete V3 batch create, update, and delete lifecycles in order.
+	 */
+	public function test_tax_rate_batch_lifecycle(): void {
+		wp_set_current_user( $this->user );
+
+		$class_slug = WC_Tax::create_tax_class( 'Batch Class' )['slug'];
+
+		$response = $this->do_rest_request(
+			'taxes/batch',
+			'POST',
+			array(
+				'create' => array(
+					array(
+						'country' => 'US',
+						'state'   => 'NY',
+						'rate'    => '4.1',
+						'name'    => 'Batch One',
+						'order'   => 1,
+						'class'   => $class_slug,
+					),
+					array(
+						'country' => 'CA',
+						'state'   => 'BC',
+						'rate'    => '6.2',
+						'name'    => 'Batch Two',
+						'order'   => 2,
+						'class'   => $class_slug,
+					),
+				),
+			)
+		);
+		$created  = $response->get_data()['create'];
+		$rate_ids = wp_list_pluck( $created, 'id' );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 2, array_unique( $rate_ids ) );
+		$this->assertContainsOnly( 'int', $rate_ids );
+		$this->assertSame( array( 'Batch One', 'Batch Two' ), wp_list_pluck( $created, 'name' ) );
+		$this->assertSame( array( '4.1000', '6.2000' ), wp_list_pluck( $created, 'rate' ) );
+		$this->assertSame( array( $class_slug, $class_slug ), wp_list_pluck( $created, 'class' ) );
+
+		$response = $this->do_rest_request(
+			'taxes/batch',
+			'POST',
+			array(
+				'update' => array(
+					array(
+						'id'    => $rate_ids[0],
+						'rate'  => '4.1111',
+						'name'  => 'Batch One Updated',
+						'order' => 7,
+					),
+					array(
+						'id'       => $rate_ids[1],
+						'rate'     => '6.2222',
+						'name'     => 'Batch Two Updated',
+						'priority' => 3,
+					),
+				),
+			)
+		);
+		$updated  = $response->get_data()['update'];
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $rate_ids, wp_list_pluck( $updated, 'id' ) );
+		$this->assertSame( array( '4.1111', '6.2222' ), wp_list_pluck( $updated, 'rate' ) );
+		$this->assertSame( array( 'Batch One Updated', 'Batch Two Updated' ), wp_list_pluck( $updated, 'name' ) );
+		$this->assertSame( 7, $updated[0]['order'] );
+		$this->assertSame( 3, $updated[1]['priority'] );
+
+		foreach ( $rate_ids as $index => $rate_id ) {
+			$response = $this->do_rest_get_request( 'taxes/' . $rate_id );
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertSame( $updated[ $index ]['rate'], $response->get_data()['rate'] );
+			$this->assertSame( $updated[ $index ]['name'], $response->get_data()['name'] );
+		}
+
+		$response = $this->do_rest_request( 'taxes/batch', 'POST', array( 'delete' => $rate_ids ) );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $rate_ids, wp_list_pluck( $response->get_data()['delete'], 'id' ) );
+
+		foreach ( $rate_ids as $rate_id ) {
+			$this->assertNull( WC_Tax::_get_tax_rate( $rate_id ) );
+			$this->assertSame( 404, $this->do_rest_get_request( 'taxes/' . $rate_id )->get_status() );
+		}
+	}
+
+	/**
 	 * Data provider for test_can_create_and_update_tax_rates_with_multiple_cities_and_postcodes.
 	 *
 	 * @return array


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Playwright `api` project exercises tax classes and tax rates as response-echo checks: post a payload, assert the JSON echoes it. Nothing reads the stored record back, checks what is gone after a delete, or proves that a filter, ordering or pagination result comes from the controller rather than from the fixture. This PR adds that coverage in PHPUnit, where the persisted state is one call away. It is purely additive: no Playwright spec changes, no production code changes. Extracted from the reference branch behind #68046.

| Test in `class-wc-rest-taxes-controller-tests.php` | System under test | What it proves beyond the response echo |
| --- | --- | --- |
| `test_tax_class_crud_lifecycle` | `WC_REST_Tax_Classes_V1_Controller` create/list/delete plus `WC_REST_Tax_Classes_V2_Controller::get_item` (V3 route) | the class exists in `WC_Tax` after create, is absent after a forced delete, the single-item and collection reads agree, and the route has no update handler (`rest_no_route`) |
| `test_tax_rate_crud_lifecycle` | `WC_REST_Taxes_V1_Controller::create_or_update_tax`, `WC_REST_Taxes_Controller::adjust_cities_and_postcodes`, `WC_Tax::_delete_tax_rate` | every field of the create and update responses matches what a fresh GET returns (including uppercase city and 4-decimal rate normalisation), and the rate row and its location rows are both gone after a forced delete |
| `test_tax_rate_batch_lifecycle` | `WC_REST_Controller::batch_items` through the taxes controller | batch create, update and delete apply the right payload to the right rate, in order, and deleted rates are gone from the table and from GET |

#### Mutation checks

Every added or changed test was mutation-checked against the code it exercises: a plausible fault was written into the controller or data store, the single test was run and had to fail on the named assertion, then the source was restored. All faults below were caught.

| Test | Faults injected (all killed) |
| --- | --- |
| `test_tax_class_crud_lifecycle` | create returns 200 instead of 201; single read looks the class up by name instead of slug; delete reports success without deleting; listing emits the raw name as the slug |
| `test_tax_rate_crud_lifecycle` | cities and postcodes written into each other's key; update skips every field when a current rate exists; `order` reports the priority; `_delete_tax_rate` clears locations but leaves the rate row; `_delete_tax_rate` removes the rate row but leaves the location rows |
| `test_tax_rate_batch_lifecycle` | every create entry gets the first payload; create echoes the request instead of the controller response; update forwards only the id; delete drops the `force` flag |

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, run `pnpm env:test` if the PHPUnit environment is not running.
2. Run `pnpm test:php:env -- --filter WC_REST_Taxes_Controller_Tests` and confirm `OK (15 tests, 89 assertions)`.

### Testing that has already taken place:

- The class passes locally in one process: 15 tests, 89 assertions (12 pre-existing, 3 added).
- 13 mutants designed and executed, 13 killed; no test needed strengthening.
- The tests rely on the base class transaction rollback for cleanup and use `assertSame` throughout, per the repository's test conventions.
- `phpcs-changed` against trunk: clean.
- Review follow-up: the delete assertion above was added after review, and its mutant (`_delete_tax_rate` keeping the location rows) fails the test with `'0'` vs `'2'`. The status assertions in the two lifecycle tests also moved above the `get_data()` reads that depend on them; forcing a `403` on create turns `Undefined array key "id"` into `Failed asserting that 403 is identical to 201`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change. A `Comment`-type changelog file is included manually: `plugins/woocommerce/changelog/test-rest-api-taxes` (patch, dev).

</details>

### Use of AI Tools

Claude Code drafted these tests on the reference branch behind #68046 and, in this split, ran the review pass (test-quality and simplification reviewer agents against the existing trunk coverage) and the mutation pass (one agent designed the faults from the controller source, another applied each one, ran the focused test, and reverted). I reviewed every test and every mutation result and take responsibility for the change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

