### PR TITLE
[tests] Add REST products and product terms collection coverage

### DIFF
--- a/plugins/woocommerce/changelog/test-rest-api-products-terms
+++ b/plugins/woocommerce/changelog/test-rest-api-products-terms
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add REST products and product terms controller tests covering collection ordering, pagination, filters and term CRUD/batch lifecycles.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
 use Automattic\WooCommerce\Tests\Helpers\MetaDataAssertionTrait;
@@ -135,6 +136,143 @@ class WC_REST_Products_Controller_Tests extends WC_Unit_Test_Case {
 			},
 			self::$products
 		);
+	}
+
+	/**
+	 * Create products whose sortable properties have independent orders.
+	 *
+	 * @return array{first: WC_Product_Simple, second: WC_Product_Simple, third: WC_Product_Simple, fourth: WC_Product_Simple, pending: WC_Product_Simple, variable: WC_Product_Variable} Products keyed by creation order.
+	 */
+	private function create_ordering_products(): array {
+		$definitions = array(
+			'first'   => array(
+				'name'           => 'Ordering Delta',
+				'slug'           => 'ordering-charlie',
+				'date_created'   => '2024-01-03 12:00:00',
+				'price'          => '40',
+				'total_sales'    => 3,
+				'average_rating' => 4.0,
+				'rating_counts'  => array( 4 => 3 ),
+			),
+			'second'  => array(
+				'name'           => 'Ordering Alpha',
+				'slug'           => 'ordering-bravo',
+				'date_created'   => '2024-01-01 12:00:00',
+				'price'          => '20',
+				'total_sales'    => 2,
+				'average_rating' => 2.0,
+				'rating_counts'  => array( 2 => 2 ),
+			),
+			'third'   => array(
+				'name'           => 'Ordering Charlie',
+				'slug'           => 'ordering-delta',
+				'date_created'   => '2024-01-06 12:00:00',
+				'price'          => '10',
+				'total_sales'    => 1,
+				'average_rating' => 3.0,
+				'rating_counts'  => array( 3 => 1 ),
+			),
+			'fourth'  => array(
+				'name'           => 'Ordering Bravo',
+				'slug'           => 'ordering-alpha',
+				'date_created'   => '2024-01-02 12:00:00',
+				'price'          => '30',
+				'total_sales'    => 4,
+				'average_rating' => 1.0,
+				'rating_counts'  => array( 1 => 4 ),
+			),
+			'pending' => array(
+				'name'           => 'Ordering Echo',
+				'date_created'   => '2024-01-04 12:00:00',
+				'price'          => '25',
+				'total_sales'    => 5,
+				'average_rating' => 0.0,
+				'rating_counts'  => array(),
+				'status'         => ProductStatus::PENDING,
+			),
+		);
+		$products    = array();
+
+		foreach ( $definitions as $key => $definition ) {
+			$props = array(
+				'name'          => $definition['name'],
+				'regular_price' => $definition['price'],
+				'price'         => $definition['price'],
+			);
+			if ( isset( $definition['slug'] ) ) {
+				$props['slug'] = $definition['slug'];
+			}
+			if ( isset( $definition['status'] ) ) {
+				$props['status'] = $definition['status'];
+			}
+			$product = WC_Helper_Product::create_simple_product( false, $props );
+			$product->set_date_created( $definition['date_created'] );
+			$product->set_total_sales( $definition['total_sales'] );
+			$product->set_average_rating( $definition['average_rating'] );
+			$product->set_rating_counts( $definition['rating_counts'] );
+			$product->set_review_count( array_sum( $definition['rating_counts'] ) );
+			$product->save();
+			$products[ $key ] = $product;
+		}
+
+		$variable = new WC_Product_Variable();
+		$variable->set_name( 'Ordering Foxtrot' );
+		$variable->set_slug( 'ordering-echo' );
+		$variable->set_date_created( '2024-01-05 12:00:00' );
+		$variable->set_total_sales( 6 );
+		$variable->set_average_rating( 5.0 );
+		$variable->set_rating_counts( array( 5 => 6 ) );
+		$variable->set_review_count( 6 );
+		$variable->save();
+		WC_Helper_Product::create_product_variation_object( $variable->get_id(), 'ORDERING LOW', 5, array() );
+		WC_Helper_Product::create_product_variation_object( $variable->get_id(), 'ORDERING HIGH', 50, array() );
+		WC_Product_Variable::sync( $variable->get_id() );
+		$products['variable'] = wc_get_product( $variable->get_id() );
+
+		return $products;
+	}
+
+	/**
+	 * Dispatch a product collection request and assert exact IDs.
+	 *
+	 * @param array<string,mixed> $query_params Query parameters for the collection request.
+	 * @param int[]               $expected_ids Product IDs in the expected response order.
+	 * @param string              $description  Assertion context.
+	 * @return WP_REST_Response
+	 */
+	private function assert_product_collection( array $query_params, array $expected_ids, string $description ): WP_REST_Response {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), "$description should return HTTP 200." );
+		$this->assertSame( $expected_ids, array_map( 'absint', wp_list_pluck( $response->get_data(), 'id' ) ), "$description should return the exact expected product IDs." );
+
+		return $response;
+	}
+
+	/**
+	 * Dispatch a product collection request constrained to the given IDs and assert their exact order.
+	 *
+	 * @param int[]       $included_ids Product IDs that constrain the collection.
+	 * @param int[]       $expected_ids Product IDs in the expected response order.
+	 * @param string|null $orderby      REST orderby value, or null to use the default.
+	 * @param string|null $order        REST order value, or null to use the default.
+	 * @param string      $description  Assertion context.
+	 */
+	private function assert_product_collection_order( array $included_ids, array $expected_ids, ?string $orderby, ?string $order, string $description ): void {
+		$query_params = array(
+			'include'  => $included_ids,
+			'per_page' => count( $included_ids ),
+		);
+		if ( null !== $orderby ) {
+			$query_params['orderby'] = $orderby;
+		}
+		if ( null !== $order ) {
+			$query_params['order'] = $order;
+		}
+
+		$this->assert_product_collection( $query_params, $expected_ids, $description );
 	}
 
 	/**
@@ -585,9 +723,278 @@ class WC_REST_Products_Controller_Tests extends WC_Unit_Test_Case {
 
 		$response_data       = $this->server->response_to_data( $response, false );
 		$encoded_data_string = wp_json_encode( $response_data );
-		$decoded_data_object = json_decode( $encoded_data_string, false ); // Ensure object instead of associative array.
+		$decoded_data_object = json_decode( $encoded_data_string, false );
+		// Ensure object instead of associative array.
 
 		$this->assertIsArray( $decoded_data_object[0]->meta_data );
+	}
+
+	/**
+	 * @testdox Product collection ordering returns exact core-field orders through the V3 route.
+	 */
+	public function test_collection_orderby_core_fields(): void {
+		$products = $this->create_ordering_products();
+		$first    = $products['first']->get_id();
+		$second   = $products['second']->get_id();
+		$third    = $products['third']->get_id();
+		$fourth   = $products['fourth']->get_id();
+		$pending  = $products['pending']->get_id();
+		$variable = $products['variable']->get_id();
+		$all      = array( $first, $second, $third, $fourth, $pending, $variable );
+
+		$this->assert_product_collection_order( $all, array( $third, $variable, $pending, $first, $fourth, $second ), null, null, 'Default date DESC ordering' );
+		$this->assert_product_collection_order( $all, array( $second, $fourth, $first, $pending, $variable, $third ), 'date', 'asc', 'Date ASC ordering' );
+		$this->assert_product_collection_order( $all, array( $third, $variable, $pending, $first, $fourth, $second ), 'date', 'desc', 'Date DESC ordering' );
+		$this->assert_product_collection_order( $all, array( $first, $second, $third, $fourth, $pending, $variable ), 'id', 'asc', 'ID ASC ordering' );
+		$this->assert_product_collection_order( $all, array( $variable, $pending, $fourth, $third, $second, $first ), 'id', 'desc', 'ID DESC ordering' );
+		$this->assert_product_collection_order( $all, array( $second, $fourth, $third, $first, $pending, $variable ), 'title', 'asc', 'Title ASC ordering' );
+		$this->assert_product_collection_order( $all, array( $variable, $pending, $first, $third, $fourth, $second ), 'title', 'desc', 'Title DESC ordering' );
+		$this->assert_product_collection_order( $all, array( $pending, $fourth, $second, $first, $third, $variable ), 'slug', 'asc', 'Slug ASC ordering' );
+		$this->assert_product_collection_order( $all, array( $variable, $third, $first, $second, $fourth, $pending ), 'slug', 'desc', 'Slug DESC ordering' );
+	}
+
+	/**
+	 * @testdox Product collection ordering returns exact lookup-field orders through the V3 route.
+	 */
+	public function test_collection_orderby_lookup_fields(): void {
+		$products = $this->create_ordering_products();
+		$first    = $products['first']->get_id();
+		$second   = $products['second']->get_id();
+		$third    = $products['third']->get_id();
+		$fourth   = $products['fourth']->get_id();
+		$pending  = $products['pending']->get_id();
+		$variable = $products['variable']->get_id();
+		$all      = array( $first, $second, $third, $fourth, $pending, $variable );
+
+		$this->assert_product_collection_order( $all, array( $variable, $third, $second, $pending, $fourth, $first ), 'price', 'asc', 'Price ASC ordering' );
+		$this->assert_product_collection_order( $all, array( $variable, $first, $fourth, $pending, $second, $third ), 'price', 'desc', 'Price DESC ordering' );
+		$this->assert_product_collection_order( $all, array( $variable, $first, $third, $second, $fourth, $pending ), 'rating', 'desc', 'Rating DESC ordering' );
+		$this->assert_product_collection_order( $all, array( $variable, $pending, $fourth, $first, $second, $third ), 'popularity', 'desc', 'Popularity DESC ordering' );
+	}
+
+	/**
+	 * @testdox Product collection include ordering preserves request order regardless of the order parameter.
+	 */
+	public function test_collection_orderby_include_order(): void {
+		$products     = $this->create_ordering_products();
+		$included_ids = array(
+			$products['pending']->get_id(),
+			$products['fourth']->get_id(),
+			$products['first']->get_id(),
+			$products['variable']->get_id(),
+			$products['third']->get_id(),
+			$products['second']->get_id(),
+		);
+
+		$this->assert_product_collection_order( $included_ids, $included_ids, 'include', 'asc', 'Include ASC ordering' );
+		$this->assert_product_collection_order( $included_ids, $included_ids, 'include', 'desc', 'Include DESC ordering' );
+	}
+
+	/**
+	 * @testdox Product collection pagination returns exact pages, totals, and offset precedence through the V3 route.
+	 */
+	public function test_collection_pagination_contract(): void {
+		$product_ids = array();
+		foreach ( range( 1, 11 ) as $index ) {
+			$product_ids[] = WC_Helper_Product::create_simple_product( true, array( 'name' => "Pagination {$index}" ) )->get_id();
+		}
+		sort( $product_ids, SORT_NUMERIC );
+
+		$base_query = array(
+			'include' => $product_ids,
+			'orderby' => 'id',
+			'order'   => 'asc',
+		);
+		$paged      = function ( int $page, ?int $offset = null ) use ( $base_query ): array {
+			$query = array_merge(
+				$base_query,
+				array(
+					'per_page' => 4,
+					'page'     => $page,
+				)
+			);
+			if ( null !== $offset ) {
+				$query['offset'] = $offset;
+			}
+			return $query;
+		};
+
+		$response = $this->assert_product_collection( $base_query, array_slice( $product_ids, 0, 10 ), 'Default pagination' );
+		$this->assertSame( '11', (string) $response->get_headers()['X-WP-Total'], 'The default total header should count all eleven fixtures.' );
+		$this->assertSame( '2', (string) $response->get_headers()['X-WP-TotalPages'], 'The default total-pages header should reflect the ten-item default.' );
+
+		$this->assert_product_collection( $paged( 1 ), array_slice( $product_ids, 0, 4 ), 'Pagination page one' );
+		$this->assert_product_collection( $paged( 2 ), array_slice( $product_ids, 4, 4 ), 'Pagination page two' );
+		$this->assert_product_collection( $paged( 2, 5 ), array_slice( $product_ids, 5, 4 ), 'Pagination with an explicit offset' );
+		$this->assert_product_collection( $paged( 3 ), array_slice( $product_ids, 8 ), 'Pagination final page' );
+
+		$response = $this->assert_product_collection( $paged( 4 ), array(), 'Pagination beyond the result set' );
+		$this->assertSame( '11', (string) $response->get_headers()['X-WP-Total'], 'An empty later page should retain the total header.' );
+		$this->assertSame( '3', (string) $response->get_headers()['X-WP-TotalPages'], 'An empty later page should retain the total-pages header.' );
+	}
+
+	/**
+	 * @testdox Product collection identity filters return exact products through the V3 route.
+	 */
+	public function test_collection_identity_filters(): void {
+		$target = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'slug' => 'identity-target',
+				'sku'  => 'identity-target-sku',
+			)
+		);
+		$other  = WC_Helper_Product::create_simple_product( true, array( 'sku' => 'identity-other-sku' ) );
+		$parent = WC_Helper_Product::create_simple_product( true, array( 'sku' => 'identity-parent-sku' ) );
+		$child  = WC_Helper_Product::create_simple_product( true, array( 'sku' => 'identity-child-sku' ) );
+		$child->set_parent_id( $parent->get_id() );
+		$child->save();
+
+		$all = array( $target->get_id(), $other->get_id(), $parent->get_id(), $child->get_id() );
+		sort( $all, SORT_NUMERIC );
+		$base_query = array(
+			'include'  => $all,
+			'per_page' => count( $all ),
+			'orderby'  => 'id',
+			'order'    => 'asc',
+		);
+
+		$included = array( $target->get_id(), $child->get_id() );
+		sort( $included, SORT_NUMERIC );
+		$this->assert_product_collection( array_merge( $base_query, array( 'include' => $included ) ), $included, 'Include filtering' );
+
+		// Exclude only applies without include, so constrain the cohort by SKU instead.
+		$excluded      = array( $other->get_id(), $parent->get_id() );
+		$exclude_query = array_merge(
+			$base_query,
+			array(
+				'exclude' => $excluded,
+				'sku'     => 'identity-target-sku,identity-other-sku,identity-parent-sku,identity-child-sku',
+			)
+		);
+		unset( $exclude_query['include'] );
+		$this->assert_product_collection( $exclude_query, array_values( array_diff( $all, $excluded ) ), 'Exclude filtering' );
+
+		$this->assert_product_collection( array_merge( $base_query, array( 'slug' => 'identity-target' ) ), array( $target->get_id() ), 'Slug filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'slug' => 'identity-missing' ) ), array(), 'Unmatched slug filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'sku' => 'identity-other-sku' ) ), array( $other->get_id() ), 'SKU filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'sku' => 'identity-missing-sku' ) ), array(), 'Unmatched SKU filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'parent' => array( $parent->get_id() ) ) ), array( $child->get_id() ), 'Parent filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'parent_exclude' => array( $parent->get_id() ) ) ), array_values( array_diff( $all, array( $child->get_id() ) ) ), 'Parent exclusion filtering' );
+	}
+
+	/**
+	 * @testdox Product collection state filters return exact sale, price, pending, and stock-state matches through the V3 route.
+	 */
+	public function test_collection_product_state_filters(): void {
+		$simple = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'State filter simple',
+				'regular_price' => '10',
+				'price'         => '10',
+			)
+		);
+
+		$external = new WC_Product_External();
+		$external->set_name( 'State filter external' );
+		$external->set_regular_price( '20' );
+		$external->set_sale_price( '15' );
+		$external->set_price( '15' );
+		$external->save();
+
+		$out_of_stock = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => '60',
+				'price'         => '60',
+				'stock_status'  => ProductStockStatus::OUT_OF_STOCK,
+			)
+		);
+		$backorder    = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => '50',
+				'price'         => '50',
+				'stock_status'  => ProductStockStatus::ON_BACKORDER,
+			)
+		);
+		$pending      = WC_Helper_Product::create_simple_product( true, array( 'status' => ProductStatus::PENDING ) );
+
+		$variable = new WC_Product_Variable();
+		$variable->set_name( 'Variable price range' );
+		$variable->save();
+		WC_Helper_Product::create_product_variation_object( $variable->get_id(), 'STATE LOW', 30, array() );
+		WC_Helper_Product::create_product_variation_object( $variable->get_id(), 'STATE HIGH', 40, array() );
+		WC_Product_Variable::sync( $variable->get_id() );
+
+		$all = array( $simple->get_id(), $external->get_id(), $out_of_stock->get_id(), $backorder->get_id(), $pending->get_id(), $variable->get_id() );
+		sort( $all, SORT_NUMERIC );
+		$base_query = array(
+			'include'  => $all,
+			'per_page' => count( $all ),
+			'orderby'  => 'id',
+			'order'    => 'asc',
+			'status'   => ProductStatus::PUBLISH,
+		);
+
+		// The on_sale filter merges its IDs into include rather than intersecting, so constrain by search instead.
+		$sale_query = array(
+			'search'  => 'State filter',
+			'orderby' => 'id',
+			'order'   => 'asc',
+			'status'  => ProductStatus::PUBLISH,
+		);
+		$this->assert_product_collection( array_merge( $sale_query, array( 'on_sale' => true ) ), array( $external->get_id() ), 'On-sale product filtering' );
+		$this->assert_product_collection( array_merge( $sale_query, array( 'on_sale' => false ) ), array( $simple->get_id() ), 'Non-sale product filtering' );
+
+		$price_matches = array( $external->get_id(), $variable->get_id() );
+		sort( $price_matches, SORT_NUMERIC );
+		$this->setExpectedDeprecated( 'wc_get_min_max_price_meta_query()' );
+		$this->assert_product_collection(
+			array_merge(
+				$base_query,
+				array(
+					'min_price' => '15',
+					'max_price' => '30',
+				)
+			),
+			$price_matches,
+			'Inclusive price filtering'
+		);
+
+		$this->assert_product_collection( array_merge( $base_query, array( 'status' => ProductStatus::PENDING ) ), array( $pending->get_id() ), 'Pending status filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'stock_status' => ProductStockStatus::OUT_OF_STOCK ) ), array( $out_of_stock->get_id() ), 'Out-of-stock filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'stock_status' => ProductStockStatus::ON_BACKORDER ) ), array( $backorder->get_id() ), 'On-backorder filtering' );
+	}
+
+	/**
+	 * @testdox Product collection category filtering includes descendant categories and tax class filtering matches exactly through the V3 route.
+	 */
+	public function test_collection_taxonomy_filters(): void {
+		$parent_category  = wp_insert_term( 'Taxonomy parent', 'product_cat' )['term_id'];
+		$child_category   = wp_insert_term( 'Taxonomy child', 'product_cat', array( 'parent' => $parent_category ) )['term_id'];
+		$sibling_category = wp_insert_term( 'Taxonomy sibling', 'product_cat' )['term_id'];
+		$tax_class_slug   = WC_Tax::create_tax_class( 'Taxonomy tax' )['slug'];
+
+		$in_child   = WC_Helper_Product::create_simple_product( true, array( 'category_ids' => array( $child_category ) ) );
+		$in_sibling = WC_Helper_Product::create_simple_product( true, array( 'category_ids' => array( $sibling_category ) ) );
+		$taxed      = WC_Helper_Product::create_simple_product( true, array( 'tax_class' => $tax_class_slug ) );
+		$untouched  = WC_Helper_Product::create_simple_product();
+
+		$all = array( $in_child->get_id(), $in_sibling->get_id(), $taxed->get_id(), $untouched->get_id() );
+		sort( $all, SORT_NUMERIC );
+		$base_query = array(
+			'include'  => $all,
+			'per_page' => count( $all ),
+			'orderby'  => 'id',
+			'order'    => 'asc',
+		);
+
+		$this->assert_product_collection( array_merge( $base_query, array( 'category' => (string) $parent_category ) ), array( $in_child->get_id() ), 'Parent category descendant filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'category' => (string) $child_category ) ), array( $in_child->get_id() ), 'Child category filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'category' => (string) $sibling_category ) ), array( $in_sibling->get_id() ), 'Sibling category filtering' );
+		$this->assert_product_collection( array_merge( $base_query, array( 'tax_class' => $tax_class_slug ) ), array( $taxed->get_id() ), 'Tax class filtering' );
 	}
 
 	/**
@@ -1611,11 +2018,12 @@ class WC_REST_Products_Controller_Tests extends WC_Unit_Test_Case {
 		$create_request_for_failure = new WP_REST_Request( 'POST', '/wc/v3/products' );
 		$create_request_for_failure->set_body_params(
 			array(
-				'name'          => 'New Product Attempt That Fails',
-				'sku'           => $original_product_sku, // Duplicate SKU.
-				'type'          => 'simple',
-				'regular_price' => '20',
-				'images'        => array(
+				'name'                                 => 'New Product Attempt That Fails',
+				'sku'                                  => $original_product_sku,
+				// Duplicate SKU.
+												'type' => 'simple',
+				'regular_price'                        => '20',
+				'images'                               => array(
 					array(
 						'src' => $shared_image_src,
 						'alt' => 'New Image To Be Cleaned Up',

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
@@ -1,16 +1,36 @@
 <?php
 
 /**
- * class WC_REST_Products_Controller_Tests.
+ * class WC_REST_Terms_Controller_Tests.
  * Terms Controller tests for V3 REST API.
  */
-class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
+class WC_REST_Terms_Controller_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * The system under test for the existing taxonomy lookup test.
+	 *
+	 * @var WC_REST_Terms_Controller
+	 */
+	private $sut;
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private $user;
 
 	/**
 	 * Runs before any test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user );
 
 		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
 		$this->sut = new class() extends WC_REST_Terms_Controller {
@@ -27,7 +47,7 @@ class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
 	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_attribute_taxonomy_name_by_id' => function( $attribute_id ) {
+				'wc_attribute_taxonomy_name_by_id' => function ( $attribute_id ) {
 					return 'taxonomy_' . $attribute_id;
 				},
 			)
@@ -41,5 +61,178 @@ class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 'taxonomy_1', $value1 );
 		$this->assertEquals( 'taxonomy_2', $value2 );
+	}
+
+	/**
+	 * Product term REST routes.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function product_term_routes() {
+		return array(
+			'product tag'            => array( 'product_tag', '/wc/v3/products/tags' ),
+			'product shipping class' => array( 'product_shipping_class', '/wc/v3/products/shipping_classes' ),
+		);
+	}
+
+	/**
+	 * @testdox A product term can complete its CRUD lifecycle through the registered V3 route.
+	 *
+	 * @dataProvider product_term_routes
+	 *
+	 * @param string $taxonomy Product term taxonomy.
+	 * @param string $route Registered V3 route.
+	 */
+	public function test_product_term_crud_lifecycle( $taxonomy, $route ): void {
+		$name        = str_replace( '_', ' ', $taxonomy ) . ' lifecycle';
+		$slug        = sanitize_title( $name );
+		$description = 'Updated through the registered V3 product term route.';
+
+		$response = $this->do_rest_request(
+			$route,
+			'POST',
+			array(
+				'name' => $name,
+			)
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status(), 'Creating the product term should return HTTP 201.' );
+		$this->assertIsInt( $data['id'], 'The created product term should have an integer ID.' );
+		$term_id = $data['id'];
+		$this->assertSame( $name, $data['name'], 'The create response should preserve the term name.' );
+		$this->assertSame( $slug, $data['slug'], 'The create response should contain the deterministic term slug.' );
+		$this->assertSame( '', $data['description'], 'A new product term should have an empty description.' );
+		$this->assertSame( 0, $data['count'], 'A new product term should have no assigned products.' );
+		$this->assertSame( rest_url( $route . '/' . $term_id ), $response->get_headers()['Location'], 'The create response should identify the registered item route.' );
+
+		$response = $this->do_rest_request( $route . '/' . $term_id );
+		$data     = $response->get_data();
+		$this->assertSame( 200, $response->get_status(), 'Retrieving the created product term should return HTTP 200.' );
+		$this->assertSame( $term_id, $data['id'], 'The item route should return the created product term.' );
+		$this->assertSame( $name, $data['name'], 'The item route should return the created term name.' );
+		$this->assertSame( $slug, $data['slug'], 'The item route should return the created term slug.' );
+		$this->assertSame( '', $data['description'], 'The item route should return the empty initial description.' );
+		$this->assertSame( 0, $data['count'], 'The item route should return the initial product count.' );
+
+		$response       = $this->do_rest_request( $route, 'GET', null, array( 'include' => array( $term_id ) ) );
+		$collection_ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertSame( 200, $response->get_status(), 'Retrieving the product-term collection should return HTTP 200.' );
+		$this->assertSame( 1, count( array_keys( $collection_ids, $term_id, true ) ), 'The product-term collection should contain the created ID exactly once.' );
+
+		$response = $this->do_rest_request(
+			$route . '/' . $term_id,
+			'PUT',
+			array(
+				'description' => $description,
+			)
+		);
+		$data     = $response->get_data();
+		$term     = get_term( $term_id, $taxonomy );
+		$this->assertSame( 200, $response->get_status(), 'Updating the product term should return HTTP 200.' );
+		$this->assertInstanceOf( WP_Term::class, $term, 'The updated term should remain persisted.' );
+		/** @var WP_Term $term */
+		$this->assertSame(
+			array( $description, $description ),
+			array( $data['description'], $term->description ),
+			'The update description should be returned and persisted.'
+		);
+		$this->assertSame( $term_id, $data['id'], 'The update response should retain the product term ID.' );
+		$this->assertSame( $name, $data['name'], 'The update response should retain the product term name.' );
+		$this->assertSame( $slug, $data['slug'], 'The update response should retain the product term slug.' );
+		$this->assertSame( 0, $data['count'], 'Updating the product term should not change its product count.' );
+
+		$response = $this->do_rest_request( $route . '/' . $term_id, 'DELETE', null, array( 'force' => true ) );
+		$this->assertSame( 200, $response->get_status(), 'Force-deleting the product term should return HTTP 200.' );
+
+		$response = $this->do_rest_request( $route . '/' . $term_id );
+		$this->assertSame( 404, $response->get_status(), 'The deleted product term should no longer be retrievable.' );
+	}
+
+	/**
+	 * @testdox Product terms can be created, updated, and deleted through the registered V3 batch route.
+	 *
+	 * @dataProvider product_term_routes
+	 *
+	 * @param string $taxonomy Product term taxonomy.
+	 * @param string $route Registered V3 route.
+	 */
+	public function test_product_term_batch_lifecycle( $taxonomy, $route ): void {
+		$name_prefix        = str_replace( '_', ' ', $taxonomy ) . ' batch';
+		$first_description  = 'First update through the registered V3 product term batch route.';
+		$second_description = 'Second update through the registered V3 product term batch route.';
+
+		$response = $this->do_rest_request(
+			$route . '/batch',
+			'POST',
+			array(
+				'create' => array(
+					array( 'name' => $name_prefix . ' one' ),
+					array( 'name' => $name_prefix . ' two' ),
+					array( 'name' => $name_prefix . ' three' ),
+				),
+			)
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'The initial batch create should return HTTP 200.' );
+		$this->assertCount( 3, $data['create'], 'The initial batch should create exactly three product terms.' );
+		$this->assertSame( array( $name_prefix . ' one', $name_prefix . ' two', $name_prefix . ' three' ), wp_list_pluck( $data['create'], 'name' ), 'The initial batch should return all three created terms.' );
+		$this->assertContainsOnly( 'int', wp_list_pluck( $data['create'], 'id' ), 'Each batch-created product term should have an integer ID.' );
+		$first_id  = $data['create'][0]['id'];
+		$second_id = $data['create'][1]['id'];
+		$third_id  = $data['create'][2]['id'];
+
+		$response = $this->do_rest_request(
+			$route . '/batch',
+			'POST',
+			array(
+				'create' => array(
+					array( 'name' => $name_prefix . ' four' ),
+				),
+				'update' => array(
+					array(
+						'id'          => $first_id,
+						'description' => $first_description,
+					),
+					array(
+						'id'          => $second_id,
+						'description' => $second_description,
+					),
+				),
+				'delete' => array( $third_id ),
+			)
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'The mixed batch should return HTTP 200.' );
+		$this->assertCount( 1, $data['create'], 'The mixed batch should create exactly one product term.' );
+		$this->assertCount( 2, $data['update'], 'The mixed batch should update exactly two product terms.' );
+		$this->assertCount( 1, $data['delete'], 'The mixed batch should delete exactly one product term.' );
+		$fourth_id = $data['create'][0]['id'];
+		$this->assertSame( $name_prefix . ' four', $data['create'][0]['name'], 'The mixed batch should return the created product term.' );
+		$this->assertSame( array( $first_id, $second_id ), wp_list_pluck( $data['update'], 'id' ), 'The mixed batch should return both updated product term IDs.' );
+		$this->assertSame( array( $first_description, $second_description ), wp_list_pluck( $data['update'], 'description' ), 'The mixed batch should return both updated descriptions.' );
+		$this->assertSame( $third_id, $data['delete'][0]['id'], 'The mixed batch should return the deleted product term ID.' );
+
+		$updated_terms = array(
+			$first_id  => $first_description,
+			$second_id => $second_description,
+		);
+		foreach ( $updated_terms as $updated_id => $expected_description ) {
+			$response = $this->do_rest_request( $route . '/' . $updated_id );
+			$term     = get_term( $updated_id, $taxonomy );
+			$this->assertSame( 200, $response->get_status(), 'Each batch-updated product term should remain retrievable.' );
+			$this->assertInstanceOf( WP_Term::class, $term, 'Each batch-updated product term should remain persisted.' );
+			/** @var WP_Term $term */
+			$this->assertSame(
+				array( $updated_id, $expected_description, $expected_description ),
+				array( $response->get_data()['id'], $response->get_data()['description'], $term->description ),
+				'Each batch update should be returned by a fresh GET and persisted in the taxonomy.'
+			);
+		}
+
+		$response = $this->do_rest_request( $route . '/' . $third_id );
+		$this->assertSame( 404, $response->get_status(), 'The batch-deleted product term should no longer be retrievable.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Playwright `api` project exercises products and product terms as response-echo checks: post a payload, assert the JSON echoes it. Nothing reads the stored record back, checks what is gone after a delete, or proves that a filter, ordering or pagination result comes from the controller rather than from the fixture. This PR adds that coverage in PHPUnit, where the persisted state is one call away. It is purely additive: no Playwright spec changes, no production code changes. Extracted from the reference branch behind #68046. The legacy `products.php` suite already covers `type`, `featured`, `tag`, `attribute`, `shipping_class`, draft status, `search` and the date filters, so those are deliberately not repeated here.

| Test | System under test | What it proves beyond the response echo |
| --- | --- | --- |
| `WC_REST_Products_Controller_Tests::test_collection_orderby_core_fields` | `WC_REST_CRUD_Controller::prepare_objects_query`, `WC_REST_Posts_Controller::prepare_items_query`, `WC_Query::get_catalog_ordering_args` | exact order for the default and for `date`, `id`, `title`, `slug` in both directions over six products whose fields deliberately disagree |
| `…::test_collection_orderby_lookup_fields` | `WC_Query::order_by_price_asc_post_clauses`, `order_by_popularity_post_clauses`, rating ordering | `price` (using the lookup table's min price for a variable product), `rating` and `popularity` orderings |
| `…::test_collection_orderby_include_order` | `WC_REST_Posts_Controller::prepare_items_query` | `orderby=include` preserves the request order for both `order` values |
| `…::test_collection_pagination_contract` | `WC_REST_CRUD_Controller::get_items`, `get_objects`, `prepare_objects_query` | default and explicit page windows, `X-WP-Total`/`X-WP-TotalPages` on every page including the empty one past the end, `offset` precedence |
| `…::test_collection_identity_filters` | `WC_REST_CRUD_Controller` and `WC_REST_Products_Controller::prepare_objects_query` | `include`, `exclude`, `slug`, `sku`, `parent`, `parent_exclude`, each returning exactly the matching products and nothing for an unmatched value |
| `…::test_collection_product_state_filters` | `WC_REST_Products_Controller::prepare_objects_query` | `on_sale` both ways, inclusive `min_price`/`max_price` (including a variable product's synced minimum), `status=pending`, `stock_status` out of stock and on backorder |
| `…::test_collection_taxonomy_filters` | `WC_REST_Products_Controller::prepare_objects_query` | a parent category matches products in a child category and not in a sibling; `tax_class` matches exactly |
| `WC_REST_Terms_Controller_Tests::test_product_term_crud_lifecycle` (tags and shipping classes) | `WC_REST_Terms_Controller::create_item`, `update_item`, `delete_item` | the `Location` header, the description persisted in the taxonomy after update, and a 404 after a forced delete |
| `…::test_product_term_batch_lifecycle` (tags and shipping classes) | `WC_REST_Controller::batch_items` | a mixed create/update/delete batch applies each payload to its own term, and the results survive a fresh GET |

The terms test class now extends `WC_REST_Unit_Test_Case` so it can dispatch real routes; its one pre-existing test is unchanged.

#### Mutation checks

Every added or changed test was mutation-checked against the code it exercises: a plausible fault was written into the controller or data store, the single test was run and had to fail on the named assertion, then the source was restored. All faults below were caught.

| Test | Faults injected (all killed) |
| --- | --- |
| orderby core fields | date direction ignored; `slug` mapped to the title column; title direction ignored |
| orderby lookup fields | ascending price reads `max_price`; price always ascending; popularity sorts on rating |
| orderby include | `include` mapped to `ID`; include order honoured only when ascending |
| pagination | total-pages off by one; out-of-bounds page skips the recount; explicit `offset` dropped |
| identity filters | `include`/`exclude` transposed; SKU branch never runs; `slug` reads the wrong parameter; `parent`/`parent_exclude` transposed |
| state filters | `on_sale` inverted; price-range branch never runs; `status` ignored; stock filter on the wrong meta key |
| taxonomy filters | descendants no longer included; category mapped to a key never sent; tax-class branch never runs |
| term CRUD | create returns 200; `Location` points at the collection; update never written; forced delete reports success without deleting |
| term batch | every update applies the first payload; update dispatches a read; delete stops forcing |

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, run `pnpm env:test` if the PHPUnit environment is not running.
2. Run `pnpm test:php:env -- --filter 'WC_REST_Products_Controller_Tests|WC_REST_Terms_Controller_Tests'` and confirm `OK (104 tests, 756 assertions)`.

### Testing that has already taken place:

- Both classes pass locally in one process: 104 tests, 756 assertions.
- 29 mutants designed and executed, 29 killed; the date-direction fault was re-pointed from `WC_Query::get_catalog_ordering_args`, whose `date` branch a product REST request cannot reach because the CRUD controller rewrites `date` to `date ID` first, to the CRUD controller branch it does reach. No test needed strengthening.
- `phpcs-changed` against trunk: clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change. A `Comment`-type changelog file is included manually: `plugins/woocommerce/changelog/test-rest-api-products-terms` (patch, dev).

</details>

### Use of AI Tools

Claude Code drafted these tests on the reference branch behind #68046 and, in this split, ran the review pass (test-quality and simplification reviewer agents against the existing trunk coverage) and the mutation pass (one agent designed the faults from the controller source, another applied each one, ran the focused test, and reverted). I reviewed every test and every mutation result and take responsibility for the change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
