### PR TITLE
Fix checkout showing no shipping options while postcode is being typed

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/address.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/address.ts
@@ -21,6 +21,10 @@ import {
 	type AddressFieldsForShippingRates as AddressFieldsForShippingRatesType,
 } from '@woocommerce/types';
 import { decodeEntities } from '@wordpress/html-entities';
+// Deep import avoids pulling the whole @woocommerce/blocks-checkout barrel
+// (React components, data stores) into base-utils. isPostcode itself has no
+// such side effects; it mirrors WC_Validation::is_postcode().
+import isPostcode from '@woocommerce/blocks-checkout/utils/validation/is-postcode';
 
 export const addressFieldsForShippingRates: AddressFieldsForShippingRatesType =
 	[ 'state', 'country', 'postcode', 'city' ];
@@ -173,6 +177,20 @@ export const hasAllFieldsForShippingRates = (
 		if ( hidden === true || required === false ) {
 			return true;
 		}
-		return isValidAddressKey( key, address ) && address[ key ] !== '';
+		if ( ! isValidAddressKey( key, address ) || address[ key ] === '' ) {
+			return false;
+		}
+		// A partially typed postcode is not enough to fetch shipping rates.
+		// Reuse the same country-aware validation used on submit.
+		if (
+			key === 'postcode' &&
+			! isPostcode( {
+				postcode: address.postcode,
+				country: address.country,
+			} )
+		) {
+			return false;
+		}
+		return true;
 	} );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/test/address.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/test/address.ts
@@ -72,6 +72,42 @@ describe( 'hasAllFieldsForShippingRates', () => {
 		expect( hasAllFieldsForShippingRates( address ) ).toBe( true );
 	} );
 
+	it( 'treats a partially typed postcode as incomplete', () => {
+		const baseAddress = {
+			first_name: 'John',
+			last_name: 'Doe',
+			company: 'Company',
+			address_1: '409 Main Street',
+			address_2: 'Apt 1',
+			city: 'London',
+			country: 'GB',
+			state: '',
+			email: 'john.doe@company',
+			phone: '+1234567890',
+		};
+
+		// A single character is not a valid UK postcode yet.
+		const partialPostcode = {
+			...baseAddress,
+			postcode: 'W',
+		};
+		expect( hasAllFieldsForShippingRates( partialPostcode ) ).toBe( false );
+
+		// An invalid postcode for the country is still incomplete.
+		const invalidPostcode = {
+			...baseAddress,
+			postcode: '!!!!',
+		};
+		expect( hasAllFieldsForShippingRates( invalidPostcode ) ).toBe( false );
+
+		// A complete, valid postcode makes the address complete.
+		const completePostcode = {
+			...baseAddress,
+			postcode: 'W1T 4JG',
+		};
+		expect( hasAllFieldsForShippingRates( completePostcode ) ).toBe( true );
+	} );
+
 	it( 'correctly checks complete addresses with optional fields', () => {
 		const address = {
 			first_name: 'John',

--- a/plugins/woocommerce/client/blocks/changelog/fix-66632-checkout-shipping-warning-postcode
+++ b/plugins/woocommerce/client/blocks/changelog/fix-66632-checkout-shipping-warning-postcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Checkout block showing "No shipping options are available" while the shopper is still typing their postcode, before the address is complete.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When "Hide shipping costs until an address is entered" is disabled, the Checkout block showed the "No shipping options are available for this address" warning as soon as the shopper typed the first character of a postcode, because `hasAllFieldsForShippingRates()` treated any non-empty postcode as complete. The warning should only appear once the address is actually complete.

This change makes `hasAllFieldsForShippingRates()` validate the postcode with the same country-aware `isPostcode()` check used when the checkout form is submitted, so a partially typed or invalid postcode keeps the neutral "Enter a shipping address to view shipping options." message instead. This also aligns the Cart block shipping summary, which uses the same helper.

Closes #66632.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up a store using the Cart and Checkout blocks with at least one shipping zone and method configured, then disable **Hide shipping costs until an address is entered** under **WooCommerce > Settings > Shipping > Shipping options**. Add a product to the cart and open the Checkout block with an empty shipping address — confirm the neutral "Enter a shipping address to view shipping options." message is shown.
2. Start typing a postcode for a country with postcode validation (for example a UK or US postcode) but do not finish it — confirm the "No shipping options are available for this address" warning does **not** appear while the postcode is incomplete, and the neutral message remains.
3. Complete the postcode with a valid value (for example `SW1A 1AA` for the UK or `90210` for the US) and fill any other required fields — confirm shipping rates load and are selectable as expected, and the warning only appears if no rates exist for the completed address.

<!-- End testing instructions -->

### Testing that has already taken place:

-   Added a unit test covering a partially typed postcode, an invalid postcode, and a complete valid postcode in `assets/js/base/utils/test/address.ts`.
-   Ran the address utils unit tests: all 9 tests pass.
-   Ran ESLint on the changed files with no errors.
-   A full package `tsc` pass reports only pre-existing errors in `address.ts` (present on `trunk` before this change) and unrelated errors in `packages/js/data/build-module`; this change introduces no new type errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually at `plugins/woocommerce/client/blocks/changelog/fix-66632-checkout-shipping-warning-postcode`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->