### PR TITLE
Scope PHPCS suppressions on extension-facing SQL queries

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-117-extensible-sql-contract-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-117-extensible-sql-contract-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace legacy WPCS suppression comments on extension-facing SQL and order note queries with scoped phpcs:ignore annotations.

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-downloads.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-downloads.php
@@ -330,7 +330,7 @@ class WC_Report_Downloads extends WP_List_Table {
 		$query_from  = apply_filters( 'woocommerce_report_downloads_query_from', $query_from );
 		$query_order = $wpdb->prepare( 'ORDER BY timestamp DESC LIMIT %d, %d;', ( $current_page - 1 ) * $per_page, $per_page );
 
-		$this->items     = $wpdb->get_results( "SELECT * {$query_from} {$query_order}" ); // WPCS: cache ok, db call ok, unprepared SQL ok.
-		$this->max_items = $wpdb->get_var( "SELECT COUNT( DISTINCT download_log_id ) {$query_from};" ); // WPCS: cache ok, db call ok, unprepared SQL ok.
+		$this->items     = $wpdb->get_results( "SELECT * {$query_from} {$query_order}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Core builds both fragments with $wpdb->prepare(); the woocommerce_report_downloads_query_from filter lets extensions supply their own SQL.
+		$this->max_items = $wpdb->get_var( "SELECT COUNT( DISTINCT download_log_id ) {$query_from};" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Core builds the fragment with $wpdb->prepare(); the woocommerce_report_downloads_query_from filter lets extensions supply their own SQL.
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-notes-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-notes-v2-controller.php
@@ -47,7 +47,7 @@ class WC_REST_Order_Notes_V2_Controller extends WC_REST_Order_Notes_V1_Controlle
 
 		// Allow filter by order note type.
 		if ( 'customer' === $request['type'] ) {
-			$args['meta_query'] = array( // WPCS: slow query ok.
+			$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one order's notes; the customer flag exists only as commentmeta, so a meta join is the only way to filter on it.
 				array(
 					'key'     => 'is_customer_note',
 					'value'   => 1,
@@ -55,7 +55,7 @@ class WC_REST_Order_Notes_V2_Controller extends WC_REST_Order_Notes_V1_Controlle
 				),
 			);
 		} elseif ( 'internal' === $request['type'] ) {
-			$args['meta_query'] = array( // WPCS: slow query ok.
+			$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one order's notes; internal notes are identified by the absence of the is_customer_note meta, so NOT EXISTS is the only way to filter on them.
 				array(
 					'key'     => 'is_customer_note',
 					'compare' => 'NOT EXISTS',

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1253,7 +1253,7 @@ function wc_get_order_notes( $args ) {
 
 	// Set WooCommerce order type.
 	if ( isset( $args['type'] ) && 'customer' === $args['type'] ) {
-		$args['meta_query'] = array( // WPCS: slow query ok.
+		$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Order notes live in wp_comments under both HPOS and legacy storage; the customer flag exists only as commentmeta, so a meta join is the only way to filter on it.
 			array(
 				'key'     => 'is_customer_note',
 				'value'   => 1,
@@ -1261,7 +1261,7 @@ function wc_get_order_notes( $args ) {
 			),
 		);
 	} elseif ( isset( $args['type'] ) && 'internal' === $args['type'] ) {
-		$args['meta_query'] = array( // WPCS: slow query ok.
+		$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Order notes live in wp_comments under both HPOS and legacy storage; internal notes are identified by the absence of the is_customer_note meta, so NOT EXISTS is the only way to filter on them.
 			array(
 				'key'     => 'is_customer_note',
 				'compare' => 'NOT EXISTS',

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
@@ -185,6 +185,6 @@ class WC_Widget_Price_Filter extends WC_Widget {
 
 		$sql = apply_filters( 'woocommerce_price_filter_sql', $sql, $meta_query_sql, $tax_query_sql );
 
-		return $wpdb->get_row( $sql ); // WPCS: unprepared SQL ok.
+		return $wpdb->get_row( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Core assembles $sql from prepared WP_Meta_Query/WP_Tax_Query clauses and esc_sql'd post types; the woocommerce_price_filter_sql filter lets extensions replace the statement.
 	}
 }

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
@@ -104,8 +104,8 @@ class WC_Widget_Products extends WC_Widget {
 			'post_type'      => 'product',
 			'no_found_rows'  => 1,
 			'order'          => $order,
-			'meta_query'     => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- The empty query container does not add a database join.
-			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- The empty query container does not add a database join.
+			'meta_query'     => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Optional container; populated only when the hide-free-products option is on.
+			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Catalog visibility and out-of-stock exclusion are stored only in the product_visibility taxonomy; term_taxonomy_id lookups use the term_relationships index.
 				'relation' => 'AND',
 			),
 		);
@@ -137,7 +137,7 @@ class WC_Widget_Products extends WC_Widget {
 					'terms'    => $product_visibility_term_ids[ ProductStockStatus::OUT_OF_STOCK ],
 					'operator' => 'NOT IN',
 				),
-			); // WPCS: slow query ok.
+			);
 		}
 
 		switch ( $show ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Legacy `// WPCS: ...` comments in the downloads report, order-note queries, and price filter widget no longer suppress PHPCS diagnostics under the current toolchain. This PR replaces them with line-scoped `phpcs:ignore` annotations that name the exact diagnostic and explain why each query must retain its current form.

- The downloads report and price filter widget identify the prepared core-owned query fragments and the public filters that allow extensions to supply or replace SQL.
- Customer and internal order-note queries document why filtering requires `commentmeta`, including the `NOT EXISTS` predicate used because internal notes are represented by the absence of the customer-note flag.
- The products widget removes a legacy comment from a line PHPCS does not report and corrects two existing annotation reasons to describe the conditions under which the query containers are populated.

There is no executable behavior change. The five PHP files are token-identical to `trunk` after comments and whitespace are removed. SQL text, query arguments, public filter names and arguments, return shapes, order-note storage, and product visibility handling remain unchanged.

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, run PHPCS against the five changed PHP files:

   ```bash
   vendor/bin/phpcs -s --report=csv \
       includes/admin/reports/class-wc-report-downloads.php \
       includes/rest-api/Controllers/Version2/class-wc-rest-order-notes-v2-controller.php \
       includes/wc-order-functions.php \
       includes/widgets/class-wc-widget-price-filter.php \
       includes/widgets/class-wc-widget-products.php
   ```

   Confirm the annotated lines do not report the scoped `PreparedSQL` or `SlowDBQuery` diagnostics.

2. Repeat the command with `--ignore-annotations` and confirm those diagnostics are reported on the annotated lines, proving that each annotation scopes a live finding.

3. From the repository root, run the required lint checks and confirm both pass:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes
   pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch
   ```

4. Visit WooCommerce → Reports → Orders → Customer downloads. Filter by product, order, user, and IP address, and confirm the results and pagination total remain correct.

5. Add the Filter Products by Price widget to a shop sidebar. Confirm its minimum and maximum prices populate on the shop archive and a product category archive.

6. Add the Products widget, toggle “Hide free products,” then enable the store-wide “Hide out of stock items” option. Confirm the widget respects both settings.

7. Create customer-facing and internal notes for an order. Request `/wp-json/wc/v2/orders/<id>/notes?type=customer` and `/wp-json/wc/v2/orders/<id>/notes?type=internal`, and confirm each response contains only the requested note type.

### Testing that has already taken place:

- PHPCS was run normally and with `--ignore-annotations` against all five changed PHP files, confirming that each annotation scopes the intended live diagnostic.
- Token equivalence against `origin/trunk` was verified with `token_get_all()`.
- `php -l` passed for all changed PHP files.
- `lint:php:changes` and `lint:changes:branch` passed.
- `git diff --check` passed.
- PHPStan, PHPUnit, and wp-env were not run, and no tests were added, because the PHP changes affect only comments and whitespace.

### Use of AI Tools

This pull request was authored with AI assistance (Claude Code) and reviewed by the author.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-117-extensible-sql-contract-suppressions`.

*\*left by Biff (AI agent) on behalf of Darren*