### PR TITLE
Annotate REST product query suppressions with exact sniff codes

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-7556-rest-product-query-suppressions
+++ b/plugins/woocommerce/changelog/fix-wooplug-7556-rest-product-query-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace legacy WPCS suppression comments on REST product and variation meta queries with explicit phpcs:ignore annotations that record why postmeta remains the correct path.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -419,7 +419,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 				$skus[] = $request['sku'];
 			}
 
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Exact _sku match; wc_product_meta_lookup truncates SKUs to 100 chars and is empty while it regenerates, so it is not an equivalent path.
 				$args,
 				array(
 					'key'     => '_sku',
@@ -431,7 +431,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Filter by tax class.
 		if ( ! empty( $request['tax_class'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- wc_product_meta_lookup.tax_class is unindexed and holds NULL where _tax_class is unset, so it is neither faster nor equivalent.
 				$args,
 				array(
 					'key'   => '_tax_class',
@@ -442,12 +442,12 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Price filter.
 		if ( ! empty( $request['min_price'] ) || ! empty( $request['max_price'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- _price is stored once per child price; wc_product_meta_lookup keeps only min/max and would match a wider range.
 		}
 
 		// Filter product in stock or out of stock.
 		if ( is_bool( $request['in_stock'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Postmeta stays correct while wc_product_meta_lookup is stale or regenerating; the _stock_status meta_key index bounds the scan.
 				$args,
 				array(
 					'key'   => '_stock_status',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -1033,7 +1033,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				$skus[] = $request['sku'];
 			}
 
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one parent's variations by post_parent; wc_product_meta_lookup truncates SKUs to 100 chars.
 				$args,
 				array(
 					'key'     => '_sku',
@@ -1058,7 +1058,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 
 		// Filter by tax class.
 		if ( ! empty( $request['tax_class'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one parent's variations by post_parent, so this resolves through the postmeta post_id index.
 				$args,
 				array(
 					'key'   => '_tax_class',
@@ -1069,13 +1069,13 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 
 		// Price filter.
 		if ( ! empty( $request['min_price'] ) || ! empty( $request['max_price'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one parent's variations by post_parent; wc_product_meta_lookup keeps only min/max and would match a wider range.
 		}
 
 		// Price filter.
 		if ( is_bool( $request['has_price'] ) ) {
 			if ( $request['has_price'] ) {
-				$args['meta_query'] = $this->add_meta_query( // phpcs:ignore Standard.Category.SniffName.ErrorCode slow query ok.
+				$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one parent's variations by post_parent; wc_product_meta_lookup keeps only min/max and would match a wider range.
 					$args,
 					array(
 						'relation' => 'AND',
@@ -1091,7 +1091,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 					)
 				);
 			} else {
-				$args['meta_query'] = $this->add_meta_query( // phpcs:ignore Standard.Category.SniffName.ErrorCode slow query ok.
+				$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one parent's variations by post_parent; wc_product_meta_lookup keeps only min/max and would match a wider range.
 					$args,
 					array(
 						'relation' => 'OR',
@@ -1111,7 +1111,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 
 		// Filter product based on stock_status.
 		if ( ! empty( $request['stock_status'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded to one parent's variations by post_parent, so this resolves through the postmeta post_id index.
 				$args,
 				array(
 					'key'   => '_stock_status',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -400,7 +400,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					$skus[] = $request['sku'];
 				}
 
-				$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+				$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Exact _sku match; wc_product_meta_lookup truncates SKUs to 100 chars and is empty while it regenerates, so it is not an equivalent path.
 					$args,
 					array(
 						'key'     => '_sku',
@@ -425,7 +425,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		// Filter by tax class.
 		if ( ! empty( $request['tax_class'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- wc_product_meta_lookup.tax_class is unindexed and holds NULL where _tax_class is unset, so it is neither faster nor equivalent.
 				$args,
 				array(
 					'key'   => '_tax_class',
@@ -436,12 +436,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		// Price filter.
 		if ( ! empty( $request['min_price'] ) || ! empty( $request['max_price'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- _price is stored once per child price; wc_product_meta_lookup keeps only min/max and would match a wider range.
 		}
 
 		// Filter product by stock_status.
 		if ( ! empty( $request['stock_status'] ) ) {
-			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Postmeta stays correct while wc_product_meta_lookup is stale or regenerating; the _stock_status meta_key index bounds the scan.
 				$args,
 				array(
 					'key'   => '_stock_status',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This replaces 14 legacy or ineffective suppression comments on REST product and variation meta queries with exact `WordPress.DB.SlowDBQuery.slow_db_query_meta_query` annotations. Each annotation records why postmeta remains the appropriate query path instead of hiding the diagnostic behind a broad or nonexistent sniff code.

Closes #67849.

No executable code changes. The query shapes, result sets, REST responses, and extension-visible query-filter payloads remain unchanged.

The queries were not moved to `wc_product_meta_lookup` because it is not behaviorally equivalent:

- Price filtering must match actual child prices rather than overlap with stored minimum and maximum values.
- Direct postmeta writes can leave lookup data absent or stale. A snapshot of 975 WooCommerce.com extension packages found 62 that directly update `_sku`, `_stock_status`, or `_price`.
- Lookup data can be incomplete while the table regenerates, and its SKU column truncates values beyond 100 characters.
- The lookup table's `tax_class` column is unindexed and represents unset values differently from the existing `standard` tax-class query.
- Variation queries are already restricted to one parent and resolve their postmeta joins through a small set of rows.

The corpus search found one consumer of the product query filter, which adds only a taxonomy clause, and no consumer of the variation query filter. This is a snapshot rather than proof that no other consumers exist, so retaining the existing `meta_query` payload is the compatible approach.

### How to test the changes in this Pull Request:

1. From the repository root, run the required lint checks:

    ```bash
    pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes
    pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch
    ```

2. From `plugins/woocommerce`, run PHPCS against the three changed controllers normally and with annotations ignored:

    ```bash
    vendor/bin/phpcs -s --report=csv includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
    vendor/bin/phpcs -s --report=csv --ignore-annotations includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
    ```

    Confirm the normal run reports no `WordPress.DB.SlowDBQuery` diagnostics on the changed lines and the `--ignore-annotations` run still reports them.

3. Run the REST product and variation test suites with HPOS enabled:

    ```bash
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'WC_REST_Products_Controller_Tests|WC_REST_Product_Variations_Controller_Tests|WC_Tests_API_Products|WC_Tests_API_Product_Variations'
    ```

4. Run the same suites with HPOS disabled:

    ```bash
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env:hpos-off -- --filter 'WC_REST_Products_Controller_Tests|WC_REST_Product_Variations_Controller_Tests|WC_Tests_API_Products|WC_Tests_API_Product_Variations'
    ```

5. Using an authenticated REST client, request `/wp-json/wc/v3/products` with representative `sku`, `tax_class`, `min_price`, `max_price`, and `stock_status` parameters. Confirm each request returns the expected products.

6. Request `/wp-json/wc/v3/products/<id>/variations?has_price=true` and again with `has_price=false`. Confirm the responses contain the expected variations.

### Testing that has already taken place:

- Normal PHPCS and `--ignore-annotations` runs completed on all three changed controllers. The annotations suppress only the intended `WordPress.DB.SlowDBQuery` diagnostics.
- `lint:php:changes` and `lint:changes:branch` pass.
- The four REST product and variation suites pass with HPOS enabled and disabled: 129 tests and 725 assertions in each run.
- `php -l` passes on all changed PHP files.
- PHPStan reports no errors for the changed controllers.
- Token comparison against `origin/trunk`, excluding comments and whitespace, is identical for all three controllers.
- Query plans and timings were captured from live REST requests against a store containing 2,600 products. Product lookup-table queries were faster for some filters but produced different behavior in the identified edge cases; variation queries were already bounded efficiently by `post_parent`.

### Use of AI Tools

Authored with AI assistance (Claude Code) and reviewed by the author.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-wooplug-7556-rest-product-query-suppressions`

*\*left by Biff (AI agent) on behalf of Darren*