### PR TITLE
Order product widgets by the lookup table for sales and rating

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-7559-product-widget-sorting
+++ b/plugins/woocommerce/changelog/fix-wooplug-7559-product-widget-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Sort the products widget by sales and the top rated products widget by rating through the product lookup table instead of post meta.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
@@ -207,7 +207,10 @@ class WC_Widget_Products extends WC_Widget {
 	 * @return WP_Query
 	 */
 	private function query_products( $query_args ) {
+		// WP_Query skips posts_clauses when a filter asks for suppressed filters, which would leave the
+		// query with no ordering at all, so stay on the post meta ordering in that case.
 		$orders_by_total_sales = isset( $query_args['meta_key'], $query_args['orderby'] )
+			&& empty( $query_args['suppress_filters'] )
 			&& 'total_sales' === $query_args['meta_key']
 			&& 'meta_value_num' === $query_args['orderby'];
 

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
@@ -160,21 +160,89 @@ class WC_Widget_Products extends WC_Widget {
 				$query_args['orderby'] = 'menu_order';
 				break;
 			case 'price':
-				$query_args['meta_key'] = '_price'; // WPCS: slow query ok.
+				// Kept on post meta: the join also drops products that have no price at all, and
+				// wc_product_meta_lookup stores 0 for those so it cannot reproduce that filter.
+				$query_args['meta_key'] = '_price'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Ordering by the _price meta is what keeps priceless products out of the list; adding the lookup table join on top of it measured slower than the meta join alone.
 				$query_args['orderby']  = 'meta_value_num';
 				break;
 			case 'rand':
 				$query_args['orderby'] = 'rand';
 				break;
 			case 'sales':
-				$query_args['meta_key'] = 'total_sales'; // WPCS: slow query ok.
+				// Left in the args so that the query args filter below keeps seeing the documented
+				// payload; the query itself is switched to wc_product_meta_lookup afterwards.
+				$query_args['meta_key'] = 'total_sales'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Part of the filter payload only; query_products() orders through wc_product_meta_lookup instead of joining post meta.
 				$query_args['orderby']  = 'meta_value_num';
 				break;
 			default:
 				$query_args['orderby'] = 'date';
 		}
 
-		return new WP_Query( apply_filters( 'woocommerce_products_widget_query_args', $query_args ) );
+		/**
+		 * Filters the query arguments the Products widget uses to fetch its products.
+		 *
+		 * @since 2.4.0
+		 * @param array $query_args Arguments passed to WP_Query.
+		 */
+		$query_args = apply_filters( 'woocommerce_products_widget_query_args', $query_args );
+
+		return $this->query_products( $query_args );
+	}
+
+	/**
+	 * Run the widget query, ordering through the product lookup table where that is equivalent to, and
+	 * cheaper than, ordering through post meta.
+	 *
+	 * Only the sales ordering is redirected. `total_sales` post meta is written for every product, so the
+	 * meta join it replaces filters nothing out, while `wc_product_meta_lookup` holds one narrow row per
+	 * product instead of one row per product in a table that grows with every extension's meta. Price
+	 * ordering deliberately stays on post meta; see the `price` case in get_products().
+	 *
+	 * The swap happens after `woocommerce_products_widget_query_args` has run, and only when nothing on
+	 * that filter changed the ordering arguments, so the filter payload keeps its documented shape and a
+	 * consumer that overrides the ordering still wins.
+	 *
+	 * @param array $query_args Query arguments, as returned by the widget query args filter.
+	 *
+	 * @return WP_Query
+	 */
+	private function query_products( $query_args ) {
+		$orders_by_total_sales = isset( $query_args['meta_key'], $query_args['orderby'] )
+			&& 'total_sales' === $query_args['meta_key']
+			&& 'meta_value_num' === $query_args['orderby'];
+
+		if ( ! $orders_by_total_sales ) {
+			return new WP_Query( $query_args );
+		}
+
+		$order = isset( $query_args['order'] ) && 'asc' === strtolower( $query_args['order'] ) ? 'ASC' : 'DESC';
+
+		unset( $query_args['meta_key'] );
+		$query_args['orderby'] = 'none';
+
+		$products = new WP_Query();
+
+		$order_by_total_sales = static function ( $clauses, $query ) use ( $products, $order ) {
+			global $wpdb;
+
+			if ( $query !== $products ) {
+				return $clauses;
+			}
+
+			if ( ! strstr( $clauses['join'], 'wc_product_meta_lookup' ) ) {
+				$clauses['join'] .= " LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON {$wpdb->posts}.ID = wc_product_meta_lookup.product_id ";
+			}
+
+			$clauses['orderby'] = " wc_product_meta_lookup.total_sales {$order}, wc_product_meta_lookup.product_id {$order} ";
+
+			return $clauses;
+		};
+
+		add_filter( 'posts_clauses', $order_by_total_sales, 10, 2 );
+		$products->query( $query_args );
+		remove_filter( 'posts_clauses', $order_by_total_sales, 10 );
+
+		return $products;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
@@ -233,7 +233,9 @@ class WC_Widget_Products extends WC_Widget {
 				$clauses['join'] .= " LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON {$wpdb->posts}.ID = wc_product_meta_lookup.product_id ";
 			}
 
-			$clauses['orderby'] = " wc_product_meta_lookup.total_sales {$order}, wc_product_meta_lookup.product_id {$order} ";
+			// The IS NULL term sorts ascending in both directions, so products that have no lookup row
+			// (a partly regenerated table, say) always land last instead of leading an ascending list.
+			$clauses['orderby'] = " wc_product_meta_lookup.total_sales IS NULL, wc_product_meta_lookup.total_sales {$order}, wc_product_meta_lookup.product_id {$order} ";
 
 			return $clauses;
 		};

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-top-rated-products.php
@@ -65,15 +65,17 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 				'no_found_rows'  => 1,
 				'post_status'    => 'publish',
 				'post_type'      => 'product',
-				'meta_key'       => '_wc_average_rating',
+				// Left in the args so that the filter above keeps seeing the documented payload; the
+				// query itself is switched to wc_product_meta_lookup in query_top_rated_products().
+				'meta_key'       => '_wc_average_rating', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Part of the filter payload only; query_top_rated_products() orders through wc_product_meta_lookup instead of joining post meta.
 				'orderby'        => 'meta_value_num',
 				'order'          => 'DESC',
-				'meta_query'     => WC()->query->get_meta_query(),
-				'tax_query'      => WC()->query->get_tax_query(),
+				'meta_query'     => WC()->query->get_meta_query(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty unless an extension adds clauses through woocommerce_product_query_meta_query; the same container the shop catalog query uses.
+				'tax_query'      => WC()->query->get_tax_query(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Product visibility exclusions are indexed by term_taxonomy_id and are the only way to hide catalog-excluded products.
 			)
-		); // WPCS: slow query ok.
+		);
 
-		$r = new WP_Query( $query_args );
+		$r = $this->query_top_rated_products( $query_args );
 
 		if ( $r->have_posts() ) {
 
@@ -103,5 +105,48 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Buffered widget markup; each dynamic value is escaped or annotated where it is rendered.
 
 		$this->cache_widget( $args, $content );
+	}
+
+	/**
+	 * Run the widget query, ordering through the product lookup table instead of the rating post meta.
+	 *
+	 * `_wc_average_rating` post meta is written for every product, so the meta join this replaces filters
+	 * nothing out, while `wc_product_meta_lookup` holds one narrow row per product instead of one row per
+	 * product in a table that grows with every extension's meta. Ordering is delegated to the same clause
+	 * callback the shop catalog uses for "sort by average rating", which also breaks ties on rating count
+	 * and product ID rather than leaving equally rated products in an undefined order.
+	 *
+	 * The swap happens after `woocommerce_top_rated_products_widget_args` has run, and only when nothing on
+	 * that filter changed the ordering arguments, so the filter payload keeps its documented shape and a
+	 * consumer that overrides the ordering still wins.
+	 *
+	 * @param array $query_args Query arguments, as returned by the widget args filter.
+	 *
+	 * @return WP_Query
+	 */
+	private function query_top_rated_products( $query_args ) {
+		$orders_by_average_rating = isset( $query_args['meta_key'], $query_args['orderby'], $query_args['order'] )
+			&& '_wc_average_rating' === $query_args['meta_key']
+			&& 'meta_value_num' === $query_args['orderby']
+			&& 'DESC' === strtoupper( $query_args['order'] );
+
+		if ( ! $orders_by_average_rating ) {
+			return new WP_Query( $query_args );
+		}
+
+		unset( $query_args['meta_key'] );
+		$query_args['orderby'] = 'none';
+
+		$products = new WP_Query();
+
+		$order_by_rating = static function ( $clauses, $query ) use ( $products ) {
+			return $query === $products ? WC()->query->order_by_rating_post_clauses( $clauses ) : $clauses;
+		};
+
+		add_filter( 'posts_clauses', $order_by_rating, 10, 2 );
+		$products->query( $query_args );
+		remove_filter( 'posts_clauses', $order_by_rating, 10 );
+
+		return $products;
 	}
 }

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-top-rated-products.php
@@ -125,7 +125,10 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 	 * @return WP_Query
 	 */
 	private function query_top_rated_products( $query_args ) {
+		// WP_Query skips posts_clauses when a filter asks for suppressed filters, which would leave the
+		// query with no ordering at all, so stay on the post meta ordering in that case.
 		$orders_by_average_rating = isset( $query_args['meta_key'], $query_args['orderby'], $query_args['order'] )
+			&& empty( $query_args['suppress_filters'] )
 			&& '_wc_average_rating' === $query_args['meta_key']
 			&& 'meta_value_num' === $query_args['orderby']
 			&& 'DESC' === strtoupper( $query_args['order'] );

--- a/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-products-test.php
@@ -13,61 +13,123 @@ declare( strict_types = 1 );
 class WC_Widget_Products_Test extends \WC_Unit_Test_Case {
 
 	/**
-	 * Sales ordering is taken from wc_product_meta_lookup rather than from the total_sales post meta.
+	 * Query the widget for its products, ordered by sales.
+	 *
+	 * Every call flushes the object cache first: the lookup table is not part of the post cache, so
+	 * WP_Query would otherwise hand back the result ids it cached for an identical earlier query.
+	 *
+	 * @param string $order 'asc' or 'desc'.
+	 *
+	 * @return int[] Product ids, in the order the widget returned them.
+	 */
+	private function sales_ordered_ids( string $order ): array {
+		wp_cache_flush();
+
+		$query = ( new WC_Widget_Products() )->get_products(
+			array(),
+			array(
+				'number'  => 3,
+				'orderby' => 'sales',
+				'order'   => $order,
+			)
+		);
+
+		return wp_list_pluck( $query->posts, 'ID' );
+	}
+
+	/**
+	 * Sales ordering comes from wc_product_meta_lookup, breaks ties deterministically, keeps products
+	 * that have no lookup row last, and steps aside for a filter that changes the ordering.
 	 */
 	public function test_sales_ordering_reads_total_sales_from_the_lookup_table(): void {
 		global $wpdb;
 
 		$ids = array();
-		foreach ( array( 30, 20, 10 ) as $total_sales ) {
+		foreach ( array( 20, 30, 10 ) as $total_sales ) {
 			$product = WC_Helper_Product::create_simple_product();
 			$product->set_total_sales( $total_sales );
 			$product->save();
 			$ids[] = $product->get_id();
 		}
 
-		// Make the lookup table rank the products the other way round from the post meta.
+		// Rank the products differently in the lookup table from the post meta, so the two sources
+		// can be told apart. Post meta ranks them p1, p0, p2; the lookup table ranks them p2, p1, p0.
 		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 10 ), array( 'product_id' => $ids[0] ) );
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 20 ), array( 'product_id' => $ids[1] ) );
 		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 30 ), array( 'product_id' => $ids[2] ) );
 
-		$widget = new WC_Widget_Products();
-		$query  = $widget->get_products(
-			array(),
-			array(
-				'number'  => 3,
-				'orderby' => 'sales',
-				'order'   => 'desc',
-			)
+		$this->assertSame(
+			array( $ids[2], $ids[1], $ids[0] ),
+			$this->sales_ordered_ids( 'desc' ),
+			'Sales ordering should follow the lookup table, not the post meta.'
 		);
 
-		$this->assertSame( array( $ids[2], $ids[1], $ids[0] ), wp_list_pluck( $query->posts, 'ID' ) );
+		// A filter that suppresses query filters would stop WP_Query running posts_clauses, so the
+		// widget has to fall back to the post meta ordering rather than emit an unordered query.
+		$suppress_filters = static function ( $args ) {
+			$args['suppress_filters'] = true;
+			return $args;
+		};
+
+		add_filter( 'woocommerce_products_widget_query_args', $suppress_filters );
+
+		try {
+			$this->assertSame(
+				array( $ids[1], $ids[0], $ids[2] ),
+				$this->sales_ordered_ids( 'desc' ),
+				'Suppressed filters should fall back to the post meta ordering.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_products_widget_query_args', $suppress_filters );
+		}
+
+		// Equal sales are broken by product id, in whichever direction the widget is ordered.
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 50 ), array( 'product_id' => $ids[0] ) );
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 50 ), array( 'product_id' => $ids[1] ) );
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 5 ), array( 'product_id' => $ids[2] ) );
+
+		$this->assertSame(
+			array( $ids[1], $ids[0], $ids[2] ),
+			$this->sales_ordered_ids( 'desc' ),
+			'Products on equal sales should be ordered by descending product id.'
+		);
+		$this->assertSame(
+			array( $ids[2], $ids[0], $ids[1] ),
+			$this->sales_ordered_ids( 'asc' ),
+			'Products on equal sales should be ordered by ascending product id.'
+		);
+
+		// A filter that changes the ordering wins; the lookup ordering is not applied on top of it.
+		$order_by_id = static function ( $args ) {
+			$args['orderby'] = 'ID';
+			return $args;
+		};
+
+		add_filter( 'woocommerce_products_widget_query_args', $order_by_id );
+
+		try {
+			$this->assertSame(
+				array( $ids[2], $ids[1], $ids[0] ),
+				$this->sales_ordered_ids( 'desc' ),
+				'A filter that changes orderby should decide the ordering.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_products_widget_query_args', $order_by_id );
+		}
 
 		// A product with no lookup row at all, as happens while the lookup table is being regenerated,
 		// sorts last whichever way round the widget is ordered.
 		$wpdb->delete( $wpdb->wc_product_meta_lookup, array( 'product_id' => $ids[2] ) );
 
-		// The lookup table is not part of the post cache, so WP_Query would otherwise hand back the
-		// result ids it cached for the identical query above.
-		wp_cache_flush();
-
-		$descending = $widget->get_products(
-			array(),
-			array(
-				'number'  => 3,
-				'orderby' => 'sales',
-				'order'   => 'desc',
-			)
+		$this->assertSame(
+			array( $ids[1], $ids[0], $ids[2] ),
+			$this->sales_ordered_ids( 'desc' ),
+			'A product with no lookup row should sort last descending.'
 		);
-		$ascending  = $widget->get_products(
-			array(),
-			array(
-				'number'  => 3,
-				'orderby' => 'sales',
-				'order'   => 'asc',
-			)
+		$this->assertSame(
+			array( $ids[0], $ids[1], $ids[2] ),
+			$this->sales_ordered_ids( 'asc' ),
+			'A product with no lookup row should sort last ascending.'
 		);
-
-		$this->assertSame( array( $ids[1], $ids[0], $ids[2] ), wp_list_pluck( $descending->posts, 'ID' ) );
-		$this->assertSame( array( $ids[0], $ids[1], $ids[2] ), wp_list_pluck( $ascending->posts, 'ID' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-products-test.php
@@ -41,5 +41,33 @@ class WC_Widget_Products_Test extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( array( $ids[2], $ids[1], $ids[0] ), wp_list_pluck( $query->posts, 'ID' ) );
+
+		// A product with no lookup row at all, as happens while the lookup table is being regenerated,
+		// sorts last whichever way round the widget is ordered.
+		$wpdb->delete( $wpdb->wc_product_meta_lookup, array( 'product_id' => $ids[2] ) );
+
+		// The lookup table is not part of the post cache, so WP_Query would otherwise hand back the
+		// result ids it cached for the identical query above.
+		wp_cache_flush();
+
+		$descending = $widget->get_products(
+			array(),
+			array(
+				'number'  => 3,
+				'orderby' => 'sales',
+				'order'   => 'desc',
+			)
+		);
+		$ascending  = $widget->get_products(
+			array(),
+			array(
+				'number'  => 3,
+				'orderby' => 'sales',
+				'order'   => 'asc',
+			)
+		);
+
+		$this->assertSame( array( $ids[1], $ids[0], $ids[2] ), wp_list_pluck( $descending->posts, 'ID' ) );
+		$this->assertSame( array( $ids[0], $ids[1], $ids[2] ), wp_list_pluck( $ascending->posts, 'ID' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-products-test.php
@@ -1,0 +1,45 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Widget_Products.
+ *
+ * @package WooCommerce\Tests\Widgets
+ */
+
+/**
+ * WC_Widget_Products_Test class.
+ */
+class WC_Widget_Products_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Sales ordering is taken from wc_product_meta_lookup rather than from the total_sales post meta.
+	 */
+	public function test_sales_ordering_reads_total_sales_from_the_lookup_table(): void {
+		global $wpdb;
+
+		$ids = array();
+		foreach ( array( 30, 20, 10 ) as $total_sales ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_total_sales( $total_sales );
+			$product->save();
+			$ids[] = $product->get_id();
+		}
+
+		// Make the lookup table rank the products the other way round from the post meta.
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 10 ), array( 'product_id' => $ids[0] ) );
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'total_sales' => 30 ), array( 'product_id' => $ids[2] ) );
+
+		$widget = new WC_Widget_Products();
+		$query  = $widget->get_products(
+			array(),
+			array(
+				'number'  => 3,
+				'orderby' => 'sales',
+				'order'   => 'desc',
+			)
+		);
+
+		$this->assertSame( array( $ids[2], $ids[1], $ids[0] ), wp_list_pluck( $query->posts, 'ID' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-top-rated-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-top-rated-products-test.php
@@ -13,47 +13,131 @@ declare( strict_types = 1 );
 class WC_Widget_Top_Rated_Products_Test extends \WC_Unit_Test_Case {
 
 	/**
-	 * Rating ordering is taken from wc_product_meta_lookup rather than from the _wc_average_rating post meta.
+	 * Render the widget and return the ids of the products it listed, in order.
+	 *
+	 * The ordering is read from the `the_post` action rather than the `the_posts` filter, because a
+	 * query that asks for suppressed filters never runs the latter.
+	 *
+	 * Every call flushes the object cache first: the lookup table is not part of the post cache, so
+	 * WP_Query would otherwise hand back the result ids it cached for an identical earlier query.
+	 *
+	 * @return int[] Product ids, in the order the widget listed them.
+	 */
+	private function rating_ordered_ids(): array {
+		wp_cache_flush();
+
+		$ordered = array();
+		$capture = function ( $post ) use ( &$ordered ) {
+			$ordered[] = (int) $post->ID;
+		};
+
+		add_action( 'the_post', $capture );
+		ob_start();
+
+		try {
+			( new WC_Widget_Top_Rated_Products() )->widget(
+				array(
+					'before_widget' => '',
+					'after_widget'  => '',
+					'before_title'  => '',
+					'after_title'   => '',
+				),
+				array( 'number' => 3 )
+			);
+		} finally {
+			ob_end_clean();
+			remove_action( 'the_post', $capture );
+		}
+
+		return $ordered;
+	}
+
+	/**
+	 * Rating ordering comes from wc_product_meta_lookup, breaks ties on rating count then product id,
+	 * and steps aside for a filter that changes the ordering.
 	 */
 	public function test_rating_ordering_reads_average_rating_from_the_lookup_table(): void {
 		global $wpdb;
 
 		$ids = array();
-		foreach ( array( '5.00', '3.00', '1.00' ) as $average_rating ) {
+		foreach ( array( '3.00', '5.00', '1.00' ) as $average_rating ) {
 			$product = WC_Helper_Product::create_simple_product();
 			$product->set_average_rating( $average_rating );
 			$product->save();
 			$ids[] = $product->get_id();
 		}
 
-		// Make the lookup table rank the products the other way round from the post meta.
+		// Rank the products differently in the lookup table from the post meta, so the two sources
+		// can be told apart. Post meta ranks them p1, p0, p2; the lookup table ranks them p2, p1, p0.
 		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'average_rating' => '1.00' ), array( 'product_id' => $ids[0] ) );
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'average_rating' => '3.00' ), array( 'product_id' => $ids[1] ) );
 		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'average_rating' => '5.00' ), array( 'product_id' => $ids[2] ) );
 
-		$ordered = array();
-		$capture = function ( $posts ) use ( &$ordered ) {
-			$ordered = wp_list_pluck( $posts, 'ID' );
+		$this->assertSame(
+			array( $ids[2], $ids[1], $ids[0] ),
+			$this->rating_ordered_ids(),
+			'Rating ordering should follow the lookup table, not the post meta.'
+		);
 
-			// Nothing needs rendering once the ordering has been captured.
-			return array();
+		// A filter that suppresses query filters would stop WP_Query running posts_clauses, so the
+		// widget has to fall back to the post meta ordering rather than emit an unordered query.
+		$suppress_filters = static function ( $args ) {
+			$args['suppress_filters'] = true;
+			return $args;
 		};
 
-		add_filter( 'the_posts', $capture );
+		add_filter( 'woocommerce_top_rated_products_widget_args', $suppress_filters );
 
-		ob_start();
-		( new WC_Widget_Top_Rated_Products() )->widget(
-			array(
-				'before_widget' => '',
-				'after_widget'  => '',
-				'before_title'  => '',
-				'after_title'   => '',
-			),
-			array( 'number' => 3 )
+		try {
+			$this->assertSame(
+				array( $ids[1], $ids[0], $ids[2] ),
+				$this->rating_ordered_ids(),
+				'Suppressed filters should fall back to the post meta ordering.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_top_rated_products_widget_args', $suppress_filters );
+		}
+
+		// Equally rated products fall back to the rating count, and then to the product id.
+		$rating_counts = array(
+			$ids[0] => 2,
+			$ids[1] => 9,
+			$ids[2] => 2,
 		);
-		ob_get_clean();
 
-		remove_filter( 'the_posts', $capture );
+		foreach ( $rating_counts as $id => $rating_count ) {
+			$wpdb->update(
+				$wpdb->wc_product_meta_lookup,
+				array(
+					'average_rating' => '5.00',
+					'rating_count'   => $rating_count,
+				),
+				array( 'product_id' => $id )
+			);
+		}
 
-		$this->assertSame( array( $ids[2], $ids[1], $ids[0] ), $ordered );
+		$this->assertSame(
+			array( $ids[1], $ids[2], $ids[0] ),
+			$this->rating_ordered_ids(),
+			'Equally rated products should be ordered by rating count, then by descending product id.'
+		);
+
+		// A filter that changes the ordering wins; the lookup ordering is not applied on top of it.
+		$order_by_id = static function ( $args ) {
+			$args['orderby'] = 'ID';
+			return $args;
+		};
+
+		add_filter( 'woocommerce_top_rated_products_widget_args', $order_by_id );
+
+		try {
+			$this->assertSame(
+				array( $ids[2], $ids[1], $ids[0] ),
+				$this->rating_ordered_ids(),
+				'A filter that changes orderby should decide the ordering.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_top_rated_products_widget_args', $order_by_id );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-top-rated-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/widgets/class-wc-widget-top-rated-products-test.php
@@ -1,0 +1,59 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Widget_Top_Rated_Products.
+ *
+ * @package WooCommerce\Tests\Widgets
+ */
+
+/**
+ * WC_Widget_Top_Rated_Products_Test class.
+ */
+class WC_Widget_Top_Rated_Products_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Rating ordering is taken from wc_product_meta_lookup rather than from the _wc_average_rating post meta.
+	 */
+	public function test_rating_ordering_reads_average_rating_from_the_lookup_table(): void {
+		global $wpdb;
+
+		$ids = array();
+		foreach ( array( '5.00', '3.00', '1.00' ) as $average_rating ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_average_rating( $average_rating );
+			$product->save();
+			$ids[] = $product->get_id();
+		}
+
+		// Make the lookup table rank the products the other way round from the post meta.
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'average_rating' => '1.00' ), array( 'product_id' => $ids[0] ) );
+		$wpdb->update( $wpdb->wc_product_meta_lookup, array( 'average_rating' => '5.00' ), array( 'product_id' => $ids[2] ) );
+
+		$ordered = array();
+		$capture = function ( $posts ) use ( &$ordered ) {
+			$ordered = wp_list_pluck( $posts, 'ID' );
+
+			// Nothing needs rendering once the ordering has been captured.
+			return array();
+		};
+
+		add_filter( 'the_posts', $capture );
+
+		ob_start();
+		( new WC_Widget_Top_Rated_Products() )->widget(
+			array(
+				'before_widget' => '',
+				'after_widget'  => '',
+				'before_title'  => '',
+				'after_title'   => '',
+			),
+			array( 'number' => 3 )
+		);
+		ob_get_clean();
+
+		remove_filter( 'the_posts', $capture );
+
+		$this->assertSame( array( $ids[2], $ids[1], $ids[0] ), $ordered );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Products widget's sales ordering and the Top Rated Products widget's rating ordering currently sort through post meta. On large catalogues this requires scanning a substantial part of `wp_postmeta`. This PR moves those orderings to `wc_product_meta_lookup`, which contains one narrow row per product and is already used for catalogue sorting.

Closes #67852.

The public query-argument filters keep receiving their existing payloads. The lookup-table ordering is applied only after those filters run and only while the identifying ordering arguments remain unchanged, so extensions that replace the ordering continue using the original query. If a filter sets `suppress_filters`, `WP_Query` would skip `posts_clauses`, so the original post meta query is used in that case as well.

The resulting behavior is:

- Sales ordering uses a `LEFT JOIN`, breaks ties by product ID, and places products without a lookup row last in both ascending and descending order.
- Rating ordering delegates to the same clause callback used by the shop catalogue, breaking ties by rating count and product ID.
- Products without lookup rows remain in both widgets. This matters while the table is incomplete, such as during regeneration or after a direct database import.
- With a current lookup table, the ordered sort values remain unchanged. Tie ordering becomes deterministic, and stale lookup data now produces the same order as the shop catalogue.
- Price, date, menu order, and random ordering are unchanged. Price remains on post meta because that join also excludes products without a price, which the lookup table cannot reproduce.
- Remaining intentional slow-query paths have scoped PHPCS exceptions naming the exact diagnostics and explaining why those queries remain.

At 50,000 products, query-only median timings were:

| Branch | Before | After | Change |
| --- | ---: | ---: | ---: |
| Products / sales descending | 86.5 ms | 45.1 ms | -47.9% |
| Products / sales ascending | 87.2 ms | 44.6 ms | -48.9% |
| Top Rated | 86.8 ms | 33.7 ms | -61.1% |

Cold end-to-end widget rendering improved by 44–46% for sales ordering and 55–58% for rating ordering. Results were effectively unchanged at 1,000 products and remained within run-to-run noise at 10,000 products. `EXPLAIN` shows the new plans using a primary-key lookup against the product lookup table instead of scanning an estimated 87,750–90,308 rows in a 1.77-million-row post meta table.

The existing filesort and redundant `GROUP BY` remain. Removing them or adding lookup-table indexes requires separate query and schema changes.

This modifies performance-sensitive query construction and should receive independent human review. No public hook names, arguments, or firing points change.

### How to test the changes in this Pull Request:

1. Run the required lint checks from the repository root and confirm they pass:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes
   pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch
   ```

2. Run PHPStan from `plugins/woocommerce` and confirm it reports no errors in the changed widget or test files:

   ```sh
   vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=4G
   ```

3. Start the test environment and run the focused tests with HPOS enabled and disabled:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce env:test:start
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- \
     --filter 'WC_Widget_Products_Test|WC_Widget_Top_Rated_Products_Test'
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env:hpos-off -- \
     --filter 'WC_Widget_Products_Test|WC_Widget_Top_Rated_Products_Test'
   ```

4. Add the Products list widget to a sidebar, select **Sales** ordering, and confirm its products match the shop catalogue's **Sort by popularity** results in both ascending and descending order.
5. Add the Products by Rating list widget and confirm its products match the shop catalogue's **Sort by average rating** results.
6. Set the Products list widget to **Price** and confirm its output is unchanged, including excluding products without a price.
7. If the store predates WooCommerce 3.6 or the widget and catalogue results differ before testing, regenerate the product lookup tables from WooCommerce → Status → Tools and repeat the comparisons.

### Testing that has already taken place:

- PHPCS was run with and without `--ignore-annotations` against both changed production files and both new test files.
- Both required branch lint commands and `php -l` passed.
- A repository-wide PHPStan run reported 10 existing errors in email code. Stashing this branch's changes produced the identical set, confirming this PR introduces none of them.
- The two focused widget tests and the `WC_Tests_Widget`, `WC_Tests_Query`, `WC_Tests_Product_Functions`, and `WC_Tests_CRUD_Data_Store` suites passed with HPOS enabled and disabled.
- Both new tests were verified to fail against the unmodified widget implementations. The missing-row assertion also catches products incorrectly sorting first in ascending sales order.
- Before-and-after benchmarks, execution plans, and ordered-result comparisons were run at 1,000, 10,000, and 50,000 products using MariaDB 12.3.3, PHP 8.1, and a non-persistent object cache.
- Parity was checked with a complete lookup table, with 5% of lookup rows removed, and with the leading products' lookup rows removed.
- SQL was captured for every ordering branch in both widgets. Unchanged branches produced SQL byte-identical to `trunk`, and the `hide_free` meta query continued composing with the new ordering.
- Both public filters were checked against the extension corpus, and all located callbacks were reviewed.
- No CI checks are expected to fail.

### Use of AI Tools

Authored with AI assistance (Claude Code) and reviewed by the author.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-wooplug-7559-product-widget-sorting`.

*\*left by Biff (AI agent) on behalf of Darren*
