### PR TITLE
Document public hooks and replace legacy output suppressions

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-121-hook-docs-and-output-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-121-hook-docs-and-output-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Escape the product title in the single product reviews heading and replace legacy WPCS output suppressions with documented hooks and exact PHPCS annotations.

--- a/plugins/woocommerce/changelog/fix-woo6-121-hook-docs-and-output-suppressions
+++ b/plugins/woocommerce/changelog/fix-woo6-121-hook-docs-and-output-suppressions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Escape the product title in the single product reviews heading and replace legacy WPCS output suppressions with documented hooks and exact PHPCS annotations.
+Run the product title in the single product reviews heading through wp_kses_post and replace legacy WPCS output suppressions with documented hooks and exact PHPCS annotations.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -356,7 +356,18 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				$termlist[] = '<a href="' . esc_url( admin_url( 'edit.php?product_cat=' . $term->slug . '&post_type=product' ) ) . '">' . esc_html( $term->name ) . '</a>';
 			}
 
-			echo apply_filters( 'woocommerce_admin_product_term_list', implode( ', ', $termlist ), 'product_cat', $this->object->get_id(), $termlist, $terms ); // WPCS: XSS ok.
+			/**
+			 * Filters the term list rendered in the products list table taxonomy column.
+			 *
+			 * @since 3.3.0
+			 *
+			 * @param string             $term_list  Comma separated list of escaped term links.
+			 * @param string             $taxonomy   Taxonomy the terms belong to.
+			 * @param int                $product_id ID of the product the terms are rendered for.
+			 * @param string[]           $termlist   Individual escaped term links.
+			 * @param WP_Term[]|WP_Error $terms      Term objects assigned to the product, or the WP_Error returned by get_the_terms().
+			 */
+			echo apply_filters( 'woocommerce_admin_product_term_list', implode( ', ', $termlist ), 'product_cat', $this->object->get_id(), $termlist, $terms ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Term names and links are escaped above; the filter returns extension-controlled markup by design.
 		}
 	}
 
@@ -373,7 +384,18 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				$termlist[] = '<a href="' . esc_url( admin_url( 'edit.php?product_tag=' . $term->slug . '&post_type=product' ) ) . '">' . esc_html( $term->name ) . '</a>';
 			}
 
-			echo apply_filters( 'woocommerce_admin_product_term_list', implode( ', ', $termlist ), 'product_tag', $this->object->get_id(), $termlist, $terms ); // WPCS: XSS ok.
+			/**
+			 * Filters the term list rendered in the products list table taxonomy column.
+			 *
+			 * @since 3.3.0
+			 *
+			 * @param string             $term_list  Comma separated list of escaped term links.
+			 * @param string             $taxonomy   Taxonomy the terms belong to.
+			 * @param int                $product_id ID of the product the terms are rendered for.
+			 * @param string[]           $termlist   Individual escaped term links.
+			 * @param WP_Term[]|WP_Error $terms      Term objects assigned to the product, or the WP_Error returned by get_the_terms().
+			 */
+			echo apply_filters( 'woocommerce_admin_product_term_list', implode( ', ', $termlist ), 'product_tag', $this->object->get_id(), $termlist, $terms ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Term names and links are escaped above; the filter returns extension-controlled markup by design.
 		}
 	}
 
@@ -440,7 +462,14 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 		$output = ob_get_clean();
 
-		echo apply_filters( 'woocommerce_product_filters', $output ); // WPCS: XSS ok.
+		/**
+		 * Filters the rendered markup for the products list table filter controls.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param string|false $output Buffered markup produced by the registered filter renderers, or false when no output buffer was active.
+		 */
+		echo apply_filters( 'woocommerce_product_filters', $output ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $output is buffered admin markup and the filter returns extension-controlled markup by design.
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/plugins/woocommerce/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -68,7 +68,14 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 			add_action( 'admin_print_footer_scripts', array( $this, 'plugin_screen_modal_js' ) );
 		}
 
-		echo apply_filters( 'woocommerce_in_plugin_update_message', $this->upgrade_notice ? '</p>' . wp_kses_post( $this->upgrade_notice ) . '<p class="dummy">' : '' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		/**
+		 * Filters the inline update message shown for WooCommerce on the Plugins screen.
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param string $message Upgrade notice markup, already run through wp_kses_post(), or an empty string.
+		 */
+		echo apply_filters( 'woocommerce_in_plugin_update_message', $this->upgrade_notice ? '</p>' . wp_kses_post( $this->upgrade_notice ) . '<p class="dummy">' : '' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The base value is run through wp_kses_post() and the filter returns extension-controlled markup by design.
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -26,6 +26,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return bool
  */
 function is_woocommerce() {
+	/**
+	 * Filters whether the current request is being handled by a WooCommerce template.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param bool $is_woocommerce True on the shop archive, a product taxonomy archive or a single product.
+	 */
 	return apply_filters( 'is_woocommerce', is_shop() || is_product_taxonomy() || is_product() );
 }
 

--- a/plugins/woocommerce/templates/single-product-reviews.php
+++ b/plugins/woocommerce/templates/single-product-reviews.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.7.0
+ * @version 11.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -31,8 +31,17 @@ if ( ! comments_open() ) {
 			$count = $product->get_review_count();
 			if ( $count && wc_review_ratings_enabled() ) {
 				/* translators: 1: reviews count 2: product name */
-				$reviews_title = sprintf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), esc_html( $count ), '<span>' . get_the_title() . '</span>' );
-				echo apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product ); // WPCS: XSS ok.
+				$reviews_title = sprintf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), esc_html( $count ), '<span>' . esc_html( get_the_title() ) . '</span>' );
+				/**
+				 * Filters the heading shown above the product review list.
+				 *
+				 * @since 3.6.0
+				 *
+				 * @param string     $reviews_title Review count heading. The count and the product title are escaped and the product title is wrapped in a span.
+				 * @param int        $count         Number of reviews for the product.
+				 * @param WC_Product $product       Product the reviews belong to.
+				 */
+				echo apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The base heading is escaped above and the filter returns extension-controlled markup by design.
 			} else {
 				esc_html_e( 'Reviews', 'woocommerce' );
 			}

--- a/plugins/woocommerce/templates/single-product-reviews.php
+++ b/plugins/woocommerce/templates/single-product-reviews.php
@@ -31,17 +31,17 @@ if ( ! comments_open() ) {
 			$count = $product->get_review_count();
 			if ( $count && wc_review_ratings_enabled() ) {
 				/* translators: 1: reviews count 2: product name */
-				$reviews_title = sprintf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), esc_html( $count ), '<span>' . esc_html( get_the_title() ) . '</span>' );
+				$reviews_title = sprintf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), esc_html( $count ), '<span>' . wp_kses_post( get_the_title() ) . '</span>' );
 				/**
 				 * Filters the heading shown above the product review list.
 				 *
 				 * @since 3.6.0
 				 *
-				 * @param string     $reviews_title Review count heading. The count and the product title are escaped and the product title is wrapped in a span.
+				 * @param string     $reviews_title Review count heading. The count is escaped, the product title is run through wp_kses_post() and wrapped in a span.
 				 * @param int        $count         Number of reviews for the product.
 				 * @param WC_Product $product       Product the reviews belong to.
 				 */
-				echo apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The base heading is escaped above and the filter returns extension-controlled markup by design.
+				echo apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The base heading is sanitised above and the filter returns extension-controlled markup by design.
 			} else {
 				esc_html_e( 'Reviews', 'woocommerce' );
 			}

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -23,10 +23,22 @@ $attribute_keys  = array_keys( $attributes );
 $variations_json = wp_json_encode( $available_variations );
 $variations_attr = function_exists( 'wc_esc_json' ) ? wc_esc_json( $variations_json ) : _wp_specialchars( $variations_json, ENT_QUOTES, 'UTF-8', true );
 
+/**
+ * Fires before the add to cart form of a variable product.
+ *
+ * @since 1.2.1
+ */
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="variations_form cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo $variations_attr; // WPCS: XSS ok. ?>">
-	<?php do_action( 'woocommerce_before_variations_form' ); ?>
+<form class="variations_form cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo $variations_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WooCommerce.Commenting.CommentHooks.MissingHookComment -- $variations_attr is already escaped for an HTML attribute by wc_esc_json() or _wp_specialchars(). A hook docblock for woocommerce_add_to_cart_form_action cannot end on the line above this inline call without leaving content before a closing PHP tag. ?>">
+	<?php
+	/**
+	 * Fires at the top of the variations form, inside the form element.
+	 *
+	 * @since 2.4.0
+	 */
+	do_action( 'woocommerce_before_variations_form' );
+	?>
 
 	<?php if ( empty( $available_variations ) && false !== $available_variations ) : ?>
 		<p class="stock out-of-stock"><?php echo esc_html( apply_filters( 'woocommerce_out_of_stock_message', __( 'This product is currently out of stock and unavailable.', 'woocommerce' ) ) ); ?></p>
@@ -70,6 +82,8 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			<?php
 				/**
 				 * Hook: woocommerce_before_single_variation.
+				 *
+				 * @since 2.1.0
 				 */
 				do_action( 'woocommerce_before_single_variation' );
 
@@ -84,14 +98,28 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 				/**
 				 * Hook: woocommerce_after_single_variation.
+				 *
+				 * @since 2.1.0
 				 */
 				do_action( 'woocommerce_after_single_variation' );
 			?>
 		</div>
 	<?php endif; ?>
 
-	<?php do_action( 'woocommerce_after_variations_form' ); ?>
+	<?php
+	/**
+	 * Fires at the bottom of the variations form, inside the form element.
+	 *
+	 * @since 2.4.0
+	 */
+	do_action( 'woocommerce_after_variations_form' );
+	?>
 </form>
 
 <?php
+/**
+ * Fires after the add to cart form of a variable product.
+ *
+ * @since 1.2.1
+ */
 do_action( 'woocommerce_after_add_to_cart_form' );

--- a/plugins/woocommerce/tests/php/templates/single-product/SingleProductReviewsTemplateTest.php
+++ b/plugins/woocommerce/tests/php/templates/single-product/SingleProductReviewsTemplateTest.php
@@ -12,14 +12,17 @@ use WC_Unit_Test_Case;
 class SingleProductReviewsTemplateTest extends WC_Unit_Test_Case {
 
 	/**
-	 * Product title containing markup that survives post content filtering on save.
+	 * Product title mixing allowed markup with a disallowed event handler attribute.
 	 */
-	private const PRODUCT_TITLE = 'Widget <strong>Deluxe</strong>';
+	private const PRODUCT_TITLE = 'Widget <strong onclick="alert(1)">Deluxe</strong>';
 
 	/**
-	 * @testdox The reviews heading escapes markup in the product title and hands the built heading to the filter.
+	 * @testdox The reviews heading keeps allowed markup from the product title, drops disallowed attributes and hands the built heading to the filter.
 	 */
-	public function test_reviews_title_escapes_product_title_and_passes_built_heading_to_filter(): void {
+	public function test_reviews_title_sanitises_product_title_and_passes_built_heading_to_filter(): void {
+		// An author with unfiltered_html can store the raw title, so the template has to sanitise it.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_name( self::PRODUCT_TITLE );
 		$product->set_review_count( 2 );
@@ -50,23 +53,24 @@ class SingleProductReviewsTemplateTest extends WC_Unit_Test_Case {
 			remove_filter( 'woocommerce_reviews_title', $title_filter );
 			$GLOBALS['product'] = $previous_product;
 			WC_Helper_Product::delete_product( $product->get_id() );
+			wp_set_current_user( 0 );
 		}
 
 		preg_match( '#<h2 class="woocommerce-Reviews-title">(.*?)</h2>#s', $html, $heading_match );
 		$heading = $heading_match[1] ?? '';
 
 		$this->assertStringContainsString(
-			'<span>Widget &lt;strong&gt;Deluxe&lt;/strong&gt;</span>',
+			'<span>Widget <strong>Deluxe</strong></span>',
 			$heading,
-			'The reviews heading should render the product title escaped inside the span.'
+			'The reviews heading should keep markup that wp_kses_post() allows in the product title.'
 		);
 		$this->assertStringNotContainsString(
-			'<strong>',
+			'onclick',
 			$heading,
-			'The reviews heading should not render markup carried by the product title.'
+			'The reviews heading should drop attributes that wp_kses_post() disallows in the product title.'
 		);
 		$this->assertSame(
-			'2 reviews for <span>Widget &lt;strong&gt;Deluxe&lt;/strong&gt;</span>',
+			'2 reviews for <span>Widget <strong>Deluxe</strong></span>',
 			$received_title,
 			'The woocommerce_reviews_title filter should receive the complete heading string.'
 		);

--- a/plugins/woocommerce/tests/php/templates/single-product/SingleProductReviewsTemplateTest.php
+++ b/plugins/woocommerce/tests/php/templates/single-product/SingleProductReviewsTemplateTest.php
@@ -1,0 +1,74 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Templates\SingleProduct;
+
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the single product reviews template.
+ */
+class SingleProductReviewsTemplateTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Product title containing markup that survives post content filtering on save.
+	 */
+	private const PRODUCT_TITLE = 'Widget <strong>Deluxe</strong>';
+
+	/**
+	 * @testdox The reviews heading escapes markup in the product title and hands the built heading to the filter.
+	 */
+	public function test_reviews_title_escapes_product_title_and_passes_built_heading_to_filter(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( self::PRODUCT_TITLE );
+		$product->set_review_count( 2 );
+		$product->save();
+
+		wp_update_post(
+			array(
+				'ID'             => $product->get_id(),
+				'comment_status' => 'open',
+			)
+		);
+
+		$this->go_to( get_permalink( $product->get_id() ) );
+
+		$previous_product   = $GLOBALS['product'] ?? null;
+		$GLOBALS['product'] = $product;
+
+		$received_title = null;
+		$title_filter   = static function ( $reviews_title ) use ( &$received_title ) {
+			$received_title = $reviews_title;
+			return $reviews_title;
+		};
+		add_filter( 'woocommerce_reviews_title', $title_filter );
+
+		try {
+			$html = wc_get_template_html( 'single-product-reviews.php' );
+		} finally {
+			remove_filter( 'woocommerce_reviews_title', $title_filter );
+			$GLOBALS['product'] = $previous_product;
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+
+		preg_match( '#<h2 class="woocommerce-Reviews-title">(.*?)</h2>#s', $html, $heading_match );
+		$heading = $heading_match[1] ?? '';
+
+		$this->assertStringContainsString(
+			'<span>Widget &lt;strong&gt;Deluxe&lt;/strong&gt;</span>',
+			$heading,
+			'The reviews heading should render the product title escaped inside the span.'
+		);
+		$this->assertStringNotContainsString(
+			'<strong>',
+			$heading,
+			'The reviews heading should not render markup carried by the product title.'
+		);
+		$this->assertSame(
+			'2 reviews for <span>Widget &lt;strong&gt;Deluxe&lt;/strong&gt;</span>',
+			$received_title,
+			'The woocommerce_reviews_title filter should receive the complete heading string.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The product title in the single product reviews heading is now run through `wp_kses_post()` before being inserted into the heading, matching how the product and reviews widget templates, the cart and order details render product names. Allowed markup saved by authors with `unfiltered_html` (such as `<strong>` or `<sup>`) still renders, while scripts and event attributes are stripped. A regression test covers the rendered heading and confirms that the `woocommerce_reviews_title` filter still receives the complete heading string.

The filter continues to receive the same three arguments, including the heading with its existing `<span>` wrapper, and its return value remains unescaped so extensions can continue returning markup. The template version is updated from 9.7.0 to 11.2.0 to reflect the output change.

This PR also documents hooks in the affected product list table, plugin update message, conditional function, reviews template and variable add-to-cart template. Legacy or obsolete output suppressions are replaced with exact `WordPress.Security.EscapeOutput.OutputNotEscaped` annotations and explanations. These updates do not change hook names, arguments or firing points.

The other four production files are token-identical to `trunk` after comments and whitespace are removed. The variable add-to-cart template also emits identical markup, so its template version remains unchanged. The `Analyze Branch Changes` check has no comment-only exemption and shows red for that file; it is not a required check, and the same accepted warning applied to #68160, #68020 and #68266.

### How to test the changes in this Pull Request:

1. Start the test environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start`.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter '/Templates/'` and confirm the template tests pass.
3. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env:hpos-off -- --filter '/Templates/'` and confirm the template tests pass with HPOS disabled.
4. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` and confirm it exits successfully.
5. As an administrator, create a product titled `Widget <strong onclick="alert(1)">Deluxe</strong>`, enable product reviews and review ratings, and add an approved review to the product.
6. Open the product page and confirm the reviews heading renders `Deluxe` in bold and the heading markup contains no `onclick` attribute.
7. Open a variable product and confirm the variation dropdowns work, the Clear link appears, and the add-to-cart form renders normally.
8. Open Products in wp-admin and confirm the Categories and Tags columns still display linked term names.

### Testing that has already taken place:

- `SingleProductReviewsTemplateTest` passed with HPOS enabled and disabled: 1 test and 3 assertions in each configuration. The allowed-markup and stripped-attribute assertions were each verified to fail against a raw `get_the_title()`.
- The template suite passed with HPOS enabled and disabled: 43 tests and 61 assertions in each configuration.
- The AddToCart blocks suite passed with HPOS enabled: 22 tests and 143 assertions.
- The focused conditional, products list table, plugins screen and review suites passed with HPOS enabled: 635 tests and 1,619 assertions.
- `lint:php:changes` completed with no output, and `lint:changes:branch` exited successfully.
- `php -l` reported no syntax errors in all six changed or added PHP files.
- PHPStan reported no change from the five pre-existing errors in the four applicable non-test files. `single-product-reviews.php` passed without errors before and after the change.
- PHP token and emitted inline HTML comparisons confirmed equivalence with `trunk` for the four comment-only production files.
- `git diff --check origin/trunk..HEAD` completed successfully.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-woo6-121-hook-docs-and-output-suppressions`.

### Use of AI Tools

Authored with AI assistance (Claude Code) and reviewed by the author.

*\*left by Biff (AI agent) on behalf of Darren*

