### PR TITLE
Fix garbled block pattern categories on non-English sites

### DIFF
--- a/plugins/woocommerce/changelog/fix-58292-pattern-category-localization
+++ b/plugins/woocommerce/changelog/fix-58292-pattern-category-localization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix block pattern categories being registered under garbled, untranslated names on non-English sites by deriving the category from the pattern's stable slug instead of its localized title.

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -240,6 +240,14 @@ class BlockPatterns {
 	/**
 	 * Parse prefixed categories from the PTK patterns into the actual WooCommerce categories.
 	 *
+	 * The Patterns Toolkit returns category identifiers as prefixed slugs (for
+	 * example `_woo_featured_selling`) whose titles may be localized (or, for
+	 * some locales, malformed). The slug is the stable, locale-independent
+	 * identifier, so derive the canonical category from it instead of from the
+	 * (possibly translated) title. This keeps the category registered under the
+	 * expected slug (for example `featured-selling`) in every locale, letting
+	 * PatternRegistry apply the translated label.
+	 *
 	 * @param array $patterns The patterns to parse.
 	 * @return array The parsed patterns.
 	 */
@@ -261,10 +269,10 @@ class BlockPatterns {
 				$pattern['categories'] = array_map(
 					function ( $category ) {
 						foreach ( self::CATEGORIES_PREFIXES as $prefix ) {
-							if ( strpos( $category['title'], $prefix ) !== false ) {
-								$parsed_category   = str_replace( $prefix, '', $category['title'] );
-								$parsed_category   = str_replace( '_', ' ', $parsed_category );
-								$category['title'] = ucfirst( $parsed_category );
+							if ( str_starts_with( $category['slug'], $prefix ) ) {
+								$canonical_slug    = substr( $category['slug'], strlen( $prefix ) );
+								$category['title'] = ucfirst( str_replace( '_', ' ', $canonical_slug ) );
+								$category['slug']  = $canonical_slug;
 							}
 						}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockPatterns/BlockPatterns.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockPatterns/BlockPatterns.php
@@ -194,6 +194,60 @@ class BlockPatterns extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that PTK categories are normalized to the canonical title derived
+	 * from their slug, rather than the (possibly localized or malformed) title.
+	 *
+	 * A German Patterns Toolkit response can return a category whose title is a
+	 * raw translation note (for example `_woo_featured_selling" translates to
+	 * "_woo_vorgestellter_verkauf" in German.`). The slug is the stable,
+	 * locale-independent identifier, so the canonical title is built from it.
+	 */
+	public function test_ptk_pattern_categories_are_normalized_from_slug() {
+		$tracking_backup = get_option( 'woocommerce_allow_tracking' );
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+
+		$patterns = array(
+			array(
+				'ID'         => 1,
+				'name'       => 'featured-product',
+				'title'      => 'Featured Product',
+				'html'       => '<p>Content</p>',
+				'categories' => array(
+					'_woo_featured_selling' => array(
+						'slug'        => '_woo_featured_selling',
+						'title'       => '_woo_featured_selling" translates to "_woo_vorgestellter_verkauf" in German.',
+						'description' => '',
+					),
+				),
+			),
+		);
+
+		$this->ptk_patterns_store
+			->method( 'get_patterns' )
+			->willReturn( $patterns );
+
+		$this->pattern_registry
+			->expects( $this->once() )
+			->method( 'register_block_pattern' )
+			->with(
+				1,
+				$this->callback(
+					function ( $pattern_data ) {
+						return array( 'Featured selling' ) === $pattern_data['categories'];
+					}
+				),
+			);
+
+		$this->block_patterns->register_ptk_patterns();
+
+		if ( false === $tracking_backup ) {
+			delete_option( 'woocommerce_allow_tracking' );
+		} else {
+			update_option( 'woocommerce_allow_tracking', $tracking_backup );
+		}
+	}
+
+	/**
 	 * Tests if patterns are registered with the cached data.
 	 */
 	public function test_invalid_cached_block_patterns_registration() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

On non-English sites, block pattern categories from the Patterns Toolkit are registered under garbled, untranslated names in the Site Editor. The Patterns Toolkit returns category identifiers as prefixed slugs (for example `_woo_featured_selling`) whose `title` may be localized or, for some locales, malformed (for example `` _woo_featured_selling" translates to "_woo_vorgestellter_verkauf" in German. ``). `BlockPatterns::parse_categories()` derived the canonical category by parsing that title, so a localized/malformed title was kebab-cased into a wrong category slug and a non-translated fallback label.

This change derives the canonical category from the stable, locale-independent `slug` instead of the title, so categories are always registered under the expected slug (for example `featured-selling`) and `PatternRegistry` applies the properly translated label.

Closes #58292.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a non-English site (for example German), enable usage tracking so Patterns Toolkit (PTK) patterns are fetched (WooCommerce > Settings > Advanced > WooCommerce.com > Usage tracking). Flush the `ptk_patterns` option and the `woocommerce_blocks_patterns` transient so the patterns are re-fetched in the site locale.
2. Open the Site Editor (Appearance > Editor) and browse the block pattern categories (for example when inserting a pattern in a template or template part).
3. Confirm the "Featured Selling" category (and the other WooCommerce categories such as "Intro", "About", "Reviews", "Social Media", "Services") appears under its translated label, and no garbled "…Translates To … In German" style labels are shown. Also confirm patterns in those categories still insert correctly in English and non-English sites.

### Testing that has already taken place:

-   Added `test_ptk_pattern_categories_are_normalized_from_slug()` to `tests/php/src/Blocks/BlockPatterns/BlockPatterns.php`, covering a malformed German category title and asserting the registry receives the canonical category title derived from the slug.
-   Ran the WooCommerce PHPCS lint on the changed files: clean.
-   Verified the transform pipeline for every `_woo_*` / `_dotcom_imported_*` category slug maps to the expected canonical slug and translated label (simulated the slug -> title -> kebab -> label-map path). PHPUnit tests require the `wp-env` Docker environment and were not run locally.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually at `plugins/woocommerce/changelog/fix-58292-pattern-category-localization`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->