### PR TITLE
Reject array order keys on pay, cancel and PayPal return paths

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-7659-order-key-array-guards
+++ b/plugins/woocommerce/changelog/fix-wooplug-7659-order-key-array-guards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Treat array-valued order keys as invalid on the order pay, cancel and PayPal return paths instead of raising a PHP error.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -497,7 +497,7 @@ class WC_Form_Handler {
 			ob_start();
 
 			// Pay for existing order.
-			$order_key = wp_unslash( $_GET['key'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$order_key = is_string( $_GET['key'] ) ? wp_unslash( $_GET['key'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$order_id  = absint( $wp->query_vars['order-pay'] );
 			$order     = wc_get_order( $order_id );
 
@@ -866,7 +866,7 @@ class WC_Form_Handler {
 		) {
 			wc_nocache_headers();
 
-			$order_key = wp_unslash( $_GET['order'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$order_key = is_string( $_GET['order'] ) ? wp_unslash( $_GET['order'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$order_id  = absint( $_GET['order_id'] );
 			$order     = wc_get_order( $order_id );
 			/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -34,7 +34,7 @@ abstract class WC_Gateway_Paypal_Response {
 		$custom = json_decode( $raw_custom );
 		if ( $custom && is_object( $custom ) ) {
 			$order_id  = $custom->order_id;
-			$order_key = $custom->order_key;
+			$order_key = is_string( $custom->order_key ) ? $custom->order_key : '';
 		} else {
 			// Nothing was found.
 			WC_Gateway_Paypal::log( 'Order ID and key were not found in "custom".', 'error' );

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -87,7 +87,7 @@ class WC_Shortcode_Checkout {
 		// Pay for existing order.
 		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flow selectors are cleaned; order access verifies key/ownership.
 			try {
-				$order_key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flow selectors are cleaned; order access verifies key/ownership.
+				$order_key = isset( $_GET['key'] ) && is_string( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flow selectors are cleaned; order access verifies key/ownership.
 				$order     = wc_get_order( $order_id );
 
 				// Order or payment link is invalid.
@@ -233,7 +233,7 @@ class WC_Shortcode_Checkout {
 		} elseif ( $order_id ) {
 
 			// Pay for order after checkout step.
-			$order_key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flow selectors are cleaned; order access verifies key/ownership.
+			$order_key = isset( $_GET['key'] ) && is_string( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flow selectors are cleaned; order access verifies key/ownership.
 			$order     = wc_get_order( $order_id );
 
 			if ( $order && $order->get_id() === $order_id && hash_equals( $order->get_order_key(), $order_key ) ) {

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -183,7 +183,7 @@ function wc_clear_cart_after_payment() {
 	if ( ! empty( $wp->query_vars['order-received'] ) ) {
 
 		$order_id  = absint( $wp->query_vars['order-received'] );
-		$order_key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Raw referer is sanitized and validated by its consumers.
+		$order_key = isset( $_GET['key'] ) && is_string( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Order key is cleaned and compared with hash_equals() against the order's key below.
 
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );

--- a/plugins/woocommerce/tests/php/includes/shortcodes/class-wc-shortcode-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/shortcodes/class-wc-shortcode-checkout-test.php
@@ -19,7 +19,9 @@ class WC_Shortcode_Checkout_Test extends WC_Unit_Test_Case {
 		global $wp;
 
 		unset( $_GET['key'] );
+		unset( $_GET['pay_for_order'] );
 		unset( $wp->query_vars['order-received'] );
+		unset( $wp->query_vars['order-pay'] );
 
 		parent::tearDown();
 	}
@@ -41,5 +43,24 @@ class WC_Shortcode_Checkout_Test extends WC_Unit_Test_Case {
 
 		$this->assertStringNotContainsString( 'woocommerce-thankyou-order-details', $output );
 		$this->assertStringNotContainsString( (string) $order->get_order_number(), $output );
+	}
+
+	/**
+	 * An array `key` on the pay-for-order page must be rejected rather than reaching hash_equals().
+	 */
+	public function test_order_pay_treats_array_order_key_as_invalid() {
+		global $wp;
+
+		$order = WC_Helper_Order::create_order( 0 );
+
+		$wp->query_vars['order-pay'] = $order->get_id();
+		$_GET['pay_for_order']       = 'true';
+		$_GET['key']                 = array( $order->get_order_key() );
+
+		ob_start();
+		WC_Shortcode_Checkout::output( array() );
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Sorry, this order is invalid and cannot be paid for.', $output );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This follows up #68266 by applying its order-key type guard to the remaining classic checkout payment, cancellation, cart-clearing and PayPal return paths. `wp_unslash()` preserves arrays and `wc_clean()` cleans them recursively, so array-valued request keys—and an array-valued key in the decoded PayPal `custom` payload—could reach `hash_equals()` on PHP 8 and raise an uncaught `TypeError` instead of using the existing invalid-order handling.

Closes #68304.

Each affected path now requires the key to be a string and otherwise treats it as absent. This covers both branches of `WC_Shortcode_Checkout::order_pay()`, `WC_Form_Handler::pay_action()`, `WC_Form_Handler::cancel_order()`, `wc_clear_cart_after_payment()` and `WC_Gateway_Paypal_Response::get_paypal_order()`. Malformed values therefore fail the existing key comparisons: payment and cancellation processing do not proceed, cart clearing is skipped, and PayPal returns `false` and logs the existing mismatch message.

String inputs retain their previous sanitization and behavior. No signatures, hooks, filters, queries or output contracts change, and no shared helper or public surface was added.

The block-based Order Confirmation path has the same array-key defect. It remains deliberately out of scope and needs a separate change.

### How to test the changes in this Pull Request:

1. Create a pending order and note its ID and order key.
2. Run `curl --globoff -i "<site>/checkout/order-pay/<id>/?pay_for_order=true&key[]=x"` and confirm it returns HTTP 200 with the "Sorry, this order is invalid and cannot be paid for." notice instead of a critical error page.
3. Run `curl -i "<site>/checkout/order-pay/<id>/?pay_for_order=true&key=<real-key>"` and confirm it returns HTTP 200 with the pay form.
4. Obtain a valid cancellation URL for the order, replace its `order` value with `order[]=x` while retaining the valid `order_id` and `_wpnonce`, and request it with curl using `--globoff`. Confirm it redirects with HTTP 302 and the order remains pending.
5. Expose `WC_Gateway_Paypal_Response::get_paypal_order()` through a test subclass and call it with `{"order_id":<id>,"order_key":["x"]}`. Confirm it returns `false` and logs `Order Keys do not match.` instead of raising a `TypeError`.
6. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Shortcode_Checkout_Test` and `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env:hpos-off -- --filter WC_Shortcode_Checkout_Test`; confirm both pass.

### Testing that has already taken place:

- The focused shortcode test class passes with HPOS enabled and disabled: 2 tests and 3 assertions in each run.
- The new anonymous `order_pay()` regression test was verified against the unmodified production file and failed with `TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, array given`.
- The other five affected call sites were verified manually against `origin/trunk` and this branch:

| Check | `origin/trunk` | This branch |
| --- | --- | --- |
| Post-checkout `order_pay()` branch | `TypeError` | Invalid-order notice |
| `WC_Form_Handler::pay_action()` | `TypeError` | No fatal; order remains pending |
| `WC_Form_Handler::cancel_order()` | `TypeError` | No fatal; order remains pending |
| `wc_clear_cart_after_payment()` | `TypeError` | No fatal |
| PayPal `get_paypal_order()` | `TypeError` | Returns `false` |
| Cancellation with the real string key | Order cancelled | Order cancelled |

- End-to-end HTTP checks confirmed that a malformed order-pay request changes from HTTP 500 to HTTP 200, a valid order-pay request remains HTTP 200, and a malformed cancellation request changes from HTTP 500 to HTTP 302 without cancelling the order.
- Before-and-after file swaps used a six-second wait for wp-env opcache revalidation and were reproduced across fixed, trunk and fixed states.
- PHPStan reports no errors for all four changed production files.
- `php -l` reports no syntax errors for all five changed PHP files.
- Focused PHPCS checks pass with annotations honored; `--ignore-annotations` confirmed that the codes reported on changed lines are unchanged from `origin/trunk`.
- `lint:php:changes`, `lint:changes:branch` and `git diff --check origin/trunk..HEAD` are clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually: `plugins/woocommerce/changelog/fix-wooplug-7659-order-key-array-guards`.

### Use of AI Tools

Authored with AI assistance (Claude Code) and reviewed by the author.

*\*left by Biff (AI agent) on behalf of Darren*