### PR TITLE
POC: skip a single test using a locally published receipt

### DIFF
--- a/.github/workflows/minimal-skip.yml
+++ b/.github/workflows/minimal-skip.yml
@@ -1,0 +1,52 @@
+name: 'Minimal skip'
+
+# Proof of concept. Scoped to its own files so it cannot affect any other PR.
+on:
+    pull_request:
+        paths:
+            - 'tools/minimal-skip/**'
+            - '.github/workflows/minimal-skip.yml'
+
+permissions:
+    contents: read
+    statuses: read
+
+jobs:
+    number:
+        name: 'Minimal skip: @woocommerce/number'
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            GH_TOKEN: ${{ github.token }}
+            HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+            CONTEXT: 'local-skip/@woocommerce/number'
+        steps:
+            - uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # v7.0.0
+
+            - name: 'Is there a receipt for this commit?'
+              id: 'receipt'
+              # Fails open: any error leaves found empty, so the test runs.
+              # Uncertainty must never skip.
+              run: |
+                  found=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/statuses" 2>/dev/null \
+                    | jq -r --arg ctx "$CONTEXT" \
+                      'map(select(.context == $ctx)) | .[0] | select(.state == "success") | .creator.login' \
+                    2>/dev/null || true)
+
+                  if [ -n "$found" ]; then
+                    echo "Receipt posted by $found. Skipping the test."
+                    echo "skip=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "No receipt. Running the test."
+                    echo "skip=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - uses: './.github/actions/setup-woocommerce-monorepo'
+              if: steps.receipt.outputs.skip != 'true'
+              with:
+                  install: '@woocommerce/number...'
+                  php-version: 'false'
+
+            - name: 'Run the test'
+              if: steps.receipt.outputs.skip != 'true'
+              run: pnpm --filter=@woocommerce/number test:js

--- a/tools/minimal-skip/README.md
+++ b/tools/minimal-skip/README.md
@@ -1,0 +1,32 @@
+# Minimal skip
+
+Run one test on your machine, leave a note on the commit saying it passed, and
+CI skips it.
+
+```sh
+./tools/minimal-skip/skip.sh
+git push
+```
+
+`Minimal skip: @woocommerce/number` then skips its test step. Push without
+running the script and it runs the test as normal.
+
+## Why it works
+
+A commit status has to be attached to a commit GitHub knows about, and the point
+is to publish *before* the branch is pushed — after is too late, because CI has
+already started. So the script pushes the commit to `refs/local-skip/<sha>`
+first. That is outside `refs/heads/*` and `refs/tags/*`, so no workflow can
+trigger on it, but the commit becomes addressable and a status will attach. The
+ref is deleted afterwards; the status stays.
+
+## What this does not do
+
+**It does not check who published the receipt.** Anyone who can write a status to
+this repository can skip this test without running it. That check is the whole
+difference between a demonstration and something safe to turn on, and it is not
+here.
+
+Nor does it decide *which* jobs are eligible, notice that the branch has fallen
+behind trunk, or remove the job from the matrix — the job is still scheduled, it
+just does no work. This exists to show the mechanism in as few lines as possible.

--- a/tools/minimal-skip/skip.sh
+++ b/tools/minimal-skip/skip.sh
@@ -41,3 +41,4 @@ gh api -X POST "repos/$REPO/statuses/$SHA" \
 
 echo
 echo "Done. Push the branch and CI will skip $PACKAGE."
+# touch 1788386685

--- a/tools/minimal-skip/skip.sh
+++ b/tools/minimal-skip/skip.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Run one test locally, and tell CI it can skip it.
+#
+# A commit status can be attached to a commit GitHub has never seen, before the
+# branch that would trigger CI is pushed. That ordering is the whole idea:
+# publishing after the push is too late, because CI has already started.
+#
+#   ./tools/minimal-skip/skip.sh
+#
+# Requires the GitHub CLI, authenticated.
+
+set -euo pipefail
+
+REPO='woocommerce/woocommerce'
+PACKAGE='@woocommerce/number'
+CONTEXT='local-skip/@woocommerce/number'
+
+SHA=$(git rev-parse HEAD)
+REF="refs/local-skip/$SHA"
+
+# Whatever happens, do not leave the temporary ref on the remote.
+trap 'git push --no-verify -q origin --delete "$REF" 2>/dev/null || true' EXIT
+
+echo "1. Run the test locally"
+pnpm --filter="$PACKAGE" test:js
+
+echo
+echo "2. Make this commit known to GitHub without pushing the branch"
+# refs/local-skip/* is outside refs/heads/* and refs/tags/*, so no workflow can
+# trigger on it — but the commit becomes addressable, which a status requires.
+git push --no-verify -q origin "HEAD:$REF"
+
+echo
+echo "3. Publish the receipt"
+gh api -X POST "repos/$REPO/statuses/$SHA" \
+  -f state=success \
+  -f context="$CONTEXT" \
+  -f description='passed locally' \
+  --jq '"   " + .context + " -> " + .state'
+
+echo
+echo "Done. Push the branch and CI will skip $PACKAGE."


### PR DESCRIPTION
Minimal proof of concept. **Not for merge.**

Run one test on your machine, leave a note on the commit saying it passed, and CI skips it. Three files, ~130 lines total, scoped by `paths:` so it cannot affect any other PR.

The one non-obvious part: a commit status can be attached to a commit GitHub has never seen, *before* the branch that triggers CI is pushed. Publishing after the push is too late — CI has already started. The script gets there by pushing the commit to `refs/local-skip/<sha>`, which is outside `refs/heads/*` and `refs/tags/*` so nothing can trigger on it, then deleting that ref once the status is attached.

## How to test

Requires the [GitHub CLI](https://cli.github.com), authenticated.

```sh
git fetch origin poc/minimal-skip && git checkout poc/minimal-skip
echo "# touch" >> tools/minimal-skip/skip.sh && git commit -qam trigger

./tools/minimal-skip/skip.sh   # runs the test, publishes the receipt
git push                        # the job skips
```

`Minimal skip: @woocommerce/number` skips its test step, logging `Receipt posted by <you>`. Push without running the script first and the same job runs the test.

## What it deliberately does not do

**It does not check who published the receipt.** Anyone who can write a status to this repository can skip the test without running it. That check is the difference between a demonstration and something safe to enable, and it is not here.

It also does not choose which jobs are eligible, notice the branch has fallen behind trunk, or remove the job from the matrix — the job is still scheduled, it just does no work.

The fuller version of this idea is in #68296.