### PR TITLE
fix: Enqueue classic theme editor fonts via enqueue_block_assets

### DIFF
--- a/plugins/woocommerce/changelog/68309-feature-fix-classic-theme-editor-fonts-iframe
+++ b/plugins/woocommerce/changelog/68309-feature-fix-classic-theme-editor-fonts-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix classic theme editor fonts stylesheet being added to the block editor iframe incorrectly.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -38,6 +38,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_command_palette_assets' ) );
+			add_action( 'enqueue_block_assets', array( $this, 'enqueue_classic_theme_editor_fonts' ) );
 			add_action( 'admin_notices', array( $this, 'render_lost_connection_notice' ) );
 		}
 
@@ -115,11 +116,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			wp_style_add_data( 'woocommerce_admin_privacy_styles', 'rtl', 'replace' );
 
 			if ( $screen && $screen->is_block_editor() ) {
-				if ( ! wp_is_block_theme() ) {
-					wp_register_style( 'woocommerce-classictheme-editor-fonts', WC()->plugin_url() . '/assets/css/woocommerce-classictheme-editor-fonts.css', array(), $version );
-					wp_enqueue_style( 'woocommerce-classictheme-editor-fonts' );
-				}
-
 				$styles = WC_Frontend_Scripts::get_styles();
 
 				if ( $styles ) {
@@ -445,6 +441,30 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			);
 		}
 
+		/**
+		 * Enqueue classic-theme editor fonts.
+		 *
+		 * Hooked to `enqueue_block_assets` instead of `admin_enqueue_scripts` so the
+		 * stylesheet is added to the block editor iframe correctly.
+		 *
+		 * @return void
+		 */
+		public function enqueue_classic_theme_editor_fonts() {
+			if ( ! is_admin() || wp_is_block_theme() ) {
+				return;
+			}
+
+			$screen = get_current_screen();
+
+			if ( ! $screen || ! $screen->is_block_editor() ) {
+				return;
+			}
+
+			$version = Constants::get_constant( 'WC_VERSION' );
+
+			wp_register_style( 'woocommerce-classictheme-editor-fonts', WC()->plugin_url() . '/assets/css/woocommerce-classictheme-editor-fonts.css', array(), $version );
+			wp_enqueue_style( 'woocommerce-classictheme-editor-fonts' );
+		}
 
 		/**
 		 * Enqueue scripts.

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
@@ -126,4 +126,34 @@ class WC_Admin_Assets_Test extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'id="wc-lost-connection-notice"', $output );
 	}
+
+	/**
+	 * @testdox Should set up the classic-theme editor fonts stylesheet correctly per theme and screen.
+	 * @testWith ["theme1", true, true]
+	 *           ["theme1", false, false]
+	 *           ["twentytwentyfour", true, false]
+	 *           ["twentytwentyfour", false, false]
+	 *
+	 * @param string $theme           Theme to switch to (`theme1` is classic, `twentytwentyfour` is a block theme).
+	 * @param bool   $is_block_editor Whether the current screen is a block editor screen.
+	 * @param bool   $expected        Whether the stylesheet should be enqueued.
+	 */
+	public function test_enqueue_classic_theme_editor_fonts( string $theme, bool $is_block_editor, bool $expected ): void {
+		$original_theme = wp_get_theme()->get_stylesheet();
+		register_theme_directory( DIR_TESTDATA . '/themedir1' );
+
+		try {
+			switch_theme( $theme );
+
+			set_current_screen( 'post' );
+			get_current_screen()->is_block_editor( $is_block_editor );
+
+			$this->sut->enqueue_classic_theme_editor_fonts();
+
+			$this->assertSame( $expected, wp_style_is( 'woocommerce-classictheme-editor-fonts', 'enqueued' ) );
+		} finally {
+			wp_dequeue_style( 'woocommerce-classictheme-editor-fonts' );
+			switch_theme( $original_theme );
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC_Admin_Assets::admin_styles()` registered and enqueued `woocommerce-classictheme-editor-fonts` on the `admin_enqueue_scripts` hook whenever the current screen was the block editor on a classic (non-block) theme. That hook runs outside of WordPress's iframe asset-registration flow for the block editor's iframed canvas, so the stylesheet is added to the iframe incorrectly, triggering:

```
`woocommerce-classictheme-editor-fonts-css` was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.
```

This PR moves the enqueue into its own method, `enqueue_classic_theme_editor_fonts()`, hooked to `enqueue_block_assets` instead, which is the hook WordPress documents for adding styles to the block editor iframe. The method keeps the exact same conditions as before (classic theme only, block editor screen only) so there should not be any change in which pages load the stylesheet, only how it's registered.

Closes #68253
Related: #63532

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Activate a classic (non-block) theme, like Storefront or Twenty Twenty-One.
2. Open the block editor for any post or page (`wp-admin/post.php?post=<id>&action=edit`).
3. Open the browser console.
4. Before the fix: `woocommerce-classictheme-editor-fonts-css was added to the iframe incorrectly` warning appears. After the fix: no warning :), and the WooCommerce icon fonts (e.g. star ratings in block previews) still render correctly in the editor.
5. Switch to a block theme (e.g. Twenty Twenty-Four) and confirm the stylesheet is not enqueued at all (`woocommerce-classictheme-editor-fonts` should not appear in the page's enqueued styles).

<!-- End testing instructions -->

### Testing that has already taken place:

- Reproduced and verified locally against a live WordPress + WooCommerce install. The console warning was present before the fix and gone after.
- Added tests `WC_Admin_Assets_Test::test_enqueue_classic_theme_editor_fonts` 

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix classic theme editor fonts stylesheet being added to the block editor iframe incorrectly.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
