### PR TITLE
Show guest order names correctly in Orders Analytics

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-1772-per-order-guest-names
+++ b/plugins/woocommerce/changelog/wooplug-1772-per-order-guest-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show each guest order's billing name in Analytics when orders share an email address.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -386,6 +386,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$order_attributions = $this->get_order_attributions_by_order_ids( array_keys( $mapped_orders ) );
 		$customers          = $this->get_customers_by_orders( $orders_data );
 		$mapped_customers   = $this->map_array_by_key( $customers, 'customer_id' );
+		$billing_details    = $this->map_array_by_key(
+			$this->get_order_billing_details_by_order_ids( $order_ids ),
+			'order_id'
+		);
 
 		$mapped_data = array();
 		foreach ( $products as $product ) {
@@ -446,6 +450,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$orders_data[ $key ]['extended_info'] = isset( $mapped_data[ $order_id ] ) ? array_merge( $defaults, $mapped_data[ $order_id ] ) : $defaults;
 			if ( $order_data['customer_id'] && isset( $mapped_customers[ $order_data['customer_id'] ] ) ) {
 				$orders_data[ $key ]['extended_info']['customer'] = $mapped_customers[ $order_data['customer_id'] ];
+			}
+
+			$billing_order_id = $order_id;
+			if (
+				isset( $billing_details[ $order_id ] )
+				&& 'shop_order_refund' === $billing_details[ $order_id ]['order_type']
+				&& $order_data['parent_id']
+			) {
+				$billing_order_id = $order_data['parent_id'];
+			}
+
+			if ( isset( $billing_details[ $billing_order_id ] ) && 0 === (int) $billing_details[ $billing_order_id ]['customer_id'] ) {
+				$orders_data[ $key ]['extended_info']['customer']['first_name'] = (string) $billing_details[ $billing_order_id ]['first_name'];
+				$orders_data[ $key ]['extended_info']['customer']['last_name']  = (string) $billing_details[ $billing_order_id ]['last_name'];
 			}
 
 			$source_type = $order_attributions[ $order_id ]['_wc_order_attribution_source_type'] ?? '';
@@ -554,6 +572,61 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		/* phpcs:enable */
 
 		return $customers;
+	}
+
+	/**
+	 * Get the customer ID and billing name stored on each order.
+	 *
+	 * @param int[] $order_ids Order IDs.
+	 * @return array
+	 */
+	private function get_order_billing_details_by_order_ids( $order_ids ) {
+		global $wpdb;
+
+		$order_ids = array_values( array_unique( array_filter( array_map( 'absint', $order_ids ) ) ) );
+		if ( empty( $order_ids ) ) {
+			return array();
+		}
+
+		$included_order_ids = implode( ',', $order_ids );
+
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$orders_table    = OrdersTableDataStore::get_orders_table_name();
+			$addresses_table = OrdersTableDataStore::get_addresses_table_name();
+
+			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
+			return $wpdb->get_results(
+				"SELECT orders.id AS order_id,
+					orders.type AS order_type,
+					orders.customer_id,
+					addresses.first_name,
+					addresses.last_name
+				FROM {$orders_table} orders
+				LEFT JOIN {$addresses_table} addresses
+					ON orders.id = addresses.order_id
+					AND addresses.address_type = 'billing'
+				WHERE orders.id IN ({$included_order_ids})",
+				ARRAY_A
+			);
+			/* phpcs:enable */
+		}
+
+		/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
+		return $wpdb->get_results(
+			"SELECT orders.ID AS order_id,
+				orders.post_type AS order_type,
+				MAX( CASE WHEN order_meta.meta_key = '_customer_user' THEN order_meta.meta_value END ) AS customer_id,
+				MAX( CASE WHEN order_meta.meta_key = '_billing_first_name' THEN order_meta.meta_value END ) AS first_name,
+				MAX( CASE WHEN order_meta.meta_key = '_billing_last_name' THEN order_meta.meta_value END ) AS last_name
+			FROM {$wpdb->posts} orders
+			LEFT JOIN {$wpdb->postmeta} order_meta
+				ON orders.ID = order_meta.post_id
+				AND order_meta.meta_key IN ( '_customer_user', '_billing_first_name', '_billing_last_name' )
+			WHERE orders.ID IN ({$included_order_ids})
+			GROUP BY orders.ID, orders.post_type",
+			ARRAY_A
+		);
+		/* phpcs:enable */
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -386,8 +386,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$order_attributions = $this->get_order_attributions_by_order_ids( array_keys( $mapped_orders ) );
 		$customers          = $this->get_customers_by_orders( $orders_data );
 		$mapped_customers   = $this->map_array_by_key( $customers, 'customer_id' );
-		$billing_details    = $this->map_array_by_key(
-			$this->get_order_billing_details_by_order_ids( $order_ids ),
+		$customer_details   = $this->map_array_by_key(
+			$this->get_order_customer_details_by_order_ids( $order_ids ),
 			'order_id'
 		);
 
@@ -452,18 +452,18 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$orders_data[ $key ]['extended_info']['customer'] = $mapped_customers[ $order_data['customer_id'] ];
 			}
 
-			$billing_order_id = $order_id;
+			$name_order_id = $order_id;
 			if (
-				isset( $billing_details[ $order_id ] )
-				&& 'shop_order_refund' === $billing_details[ $order_id ]['order_type']
+				isset( $customer_details[ $order_id ] )
+				&& 'shop_order_refund' === $customer_details[ $order_id ]['order_type']
 				&& $order_data['parent_id']
 			) {
-				$billing_order_id = $order_data['parent_id'];
+				$name_order_id = $order_data['parent_id'];
 			}
 
-			if ( isset( $billing_details[ $billing_order_id ] ) && 0 === (int) $billing_details[ $billing_order_id ]['customer_id'] ) {
-				$orders_data[ $key ]['extended_info']['customer']['first_name'] = (string) $billing_details[ $billing_order_id ]['first_name'];
-				$orders_data[ $key ]['extended_info']['customer']['last_name']  = (string) $billing_details[ $billing_order_id ]['last_name'];
+			if ( isset( $customer_details[ $name_order_id ] ) && 0 === (int) $customer_details[ $name_order_id ]['customer_id'] ) {
+				$orders_data[ $key ]['extended_info']['customer']['first_name'] = (string) $customer_details[ $name_order_id ]['first_name'];
+				$orders_data[ $key ]['extended_info']['customer']['last_name']  = (string) $customer_details[ $name_order_id ]['last_name'];
 			}
 
 			$source_type = $order_attributions[ $order_id ]['_wc_order_attribution_source_type'] ?? '';
@@ -575,12 +575,16 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	}
 
 	/**
-	 * Get the customer ID and billing name stored on each order.
+	 * Get the customer ID and customer name stored on each order.
+	 *
+	 * The name falls back from billing to shipping per field, matching how
+	 * Automattic\WooCommerce\Admin\Overrides\Order builds the customer lookup row. Without that
+	 * fallback an order that only has a shipping name would lose the name it used to display.
 	 *
 	 * @param int[] $order_ids Order IDs.
 	 * @return array
 	 */
-	private function get_order_billing_details_by_order_ids( $order_ids ) {
+	private function get_order_customer_details_by_order_ids( $order_ids ) {
 		global $wpdb;
 
 		$order_ids = array_values( array_unique( array_filter( array_map( 'absint', $order_ids ) ) ) );
@@ -599,12 +603,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				"SELECT orders.id AS order_id,
 					orders.type AS order_type,
 					orders.customer_id,
-					addresses.first_name,
-					addresses.last_name
+					COALESCE( NULLIF( billing.first_name, '' ), shipping.first_name, '' ) AS first_name,
+					COALESCE( NULLIF( billing.last_name, '' ), shipping.last_name, '' ) AS last_name
 				FROM {$orders_table} orders
-				LEFT JOIN {$addresses_table} addresses
-					ON orders.id = addresses.order_id
-					AND addresses.address_type = 'billing'
+				LEFT JOIN {$addresses_table} billing
+					ON orders.id = billing.order_id
+					AND billing.address_type = 'billing'
+				LEFT JOIN {$addresses_table} shipping
+					ON orders.id = shipping.order_id
+					AND shipping.address_type = 'shipping'
 				WHERE orders.id IN ({$included_order_ids})",
 				ARRAY_A
 			);
@@ -616,12 +623,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			"SELECT orders.ID AS order_id,
 				orders.post_type AS order_type,
 				MAX( CASE WHEN order_meta.meta_key = '_customer_user' THEN order_meta.meta_value END ) AS customer_id,
-				MAX( CASE WHEN order_meta.meta_key = '_billing_first_name' THEN order_meta.meta_value END ) AS first_name,
-				MAX( CASE WHEN order_meta.meta_key = '_billing_last_name' THEN order_meta.meta_value END ) AS last_name
+				COALESCE(
+					NULLIF( MAX( CASE WHEN order_meta.meta_key = '_billing_first_name' THEN order_meta.meta_value END ), '' ),
+					MAX( CASE WHEN order_meta.meta_key = '_shipping_first_name' THEN order_meta.meta_value END ),
+					''
+				) AS first_name,
+				COALESCE(
+					NULLIF( MAX( CASE WHEN order_meta.meta_key = '_billing_last_name' THEN order_meta.meta_value END ), '' ),
+					MAX( CASE WHEN order_meta.meta_key = '_shipping_last_name' THEN order_meta.meta_value END ),
+					''
+				) AS last_name
 			FROM {$wpdb->posts} orders
 			LEFT JOIN {$wpdb->postmeta} order_meta
 				ON orders.ID = order_meta.post_id
-				AND order_meta.meta_key IN ( '_customer_user', '_billing_first_name', '_billing_last_name' )
+				AND order_meta.meta_key IN ( '_customer_user', '_billing_first_name', '_billing_last_name', '_shipping_first_name', '_shipping_last_name' )
 			WHERE orders.ID IN ({$included_order_ids})
 			GROUP BY orders.ID, orders.post_type",
 			ARRAY_A

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -482,8 +482,8 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$data_store = new OrdersDataStore();
 		$data       = $data_store->get_data(
 			array(
-				'after'          => gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() ),
-				'before'         => gmdate( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() ),
+				'after'          => gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getOffsetTimestamp() - DAY_IN_SECONDS ),
+				'before'         => gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getOffsetTimestamp() + DAY_IN_SECONDS ),
 				'extended_info'  => 1,
 				'order_includes' => $order_ids,
 			)

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -121,6 +121,121 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should use each guest order's billing name when the orders share an email address.
+	 */
+	public function test_extended_info_uses_each_guest_orders_billing_name_when_email_is_shared(): void {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$registered_customer = new WC_Customer();
+		$registered_customer->set_username( 'marketplace-account' );
+		$registered_customer->set_password( 'password' );
+		$registered_customer->set_email( 'marketplace@example.org' );
+		$registered_customer->set_first_name( 'Registered' );
+		$registered_customer->set_last_name( 'Customer' );
+		$registered_customer->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$first_order = $this->create_guest_order( $product, 'marketplace@example.org' );
+		$first_order->set_billing_first_name( 'Ada' );
+		$first_order->set_billing_last_name( 'Lovelace' );
+		$first_order->save();
+
+		$second_order = $this->create_guest_order( $product, 'marketplace@example.org' );
+		$second_order->set_billing_first_name( 'Grace' );
+		$second_order->set_billing_last_name( 'Hopper' );
+		$second_order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$rows = $this->get_extended_report_rows_by_order_id(
+			$first_order,
+			array( $first_order->get_id(), $second_order->get_id() )
+		);
+
+		$this->assertNotEmpty( $rows[ $first_order->get_id() ]['customer_id'], 'Guest orders should have an analytics customer ID' );
+		$this->assertEquals(
+			$rows[ $first_order->get_id() ]['customer_id'],
+			$rows[ $second_order->get_id() ]['customer_id'],
+			'Orders sharing an email should retain the same analytics customer identity'
+		);
+		$this->assertSame( 'Ada', $rows[ $first_order->get_id() ]['extended_info']['customer']['first_name'], 'The first order should use its own billing first name' );
+		$this->assertSame( 'Lovelace', $rows[ $first_order->get_id() ]['extended_info']['customer']['last_name'], 'The first order should use its own billing last name' );
+		$this->assertSame( 'Grace', $rows[ $second_order->get_id() ]['extended_info']['customer']['first_name'], 'The second order should use its own billing first name' );
+		$this->assertSame( 'Hopper', $rows[ $second_order->get_id() ]['extended_info']['customer']['last_name'], 'The second order should use its own billing last name' );
+	}
+
+	/**
+	 * @testdox Should keep the profile name for a registered customer's order.
+	 */
+	public function test_extended_info_keeps_registered_customer_profile_name(): void {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$customer_id = $this->factory->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => 'registered-customer@example.org',
+				'first_name' => 'Profile',
+				'last_name'  => 'Customer',
+			)
+		);
+		$product     = WC_Helper_Product::create_simple_product();
+		$order       = WC_Helper_Order::create_order( $customer_id, $product );
+		$order->set_billing_first_name( 'Order' );
+		$order->set_billing_last_name( 'Name' );
+		$order->set_total( 25 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$rows = $this->get_extended_report_rows_by_order_id( $order, array( $order->get_id() ) );
+
+		$this->assertSame( 'Profile', $rows[ $order->get_id() ]['extended_info']['customer']['first_name'] );
+		$this->assertSame( 'Customer', $rows[ $order->get_id() ]['extended_info']['customer']['last_name'] );
+	}
+
+	/**
+	 * @testdox Should use the parent billing name for refunds and the order billing name for ordinary child orders.
+	 */
+	public function test_extended_info_resolves_billing_name_source_by_order_type(): void {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$parent_order = $this->create_guest_order( $product, 'parent@example.org' );
+		$parent_order->set_billing_first_name( 'Parent' );
+		$parent_order->set_billing_last_name( 'Customer' );
+		$parent_order->save();
+
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 25,
+				'order_id' => $parent_order->get_id(),
+			)
+		);
+		$this->assertInstanceOf( WC_Order_Refund::class, $refund, 'The refund fixture should be created' );
+
+		$child_order = $this->create_guest_order( $product, 'child@example.org' );
+		$child_order->set_parent_id( $parent_order->get_id() );
+		$child_order->set_billing_first_name( 'Child' );
+		$child_order->set_billing_last_name( 'Customer' );
+		$child_order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$rows = $this->get_extended_report_rows_by_order_id(
+			$parent_order,
+			array( $refund->get_id(), $child_order->get_id() )
+		);
+
+		$this->assertSame( 'Parent', $rows[ $refund->get_id() ]['extended_info']['customer']['first_name'], 'A refund should use its parent order billing name' );
+		$this->assertSame( 'Customer', $rows[ $refund->get_id() ]['extended_info']['customer']['last_name'], 'A refund should use its parent order billing name' );
+		$this->assertSame( 'Child', $rows[ $child_order->get_id() ]['extended_info']['customer']['first_name'], 'An ordinary child order should use its own billing name' );
+		$this->assertSame( 'Customer', $rows[ $child_order->get_id() ]['extended_info']['customer']['last_name'], 'An ordinary child order should use its own billing name' );
+	}
+
+	/**
 	 * Test that refunded orders in list have products.
 	 */
 	public function test_products_in_orders() {
@@ -331,8 +446,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Creates a completed order for a guest customer, using a billing email that is not attached to
-	 * any registered user.
+	 * Creates a completed order for a guest customer.
 	 *
 	 * @param WC_Product $product      Product to add to the order.
 	 * @param string     $email        Billing email used to identify the guest customer.
@@ -355,6 +469,27 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$order->save();
 
 		return $order;
+	}
+
+	/**
+	 * Returns extended report rows keyed by order ID.
+	 *
+	 * @param WC_Order $order     Order used to derive the reporting time frame.
+	 * @param int[]    $order_ids Order IDs to include.
+	 * @return array
+	 */
+	private function get_extended_report_rows_by_order_id( $order, $order_ids ) {
+		$data_store = new OrdersDataStore();
+		$data       = $data_store->get_data(
+			array(
+				'after'          => gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() ),
+				'before'         => gmdate( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() ),
+				'extended_info'  => 1,
+				'order_includes' => $order_ids,
+			)
+		);
+
+		return array_column( $data->data, null, 'order_id' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -166,6 +166,40 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should fall back to a guest order's shipping name when it has no billing name.
+	 */
+	public function test_extended_info_falls_back_to_shipping_name_for_a_guest_order(): void {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$named_order = $this->create_guest_order( $product, 'warehouse@example.org' );
+		$named_order->set_billing_first_name( 'Katherine' );
+		$named_order->set_billing_last_name( 'Johnson' );
+		$named_order->save();
+
+		// Orders taken in person or over the API can reach Analytics with a shipping name only.
+		$shipping_only_order = $this->create_guest_order( $product, 'warehouse@example.org' );
+		$shipping_only_order->set_billing_first_name( '' );
+		$shipping_only_order->set_billing_last_name( '' );
+		$shipping_only_order->set_shipping_first_name( 'Mary' );
+		$shipping_only_order->set_shipping_last_name( 'Jackson' );
+		$shipping_only_order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$rows = $this->get_extended_report_rows_by_order_id(
+			$named_order,
+			array( $named_order->get_id(), $shipping_only_order->get_id() )
+		);
+
+		$this->assertSame( 'Mary', $rows[ $shipping_only_order->get_id() ]['extended_info']['customer']['first_name'], 'An order without a billing first name should use its own shipping first name' );
+		$this->assertSame( 'Jackson', $rows[ $shipping_only_order->get_id() ]['extended_info']['customer']['last_name'], 'An order without a billing last name should use its own shipping last name' );
+		$this->assertSame( 'Katherine', $rows[ $named_order->get_id() ]['extended_info']['customer']['first_name'], 'The billing name should still win when the order has one' );
+		$this->assertSame( 'Johnson', $rows[ $named_order->get_id() ]['extended_info']['customer']['last_name'], 'The billing name should still win when the order has one' );
+	}
+
+	/**
 	 * @testdox Should keep the profile name for a registered customer's order.
 	 */
 	public function test_extended_info_keeps_registered_customer_profile_name(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Use each guest order's stored billing name in the Orders Analytics response instead of reusing the customer lookup row shared by orders with the same email address. Guest refunds use their parent order's billing details, and registered-customer names are not overridden.

The report page performs one bounded billing-details query for its order IDs. Both HPOS and CPT storage are supported. The REST schema is unchanged; affected guest orders now return corrected `extended_info.customer.first_name` and `last_name` values. Multisite uses the current site's table names but was not tested separately.

Closes #43099, closes WOOPLUG-1772

Bug introduced in PR [#1578](https://github.com/woocommerce/woocommerce-admin/pull/1578).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create two guest orders with the same billing email and different billing names.
2. Create a registered-customer order, and create a refund for one guest order.
3. Import or refresh Analytics data, then open Analytics > Orders and enable the Customer column.
4. Confirm that both guest orders show their own names, the guest refund shows its parent order's name, and the registered order keeps its registered-customer name.

<!-- End testing instructions -->

### Testing that has already taken place:

Targeted report tests pass against both HPOS and CPT storage, including guest, registered-customer, child-order, and refund cases. PHP linting, coding standards, static analysis, and independent pre-merge reviews pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.
</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Codex authored the implementation and tests under maintainer direction. Codex and Claude Code performed independent pre-merge reviews; their valid findings were addressed and verified.
