### PR TITLE
Keep emailed Analytics report downloads available for retry

### DIFF
--- a/plugins/woocommerce/changelog/wooa7s-1857-repeatable-report-downloads
+++ b/plugins/woocommerce/changelog/wooa7s-1857-repeatable-report-downloads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep emailed Analytics report exports downloadable for a week instead of deleting them on the first request.

--- a/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
@@ -21,7 +21,11 @@ do_action( 'woocommerce_email_header', $email_heading, $email );
 </a>
 <p>
 	<?php
-		/** @var string $retention Length of time the download link stays valid, passed by ReportCSVEmail. */
+		/**
+		 * Length of time the download link stays valid, passed in by ReportCSVEmail.
+		 *
+		 * @var string $retention
+		 */
 		/* translators: %s: length of time the download link stays valid, e.g. "1 week" */
 		echo esc_html( sprintf( __( 'This link is available for %s.', 'woocommerce' ), $retention ) );
 	?>

--- a/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
@@ -19,6 +19,13 @@ do_action( 'woocommerce_email_header', $email_heading, $email );
 		echo esc_html( sprintf( __( 'Download your %s Report', 'woocommerce' ), $report_name ) );
 	?>
 </a>
+<p>
+	<?php
+		/** @var string $retention Length of time the download link stays valid, passed by ReportCSVEmail. */
+		/* translators: %s: length of time the download link stays valid, e.g. "1 week" */
+		echo esc_html( sprintf( __( 'This link is available for %s.', 'woocommerce' ), $retention ) );
+	?>
+</p>
 <?php
 /*
  * @hooked WC_Emails::email_footer() Output the email footer

--- a/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
@@ -16,7 +16,11 @@ echo wp_kses_post( sprintf( __( 'Download your %1$s Report: %2$s', 'woocommerce'
 
 echo "\n\n";
 
-/** @var string $retention Length of time the download link stays valid, passed by ReportCSVEmail. */
+/**
+ * Length of time the download link stays valid, passed in by ReportCSVEmail.
+ *
+ * @var string $retention
+ */
 /* translators: %s: length of time the download link stays valid, e.g. "1 week" */
 echo esc_html( sprintf( __( 'This link is available for %s.', 'woocommerce' ), $retention ) );
 

--- a/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
@@ -14,6 +14,12 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 /* translators: %1$s: report name, %2$s: download URL */
 echo wp_kses_post( sprintf( __( 'Download your %1$s Report: %2$s', 'woocommerce' ), $report_name, $download_url ) );
 
+echo "\n\n";
+
+/** @var string $retention Length of time the download link stays valid, passed by ReportCSVEmail. */
+/* translators: %s: length of time the download link stays valid, e.g. "1 week" */
+echo esc_html( sprintf( __( 'This link is available for %s.', 'woocommerce' ), $retention ) );
+
 echo "\n\n----------------------------------------\n\n";
 
 echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -132,6 +132,7 @@ class ReportCSVEmail extends \WC_Email {
 				'sent_to_admin' => true,
 				'plain_text'    => false,
 				'email'         => $this,
+				'retention'     => $this->get_retention_period(),
 			),
 			'',
 			$this->template_base
@@ -153,10 +154,21 @@ class ReportCSVEmail extends \WC_Email {
 				'sent_to_admin' => true,
 				'plain_text'    => true,
 				'email'         => $this,
+				'retention'     => $this->get_retention_period(),
 			),
 			'',
 			$this->template_base
 		);
+	}
+
+	/**
+	 * Get how long the emailed download link stays valid, for display.
+	 *
+	 * @since 11.2.0
+	 * @return string Human readable length of time, e.g. "1 week".
+	 */
+	protected function get_retention_period() {
+		return human_time_diff( 0, ReportExporter::EXPORT_RETENTION_PERIOD );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -116,6 +116,45 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 		return self::get_reports_directory() . $this->get_filename();
 	}
 
+	/**
+	 * Check whether the generated export is still on disk.
+	 *
+	 * @since 11.2.0
+	 * @return bool
+	 */
+	public function export_file_exists() {
+		return file_exists( $this->get_file_path() );
+	}
+
+	/**
+	 * Write the export to the output, leaving the file in place. Send the download headers first.
+	 *
+	 * @since 11.2.0
+	 * @return void
+	 */
+	public function stream_export_file() {
+		$this->send_content( $this->get_headers_row_file() );
+
+		// Stream the body instead of reading it into memory. Exports are emailed precisely when the
+		// report is too large to return in one request, so it can be far larger than the memory limit.
+		readfile( $this->get_file_path() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile, WordPress.Security.EscapeOutput.OutputNotEscaped -- Streaming a generated CSV download.
+	}
+
+	/**
+	 * Serve the export file.
+	 *
+	 * Unlike the parent, this keeps the file so that the download link WooCommerce emails to the
+	 * merchant works more than once. ReportExporter::delete_expired_exports() removes it later.
+	 *
+	 * @since 11.2.0
+	 * @return void
+	 */
+	public function export() {
+		$this->send_headers();
+		$this->stream_export_file();
+		die();
+	}
+
 
 	/**
 	 * Setter for report type.

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -117,13 +117,16 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	}
 
 	/**
-	 * Check whether the generated export is still on disk.
+	 * Check whether a complete generated export is still on disk.
+	 *
+	 * The `.headers` companion is only written once the export reaches 100%, so a body without one
+	 * is an export that never finished and must not be served.
 	 *
 	 * @since 11.2.0
 	 * @return bool
 	 */
 	public function export_file_exists() {
-		return file_exists( $this->get_file_path() );
+		return file_exists( $this->get_file_path() ) && file_exists( $this->get_headers_row_file_path() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -40,6 +40,11 @@ class ReportExporter {
 	const DOWNLOAD_EXPORT_ACTION = 'woocommerce_admin_download_report_csv';
 
 	/**
+	 * How long a generated export stays available for download.
+	 */
+	const EXPORT_RETENTION_PERIOD = WEEK_IN_SECONDS;
+
+	/**
 	 * Get all available scheduling actions.
 	 * Used to determine action hook names and clear events.
 	 *
@@ -70,8 +75,51 @@ class ReportExporter {
 		// Initialize scheduled action handlers.
 		self::scheduler_init();
 
-		// Report download handler.
+		self::init_export_files();
+	}
+
+	/**
+	 * Hook in the handlers that serve and expire already generated exports.
+	 *
+	 * These stay registered when Analytics is switched off, so a link that was already emailed
+	 * keeps working and old exports still get cleaned up, even though no new ones are generated.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 * @return void
+	 */
+	public static function init_export_files() {
 		add_action( 'admin_init', array( __CLASS__, 'download_export_file' ) );
+		add_action( 'wc_admin_daily', array( __CLASS__, 'delete_expired_exports' ) );
+	}
+
+	/**
+	 * Delete generated exports that are past the retention period.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 * @return void
+	 */
+	public static function delete_expired_exports() {
+		$expired_before = time() - self::EXPORT_RETENTION_PERIOD;
+
+		// Both the report body and its `.headers` companion, but never the directory's
+		// .htaccess and index.html guards.
+		$paths = glob( ReportCSVExporter::get_reports_directory() . '*.csv*' );
+		if ( ! $paths ) {
+			return;
+		}
+
+		foreach ( $paths as $path ) {
+			if ( ! is_file( $path ) ) {
+				continue;
+			}
+
+			$modified = filemtime( $path );
+			if ( $modified && $modified < $expired_before ) {
+				wp_delete_file( $path );
+			}
+		}
 	}
 
 	/**
@@ -175,18 +223,47 @@ class ReportExporter {
 	 * Serve the export file.
 	 */
 	public static function download_export_file() {
-		// @todo - add nonce? (nonces are good for 24 hours)
+		/*
+		 * A read-only download of a report the requesting user is already allowed to view, gated on
+		 * the view_woocommerce_reports capability, so a nonce would only prevent nuisance CSRF. The
+		 * action is compared verbatim against a fixed name, and set_filename() applies
+		 * sanitize_file_name(), which keeps the path inside the reports directory. A nonce is not an
+		 * option here either: nonces last 24 hours, and this link is emailed and kept for a week.
+		 */
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if (
-			isset( $_GET['action'] ) &&
-			! empty( $_GET['filename'] ) &&
-			is_string( $_GET['filename'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Download of a report file generated for the requesting user and deleted once served; gated on the view_woocommerce_reports capability, so a nonce would only prevent nuisance CSRF.
-			self::DOWNLOAD_EXPORT_ACTION === wp_unslash( $_GET['action'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Download of a report file generated for the requesting user and deleted once served; gated on the view_woocommerce_reports capability, so a nonce would only prevent nuisance CSRF. The value is only compared verbatim against a fixed action name.
-			current_user_can( 'view_woocommerce_reports' )
+			! isset( $_GET['action'] ) ||
+			self::DOWNLOAD_EXPORT_ACTION !== wp_unslash( $_GET['action'] ) ||
+			empty( $_GET['filename'] ) ||
+			! is_string( $_GET['filename'] ) ||
+			! current_user_can( 'view_woocommerce_reports' )
 		) {
-			$exporter = new ReportCSVExporter();
-			$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Download of a report file generated for the requesting user and deleted once served; gated on the view_woocommerce_reports capability, so a nonce would only prevent nuisance CSRF. set_filename() applies sanitize_file_name(), which keeps the path inside the reports directory.
-			$exporter->export();
+			return;
 		}
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( wp_unslash( $_GET['filename'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		// Say so rather than serving an empty CSV: the exporter creates a blank file for a path
+		// that no longer exists, which reads as a report with no results.
+		if ( ! $exporter->export_file_exists() ) {
+			wp_die(
+				esc_html(
+					sprintf(
+						/* translators: %s: length of time an export is kept, e.g. "1 week". */
+						__( 'This report export is no longer available. Exports are kept for %s, so please request a new one.', 'woocommerce' ),
+						human_time_diff( 0, self::EXPORT_RETENTION_PERIOD )
+					)
+				),
+				esc_html__( 'Report export unavailable', 'woocommerce' ),
+				array( 'response' => 404 )
+			);
+		}
+
+		$exporter->send_headers();
+		$exporter->stream_export_file();
+		exit;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -179,6 +179,9 @@ class FeaturePlugin {
 			CategoryLookup::instance()->init();
 			// Initialize Reports exporter.
 			ReportExporter::init();
+		} else {
+			// Already generated exports still need serving and expiring.
+			ReportExporter::init_export_files();
 		}
 
 		// Admin note providers.

--- a/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for the Analytics report export email.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin;
+
+use Automattic\WooCommerce\Admin\ReportCSVEmail;
+use Automattic\WooCommerce\Admin\ReportExporter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the emailed report download link.
+ */
+class ReportCSVEmailTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Build an email addressed at a generated export.
+	 *
+	 * @return ReportCSVEmail
+	 */
+	private function create_email(): ReportCSVEmail {
+		$email = new ReportCSVEmail();
+
+		foreach ( array(
+			'report_type'  => 'Orders',
+			'download_url' => 'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
+		) as $name => $value ) {
+			$property = new \ReflectionProperty( ReportCSVEmail::class, $name );
+			$property->setAccessible( true );
+			$property->setValue( $email, $value );
+		}
+
+		return $email;
+	}
+
+	/**
+	 * @testdox The HTML email says how long the download link stays valid.
+	 */
+	public function test_html_email_states_the_retention_period(): void {
+		$content = $this->create_email()->get_content_html();
+
+		$this->assertStringContainsString(
+			'This link is available for ' . human_time_diff( 0, ReportExporter::EXPORT_RETENTION_PERIOD ) . '.',
+			$content,
+			'The HTML email should tell the merchant how long the link lasts.'
+		);
+	}
+
+	/**
+	 * @testdox The plain text email says how long the download link stays valid.
+	 */
+	public function test_plain_email_states_the_retention_period(): void {
+		$content = $this->create_email()->get_content_plain();
+
+		$this->assertStringContainsString(
+			'This link is available for ' . human_time_diff( 0, ReportExporter::EXPORT_RETENTION_PERIOD ) . '.',
+			$content,
+			'The plain text email should tell the merchant how long the link lasts.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Tests for the Analytics report exporter.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin;
+
+use Automattic\WooCommerce\Admin\ReportCSVExporter;
+use Automattic\WooCommerce\Admin\ReportExporter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for retained report exports.
+ */
+class ReportExporterTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Paths written by a test, removed in tear down.
+	 *
+	 * @var string[]
+	 */
+	private $paths = array();
+
+	/**
+	 * Remove files that the database transaction does not roll back.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->paths as $path ) {
+			if ( file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
+		$this->paths = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Write an export to the reports directory.
+	 *
+	 * @param string $filename Filename without the extension.
+	 * @param string $body     Export body.
+	 * @param int    $age      How long ago the export was written, in seconds.
+	 * @return string Resolved filename, as the download handler and cleanup see it.
+	 */
+	private function create_export( string $filename, string $body = "1,2\n", int $age = 0 ): string {
+		ReportCSVExporter::maybe_create_directory();
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( $filename );
+		$resolved = $exporter->get_filename();
+		$path     = ReportCSVExporter::get_reports_directory() . $resolved;
+
+		$this->write_file( $path, $body, $age );
+		$this->write_file( $path . '.headers', "id,total\n", $age );
+
+		return $resolved;
+	}
+
+	/**
+	 * Write one file and backdate it.
+	 *
+	 * @param string $path     File path.
+	 * @param string $contents File contents.
+	 * @param int    $age      How long ago the file was written, in seconds.
+	 * @return void
+	 */
+	private function write_file( string $path, string $contents, int $age ): void {
+		file_put_contents( $path, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		touch( $path, time() - $age ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
+
+		$this->paths[] = $path;
+	}
+
+	/**
+	 * @testdox Downloading an export streams it without consuming it, so the link can be reused.
+	 */
+	public function test_streaming_an_export_leaves_it_in_place(): void {
+		$filename = $this->create_export( 'wc-orders-report-export-repeatable', "42,7\n" );
+		$path     = ReportCSVExporter::get_reports_directory() . $filename;
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( $filename );
+
+		ob_start();
+		$exporter->stream_export_file();
+		$first = ob_get_clean();
+
+		$this->assertStringContainsString( '42,7', $first, 'The export body should be streamed to the client.' );
+		$this->assertStringContainsString( 'id,total', $first, 'The stored header row should be streamed ahead of the body.' );
+		$this->assertFileExists( $path, 'Serving an export should not delete it.' );
+
+		ob_start();
+		$exporter->stream_export_file();
+		$second = ob_get_clean();
+
+		$this->assertSame( $first, $second, 'A second download should return the same export.' );
+	}
+
+	/**
+	 * @testdox An export that is gone reports itself as missing instead of serving an empty report.
+	 */
+	public function test_missing_export_is_reported_as_missing(): void {
+		$filename = $this->create_export( 'wc-orders-report-export-missing' );
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( $filename );
+
+		$this->assertTrue( $exporter->export_file_exists(), 'A generated export should be reported as available.' );
+
+		wp_delete_file( ReportCSVExporter::get_reports_directory() . $filename );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'A deleted export should be reported as unavailable.' );
+	}
+
+	/**
+	 * @testdox Daily cleanup deletes only exports past the retention period.
+	 */
+	public function test_cleanup_deletes_only_expired_exports(): void {
+		$reports_dir = ReportCSVExporter::get_reports_directory();
+		$expired     = $this->create_export( 'wc-orders-report-export-expired', "1,2\n", ReportExporter::EXPORT_RETENTION_PERIOD + HOUR_IN_SECONDS );
+		$fresh       = $this->create_export( 'wc-orders-report-export-fresh', "3,4\n", ReportExporter::EXPORT_RETENTION_PERIOD - HOUR_IN_SECONDS );
+
+		ReportExporter::delete_expired_exports();
+
+		$this->assertFileDoesNotExist( $reports_dir . $expired, 'An expired export should be deleted.' );
+		$this->assertFileDoesNotExist( $reports_dir . $expired . '.headers', 'An expired export header row should be deleted too.' );
+		$this->assertFileExists( $reports_dir . $fresh, 'An export inside the retention period should be kept.' );
+		$this->assertFileExists( $reports_dir . $fresh . '.headers', 'An export header row inside the retention period should be kept.' );
+		$this->assertFileExists( $reports_dir . '.htaccess', 'Cleanup should not touch the directory guards.' );
+		$this->assertFileExists( $reports_dir . 'index.html', 'Cleanup should not touch the directory guards.' );
+	}
+
+	/**
+	 * @testdox Cleanup runs from the daily WooCommerce Admin event.
+	 */
+	public function test_cleanup_is_hooked_to_the_daily_event(): void {
+		$this->assertSame(
+			10,
+			has_action( 'wc_admin_daily', array( ReportExporter::class, 'delete_expired_exports' ) ),
+			'Expired exports should be cleaned up by the daily event rather than on each request.'
+		);
+		$this->assertSame(
+			10,
+			has_action( 'admin_init', array( ReportExporter::class, 'download_export_file' ) ),
+			'The download handler should be registered.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -117,6 +117,20 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox An export that never finished writing reports itself as missing.
+	 */
+	public function test_incomplete_export_is_reported_as_missing(): void {
+		$filename = $this->create_export( 'wc-orders-report-export-incomplete' );
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( $filename );
+
+		// A body with no `.headers` companion is an export that stopped before reaching 100%.
+		wp_delete_file( ReportCSVExporter::get_reports_directory() . $filename . '.headers' );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'An unfinished export should be reported as unavailable.' );
+	}
+
+	/**
 	 * @testdox Daily cleanup deletes only exports past the retention period.
 	 */
 	public function test_cleanup_deletes_only_expired_exports(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/FeaturePluginTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/FeaturePluginTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
+use Automattic\WooCommerce\Admin\ReportExporter;
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Internal\Admin\FeaturePlugin;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
@@ -140,6 +141,35 @@ class FeaturePluginTest extends WC_Unit_Test_Case {
 		}
 
 		$this->assertSame( 0, $translation_count, 'The bootstrap gate should not translate WooCommerce feature definitions.' );
+	}
+
+	/**
+	 * @testdox Serving and expiring existing exports stays enabled when Analytics is disabled.
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_export_files_are_still_handled_when_analytics_is_disabled(): void {
+		$export_hook        = ReportExporter::get_action( 'export_report' );
+		$scheduler_hook     = ReportExporter::get_action( 'schedule_action' );
+		$scheduler_callback = array( ReportExporter::class, 'do_action_or_reschedule' );
+		$download_callback  = array( ReportExporter::class, 'download_export_file' );
+		$cleanup_callback   = array( ReportExporter::class, 'delete_expired_exports' );
+
+		$this->assertIsString( $export_hook, 'The export hook should be defined.' );
+		$this->assertIsString( $scheduler_hook, 'The scheduler hook should be defined.' );
+
+		remove_action( $export_hook, $scheduler_callback, 10 );
+		remove_action( $scheduler_hook, $scheduler_callback, 10 );
+		remove_action( 'admin_init', $download_callback, 10 );
+		remove_action( 'wc_admin_daily', $cleanup_callback, 10 );
+		update_option( Analytics::TOGGLE_OPTION_NAME, 'no' );
+
+		FeaturePlugin::instance()->includes();
+
+		$this->assertSame( 10, has_action( 'admin_init', $download_callback ), 'Links that were already emailed should keep working.' );
+		$this->assertSame( 10, has_action( 'wc_admin_daily', $cleanup_callback ), 'Existing exports should still expire.' );
+		$this->assertFalse( has_action( $export_hook, $scheduler_callback ), 'Export generation should stay disabled.' );
+		$this->assertFalse( has_action( $scheduler_hook, $scheduler_callback ), 'Export scheduling should stay disabled.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Keep completed Analytics report exports available for repeat downloads instead of deleting them on the first request. `ReportCSVExporter::export()` no longer unlinks the file it just served, and the body is streamed with `readfile()` rather than read into memory, since these exports exist precisely because the report was too large to return in one request.

Expiry is a single sweep on the existing `wc_admin_daily` event. `ReportExporter::delete_expired_exports()` globs the reports directory for `*.csv*` — the report body and its `.headers` companion, never the directory's `.htaccess` and `index.html` guards — and deletes each file whose own modification time is older than `EXPORT_RETENTION_PERIOD` (one week). Nothing is scheduled per export.

A download for a file that is gone now returns a 404 page naming the retention period, instead of the empty CSV the exporter would otherwise generate for a missing path. An export whose `.headers` companion was never written is treated the same way: `WC_CSV_Batch_Exporter` only writes that file at 100%, so a body without one is an export that stopped part way.

Serving and expiry stay registered when Analytics is switched off, via `ReportExporter::init_export_files()` on the `else` branch of the `FeaturePlugin` analytics gate, so an already emailed link keeps working and old exports still get cleaned up. Generation and email handlers remain disabled there.

The export email now states how long the link lasts ("This link is available for 1 week."), in both the HTML and plain text templates. It reads the same `EXPORT_RETENTION_PERIOD` constant as the 404 page, so the two cannot drift. Previously the retention period was only stated on the 404 page, which the merchant reaches after the link has already stopped working.

**Backward compatibility:** additive only. New public members are `ReportExporter::EXPORT_RETENTION_PERIOD`, `ReportExporter::init_export_files()`, `ReportExporter::delete_expired_exports()`, `ReportCSVExporter::export_file_exists()` and `ReportCSVExporter::stream_export_file()`. No existing signature, hook or download URL changes, and no capability check is relaxed.

`ReportCSVExporter` is a public, non-`Internal` class, so its new methods are worth stating explicitly. `export_file_exists()` and `stream_export_file()` are new in this release and safe for extensions to call. Because neither existed before, the `.headers` completeness check in `export_file_exists()` has no prior behavior to preserve. Both are added to the concrete class, not to an interface, so nothing external has to implement them. An existing subclass that happens to define a method of the same name would override ours rather than break, since both take no arguments.

The one behavior change on an existing method is `ReportCSVExporter::export()`, which keeps the file it serves instead of deleting it; a subclass or caller relying on the file being consumed would see it persist until the daily sweep. That is the change in this PR most likely to be noticed externally. No new hook is introduced.

The two export email templates gain a new `$retention` variable and one new string. A theme or plugin overriding either template keeps working and simply does not show the new line, since the variable is passed in addition to the existing ones rather than replacing any of them. Multisite uses each site's own upload directory and cron, but was not tested separately.

Fixes WOOA7S-1857.

Bug introduced in PR [#2899](https://github.com/woocommerce/woocommerce-admin/pull/2899).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create more orders than the current report page size, then request an emailed export from Analytics > Orders.
2. Open the emailed link and confirm that the complete CSV downloads.
3. Open or paste the same link again and confirm that the same complete CSV downloads again, with the same contents.
4. Delete the generated file from `wp-content/uploads/woocommerce_uploads/reports/`, open the link again, and confirm a 404 page saying the export is no longer available, rather than an empty CSV.
5. Delete only the `.headers` companion of a generated export, open the link, and confirm the same 404 rather than a CSV with no header row.
6. Backdate a generated export's modification time by more than a week (`touch -t`), run `wc_admin_daily`, and confirm that file is deleted while a fresh export and the directory's `.htaccess`/`index.html` are left in place.
7. Confirm the export email says "This link is available for 1 week." under the download link, in both an HTML client and a plain text one.
8. Disable Analytics and confirm the retained link still downloads and the daily cleanup still runs, while report generation and email callbacks remain disabled.

<!-- End testing instructions -->

### Testing that has already taken place:

`ReportExporterTest` covers repeated streaming without consuming the file, a missing export, an export missing its `.headers` companion, retention-period cleanup that spares fresh files, and cleanup firing from `wc_admin_daily`. `ReportCSVEmailTest` covers the retention line rendering in both the HTML and plain text emails. `FeaturePluginTest` covers the analytics gate and that serving and expiry stay enabled when Analytics is disabled. PHP linting, branch coding standards, and PHPStan pass. Independent pre-merge reviews were performed and their valid findings addressed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.
</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Codex authored the implementation and tests under maintainer direction. Codex and Claude Code performed independent pre-merge reviews; their valid findings were addressed and verified.
