### PR TITLE
Stop the analytics tracking proxy from accepting client-supplied server props

### DIFF
--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -72,6 +72,22 @@ add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
 add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 ```
 
+This registers the unauthenticated `POST /wp-json/woocommerce-analytics/v1/track`
+endpoint. Sites without proxy tracking enabled do not get it.
+
+Events arriving through it are untrusted: server-derived properties are replaced
+with the server's own values. The set is
+`WC_Analytics_Tracking::get_reserved_property_names()`, which includes generic
+names like `url`, `device` and `timezone` — rename event properties that would
+collide. `_lg`, `_dl` and `_dr` stay the client's, because they describe the page
+the event happened on rather than the `/track` request.
+
+**The filter must resolve to the same value for every request on a site.** One
+that varies by cohort, percentage or geo makes cached pages disagree with what
+`/track` decides, and makes the speed module install and uninstall itself on
+alternate runs. Turning it off also drops events from pages already held in a
+cache, whose visitors keep posting to an endpoint that no longer exists.
+
 ## Privacy & Consent Management
 
 ### WP Consent API Integration

--- a/packages/php/woocommerce-analytics/changelog/fix-dotcom-18362-search-event-name
+++ b/packages/php/woocommerce-analytics/changelog/fix-dotcom-18362-search-event-name
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: fixed
 
 Rename the store search event so Tracks ingest stops rejecting it.

--- a/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
@@ -1,0 +1,4 @@
+Significance: minor
+Type: security
+
+Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, and register it only on sites with proxy tracking enabled. Adds `WC_Analytics_Tracking::record_client_event()` and a third `$is_client_supplied` argument to the `jetpack_woocommerce_analytics_event_props` filter.

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -41,7 +41,10 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'track_events' ),
-					'permission_callback' => '__return_true', // no need to check permissions
+					// Unauthenticated by design: this receives front-end events. The route
+					// is registered only while proxy tracking is enabled, and records via
+					// record_client_event(), which strips server-owned properties.
+					'permission_callback' => '__return_true',
 					'schema'              => array( $this, 'get_public_item_schema' ),
 				),
 			)
@@ -91,7 +94,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 			// Validate event name and properties.
 			$event_name = $event['event_name'] ?? null;
 			$properties = $event['properties'] ?? array();
-			if ( ! $event_name || ! is_array( $properties ) ) {
+			if ( ! $event_name || ! is_string( $event_name ) || ! is_array( $properties ) ) {
 				$results[ $index ] = array(
 					'success' => false,
 					'error'   => 'Missing event_name or invalid properties',
@@ -100,7 +103,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 				continue;
 			}
 
-			$result = WC_Analytics_Tracking::record_event( $event_name, $properties );
+			$result = WC_Analytics_Tracking::record_client_event( $event_name, $properties );
 
 			if ( is_wp_error( $result ) ) {
 				$results[ $index ] = array(

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -33,6 +33,46 @@ class WC_Analytics_Tracking {
 	const DAILY_SALT_OPTION = 'woocommerce_analytics_daily_salt';
 
 	/**
+	 * Property names a client is authoritative for on the proxy path.
+	 *
+	 * The server's own values for these describe the /track request, not the page
+	 * the event happened on. `_via_ref` is excluded despite sharing a header with
+	 * `_dr`: it records what fired the pixel, and is not used for page attribution.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var string[]
+	 */
+	const CLIENT_OVERRIDABLE_PROPERTIES = array( '_lg', '_dl', '_dr' );
+
+	/**
+	 * Identity and envelope property names a client may never set.
+	 *
+	 * Each is already protected by merge ordering in `get_properties()` or by
+	 * `Pixel_Builder::validate_and_sanitize()`. Listed anyway so that neither is
+	 * the only thing standing between a client and the visitor id.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var string[]
+	 */
+	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', '_ts', 'browser_type' );
+
+	/**
+	 * Path suffix of the proxy tracking endpoint.
+	 *
+	 * The MU-plugin speed module template declares its own copy: it tests the
+	 * request shape before loading the autoloader, so no package class exists yet.
+	 * Change both together; `test_mu_plugin_template_stays_in_step_with_the_package()`
+	 * fails if you do not.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var string
+	 */
+	const PROXY_REQUEST_PATH = 'woocommerce-analytics/v1/track';
+
+	/**
 	 * Event queue.
 	 *
 	 * @var array
@@ -68,15 +108,28 @@ class WC_Analytics_Tracking {
 	private static $cached_visitor_id = null;
 
 	/**
+	 * Memoized reserved property names for the current request.
+	 *
+	 * @var string[]|null
+	 */
+	private static $reserved_property_names = null;
+
+	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
+	 *
+	 * @since 0.18.0 Added the `$is_client_supplied` parameter.
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Custom properties to send with the event.
+	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted
+	 *                                   client. Reserved property names are stripped when
+	 *                                   true. Defaults to false for server-side callers.
 	 *
-	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA,
-	 *                       or cookie-less context); WP_Error if pixel firing failed.
+	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA, or
+	 *                       cookie-less context); WP_Error for an unusable client
+	 *                       event name, or if the pixel could not be built or fired.
 	 */
-	public static function record_event( $event_name, $event_properties = array() ) {
+	public static function record_event( $event_name, $event_properties = array(), $is_client_supplied = false ) {
 		// Check consent before recording any event.
 		if ( ! Consent_Manager::has_analytics_consent() ) {
 			return true; // Skip recording.
@@ -92,8 +145,21 @@ class WC_Analytics_Tracking {
 			return true;
 		}
 
+		// The guard covers MU-plugin copies predating record_client_event(); see is_proxy_tracking_request().
+		$is_client_supplied = $is_client_supplied || self::is_proxy_tracking_request();
+
+		if ( $is_client_supplied ) {
+			// An error rather than a silent skip: an unusable name produces no pixel,
+			// and reporting success for it is what makes the loss invisible.
+			if ( ! self::is_valid_client_name( $event_name ) ) {
+				return new WP_Error( 'invalid_event_name', 'the event name is empty or not a string', array( 'status' => 400 ) );
+			}
+
+			$event_properties = self::strip_reserved_properties( $event_properties );
+		}
+
 		$prefixed_event_name = self::PREFIX . $event_name;
-		$properties          = self::get_properties( $prefixed_event_name, $event_properties );
+		$properties          = self::get_properties( $prefixed_event_name, $event_properties, $is_client_supplied );
 
 		// Record Tracks event.
 		$tracks_error  = null;
@@ -121,6 +187,24 @@ class WC_Analytics_Tracking {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Record an event whose properties came from an untrusted client.
+	 *
+	 * The entry point for the tracking proxy: the REST controller and the MU-plugin
+	 * speed module both come through here. A distinct method rather than a sanitizer
+	 * callers must remember to invoke, so a wrong choice is visible at the call site.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param string $event_name The name of the event.
+	 * @param array  $event_properties Client-supplied properties.
+	 *
+	 * @return bool|WP_Error True on emit or deliberate skip; WP_Error if pixel firing failed.
+	 */
+	public static function record_client_event( $event_name, $event_properties = array() ) {
+		return self::record_event( $event_name, $event_properties, true );
 	}
 
 	/**
@@ -313,23 +397,47 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get all properties for the event including filtered and identity properties.
 	 *
+	 * @since 0.18.0 Added the `$is_client_supplied` parameter.
+	 *
 	 * @param string $event_name Event name.
 	 * @param array  $event_properties Event specific properties.
+	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted client.
 	 * @return array
 	 */
-	public static function get_properties( $event_name, $event_properties ) {
+	public static function get_properties( $event_name, $event_properties, $is_client_supplied = false ) {
 		$common_properties = self::get_common_properties();
 
 		/**
 		 * Allow defining custom event properties in WooCommerce Analytics.
 		 *
+		 * On the proxy path (`$is_client_supplied`) a reserved name a callback returns
+		 * is discarded, because the server re-asserts its own value below. Names a
+		 * callback introduces are not reserved and are kept.
+		 *
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
+		 * @since 0.18.0 Added the `$is_client_supplied` parameter.
 		 *
-		 * @param array $all_props Array of event props to be filtered.
+		 * @param array  $all_props Array of event props to be filtered.
+		 * @param string $event_name Event name.
+		 * @param bool   $is_client_supplied Whether the props came from an untrusted client.
 		 */
-		$properties = apply_filters( 'jetpack_woocommerce_analytics_event_props', array_merge( $common_properties, $event_properties ), $event_name );
+		$properties = apply_filters(
+			'jetpack_woocommerce_analytics_event_props',
+			array_merge( $common_properties, $event_properties ),
+			$event_name,
+			$is_client_supplied
+		);
+
+		if ( $is_client_supplied ) {
+			// A callback that defers to an existing value hands a reserved property
+			// back to the client, which supplied it. Re-assert the server's own.
+			$properties = array_merge(
+				$properties,
+				array_intersect_key( $common_properties, array_flip( self::get_reserved_property_names() ) )
+			);
+		}
 
 		$required_properties = $event_name
 			? array(
@@ -365,6 +473,133 @@ class WC_Analytics_Tracking {
 		}
 
 		return $all_properties;
+	}
+
+	/**
+	 * Get the property names a client may not set.
+	 *
+	 * Derived from `get_common_properties()` rather than restated as a literal, so a
+	 * newly added common property is protected with no edit here. The pinned list in
+	 * `WC_Analytics_Tracking_Reserved_Props_Test` still fails on the addition, on
+	 * purpose: protection is automatic, granting an exemption is not. Memoized because
+	 * a batch would otherwise recompute the common properties once per event.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @return string[] Reserved property names.
+	 */
+	public static function get_reserved_property_names() {
+		if ( null !== self::$reserved_property_names ) {
+			return self::$reserved_property_names;
+		}
+
+		$server_owned = array_diff(
+			array_keys( self::get_common_properties() ),
+			self::CLIENT_OVERRIDABLE_PROPERTIES
+		);
+
+		self::$reserved_property_names = array_values(
+			array_unique( array_merge( $server_owned, self::RESERVED_IDENTITY_PROPERTIES ) )
+		);
+
+		return self::$reserved_property_names;
+	}
+
+	/**
+	 * Remove server-owned properties from a client-supplied property array.
+	 *
+	 * Stripping is silent and the event still records: rejecting it would turn the
+	 * endpoint into an oracle for probing the reserved list.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param array $event_properties Client-supplied properties. A non-array is
+	 *                                tolerated, since the REST body is attacker-shaped.
+	 * @return array Properties with reserved names removed; empty array for empty or
+	 *               non-array input.
+	 */
+	public static function strip_reserved_properties( $event_properties ) {
+		if ( ! is_array( $event_properties ) || empty( $event_properties ) ) {
+			return array();
+		}
+
+		return array_diff_key(
+			$event_properties,
+			array_flip( self::get_reserved_property_names() )
+		);
+	}
+
+	/**
+	 * Whether a client-supplied event or property name is usable.
+	 *
+	 * Without the type check an array name reaches `PREFIX . $event_name` and writes
+	 * a PHP warning to the log, unauthenticated.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param mixed $name Client-supplied name.
+	 * @return bool True when the name is a non-empty string.
+	 */
+	private static function is_valid_client_name( $name ) {
+		return is_string( $name ) && '' !== $name;
+	}
+
+	/**
+	 * Whether the current request is a POST to the proxy tracking endpoint.
+	 *
+	 * Worth explaining because a URL-shape test does not belong in a security path:
+	 * this is a safety net, not the boundary. The boundary is `record_client_event()`,
+	 * which survives subdirectory installs, rewrites and proxying. This exists only
+	 * because an MU-plugin copy installed before that method existed calls
+	 * `record_event()` directly, and rewriting an installed copy needs admin traffic,
+	 * an expired transient and a writable mu-plugins directory, none of them
+	 * guaranteed. Remove once a package-version floor rules such a copy out.
+	 *
+	 * Matches `is_proxy_request()` in the MU-plugin template; see PROXY_REQUEST_PATH.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @return bool True when the request shape matches the proxy endpoint.
+	 */
+	public static function is_proxy_tracking_request() {
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared against a fixed string below; unsanitized on purpose to stay byte-for-byte in step with the MU-plugin template's read.
+		$raw_method = wp_unslash( $_SERVER['REQUEST_METHOD'] );
+		if ( ! is_string( $raw_method ) || 'POST' !== strtoupper( $raw_method ) ) {
+			return false;
+		}
+
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Parsed and character-restricted below; sanitizing first would mangle the path.
+		$raw_uri = wp_unslash( $_SERVER['REQUEST_URI'] );
+		if ( ! is_string( $raw_uri ) || '' === $raw_uri ) {
+			return false;
+		}
+
+		$path = wp_parse_url( $raw_uri, PHP_URL_PATH );
+		if ( ! is_string( $path ) ) {
+			return false;
+		}
+
+		// Reject anything outside expected URL path characters, matching the template.
+		if ( preg_match( '/[^A-Za-z0-9\-._~\/]/', $path ) ) {
+			return false;
+		}
+
+		$normalized_path = rtrim( $path, '/' );
+		$proxy_suffix    = '/' . ltrim( self::PROXY_REQUEST_PATH, '/' );
+
+		if ( strlen( $normalized_path ) < strlen( $proxy_suffix ) ) {
+			return false;
+		}
+
+		return substr( $normalized_path, -strlen( $proxy_suffix ) ) === $proxy_suffix;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -59,20 +59,6 @@ class WC_Analytics_Tracking {
 	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', '_ts', 'browser_type' );
 
 	/**
-	 * Path suffix of the proxy tracking endpoint.
-	 *
-	 * The MU-plugin speed module template declares its own copy: it tests the
-	 * request shape before loading the autoloader, so no package class exists yet.
-	 * Change both together; `test_mu_plugin_template_stays_in_step_with_the_package()`
-	 * fails if you do not.
-	 *
-	 * @since 0.18.0
-	 *
-	 * @var string
-	 */
-	const PROXY_REQUEST_PATH = 'woocommerce-analytics/v1/track';
-
-	/**
 	 * Event queue.
 	 *
 	 * @var array
@@ -144,9 +130,6 @@ class WC_Analytics_Tracking {
 		if ( empty( self::get_visitor_id() ) ) {
 			return true;
 		}
-
-		// The guard covers MU-plugin copies predating record_client_event(); see is_proxy_tracking_request().
-		$is_client_supplied = $is_client_supplied || self::is_proxy_tracking_request();
 
 		if ( $is_client_supplied ) {
 			// An error rather than a silent skip: an unusable name produces no pixel,
@@ -542,64 +525,6 @@ class WC_Analytics_Tracking {
 	 */
 	private static function is_valid_client_name( $name ) {
 		return is_string( $name ) && '' !== $name;
-	}
-
-	/**
-	 * Whether the current request is a POST to the proxy tracking endpoint.
-	 *
-	 * Worth explaining because a URL-shape test does not belong in a security path:
-	 * this is a safety net, not the boundary. The boundary is `record_client_event()`,
-	 * which survives subdirectory installs, rewrites and proxying. This exists only
-	 * because an MU-plugin copy installed before that method existed calls
-	 * `record_event()` directly, and rewriting an installed copy needs admin traffic,
-	 * an expired transient and a writable mu-plugins directory, none of them
-	 * guaranteed. Remove once a package-version floor rules such a copy out.
-	 *
-	 * Matches `is_proxy_request()` in the MU-plugin template; see PROXY_REQUEST_PATH.
-	 *
-	 * @since 0.18.0
-	 *
-	 * @return bool True when the request shape matches the proxy endpoint.
-	 */
-	public static function is_proxy_tracking_request() {
-		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
-			return false;
-		}
-
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared against a fixed string below; unsanitized on purpose to stay byte-for-byte in step with the MU-plugin template's read.
-		$raw_method = wp_unslash( $_SERVER['REQUEST_METHOD'] );
-		if ( ! is_string( $raw_method ) || 'POST' !== strtoupper( $raw_method ) ) {
-			return false;
-		}
-
-		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
-			return false;
-		}
-
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Parsed and character-restricted below; sanitizing first would mangle the path.
-		$raw_uri = wp_unslash( $_SERVER['REQUEST_URI'] );
-		if ( ! is_string( $raw_uri ) || '' === $raw_uri ) {
-			return false;
-		}
-
-		$path = wp_parse_url( $raw_uri, PHP_URL_PATH );
-		if ( ! is_string( $path ) ) {
-			return false;
-		}
-
-		// Reject anything outside expected URL path characters, matching the template.
-		if ( preg_match( '/[^A-Za-z0-9\-._~\/]/', $path ) ) {
-			return false;
-		}
-
-		$normalized_path = rtrim( $path, '/' );
-		$proxy_suffix    = '/' . ltrim( self::PROXY_REQUEST_PATH, '/' );
-
-		if ( strlen( $normalized_path ) < strlen( $proxy_suffix ) ) {
-			return false;
-		}
-
-		return substr( $normalized_path, -strlen( $proxy_suffix ) ) === $proxy_suffix;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -266,15 +266,25 @@ trait Woo_Analytics_Trait {
 		/**
 		 * Allow defining custom event properties in WooCommerce Analytics.
 		 *
+		 * See `WC_Analytics_Tracking::get_properties()` for the full contract
+		 * around `$is_client_supplied`.
+		 *
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
+		 * @since 0.18.0 Added the `$is_client_supplied` parameter. This call site
+		 *               also began passing `$event_name`, which the hook already had.
 		 *
-		 * @param array $properties Array of event props to be filtered.
+		 * @param array  $properties Array of event props to be filtered.
+		 * @param string $event_name Event name. Empty string here: this call builds
+		 *                           common properties, not properties for a specific event.
+		 * @param bool   $is_client_supplied Whether the props came from an untrusted client.
 		 */
 		$properties = apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
-			$common_properties
+			$common_properties,
+			'',
+			false
 		);
 
 		return $properties;
@@ -298,7 +308,9 @@ trait Woo_Analytics_Trait {
 		/** This filter is documented in src/class-woo-analytics-trait.php */
 		return apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
-			$common_properties
+			$common_properties,
+			'',
+			false
 		);
 	}
 

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -22,7 +22,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.16.3';
+	const PACKAGE_VERSION = '0.18.0';
 
 	/**
 	 * Proxy speed module version option.
@@ -174,8 +174,16 @@ class Woocommerce_Analytics {
 
 	/**
 	 * Register REST API routes.
+	 *
+	 * The tracking proxy endpoint is unauthenticated by design — it exists to
+	 * receive front-end events — so it is registered only while proxy tracking is
+	 * enabled, rather than on every site running the package.
 	 */
 	public static function register_rest_routes() {
+		if ( ! \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ) {
+			return;
+		}
+
 		$controller = new WC_Analytics_Tracking_Proxy();
 		$controller->register_routes();
 	}

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -61,8 +61,8 @@ class WooCommerceAnalyticsProxySpeed {
 	/**
 	 * Check if current request is a proxy request.
 	 *
-	 * Cannot delegate to WC_Analytics_Tracking::is_proxy_tracking_request(): init()
-	 * calls this before load_autoloader(). A test pins both copies together.
+	 * Self-contained on purpose: init() calls this before load_autoloader(), so no
+	 * package class exists yet to delegate to.
 	 *
 	 * @return bool
 	 */

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -61,6 +61,9 @@ class WooCommerceAnalyticsProxySpeed {
 	/**
 	 * Check if current request is a proxy request.
 	 *
+	 * Cannot delegate to WC_Analytics_Tracking::is_proxy_tracking_request(): init()
+	 * calls this before load_autoloader(). A test pins both copies together.
+	 *
 	 * @return bool
 	 */
 	private function is_proxy_request() {
@@ -115,6 +118,13 @@ class WooCommerceAnalyticsProxySpeed {
 
 		if ( ! class_exists( '\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking' ) ) {
 			error_log( 'WooCommerce Analytics Proxy Speed Module: WC_Analytics_Tracking class not found after loading autoloader.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			return false;
+		}
+
+		// The autoloader resolves the highest version across active plugins, which can
+		// be older than the one that wrote this file. Fall back rather than fatal.
+		if ( ! method_exists( '\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking', 'record_client_event' ) ) {
+			error_log( 'WooCommerce Analytics Proxy Speed Module: the loaded WC_Analytics_Tracking predates record_client_event().' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			return false;
 		}
 
@@ -205,7 +215,7 @@ class WooCommerceAnalyticsProxySpeed {
 			$event_name = $event['event_name'] ?? null;
 			$properties = $event['properties'] ?? array();
 
-			if ( ! $event_name || ! is_array( $properties ) ) {
+			if ( ! $event_name || ! is_string( $event_name ) || ! is_array( $properties ) ) {
 				$results[ $index ] = array(
 					'success' => false,
 					'error'   => 'Missing event_name or invalid properties',
@@ -214,7 +224,7 @@ class WooCommerceAnalyticsProxySpeed {
 				continue;
 			}
 
-			$result = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::record_event( $event_name, $properties );
+			$result = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::record_client_event( $event_name, $properties );
 
 			if ( is_wp_error( $result ) ) {
 				$results[ $index ] = array(

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Test.php
@@ -148,6 +148,42 @@ class Universal_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Universal consumes Woo_Analytics_Trait, whose get_common_properties()
+	 * and get_page_common_properties() both fire
+	 * jetpack_woocommerce_analytics_event_props with three arguments. A
+	 * callback registered with accepted_args = 3 used to fatal with an
+	 * ArgumentCountError because both call sites passed only one argument;
+	 * this pins the fix and the exact values passed ('' for the event name,
+	 * since neither call builds properties for a specific event, and false
+	 * for is_client_supplied, since neither is on the proxy path).
+	 */
+	public function test_trait_filter_call_sites_pass_empty_event_name_and_false_client_flag(): void {
+		$seen     = array();
+		$callback = function ( $props, $event_name, $is_client_supplied ) use ( &$seen ) {
+			$seen[] = array( $event_name, $is_client_supplied );
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10, 3 );
+
+		try {
+			$universal = new Universal();
+			$universal->get_common_properties();
+			$universal->get_page_common_properties();
+		} finally {
+			remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10 );
+		}
+
+		$this->assertSame(
+			array(
+				array( '', false ),
+				array( '', false ),
+			),
+			$seen,
+			'Both trait call sites must invoke the filter with an empty-string event name and a false client-supplied flag, without fataling.'
+		);
+	}
+
+	/**
 	 * Reset the WC_Analytics_Tracking::$pixel_batch_queue static so each
 	 * test starts from a known-empty state.
 	 */

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Tests for the tracking proxy REST route.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use Automattic\Woocommerce_Analytics;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests that the proxy route only exists where proxy tracking is enabled, and
+ * that dispatching a request through it goes through the untrusted-client
+ * entry point rather than the trusted one.
+ */
+class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
+
+	/**
+	 * Route path as registered with the REST server.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/woocommerce-analytics/v1/track';
+
+	/**
+	 * Snapshot of $_SERVER taken in set_up(), restored in tear_down(). The
+	 * dispatch test below controls REQUEST_METHOD/REQUEST_URI to keep the
+	 * request-shape guard in WC_Analytics_Tracking::record_event() inactive,
+	 * so a passing test can only be explained by the REST controller's own
+	 * call to record_client_event().
+	 *
+	 * @var array
+	 */
+	private $server_snapshot = array();
+
+	/**
+	 * Start each test with a clean REST server and no feature filters.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		$GLOBALS['wp_rest_server'] = null;
+		$this->server_snapshot     = $_SERVER;
+		$this->reset_pixel_batch_queue();
+	}
+
+	/**
+	 * Leave no REST server, filters, $_SERVER/$_COOKIE mutation, or queued
+	 * pixel behind. Runs unconditionally regardless of the test outcome, so a
+	 * failed assertion mid-test cannot leak the tk_ai cookie set by the
+	 * dispatch test into the next test.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		$GLOBALS['wp_rest_server'] = null;
+		$_SERVER                   = $this->server_snapshot;
+		unset( $_COOKIE['tk_ai'] );
+		$this->reset_pixel_batch_queue();
+		parent::tear_down();
+	}
+
+	/**
+	 * Read the queued pixel URLs via reflection, as
+	 * WC_Analytics_Tracking_Reserved_Props_Test does.
+	 *
+	 * @return array
+	 */
+	private function get_pixel_batch_queue(): array {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
+
+	/**
+	 * Clear the queued pixel URLs and every per-request memo, so one test's
+	 * cookie, IP or event cannot leak into the next. `cached_ip` in particular
+	 * survives the whole PHP process, so a test that never set REMOTE_ADDR would
+	 * otherwise pin '' for every test after it.
+	 */
+	private function reset_pixel_batch_queue(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+
+		$property = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+
+		$ip = $reflection->getProperty( 'cached_ip' );
+		$ip->setAccessible( true );
+		$ip->setValue( null, null );
+
+		$reserved = $reflection->getProperty( 'reserved_property_names' );
+		$reserved->setAccessible( true );
+		$reserved->setValue( null, null );
+
+		$visitor = $reflection->getProperty( 'cached_visitor_id' );
+		$visitor->setAccessible( true );
+		$visitor->setValue( null, null );
+	}
+
+	/**
+	 * Parse the query string of the single queued pixel into an array.
+	 *
+	 * @return array
+	 */
+	private function get_queued_pixel_props(): array {
+		$queue = $this->get_pixel_batch_queue();
+		$this->assertCount( 1, $queue, 'Expected exactly one queued pixel.' );
+
+		$query = wp_parse_url( $queue[0], PHP_URL_QUERY );
+		$props = array();
+		parse_str( (string) $query, $props );
+
+		return $props;
+	}
+
+	/**
+	 * The endpoint is unauthenticated by design, so it must not exist on the
+	 * sites that never opted into proxy tracking — which is every site, by
+	 * default.
+	 */
+	public function test_route_is_not_registered_when_proxy_tracking_is_disabled(): void {
+		Woocommerce_Analytics::register_rest_routes();
+
+		$this->assertArrayNotHasKey( self::ROUTE, rest_get_server()->get_routes() );
+	}
+
+	/**
+	 * The endpoint still exists where the feature is on, otherwise the client
+	 * has nowhere to post.
+	 */
+	public function test_route_is_registered_when_proxy_tracking_is_enabled(): void {
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		Woocommerce_Analytics::register_rest_routes();
+
+		$this->assertArrayHasKey( self::ROUTE, rest_get_server()->get_routes() );
+	}
+
+	/**
+	 * The security boundary is WC_Analytics_Tracking::record_client_event(),
+	 * not the request-shape guard in record_event() — that guard is documented
+	 * as a removable net for stale MU-plugin copies. This test proves the
+	 * controller itself goes through record_client_event() by dispatching a
+	 * real WP_REST_Request through the REST server with $_SERVER deliberately
+	 * shaped so the guard does NOT match (REQUEST_URI is the genuine
+	 * `?rest_route=` form, whose parsed path is `/` — see
+	 * non_proxy_request_provider() in WC_Analytics_Tracking_Reserved_Props_Test).
+	 * On a plain-permalink site this is exactly what `rest_url()` produces, so
+	 * it is also the realistic shape, not a contrived one.
+	 *
+	 * If WC_Analytics_Tracking_Proxy::track_events() is ever changed to call
+	 * record_event() instead of record_client_event(), this is the only test
+	 * that fails: every other test in the suite drives record_client_event()
+	 * or record_event() directly rather than through a real REST dispatch, so
+	 * none of them would catch a silent revert on a plain-permalink site.
+	 */
+	public function test_track_events_strips_reserved_properties_through_the_rest_route(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		// Seeded so the assertions below prove the server's value replaced the
+		// forged one. Unseeded, store_id is absent from the pixel entirely and
+		// _via_ip is '', so an assertNotSame() would pass on absence alone.
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::register_rest_routes();
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'event_name' => 'add_to_cart',
+					'properties' => array(
+						'store_id' => 'someone-elses-store',
+						'_via_ip'  => '8.8.8.8',
+						'pi'       => 42,
+					),
+				)
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'store_id must be the server value, not merely absent.' );
+		$this->assertSame( '203.0.113.7', $props['_via_ip'] ?? null, '_via_ip must be the server value, not merely absent.' );
+		$this->assertSame( '42', $props['pi'] ?? null, 'Event-specific properties must still survive.' );
+	}
+
+	/**
+	 * The route being absent from get_routes() is a white-box fact; what actually
+	 * has to hold is that a POST arriving anyway records nothing.
+	 */
+	public function test_post_records_nothing_on_a_site_that_never_enabled_proxy_tracking(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		// No filter: proxy tracking is off: proxy tracking has never been on here.
+		Woocommerce_Analytics::register_rest_routes();
+
+		$response = rest_do_request( $this->build_track_request() );
+
+		$this->assertSame( 404, $response->get_status(), 'A site that never used proxy tracking must not expose the endpoint.' );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued when the route is gated off.' );
+	}
+
+	/**
+	 * A single valid event, for the tests that only care about the response.
+	 *
+	 * @return \WP_REST_Request
+	 */
+	private function build_track_request(): \WP_REST_Request {
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'event_name' => 'add_to_cart',
+					'properties' => array( 'pi' => 42 ),
+				)
+			)
+		);
+
+		return $request;
+	}
+
+	/**
+	 * The batch loop is the controller's main path, and the memoized reserved
+	 * list is justified by batches specifically — so a later event in the same
+	 * request must still be stripped. Also covers the 207 partial-failure branch,
+	 * which nothing else exercises.
+	 */
+	public function test_batch_strips_every_event_and_reports_per_event_results(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::register_rest_routes();
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					// No event_name: must fail on its own without aborting the batch.
+					array( 'properties' => array( 'pi' => 1 ) ),
+					array(
+						'event_name' => 'add_to_cart',
+						'properties' => array(
+							'store_id' => 'someone-elses-store',
+							'pi'       => 2,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 207, $response->get_status() );
+		$this->assertFalse( $data['results'][0]['success'] );
+		$this->assertTrue( $data['results'][1]['success'] );
+
+		$props = $this->get_queued_pixel_props();
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'The memoized reserved list must still strip on a later event in the batch.' );
+		$this->assertSame( '2', $props['pi'] ?? null );
+	}
+
+}

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -42,13 +42,13 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Clear the memoized reserved-name list after each test.
+	 * Reset the process-global state WorDBless does not.
 	 *
-	 * Runs unconditionally regardless of the test outcome, so a seeded
-	 * `woocommerce_store_id` option, the blog-details transient, or the cached
-	 * IP address set up for one test (to prove substitution rather than mere
-	 * absence, see test_record_client_event_drops_client_supplied_server_properties())
-	 * cannot leak into the next test even if an assertion fails first.
+	 * Options and transients are cleared by `BaseTestCase`, so the seeded
+	 * `woocommerce_store_id` is already handled. The memoized reserved-name list,
+	 * the pixel queue and the cached IP are static properties WorDBless never
+	 * sees, and they would otherwise carry one test's environment into the next.
+	 * Runs unconditionally, so a failed assertion cannot skip the reset.
 	 */
 	public function tear_down(): void {
 		$_SERVER = $this->server_snapshot;

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -18,12 +18,10 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	/**
 	 * Snapshot of $_SERVER taken in set_up(), restored in tear_down().
 	 *
-	 * Several tests mutate REQUEST_METHOD/REQUEST_URI to exercise
-	 * is_proxy_tracking_request(). Restoring the full array — rather than
-	 * unset()-ing the specific keys a test touched — puts back whatever the
-	 * WordPress bootstrap actually populated (e.g. REQUEST_URI defaults to
-	 * '', not "absent"), and does so from tear_down() so a failed assertion
-	 * mid-test cannot skip cleanup and leak state into the next test.
+	 * Restoring the full array — rather than unset()-ing the specific keys a
+	 * test touched — puts back whatever the WordPress bootstrap actually
+	 * populated, and does so from tear_down() so a failed assertion mid-test
+	 * cannot skip cleanup and leak state into the next test.
 	 *
 	 * @var array
 	 */
@@ -320,142 +318,6 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Simulates a stale MU-plugin copy: it calls record_event() with no flag,
-	 * during a POST to the track endpoint. The guard must strip anyway.
-	 *
-	 * `woocommerce_store_id` is seeded so the assertion proves the server's value
-	 * replaced the forged one. Without it the property is absent from the pixel
-	 * entirely — `get_option()` returns null and `http_build_query()` drops nulls
-	 * — and an assertNotSame() would pass on absence alone.
-	 */
-	public function test_record_event_strips_during_a_proxy_request(): void {
-		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = '/wp-json/woocommerce-analytics/v1/track';
-		update_option( 'woocommerce_store_id', 'real-store-id' );
-		$this->reset_pixel_batch_queue();
-
-		WC_Analytics_Tracking::record_event(
-			'add_to_cart',
-			array( 'store_id' => 'someone-elses-store' )
-		);
-
-		$props = $this->get_queued_pixel_props();
-
-		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'The server value must replace the forged one, not merely be absent.' );
-	}
-
-	/**
-	 * The over-stripping guard. If the path or method test is ever loosened,
-	 * this is what fails — trusted server-side callers must keep their
-	 * properties on every request that is not a proxy POST.
-	 *
-	 * @dataProvider non_proxy_request_provider
-	 *
-	 * @param string $method Request method.
-	 * @param string $uri    Request URI.
-	 */
-	public function test_record_event_does_not_strip_outside_a_proxy_request( string $method, string $uri ): void {
-		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
-		$_SERVER['REQUEST_METHOD'] = $method;
-		$_SERVER['REQUEST_URI']    = $uri;
-		$this->reset_pixel_batch_queue();
-
-		WC_Analytics_Tracking::record_event(
-			'add_to_cart',
-			array( 'store_id' => 'set-by-trusted-caller' )
-		);
-
-		$props = $this->get_queued_pixel_props();
-
-		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] ?? null );
-
-		$this->reset_pixel_batch_queue();
-		unset( $_COOKIE['tk_ai'] );
-	}
-
-	/**
-	 * Requests that must not trigger the guard.
-	 *
-	 * The `?rest_route=` case is load-bearing, not incidental: on a
-	 * plain-permalink site `rest_url()` produces exactly this shape, whose
-	 * parsed path is `/`, so the guard correctly does not match it — and
-	 * neither does `WooCommerceAnalyticsProxySpeed::is_proxy_request()` in the
-	 * MU-plugin template. The two copies agreeing here is what keeps a stale
-	 * template from intercepting a request this guard would not recognise. On
-	 * such sites `record_client_event()` — not this guard — is the only thing
-	 * stripping reserved properties.
-	 *
-	 * @return array<string, array{0: string, 1: string}>
-	 */
-	public function non_proxy_request_provider(): array {
-		return array(
-			'GET to the track path'          => array( 'GET', '/wp-json/woocommerce-analytics/v1/track' ),
-			'POST to the Store API'          => array( 'POST', '/wp-json/wc/store/v1/checkout' ),
-			'POST to a lookalike suffix'     => array( 'POST', '/wp-json/other/woocommerce-analytics/v1/tracking' ),
-			'POST to the site root'          => array( 'POST', '/' ),
-			'POST with rest_route query var' => array( 'POST', '/?rest_route=/woocommerce-analytics/v1/track' ),
-		);
-	}
-
-	/**
-	 * Shapes that must still match, so the safety net is not defeated by a
-	 * query string, a trailing slash, or a subdirectory install.
-	 *
-	 * @dataProvider proxy_request_shape_provider
-	 *
-	 * @param string $uri Request URI.
-	 */
-	public function test_is_proxy_tracking_request_matches_real_world_shapes( string $uri ): void {
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = $uri;
-
-		$this->assertTrue( WC_Analytics_Tracking::is_proxy_tracking_request(), $uri );
-	}
-
-	/**
-	 * URIs that must match.
-	 *
-	 * Note what is deliberately absent: the genuine `?rest_route=` query-var
-	 * form (e.g. `/?rest_route=/woocommerce-analytics/v1/track`, what
-	 * `rest_url()` produces on a plain-permalink site) does NOT match this
-	 * guard — its parsed path is just `/`. That is covered as a non-matching
-	 * case in non_proxy_request_provider(), not here.
-	 *
-	 * @return array<string, array{0: string}>
-	 */
-	public function proxy_request_shape_provider(): array {
-		return array(
-			'plain'                                    => array( '/wp-json/woocommerce-analytics/v1/track' ),
-			'trailing slash'                           => array( '/wp-json/woocommerce-analytics/v1/track/' ),
-			'query string'                             => array( '/wp-json/woocommerce-analytics/v1/track?_wpnonce=abc123' ),
-			'subdirectory'                             => array( '/shop/wp-json/woocommerce-analytics/v1/track' ),
-			'index.php-prefixed pretty-permalink form' => array( '/index.php/wp-json/woocommerce-analytics/v1/track' ),
-		);
-	}
-
-	/**
-	 * The character restriction on the path must reject anything outside the
-	 * allowed set, matching the MU-plugin template's is_proxy_request(). This
-	 * is the one piece of the "kept in step with the template" claim that was
-	 * previously covered only by inspection, not by an assertion.
-	 *
-	 * The disallowed '%' sits mid-path, not at the end, on purpose: the path
-	 * still ends with the exact proxy suffix, so the suffix comparison alone
-	 * would accept this request. Only the character-restriction check can
-	 * reject it. A trailing disallowed character (e.g. a suffix of
-	 * "/track%20") would also break the suffix match by itself, so it would
-	 * return false regardless of whether the character check exists — that
-	 * shape cannot isolate the regex, and must not be used here.
-	 */
-	public function test_is_proxy_tracking_request_rejects_disallowed_characters(): void {
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = '/wp%20json/woocommerce-analytics/v1/track';
-
-		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
-	}
-
-	/**
 	 * A callback that assigns unconditionally beats a client value of the same
 	 * name. This is the pattern the filter docblock tells extensions to use.
 	 */
@@ -628,86 +490,13 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The guard's defensive early returns, none of which a data provider typed
-	 * `string` can reach. WorDBless leaves REQUEST_METHOD absent and REQUEST_URI
-	 * empty, so without this the `! isset()` branches are never executed and
-	 * could be deleted with the suite still green.
-	 *
-	 * @dataProvider malformed_request_provider
-	 *
-	 * @param array $server Superglobal overrides; a null value means unset the key.
-	 */
-	public function test_is_proxy_tracking_request_is_false_for_malformed_requests( array $server ): void {
-		foreach ( $server as $key => $value ) {
-			if ( null === $value ) {
-				unset( $_SERVER[ $key ] );
-				continue;
-			}
-			$_SERVER[ $key ] = $value;
-		}
-
-		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
-	}
-
-	/**
-	 * Malformed request shapes that must not reach the suffix comparison.
-	 *
-	 * @return array<string, array{0: array}>
-	 */
-	public function malformed_request_provider(): array {
-		$uri = '/wp-json/woocommerce-analytics/v1/track';
-
-		return array(
-			'no REQUEST_METHOD (WP-CLI, cron)' => array(
-				array(
-					'REQUEST_METHOD' => null,
-					'REQUEST_URI'    => $uri,
-				),
-			),
-			'no REQUEST_URI'                   => array(
-				array(
-					'REQUEST_METHOD' => 'POST',
-					'REQUEST_URI'    => null,
-				),
-			),
-			'empty REQUEST_URI'                => array(
-				array(
-					'REQUEST_METHOD' => 'POST',
-					'REQUEST_URI'    => '',
-				),
-			),
-			'non-string REQUEST_URI'           => array(
-				array(
-					'REQUEST_METHOD' => 'POST',
-					'REQUEST_URI'    => array( $uri ),
-				),
-			),
-		);
-	}
-
-	/**
-	 * The two copies of the request-shape logic must not drift: the template's
-	 * copy is the first thing that decides whether a request is a proxy POST, it
-	 * runs before the autoloader so it cannot delegate, and nothing else in the
-	 * suite executes it. Asserting on the source text is crude, but it is the
-	 * only thing standing behind the "Change both together" comments.
+	 * The template must record through the untrusted-client entry point. Nothing
+	 * in the suite executes the template, so asserting on its source text is
+	 * crude, but it is the only thing standing behind that requirement.
 	 */
 	public function test_mu_plugin_template_stays_in_step_with_the_package(): void {
 		$template = file_get_contents(
 			dirname( __DIR__, 2 ) . '/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php'
-		);
-
-		$this->assertSame(
-			1,
-			preg_match( "/const PROXY_REQUEST_PATH = '([^']+)';/", $template, $matches ),
-			'The template must declare PROXY_REQUEST_PATH.'
-		);
-		$this->assertSame( WC_Analytics_Tracking::PROXY_REQUEST_PATH, $matches[1] );
-
-		$this->assertStringContainsString(
-			'preg_match( \'/[^A-Za-z0-9\-._~\/]/\', $path )',
-			$template,
-			'The template must keep the same character restriction as is_proxy_tracking_request().'
 		);
 
 		$this->assertStringContainsString(

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -1,0 +1,724 @@
+<?php
+/**
+ * Tests for the reserved-property set that keeps client-supplied event
+ * properties from overriding the ones the server derives.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for WC_Analytics_Tracking reserved property handling.
+ */
+class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
+
+	/**
+	 * Snapshot of $_SERVER taken in set_up(), restored in tear_down().
+	 *
+	 * Several tests mutate REQUEST_METHOD/REQUEST_URI to exercise
+	 * is_proxy_tracking_request(). Restoring the full array — rather than
+	 * unset()-ing the specific keys a test touched — puts back whatever the
+	 * WordPress bootstrap actually populated (e.g. REQUEST_URI defaults to
+	 * '', not "absent"), and does so from tear_down() so a failed assertion
+	 * mid-test cannot skip cleanup and leak state into the next test.
+	 *
+	 * @var array
+	 */
+	private $server_snapshot = array();
+
+	/**
+	 * Clear the memoized reserved-name list before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->server_snapshot = $_SERVER;
+		$this->reset_reserved_property_names();
+		$this->reset_pixel_batch_queue();
+		$this->reset_cached_ip();
+		delete_transient( 'wc_analytics_blog_details' );
+	}
+
+	/**
+	 * Clear the memoized reserved-name list after each test.
+	 *
+	 * Runs unconditionally regardless of the test outcome, so a seeded
+	 * `woocommerce_store_id` option, the blog-details transient, or the cached
+	 * IP address set up for one test (to prove substitution rather than mere
+	 * absence, see test_record_client_event_drops_client_supplied_server_properties())
+	 * cannot leak into the next test even if an assertion fails first.
+	 */
+	public function tear_down(): void {
+		$_SERVER = $this->server_snapshot;
+		unset( $_COOKIE['tk_ai'] );
+		$this->reset_reserved_property_names();
+		$this->reset_pixel_batch_queue();
+		$this->reset_cached_ip();
+		delete_transient( 'wc_analytics_blog_details' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The memo persists for the life of the PHP process, so tests must clear it
+	 * or the first test's environment leaks into every later one.
+	 */
+	private function reset_reserved_property_names(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'reserved_property_names' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Pins the effective reserved set. This test exists to fail: adding a
+	 * property to get_session_properties(), get_page_common_properties() or
+	 * get_server_details() must force a deliberate decision about whether a
+	 * client may set it, rather than silently inheriting protection or silently
+	 * missing out on it.
+	 */
+	public function test_reserved_property_names_match_the_documented_set(): void {
+		$expected = array(
+			// get_session_properties().
+			'session_id',
+			'landing_page',
+			'is_engaged',
+			// get_page_common_properties().
+			'ui',
+			'blog_id',
+			'store_id',
+			'url',
+			'woo_version',
+			'wp_version',
+			'store_admin',
+			'device',
+			'store_currency',
+			'timezone',
+			'is_guest',
+			// get_server_details(), minus CLIENT_OVERRIDABLE_PROPERTIES.
+			'_via_ua',
+			'_via_ip',
+			'_via_ref',
+			// Identity and envelope.
+			'_ui',
+			'_ut',
+			'_en',
+			'_ts',
+			'browser_type',
+		);
+
+		$actual = WC_Analytics_Tracking::get_reserved_property_names();
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * The three properties the client is authoritative for must not be
+	 * reserved: on the proxy path the server's values describe the /track
+	 * request, not the page the event happened on.
+	 */
+	public function test_client_overridable_properties_are_not_reserved(): void {
+		$reserved = WC_Analytics_Tracking::get_reserved_property_names();
+
+		$this->assertNotContains( '_lg', $reserved );
+		$this->assertNotContains( '_dl', $reserved );
+		$this->assertNotContains( '_dr', $reserved );
+	}
+
+	/**
+	 * The strip removes reserved names and leaves everything else — including
+	 * arbitrary event-specific properties — untouched.
+	 */
+	public function test_strip_removes_reserved_names_only(): void {
+		$stripped = WC_Analytics_Tracking::strip_reserved_properties(
+			array(
+				'_via_ip'     => '8.8.8.8',
+				'store_id'    => 'someone-elses-store',
+				'blog_id'     => 12345,
+				'session_id'  => 'forged-session',
+				'store_admin' => 1,
+				'is_guest'    => 0,
+				'_ui'         => 'forged-visitor',
+				'_lg'         => 'en-GB',
+				'_dl'         => 'https://example.com/product/thing',
+				'_dr'         => 'https://example.com/',
+				'pi'          => 42,
+				'pq'          => 2,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'_lg' => 'en-GB',
+				'_dl' => 'https://example.com/product/thing',
+				'_dr' => 'https://example.com/',
+				'pi'  => 42,
+				'pq'  => 2,
+			),
+			$stripped
+		);
+	}
+
+	/**
+	 * Defensive: the REST body is attacker-shaped, so a non-array or empty
+	 * value must not fatal.
+	 */
+	public function test_strip_handles_empty_and_non_array_input(): void {
+		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( array() ) );
+		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( 'not-an-array' ) );
+		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( null ) );
+	}
+
+	/**
+	 * Read the queued pixel URLs. record_event() queues rather than sends when
+	 * the Requests library supports request_multiple(), which it does here.
+	 *
+	 * @return array
+	 */
+	private function get_pixel_batch_queue(): array {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
+
+	/**
+	 * Clear the queued pixel URLs and the cached visitor id, so one test's
+	 * cookie cannot leak into the next.
+	 */
+	private function reset_pixel_batch_queue(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+
+		$property = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+
+		$visitor = $reflection->getProperty( 'cached_visitor_id' );
+		$visitor->setAccessible( true );
+		$visitor->setValue( null, null );
+	}
+
+	/**
+	 * Clear the cached IP address, so a REMOTE_ADDR seeded for one test cannot
+	 * leak into the next: get_user_ip_address() memoizes its result for the
+	 * life of the PHP process.
+	 */
+	private function reset_cached_ip(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'cached_ip' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Parse the query string of the single queued pixel into an array.
+	 *
+	 * @return array
+	 */
+	private function get_queued_pixel_props(): array {
+		$queue = $this->get_pixel_batch_queue();
+		$this->assertCount( 1, $queue, 'Expected exactly one queued pixel.' );
+
+		$query = wp_parse_url( $queue[0], PHP_URL_QUERY );
+		$props = array();
+		parse_str( (string) $query, $props );
+
+		return $props;
+	}
+
+	/**
+	 * A client that posts server-owned properties must not see them reach the
+	 * pixel. This is the core of WOOA7S-1803.
+	 *
+	 * Both `store_id` and `_via_ip` are seeded with a real server-derived value
+	 * before the call, so the assertions prove the server's value replaced the
+	 * client's forged one, not merely that the forged one is absent. Under
+	 * WorDBless, `get_option( 'woocommerce_store_id', null )` is null and
+	 * `http_build_query()` drops null values, so an assertNotSame() against an
+	 * unseeded environment would pass on absence alone and miss a stripped-but-
+	 * not-substituted bug.
+	 */
+	public function test_record_client_event_drops_client_supplied_server_properties(): void {
+		$_COOKIE['tk_ai']       = 'test-visitor-id-1234567890ab';
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'_via_ip'  => '8.8.8.8',
+				'store_id' => 'someone-elses-store',
+				'_ui'      => 'forged-visitor',
+				'pi'       => 42,
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( '203.0.113.7', $props['_via_ip'] ?? null, '_via_ip must come from the server (REMOTE_ADDR), not the client.' );
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'store_id must come from the server (woocommerce_store_id option), not the client.' );
+		$this->assertSame( 'test-visitor-id-1234567890ab', $props['_ui'] ?? null, '_ui must come from the tk_ai cookie.' );
+		$this->assertSame( '42', $props['pi'] ?? null, 'Event-specific properties must survive.' );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * The three client-authoritative properties must survive to the pixel,
+	 * otherwise proxy-mode page attribution breaks: the server's values would
+	 * describe the /track request instead of the page.
+	 */
+	public function test_record_client_event_keeps_client_authoritative_properties(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'_lg' => 'en-GB',
+				'_dl' => 'https://example.com/product/thing',
+				'_dr' => 'https://example.com/',
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'en-GB', $props['_lg'] ?? null );
+		$this->assertSame( 'https://example.com/product/thing', $props['_dl'] ?? null );
+		$this->assertSame( 'https://example.com/', $props['_dr'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * The trusted path is unchanged: a server-side caller can still set a
+	 * property that collides with a common one. Universal and My_Account rely
+	 * on record_event() keeping these semantics.
+	 */
+	public function test_record_event_leaves_trusted_caller_properties_alone(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'store_id' => 'set-by-trusted-caller' )
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * Simulates a stale MU-plugin copy: it calls record_event() with no flag,
+	 * during a POST to the track endpoint. The guard must strip anyway.
+	 *
+	 * `woocommerce_store_id` is seeded so the assertion proves the server's value
+	 * replaced the forged one. Without it the property is absent from the pixel
+	 * entirely — `get_option()` returns null and `http_build_query()` drops nulls
+	 * — and an assertNotSame() would pass on absence alone.
+	 */
+	public function test_record_event_strips_during_a_proxy_request(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/woocommerce-analytics/v1/track';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'store_id' => 'someone-elses-store' )
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'The server value must replace the forged one, not merely be absent.' );
+	}
+
+	/**
+	 * The over-stripping guard. If the path or method test is ever loosened,
+	 * this is what fails — trusted server-side callers must keep their
+	 * properties on every request that is not a proxy POST.
+	 *
+	 * @dataProvider non_proxy_request_provider
+	 *
+	 * @param string $method Request method.
+	 * @param string $uri    Request URI.
+	 */
+	public function test_record_event_does_not_strip_outside_a_proxy_request( string $method, string $uri ): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = $method;
+		$_SERVER['REQUEST_URI']    = $uri;
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'store_id' => 'set-by-trusted-caller' )
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * Requests that must not trigger the guard.
+	 *
+	 * The `?rest_route=` case is load-bearing, not incidental: on a
+	 * plain-permalink site `rest_url()` produces exactly this shape, whose
+	 * parsed path is `/`, so the guard correctly does not match it — and
+	 * neither does `WooCommerceAnalyticsProxySpeed::is_proxy_request()` in the
+	 * MU-plugin template. The two copies agreeing here is what keeps a stale
+	 * template from intercepting a request this guard would not recognise. On
+	 * such sites `record_client_event()` — not this guard — is the only thing
+	 * stripping reserved properties.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function non_proxy_request_provider(): array {
+		return array(
+			'GET to the track path'          => array( 'GET', '/wp-json/woocommerce-analytics/v1/track' ),
+			'POST to the Store API'          => array( 'POST', '/wp-json/wc/store/v1/checkout' ),
+			'POST to a lookalike suffix'     => array( 'POST', '/wp-json/other/woocommerce-analytics/v1/tracking' ),
+			'POST to the site root'          => array( 'POST', '/' ),
+			'POST with rest_route query var' => array( 'POST', '/?rest_route=/woocommerce-analytics/v1/track' ),
+		);
+	}
+
+	/**
+	 * Shapes that must still match, so the safety net is not defeated by a
+	 * query string, a trailing slash, or a subdirectory install.
+	 *
+	 * @dataProvider proxy_request_shape_provider
+	 *
+	 * @param string $uri Request URI.
+	 */
+	public function test_is_proxy_tracking_request_matches_real_world_shapes( string $uri ): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = $uri;
+
+		$this->assertTrue( WC_Analytics_Tracking::is_proxy_tracking_request(), $uri );
+	}
+
+	/**
+	 * URIs that must match.
+	 *
+	 * Note what is deliberately absent: the genuine `?rest_route=` query-var
+	 * form (e.g. `/?rest_route=/woocommerce-analytics/v1/track`, what
+	 * `rest_url()` produces on a plain-permalink site) does NOT match this
+	 * guard — its parsed path is just `/`. That is covered as a non-matching
+	 * case in non_proxy_request_provider(), not here.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function proxy_request_shape_provider(): array {
+		return array(
+			'plain'                                    => array( '/wp-json/woocommerce-analytics/v1/track' ),
+			'trailing slash'                           => array( '/wp-json/woocommerce-analytics/v1/track/' ),
+			'query string'                             => array( '/wp-json/woocommerce-analytics/v1/track?_wpnonce=abc123' ),
+			'subdirectory'                             => array( '/shop/wp-json/woocommerce-analytics/v1/track' ),
+			'index.php-prefixed pretty-permalink form' => array( '/index.php/wp-json/woocommerce-analytics/v1/track' ),
+		);
+	}
+
+	/**
+	 * The character restriction on the path must reject anything outside the
+	 * allowed set, matching the MU-plugin template's is_proxy_request(). This
+	 * is the one piece of the "kept in step with the template" claim that was
+	 * previously covered only by inspection, not by an assertion.
+	 *
+	 * The disallowed '%' sits mid-path, not at the end, on purpose: the path
+	 * still ends with the exact proxy suffix, so the suffix comparison alone
+	 * would accept this request. Only the character-restriction check can
+	 * reject it. A trailing disallowed character (e.g. a suffix of
+	 * "/track%20") would also break the suffix match by itself, so it would
+	 * return false regardless of whether the character check exists — that
+	 * shape cannot isolate the regex, and must not be used here.
+	 */
+	public function test_is_proxy_tracking_request_rejects_disallowed_characters(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp%20json/woocommerce-analytics/v1/track';
+
+		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
+	}
+
+	/**
+	 * A callback that assigns unconditionally beats a client value of the same
+	 * name. This is the pattern the filter docblock tells extensions to use.
+	 */
+	public function test_filter_callback_assigning_unconditionally_beats_the_client(): void {
+		$callback = function ( $props ) {
+			$props['partner_tier'] = 'gold';
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'partner_tier' => 'forged' ),
+			true
+		);
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$this->assertSame( 'gold', $props['partner_tier'] );
+	}
+
+	/**
+	 * The known limitation, asserted so it is a recorded decision rather than an
+	 * assumption: a callback that defers to an existing value loses to the
+	 * client, because the reserved set cannot cover names the filter invents.
+	 * If this ever starts passing, the limitation has been closed and the spec
+	 * needs updating.
+	 */
+	public function test_filter_callback_deferring_to_an_existing_value_loses_to_the_client(): void {
+		$callback = function ( $props ) {
+			$props['partner_tier'] = isset( $props['partner_tier'] ) ? $props['partner_tier'] : 'gold';
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'partner_tier' => 'forged' ),
+			true
+		);
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$this->assertSame( 'forged', $props['partner_tier'], 'Known limitation: see the spec.' );
+	}
+
+	/**
+	 * The third argument tells a callback whether the properties it is looking
+	 * at came from an untrusted client, which is the only way it can know to
+	 * assign unconditionally.
+	 */
+	public function test_filter_receives_the_client_supplied_flag(): void {
+		$seen     = array();
+		$callback = function ( $props, $event_name, $is_client_supplied ) use ( &$seen ) {
+			$seen[] = array( $event_name, $is_client_supplied );
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10, 3 );
+
+		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_add_to_cart', array(), true );
+		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', array(), false );
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10 );
+
+		$this->assertSame(
+			array(
+				array( 'woocommerceanalytics_add_to_cart', true ),
+				array( 'woocommerceanalytics_product_view', false ),
+			),
+			$seen
+		);
+	}
+
+	/**
+	 * A callback that defers to an existing value hands a *reserved* property
+	 * straight back to the client that supplied it. The strip runs before the
+	 * filter, so it cannot see this; get_properties() re-asserts the server's
+	 * values afterwards. Contrast with
+	 * test_filter_callback_deferring_to_an_existing_value_loses_to_the_client(),
+	 * which covers a name the filter invents — still the client's to win.
+	 */
+	public function test_filter_callback_cannot_hand_a_reserved_property_back_to_the_client(): void {
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		$callback = function ( $props ) {
+			$props['store_id'] = isset( $props['store_id'] ) ? $props['store_id'] : 'unused';
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'store_id' => 'someone-elses-store' ),
+			true
+		);
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$this->assertSame( 'real-store-id', $props['store_id'] );
+	}
+
+	/**
+	 * The trusted path must keep its escape hatch: a server-side caller can still
+	 * set a property that collides with a common one, and the post-filter
+	 * re-assertion must not take that away.
+	 */
+	public function test_reserved_properties_are_not_re_asserted_for_trusted_callers(): void {
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'store_id' => 'set-by-trusted-caller' ),
+			false
+		);
+
+		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] );
+	}
+
+	/**
+	 * `_ts` is in $required_properties and in RESERVED_IDENTITY_PROPERTIES, so a
+	 * client cannot forge the event timestamp at either layer.
+	 */
+	public function test_client_cannot_forge_the_event_timestamp(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'_ts' => '1',
+				'pi'  => 42,
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertMatchesRegularExpression( '/^\d{13}$/', (string) ( $props['_ts'] ?? '' ), '_ts must be the server timestamp.' );
+	}
+
+	/**
+	 * A JSON array survives the consumers' truthiness check and reaches
+	 * `PREFIX . $event_name`, where PHP writes a warning to the log on an
+	 * unauthenticated request. `failOnWarning` makes that warning fail the test.
+	 *
+	 * @dataProvider unusable_client_event_name_provider
+	 *
+	 * @param mixed $event_name Name a client could post.
+	 */
+	public function test_client_events_with_an_unusable_name_are_dropped( $event_name ): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		$result = WC_Analytics_Tracking::record_client_event( $event_name, array( 'pi' => 42 ) );
+
+		$this->assertTrue( is_wp_error( $result ), 'Reporting success for an event that produced no pixel is what hides the loss.' );
+		$this->assertSame( 'invalid_event_name', $result->get_error_code() );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued for an unusable event name.' );
+	}
+
+	/**
+	 * Names a client could post that cannot become an `_en` value.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function unusable_client_event_name_provider(): array {
+		return array(
+			'array'      => array( array( 'product_view' ) ),
+			'nested map' => array( array( 'name' => 'product_view' ) ),
+			'empty'      => array( '' ),
+		);
+	}
+
+	/**
+	 * The guard's defensive early returns, none of which a data provider typed
+	 * `string` can reach. WorDBless leaves REQUEST_METHOD absent and REQUEST_URI
+	 * empty, so without this the `! isset()` branches are never executed and
+	 * could be deleted with the suite still green.
+	 *
+	 * @dataProvider malformed_request_provider
+	 *
+	 * @param array $server Superglobal overrides; a null value means unset the key.
+	 */
+	public function test_is_proxy_tracking_request_is_false_for_malformed_requests( array $server ): void {
+		foreach ( $server as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+				continue;
+			}
+			$_SERVER[ $key ] = $value;
+		}
+
+		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
+	}
+
+	/**
+	 * Malformed request shapes that must not reach the suffix comparison.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function malformed_request_provider(): array {
+		$uri = '/wp-json/woocommerce-analytics/v1/track';
+
+		return array(
+			'no REQUEST_METHOD (WP-CLI, cron)' => array(
+				array(
+					'REQUEST_METHOD' => null,
+					'REQUEST_URI'    => $uri,
+				),
+			),
+			'no REQUEST_URI'                   => array(
+				array(
+					'REQUEST_METHOD' => 'POST',
+					'REQUEST_URI'    => null,
+				),
+			),
+			'empty REQUEST_URI'                => array(
+				array(
+					'REQUEST_METHOD' => 'POST',
+					'REQUEST_URI'    => '',
+				),
+			),
+			'non-string REQUEST_URI'           => array(
+				array(
+					'REQUEST_METHOD' => 'POST',
+					'REQUEST_URI'    => array( $uri ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * The two copies of the request-shape logic must not drift: the template's
+	 * copy is the first thing that decides whether a request is a proxy POST, it
+	 * runs before the autoloader so it cannot delegate, and nothing else in the
+	 * suite executes it. Asserting on the source text is crude, but it is the
+	 * only thing standing behind the "Change both together" comments.
+	 */
+	public function test_mu_plugin_template_stays_in_step_with_the_package(): void {
+		$template = file_get_contents(
+			dirname( __DIR__, 2 ) . '/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php'
+		);
+
+		$this->assertSame(
+			1,
+			preg_match( "/const PROXY_REQUEST_PATH = '([^']+)';/", $template, $matches ),
+			'The template must declare PROXY_REQUEST_PATH.'
+		);
+		$this->assertSame( WC_Analytics_Tracking::PROXY_REQUEST_PATH, $matches[1] );
+
+		$this->assertStringContainsString(
+			'preg_match( \'/[^A-Za-z0-9\-._~\/]/\', $path )',
+			$template,
+			'The template must keep the same character restriction as is_proxy_tracking_request().'
+		);
+
+		$this->assertStringContainsString(
+			'::record_client_event(',
+			$template,
+			'The template must record through the untrusted-client entry point.'
+		);
+		$this->assertStringNotContainsString(
+			'::record_event(',
+			$template,
+			'The template must not call the trusted entry point.'
+		);
+	}
+}

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
@@ -55,6 +55,10 @@ class WC_Analytics_Tracking_Test extends BaseTestCase {
 		$queue = $reflection->getProperty( 'pixel_batch_queue' );
 		$queue->setAccessible( true );
 		$queue->setValue( null, array() );
+
+		$reserved = $reflection->getProperty( 'reserved_property_names' );
+		$reserved->setAccessible( true );
+		$reserved->setValue( null, null );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -140,7 +140,6 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 	 * Test that update is skipped when version matches current package version.
 	 */
 	public function test_maybe_update_proxy_speed_module_skips_when_version_matches(): void {
-		// Enable the feature flag so the update path is checked.
 		add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
 
 		// Set version to match current.

--- a/packages/php/woocommerce-analytics/tests/php/bootstrap.php
+++ b/packages/php/woocommerce-analytics/tests/php/bootstrap.php
@@ -17,3 +17,6 @@ require_once __DIR__ . '/mocks/class-wc-tracks.php';
 
 // Initialize WordPress test environment using WorDBless (database-less).
 \WorDBless\Load::load();
+
+// Depends on WP_REST_Controller, so it must come after WorDBless has loaded core.
+require_once __DIR__ . '/mocks/class-wc-rest-controller.php';

--- a/packages/php/woocommerce-analytics/tests/php/mocks/class-wc-rest-controller.php
+++ b/packages/php/woocommerce-analytics/tests/php/mocks/class-wc-rest-controller.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Minimal WC_REST_Controller stub.
+ *
+ * WooCommerce is not loaded under WorDBless, so the real controller base class
+ * is unavailable and anything extending it cannot be instantiated in tests. The
+ * package only relies on the WP_REST_Controller behaviour it inherits, so an
+ * empty subclass is enough.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+if ( ! class_exists( 'WC_REST_Controller' ) ) {
+	/**
+	 * Stub for WooCommerce's REST controller base class.
+	 */
+	class WC_REST_Controller extends WP_REST_Controller {} // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+}


### PR DESCRIPTION
### Submission Review Guidelines:


-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

> [!IMPORTANT]
> First of three stacked PRs replacing #67097. Review and merge in order.
>
> 1. **This PR**: stop the endpoint accepting client-supplied server properties, and register it only where proxy tracking is on.
> 2. #68314: bound how much a client can send.
> 3. #68315: keep the route registered and answer `403` once a site turns the feature off.

**The problem**

`POST /wp-json/woocommerce-analytics/v1/track` is unauthenticated by design and registered on every site running the package. `get_properties()` merges caller-supplied properties **after** the server-derived ones, so a posted `_via_ip`, `session_id`, `blog_id`, `store_id`, `store_admin` or `is_guest` wins over the server's own value.

Anyone can therefore write events into the Tracks / ClickHouse pipeline with attacker-chosen geo, session identity and store identifiers. This is a data-integrity problem for the analytics pipeline, not a site compromise.

**The fix**

-   Add `record_client_event()` as the untrusted entry point: it strips server-derived properties before calling `record_event()`. The REST controller and the MU-plugin speed module both call it.
-   Re-assert the server's own values after `jetpack_woocommerce_analytics_event_props` runs, so a callback that defers to an existing value cannot hand a reserved property back to the client that supplied it.
-   Register the REST route only while `Features::is_proxy_tracking_enabled()` is true, so the unauthenticated surface does not exist on sites that never opted in.
-   Reject a non-string event name at both entry points. An array name previously reached `PREFIX . $event_name` and wrote an `Array to string conversion` warning from an unauthenticated request.
-   Bump `PACKAGE_VERSION` from `0.16.3` to `0.18.0`. It is the only trigger for rewriting an already-installed MU-plugin speed module, and this PR changes the template.

The reserved set is `WC_Analytics_Tracking::get_reserved_property_names()`, derived from `get_common_properties()` rather than restated as a literal. `_lg`, `_dl` and `_dr` stay client-owned on purpose: the server's own values describe the `/track` POST, not the page the event happened on.

WOOA7S-1803's fifth finding (`ch` is client-settable) is not here. Deriving it from site state needs the resolved flag readable at MU-plugin stage, which is the mechanism #68315 introduces, so it ships there. Tracked as WOOA7S-1806.

Closes WOOA7S-1803 findings 1-4.

(For Bug Fixes) Not a regression from a specific PR: the endpoint has behaved this way since proxy tracking was introduced.

### Screenshots or screen recordings:


<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable: no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

Step 1 covers the whole change. Steps 2 to 6 are the manual pass; step 5 matters most, because the MU-plugin speed module has **no execution coverage in the suite** and this PR changes it.

#### 1. Package suite

```bash
cd packages/php/woocommerce-analytics
composer install
XDEBUG_MODE=off ./vendor/bin/phpunit --colors=never
```

#### 2. Setup

You need a store (local or Jurassic Ninja) with WooCommerce active, a plugin that vendors this package active, pretty permalinks and `WP_DEBUG_LOG` on. Allow statistics if a consent plugin is installed. With Jetpack as the host plugin it must be **connected** to WordPress.com, since `should_track_store()` returns early without a connection and `rest_api_init` never runs.

This package does not run from the monorepo directly. It ships as the composer package `automattic/woocommerce-analytics`, vendored inside plugins, so it has to be deployed onto a site. Several active plugins can vendor it and the Jetpack autoloader resolves the **highest version** across all of them, so ask the site over HTTP which copy it loads rather than using `wp eval`, which can resolve differently.

```php
<?php // wp-content/mu-plugins/00-wca-probe.php, delete when done.
add_action( 'init', function () {
	if ( ! isset( $_GET['wca_probe'] ) ) { return; }
	header( 'Content-Type: text/plain' );
	echo ( new ReflectionClass( '\Automattic\Woocommerce_Analytics' ) )->getFileName(), "\n";
	echo 'PACKAGE_VERSION=', \Automattic\Woocommerce_Analytics::PACKAGE_VERSION, "\n";
	exit;
}, 999 );
```

```bash
SITE=https://example.com
curl -s "$SITE/?wca_probe=1"

cd packages/php/woocommerce-analytics
rsync -a --delete --exclude client/ src/ "<the path printed above>/../src/"

curl -s "$SITE/?wca_probe=1"   # PACKAGE_VERSION=0.18.0
```

Re-run the probe until it reports `0.18.0`. If it still reports an older version, another active plugin carries a higher-versioned copy and that is the one to deploy into. Restart PHP-FPM if opcache holds files.

Add the harness in `wp-content/mu-plugins/00-wca-proxy-test.php`:

```php
<?php
// Test harness for WOOA7S-1803. Delete when done.

// Priority 99 outranks plugins that force proxy tracking on at the default priority.
add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', function () {
	return 'yes' === get_option( 'wca_proxy_on' );
}, 99 );

add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', function () {
	return 'yes' === get_option( 'wca_module_on' );
}, 99 );

// Proxy-path pixels are fired by PHP, so they never appear in the browser Network tab.
add_filter(
	'jetpack_woocommerce_analytics_event_props',
	function ( $props, $event_name, $is_client_supplied ) {
		error_log( "WCA $event_name client=" . var_export( $is_client_supplied, true ) . ' ' . wp_json_encode( $props ) );
		return $props;
	},
	PHP_INT_MAX,
	3
);
```

```bash
TRACK="$SITE/wp-json/woocommerce-analytics/v1/track"
EVENT='[{"event_name":"product_view","properties":{"pi":42}}]'
tail -f wp-content/debug.log
```

> [!IMPORTANT]
> If the host plugin runs Jetpack's bot check, `curl/` is on its bot list and `record_event()` skips silently: every request returns `{"success":true}` and records nothing. Add `-A "$UA"` with a browser User-Agent if the `debug.log` line never appears.

> [!NOTE]
> On `trunk` the three-argument callback above throws `ArgumentCountError`, because the trait's call sites pass one argument, and it takes the page payload with it: rendering stops at the error, so `wcAnalytics` never reaches the HTML. That latent bug is also fixed here.

#### 3. The endpoint exists only where proxy tracking is enabled

```bash
wp option update wca_proxy_on no
curl -s "$SITE/wp-json/woocommerce-analytics/v1" | jq '.routes | keys'
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"

wp option update wca_proxy_on yes
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"
```

Expected: with the feature off, `wp-json/woocommerce-analytics/v1` returns `404 rest_no_route` (`/track` was its only route), the root index at `wp-json/` no longer lists `woocommerce-analytics/v1`, and the `POST` is `404`. With it on, `200` plus a `WCA …` line in `debug.log`. On `trunk` both states return `200`.

> [!NOTE]
> A bare `200` does not mean the event was recorded. With proxy tracking off there is no IP-based visitor id, so `record_event()` skips silently unless the request carries a `tk_ai` cookie. The `debug.log` line is the only proof either way.

#### 4. A real POST cannot set server-owned properties

```bash
wp option update wca_proxy_on yes
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":"product_view","properties":{
    "_via_ip":"8.8.8.8","store_id":"someone-elses-store","blog_id":424242,
    "session_id":"forged-session","store_admin":1,"is_guest":0,"ui":999,
    "_ui":"forged-visitor","device":"forged","timezone":"Antarctica/Troll",
    "_lg":"en-GB","_dl":"https://example.com/product/thing","_dr":"https://example.com/",
    "pi":42,"pq":2}}]'
```

Expected in the logged properties:

-   **Server values win.** `_via_ip` is the requesting IP, not `8.8.8.8`; `store_id`, `blog_id`, `timezone` and `device` are this store's own; `store_admin=0`, `is_guest=1`, `ui=0`; no `forged-session` or `forged-visitor` anywhere. The line reads `client=true`.
-   **Client values pass through.** `_lg=en-GB`, `_dl`, `_dr`, `pi=42`, `pq=2`.
-   On `trunk`, the same request records every forged value.

Then check that an unusable event name is refused without a PHP warning:

```bash
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":["array"],"properties":{}},{"event_name":"good","properties":{"ok":"1"}}]'
```

Expected: `207` with `"Missing event_name or invalid properties"` for the first event, and no `Array to string conversion` line in `debug.log`.

#### 5. The MU-plugin speed module

**This is the path with no automated coverage.** It bypasses the REST stack and runs before plugins load, so a mistake here is a fatal on every proxy POST rather than a failed assertion.

```bash
wp option update wca_proxy_on yes
wp option update wca_module_on yes
wp transient delete woocommerce_analytics_proxy_speed_module_version_check
# visit $SITE/wp-admin/ as an admin, which runs the admin_init installer
grep -m1 Version wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php

curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"
```

Expected: the header reads `Version: 0.18.0`, and the response is `{"success":true,"results":[{"success":true}],"is_proxy_speed_module":true}`. Re-send the forged payload from step 4 through this path and confirm `debug.log` shows `client=true` with the server's own values.

#### 6. First-party events still work

Browse the shop with proxy tracking on and add a product to cart.

Expected: events still delivered (`POST /track` returns `200`, `client=true` in the log), page attribution correct (`_dl`, `_dr` and `_lg` reflect the page, not the `/track` request), and product properties intact (`pi`, `pn`, `pc`, `pp`, `pt`). Then set `wca_proxy_on` to `no` and confirm normal tracking is unaffected: `client=false` lines and no `/track` requests.

Afterwards delete both harness files, reset the options, and reactivate anything you deactivated.

<!-- End testing instructions -->
### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

**Automated**

-   Package PHPUnit suite under WorDBless (PHP 8.1, PHPUnit 9.6.34): `OK (114 tests, 217 assertions)`, no PHP warnings.
-   `composer phpcs`: only the 5 pre-existing findings in `src/class-universal.php`, nothing new.
-   New tests: `WC_Analytics_Tracking_Reserved_Props_Test.php` (stripping, reserved-set snapshot, filter contract, template sync guard), `WC_Analytics_Tracking_Proxy_Test.php` (route gating and a real REST dispatch), `Universal_Test.php` (trait filter arity).

**Manual.** Local store: WooCommerce 11.1.0-dev, WordPress 7.0, Jetpack 16.1-a.5 connected, `premium-analytics` active, storefront over HTTPS via a tunnel, this branch's `src/` deployed into the vendored copy and confirmed loaded over HTTP as `PACKAGE_VERSION=0.18.0`.

-   **Reproduced first.** Against the shipped copy, one `POST /track` wrote every forged value into the event: `_via_ip=8.8.8.8`, `store_id=someone-elses-store`, `blog_id=424242`, `session_id=forged-session`, `store_admin=1`, `is_guest=0`, `ui=999`, `device=forged`, `timezone=Antarctica/Troll`, `_ui=forged-visitor`.
-   **Stripping is identical on both paths.** The same payload through the REST route and through the MU-plugin fast path recorded the server's own values for all ten names, with `_lg`, `_dl`, `_dr`, `pi` and `pq` passing through unchanged and `client=true` at the filter.
-   **Route gating.** With proxy tracking off, the namespace returns `404`, the root index does not list it, and the `POST` is `404`. With it on: `200` and the event recorded.
-   **An array `event_name`** returned `207` and produced zero `Array to string conversion` lines.
-   **Filter arity.** A three-argument callback throws `ArgumentCountError` on the shipped copy and stops page rendering, so no `wcAnalytics` payload reaches the HTML. On this branch it runs cleanly and reports `client=true` on `/track`, `client=false` on page output.
-   **First-party flow in a real browser.** Shop, product page, add to cart: `session_started`, `page_view`, `session_engagement` and `product_view` recorded with `_dl` pointing at the product page rather than `/track`, product properties intact, and `add_to_cart` still on the server path at `client=false`. No console errors, no PHP warnings.

### Milestone


<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry


<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry has already been committed manually at `packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening` (significance: minor, type: security), so neither box above is checked. Minor rather than patch because the change adds public API: `record_client_event()` and a third filter argument.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

(Type is `Security`, matching the 0.16.7 entry for WOOA7S-1800 part 1, not listed as a checkbox option in this template's Type list. Entry is already committed as a file with `Type: security`.)

#### Message <!-- Add a changelog message here -->

Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, and only register it where proxy tracking is enabled.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

N/A: entry already committed as a file (see above).

</details>

### Release Communication


<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

-   [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
-   [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

-   Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

-   Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>

---

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code. The implementation and tests were drafted with AI assistance and reviewed line by line before commit.
### Backward compatibility


All signature changes are additive. The behavioural changes are what need review.

1.  **The REST route exists only while proxy tracking is enabled.** `/wp-json/woocommerce-analytics/v1/track` no longer resolves where `Features::is_proxy_tracking_enabled()` is false. Removing that unauthenticated surface for the default case is the point of the change, and any third party posting there breaks.

    Known gap: a site that turns the feature *off* loses events from pages already in a page cache or CDN, which still carry `proxy: true`. `flush()` prefers `sendBeacon`, which discards the response, so the `404` is invisible in the browser as well. #68315 replaces this gate with a `403`.

2.  **Reserved property names are silently overwritten on the proxy path.** A client sending `store_id`, `_via_ip`, `session_id`, `ui` or any other server-owned name gets the server's value and the event still records. This includes values a `jetpack_woocommerce_analytics_event_props` callback sets, since the server's own are re-asserted after the filter. Names a callback *introduces* are not reserved and remain the callback's. Callers needing a reserved name for their own data must rename it.

3.  **A non-string event name is rejected** at both entry points, reported as `"Missing event_name or invalid properties"` for that event.

4.  **`record_event()` and `get_properties()` gain an optional third `$is_client_supplied` argument**, defaulting to `false`. Purely additive: `record_event()` strips only when the caller asks it to, so existing callers are unaffected.

    An earlier revision also stripped during any `POST` to `/track`, to cover a speed module installed before `record_client_event()` existed. That copy cannot exist: the module is off by default and has never been enabled on a public site, and any module installed from here on is written by a template that calls `record_client_event()` directly. Dropping the guard keeps a URL-shape test out of the security path, and avoids stripping first-party events that happen to fire during a proxy POST.

5.  **`jetpack_woocommerce_analytics_event_props` gains a third argument** (`$is_client_supplied`, additive). This also fixes a latent bug: callbacks registered with `accepted_args >= 2` used to fatal with `ArgumentCountError`, because the trait's call sites passed one argument.

**Operational note:** `woocommerce_analytics_experimental_proxy_tracking_enabled` must resolve to the same value for every request on a site. A callback that varies by cohort, percentage or geo produces cached pages whose `proxy` flag disagrees with what `/track` decides.

### Follow-ups this PR deliberately leaves alone


-   **`_via_ip` is only as trustworthy as the site's proxy setup.** Stripping the client's `_via_ip` property makes the server's own value win, but `get_user_ip_address()` prefers `HTTP_CF_CONNECTING_IP` and `HTTP_X_FORWARDED_FOR` over `REMOTE_ADDR`, so on a site that is not behind a proxy overwriting them a caller can still choose the recorded IP through a request header. Narrowing this to `REMOTE_ADDR` alone would break every site behind Cloudflare or a load balancer, so it needs a trusted-proxy declaration rather than a one-line change. Tracked as WOOA7S-1800.
-   **`strip_reserved_properties()` is public with no caller outside its own class.** It is public because the tests drive it directly. Making it private means reworking those tests to go through `record_client_event()`. `get_reserved_property_names()` stays public on purpose, since the README points extension authors at it.
-   **The MU-plugin template has no execution coverage.** `phpcs` parses it, but no test loads it: the sync test only matches strings in the source.
-   **`Woocommerce_Analytics_Test` cannot exercise the install paths.** `WPMU_PLUGIN_DIR` is defined by the test bootstrap while each test builds a fresh `uniqid()` temp directory, so those tests assert against a directory the code never writes to.
-   **`record_event()` returns `true` for four different outcomes**: no consent, bot UA, no visitor id, and an actual emit. Distinguishing them means changing a public signature.
-   **Nothing keeps `PACKAGE_VERSION` and `composer.json` in sync.** They had drifted before this PR and can drift again.



