### PR TITLE
Bound what the analytics tracking proxy endpoint accepts

### DIFF
--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -75,27 +75,14 @@ add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__retu
 This registers the unauthenticated `POST /wp-json/woocommerce-analytics/v1/track`
 endpoint. Sites without proxy tracking enabled do not get it.
 
-Events arriving through it are untrusted:
+Events arriving through it are untrusted. Server-derived properties replace
+client values; the reserved set is
+`WC_Analytics_Tracking::get_reserved_property_names()`. `_lg`, `_dl`, and
+`_dr` are client values because they describe the page, not the `/track` request.
 
--   Server-derived properties are replaced with the server's own values. The set
-    is `WC_Analytics_Tracking::get_reserved_property_names()`, which includes
-    generic names like `url`, `device` and `timezone`. Rename event properties
-    that would collide. `_lg`, `_dl` and `_dr` stay the client's: they describe
-    the page, not the `/track` request.
--   Input is bounded, and the event still records. An over-long value is trimmed
-    with a trailing `…` rather than dropped, and the encoded payload budget is
-    spent on the cheapest properties first, so one long value costs its own tail
-    instead of every property after it. Trimming is not reported back: an
-    unauthenticated endpoint that says which values it rejected is an oracle for
-    probing the limits.
--   Two cases do return an error, because the alternative is reporting a success
-    for an event that produced nothing: an unusable `event_name`, and a finished
-    pixel URL over the byte ceiling. Events past the batch limit get no result
-    entry at all.
--   The same value cap applies to what the server derives from request headers
-    (`_via_ua`, `_dr`, `_via_ref`, `_dl`) and from the session cookie. Those are
-    caller-influenced too, and uncapped they cost the whole event rather than
-    their own tail.
+Input is limited. Long values are truncated with `…`, and the payload budget
+keeps the cheapest properties first. The same value limit applies to
+request-derived values and the session cookie.
 
 | Limit                     | Value |
 | ------------------------- | ----- |
@@ -107,9 +94,8 @@ Events arriving through it are untrusted:
 | Encoded payload per event | 4096  |
 | Pixel URL bytes           | 8192  |
 
-A value at the character cap can exceed the byte budget on its own once
-percent-encoded, since one CJK character costs nine bytes in a URL. The budget
-wins in that case and trims the value further.
+Invalid event names and oversized pixel URLs return an error. Events beyond the
+batch limit are ignored.
 
 **The filter must resolve to the same value for every request on a site.** One
 that varies by cohort, percentage or geo makes cached pages disagree with what

--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -75,12 +75,25 @@ add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__retu
 This registers the unauthenticated `POST /wp-json/woocommerce-analytics/v1/track`
 endpoint. Sites without proxy tracking enabled do not get it.
 
-Events arriving through it are untrusted: server-derived properties are replaced
-with the server's own values. The set is
-`WC_Analytics_Tracking::get_reserved_property_names()`, which includes generic
-names like `url`, `device` and `timezone` — rename event properties that would
-collide. `_lg`, `_dl` and `_dr` stay the client's, because they describe the page
-the event happened on rather than the `/track` request.
+Events arriving through it are untrusted:
+
+-   Server-derived properties are replaced with the server's own values. The set
+    is `WC_Analytics_Tracking::get_reserved_property_names()`, which includes
+    generic names like `url`, `device` and `timezone`. Rename event properties
+    that would collide. `_lg`, `_dl` and `_dr` stay the client's: they describe
+    the page, not the `/track` request.
+-   Input is bounded silently. Over-limit properties are dropped and the event
+    still records; events past the batch limit are not recorded at all.
+
+| Limit                     | Value |
+| ------------------------- | ----- |
+| Events per request        | 50    |
+| Properties per event      | 50    |
+| Members per array value   | 50    |
+| Characters per value      | 200   |
+| Characters per name       | 100   |
+| Encoded payload per event | 4096  |
+| Pixel URL bytes           | 8192  |
 
 **The filter must resolve to the same value for every request on a site.** One
 that varies by cohort, percentage or geo makes cached pages disagree with what

--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -82,18 +82,34 @@ Events arriving through it are untrusted:
     generic names like `url`, `device` and `timezone`. Rename event properties
     that would collide. `_lg`, `_dl` and `_dr` stay the client's: they describe
     the page, not the `/track` request.
--   Input is bounded silently. Over-limit properties are dropped and the event
-    still records; events past the batch limit are not recorded at all.
+-   Input is bounded, and the event still records. An over-long value is trimmed
+    with a trailing `…` rather than dropped, and the encoded payload budget is
+    spent on the cheapest properties first, so one long value costs its own tail
+    instead of every property after it. Trimming is not reported back: an
+    unauthenticated endpoint that says which values it rejected is an oracle for
+    probing the limits.
+-   Two cases do return an error, because the alternative is reporting a success
+    for an event that produced nothing: an unusable `event_name`, and a finished
+    pixel URL over the byte ceiling. Events past the batch limit get no result
+    entry at all.
+-   The same value cap applies to what the server derives from request headers
+    (`_via_ua`, `_dr`, `_via_ref`, `_dl`) and from the session cookie. Those are
+    caller-influenced too, and uncapped they cost the whole event rather than
+    their own tail.
 
 | Limit                     | Value |
 | ------------------------- | ----- |
 | Events per request        | 50    |
 | Properties per event      | 50    |
 | Members per array value   | 50    |
-| Characters per value      | 200   |
+| Characters per value      | 1000  |
 | Characters per name       | 100   |
 | Encoded payload per event | 4096  |
 | Pixel URL bytes           | 8192  |
+
+A value at the character cap can exceed the byte budget on its own once
+percent-encoded, since one CJK character costs nine bytes in a URL. The budget
+wins in that case and trims the value further.
 
 **The filter must resolve to the same value for every request on a site.** One
 that varies by cohort, percentage or geo makes cached pages disagree with what

--- a/packages/php/woocommerce-analytics/changelog/wooa7s-client-input-bounds
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-client-input-bounds
@@ -1,0 +1,4 @@
+Significance: minor
+Type: security
+
+Bound what the unauthenticated tracking proxy endpoint accepts: events per request, properties per event, array members, value and name lengths, an encoded payload budget per event, and a ceiling on the pixel URL that is fired.

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -77,9 +77,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 			$events = array( $events );
 		}
 
-		// Bound the batch: every event becomes an outbound pixel request, and this
-		// endpoint is unauthenticated. Dropping the tail is silent on purpose — see
-		// WC_Analytics_Tracking::sanitize_client_properties().
+		// Limit unauthenticated callers to a bounded number of pixel requests.
 		if ( count( $events ) > WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST ) {
 			$events = array_slice( $events, 0, WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST, true );
 		}

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -77,6 +77,13 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 			$events = array( $events );
 		}
 
+		// Bound the batch: every event becomes an outbound pixel request, and this
+		// endpoint is unauthenticated. Dropping the tail is silent on purpose — see
+		// WC_Analytics_Tracking::sanitize_client_properties().
+		if ( count( $events ) > WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST ) {
+			$events = array_slice( $events, 0, WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST, true );
+		}
+
 		$results    = array();
 		$has_errors = false;
 

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -59,6 +59,96 @@ class WC_Analytics_Tracking {
 	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', '_ts', 'browser_type' );
 
 	/**
+	 * Maximum number of events a single client request may record.
+	 *
+	 * Each event becomes an outbound pixel request, so an unbounded batch turns
+	 * the unauthenticated endpoint into an amplifier. The client's own batch size
+	 * is 10 (see `api-client.ts`); the headroom is for retries coalescing.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_EVENTS_PER_REQUEST = 50;
+
+	/**
+	 * Maximum number of properties a client may set on one event.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_PROPERTIES_PER_EVENT = 50;
+
+	/**
+	 * Maximum length of a single client-supplied property value.
+	 *
+	 * Set for the same reason `Woo_Analytics_Trait::cap_page_string()` bounds
+	 * caller-influenced strings on the page-output path: values reach the pixel
+	 * URL, which is rejected outright once it grows too long. The two are
+	 * independent — a change to one does not imply a change to the other.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_PROPERTY_LENGTH = 200;
+
+	/**
+	 * Maximum length of a client-supplied event or property name.
+	 *
+	 * `Pixel_Builder` checks a name's characters but not its length.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_NAME_LENGTH = 100;
+
+	/**
+	 * Maximum number of members in a client-supplied array value.
+	 *
+	 * `get_properties()` joins members into one string, which the per-value cap
+	 * never sees, so an array of short members is otherwise unbounded.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_ARRAY_MEMBERS = 50;
+
+	/**
+	 * Maximum total length of one event's client-supplied properties.
+	 *
+	 * The other caps bound each axis separately and multiply: at their limits one
+	 * event still built a 512KB pixel URL. This bounds the product.
+	 *
+	 * Counted after percent-encoding, in bytes, unlike the per-value cap which
+	 * counts characters. A `%` or a CJK character costs three bytes in the URL,
+	 * so counting characters here would under-count by 3x and let the budget pass
+	 * a payload that still blows past MAX_PIXEL_URL_LENGTH.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_PAYLOAD_LENGTH = 4096;
+
+	/**
+	 * Maximum length of a pixel URL this package will fire.
+	 *
+	 * The backstop for every other cap. It is the only bound that sees the final
+	 * URL, so it is also the only one covering properties a
+	 * `jetpack_woocommerce_analytics_event_props` callback added after the
+	 * client-side caps ran.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @var int
+	 */
+	const MAX_PIXEL_URL_LENGTH = 8192;
+
+	/**
 	 * Event queue.
 	 *
 	 * @var array
@@ -108,8 +198,9 @@ class WC_Analytics_Tracking {
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Custom properties to send with the event.
 	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted
-	 *                                   client. Reserved property names are stripped when
-	 *                                   true. Defaults to false for server-side callers.
+	 *                                   client. Reserved property names are stripped and the
+	 *                                   rest are bounded when true. Defaults to false for
+	 *                                   server-side callers.
 	 *
 	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA, or
 	 *                       cookie-less context); WP_Error for an unusable client
@@ -132,13 +223,15 @@ class WC_Analytics_Tracking {
 		}
 
 		if ( $is_client_supplied ) {
-			// An error rather than a silent skip: an unusable name produces no pixel,
-			// and reporting success for it is what makes the loss invisible.
+			// An error rather than a silent skip: the caller sent a name that cannot
+			// be recorded, and reporting success for an event that produced no pixel
+			// is what makes the loss invisible. Telling a client about its own
+			// malformed input leaks nothing.
 			if ( ! self::is_valid_client_name( $event_name ) ) {
-				return new WP_Error( 'invalid_event_name', 'the event name is empty or not a string', array( 'status' => 400 ) );
+				return new WP_Error( 'invalid_event_name', 'the event name is empty, too long, or not a string', 400 );
 			}
 
-			$event_properties = self::strip_reserved_properties( $event_properties );
+			$event_properties = self::sanitize_client_properties( $event_properties );
 		}
 
 		$prefixed_event_name = self::PREFIX . $event_name;
@@ -255,6 +348,25 @@ class WC_Analytics_Tracking {
 			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
 		}
 
+		if ( strlen( $pixel_url ) > self::MAX_PIXEL_URL_LENGTH ) {
+			// No call site checks this return value, so the log line is the only
+			// signal that an event was dropped.
+			$error_message = sprintf(
+				'WooCommerce Analytics: dropped a %d byte tracks pixel, over the %d byte limit.',
+				strlen( $pixel_url ),
+				self::MAX_PIXEL_URL_LENGTH
+			);
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->warning( $error_message, array( 'source' => 'woocommerce-analytics' ) );
+			} else {
+				// Fallback for MU-plugin stage when WooCommerce logger is not available.
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( $error_message );
+			}
+
+			return new WP_Error( 'pixel_too_long', 'tracks pixel URL exceeds the maximum length', 400 );
+		}
+
 		// Check if batching is supported.
 		$can_batch = ( class_exists( 'WpOrg\Requests\Requests' ) && method_exists( 'WpOrg\Requests\Requests', 'request_multiple' ) )
 			|| ( class_exists( 'Requests' ) && method_exists( 'Requests', 'request_multiple' ) );
@@ -334,9 +446,12 @@ class WC_Analytics_Tracking {
 	private static function get_session_properties() {
 		$session_details = self::get_session_details();
 
+		// Capped here rather than only on the proxy path: the cookie is client-writable
+		// on every request, and first-party events never meet the client caps, so an
+		// oversized cookie would push their pixel past MAX_PIXEL_URL_LENGTH.
 		return array(
-			'session_id'   => $session_details['session_id'] ?? null,
-			'landing_page' => $session_details['landing_page'] ?? null,
+			'session_id'   => self::cap_client_value( $session_details['session_id'] ?? null ),
+			'landing_page' => self::cap_client_value( $session_details['landing_page'] ?? null ),
 			'is_engaged'   => $session_details['is_engaged'] ?? null,
 		);
 	}
@@ -433,26 +548,8 @@ class WC_Analytics_Tracking {
 
 		$all_properties = array_merge( $properties, $required_properties );
 
-		// Convert array values to a comma-separated string and URL-encode them to ensure compatibility with JavaScript's encodeURIComponent() for pixel URL transmission.
 		foreach ( $all_properties as $key => $value ) {
-			if ( ! is_array( $value ) ) {
-				continue;
-			}
-
-			if ( empty( $value ) ) {
-				$all_properties[ $key ] = '';
-				continue;
-			}
-
-			$is_indexed_array = array_keys( $value ) === range( 0, count( $value ) - 1 );
-			if ( $is_indexed_array ) {
-				$value_string           = implode( ',', $value );
-				$all_properties[ $key ] = rawurlencode( $value_string );
-				continue;
-			}
-
-			// Serialize non-indexed arrays to JSON strings.
-			$all_properties[ $key ] = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+			$all_properties[ $key ] = self::flatten_property_value( $value );
 		}
 
 		return $all_properties;
@@ -513,6 +610,75 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
+	 * Strip and bound a client-supplied property array.
+	 *
+	 * The single place the untrusted-input rules are applied, so that the REST
+	 * controller, the MU-plugin speed module and the stale-template safety net
+	 * cannot drift apart on what "sanitized" means.
+	 *
+	 * Capping is silent and lossy for the same reason stripping is: an
+	 * unauthenticated endpoint that reports which values it rejected is an oracle,
+	 * and analytics should not fail loudly on a malformed client. Truncated values
+	 * keep an ellipsis so they stay distinguishable downstream from a value that
+	 * genuinely ended at the limit, matching `Woo_Analytics_Trait::cap_page_string()`.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param array $event_properties Client-supplied properties.
+	 * @return array Sanitized properties.
+	 */
+	public static function sanitize_client_properties( $event_properties ) {
+		$event_properties = self::strip_reserved_properties( $event_properties );
+
+		if ( count( $event_properties ) > self::MAX_CLIENT_PROPERTIES_PER_EVENT ) {
+			$event_properties = array_slice( $event_properties, 0, self::MAX_CLIENT_PROPERTIES_PER_EVENT, true );
+		}
+
+		$budget = self::MAX_CLIENT_PAYLOAD_LENGTH;
+
+		foreach ( $event_properties as $key => $value ) {
+			// Dropped, not truncated: two long names could truncate to the same key.
+			if ( ! self::is_valid_client_name( $key ) || ! Pixel_Builder::prop_name_is_valid( $key ) ) {
+				unset( $event_properties[ $key ] );
+				continue;
+			}
+
+			$was_array = is_array( $value ) && ! empty( $value );
+
+			// Arrays are flattened later by get_properties(); bound their members too.
+			if ( is_array( $value ) ) {
+				if ( count( $value ) > self::MAX_CLIENT_ARRAY_MEMBERS ) {
+					$value = array_slice( $value, 0, self::MAX_CLIENT_ARRAY_MEMBERS, true );
+				}
+
+				// Trimmed to fit rather than dropped: losing a few categories is
+				// easier to notice than the whole property disappearing, and the
+				// member cap alone always exceeds the budget.
+				$value = self::fit_client_array(
+					array_map( array( __CLASS__, 'cap_client_value' ), $value ),
+					$budget - strlen( $key )
+				);
+			} else {
+				$value = self::cap_client_value( $value );
+			}
+
+			$cost = strlen( $key ) + self::measure_client_value( $value );
+
+			// The budget is only spent on properties that survive, or one oversized
+			// value would charge its key against everything after it.
+			if ( ( $was_array && array() === $value ) || $cost > $budget ) {
+				unset( $event_properties[ $key ] );
+				continue;
+			}
+
+			$budget                  -= $cost;
+			$event_properties[ $key ] = $value;
+		}
+
+		return $event_properties;
+	}
+
+	/**
 	 * Whether a client-supplied event or property name is usable.
 	 *
 	 * Without the type check an array name reaches `PREFIX . $event_name` and writes
@@ -521,10 +687,106 @@ class WC_Analytics_Tracking {
 	 * @since 0.18.0
 	 *
 	 * @param mixed $name Client-supplied name.
-	 * @return bool True when the name is a non-empty string.
+	 * @return bool True when the name is a non-empty string within the length bound.
 	 */
 	private static function is_valid_client_name( $name ) {
-		return is_string( $name ) && '' !== $name;
+		return is_string( $name )
+			&& '' !== $name
+			&& mb_strlen( $name ) <= self::MAX_CLIENT_NAME_LENGTH;
+	}
+
+	/**
+	 * Reduce one property value to the string that goes into the pixel URL.
+	 *
+	 * Array values are joined and encoded for compatibility with the client's
+	 * `encodeURIComponent()`; an associative array becomes JSON, which carries its
+	 * keys. The single definition matters: the payload budget measures a value by
+	 * running it through here, and an approximation that missed the JSON branch
+	 * charged nothing for those keys.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param mixed $value Property value.
+	 * @return mixed The scalar it serializes to; non-array values are returned as-is.
+	 */
+	private static function flatten_property_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( empty( $value ) ) {
+			return '';
+		}
+
+		if ( array_keys( $value ) === range( 0, count( $value ) - 1 ) ) {
+			return rawurlencode( implode( ',', $value ) );
+		}
+
+		return wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * Bytes one value contributes to the pixel URL.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param mixed $value Already-capped client value.
+	 * @return int Byte count after `flatten_property_value()` and the encoding
+	 *             `http_build_query()` applies on top of it.
+	 */
+	private static function measure_client_value( $value ) {
+		// urlencode(), not rawurlencode(): http_build_query() defaults to RFC1738,
+		// which writes `~` as %7E. Measuring with rawurlencode() under-counted a
+		// tilde threefold, the same way counting characters under-counted a `%`.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- Deliberate: mirrors http_build_query()'s RFC1738 encoding so the budget measures the bytes the finished URL carries.
+		return strlen( urlencode( (string) self::flatten_property_value( $value ) ) );
+	}
+
+	/**
+	 * Drop trailing members until an array value fits the remaining budget.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param array $members Already-capped members.
+	 * @param int   $budget Bytes still available for this value.
+	 * @return array Members that fit; empty when even one does not.
+	 */
+	private static function fit_client_array( $members, $budget ) {
+		while ( ! empty( $members ) && self::measure_client_value( $members ) > $budget ) {
+			array_pop( $members );
+		}
+
+		return $members;
+	}
+
+	/**
+	 * Bound one client-supplied value on its way to the pixel URL.
+	 *
+	 * Nested arrays are collapsed to an empty string rather than capped: the
+	 * flattening in `get_properties()` calls `implode()` on array members, which
+	 * emits an "Array to string conversion" warning for a nested one. Letting an
+	 * unauthenticated caller write warnings into the error log is the actual
+	 * problem; the value itself is meaningless either way.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param mixed $value Client-supplied value.
+	 * @return mixed Bounded value.
+	 */
+	private static function cap_client_value( $value ) {
+		if ( is_array( $value ) || is_object( $value ) ) {
+			return '';
+		}
+
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( mb_strlen( $value ) <= self::MAX_CLIENT_PROPERTY_LENGTH ) {
+			return $value;
+		}
+
+		return mb_substr( $value, 0, self::MAX_CLIENT_PROPERTY_LENGTH - 1 ) . '…';
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -81,18 +81,23 @@ class WC_Analytics_Tracking {
 	const MAX_CLIENT_PROPERTIES_PER_EVENT = 50;
 
 	/**
-	 * Maximum length of a single client-supplied property value.
+	 * Maximum length of a single property value bound for the pixel URL.
 	 *
-	 * Set for the same reason `Woo_Analytics_Trait::cap_page_string()` bounds
-	 * caller-influenced strings on the page-output path: values reach the pixel
-	 * URL, which is rejected outright once it grows too long. The two are
-	 * independent — a change to one does not imply a change to the other.
+	 * Not the event's size limit — MAX_CLIENT_PAYLOAD_LENGTH is, and it applies
+	 * whatever this is set to. This only stops one value spending the whole
+	 * budget, so it is set well above real values rather than close to them: an
+	 * ad-click landing URL carrying `gclid` and `fbclid` runs past 200
+	 * characters, and truncating it destroys the campaign attribution the event
+	 * exists to record.
+	 *
+	 * Deliberately unlike `Woo_Analytics_Trait::cap_page_string()`, which bounds
+	 * breadcrumb titles and search terms. Those are short by nature; URLs are not.
 	 *
 	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
-	const MAX_CLIENT_PROPERTY_LENGTH = 200;
+	const MAX_CLIENT_PROPERTY_LENGTH = 1000;
 
 	/**
 	 * Maximum length of a client-supplied event or property name.
@@ -108,8 +113,11 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum number of members in a client-supplied array value.
 	 *
-	 * `get_properties()` joins members into one string, which the per-value cap
-	 * never sees, so an array of short members is otherwise unbounded.
+	 * Not a size bound: `fit_client_array()` already drops members until the value
+	 * fits the payload budget, whatever the count. This caps the work that costs,
+	 * since fitting re-measures the whole array on every pop, and an array of
+	 * hundreds of thousands of one-character members would otherwise be measured
+	 * that many times.
 	 *
 	 * @since 0.18.0
 	 *
@@ -124,9 +132,10 @@ class WC_Analytics_Tracking {
 	 * event still built a 512KB pixel URL. This bounds the product.
 	 *
 	 * Counted after percent-encoding, in bytes, unlike the per-value cap which
-	 * counts characters. A `%` or a CJK character costs three bytes in the URL,
-	 * so counting characters here would under-count by 3x and let the budget pass
-	 * a payload that still blows past MAX_PIXEL_URL_LENGTH.
+	 * counts characters. A `%` costs three bytes in the URL and a CJK character
+	 * nine — three UTF-8 bytes, each percent-encoded — so counting characters
+	 * here would under-count by up to 9x and let the budget pass a payload that
+	 * still blows past MAX_PIXEL_URL_LENGTH.
 	 *
 	 * @since 0.18.0
 	 *
@@ -349,10 +358,11 @@ class WC_Analytics_Tracking {
 		}
 
 		if ( strlen( $pixel_url ) > self::MAX_PIXEL_URL_LENGTH ) {
-			// No call site checks this return value, so the log line is the only
-			// signal that an event was dropped.
+			// The proxy endpoint reports this error back to its caller, but no
+			// first-party call site checks the return value, so for those events the
+			// log line is the only signal that one was dropped.
 			$error_message = sprintf(
-				'WooCommerce Analytics: dropped a %d byte tracks pixel, over the %d byte limit.',
+				'WooCommerce Analytics: dropped a %d byte pixel, over the %d byte limit.',
 				strlen( $pixel_url ),
 				self::MAX_PIXEL_URL_LENGTH
 			);
@@ -450,9 +460,9 @@ class WC_Analytics_Tracking {
 		// on every request, and first-party events never meet the client caps, so an
 		// oversized cookie would push their pixel past MAX_PIXEL_URL_LENGTH.
 		return array(
-			'session_id'   => self::cap_client_value( $session_details['session_id'] ?? null ),
-			'landing_page' => self::cap_client_value( $session_details['landing_page'] ?? null ),
-			'is_engaged'   => $session_details['is_engaged'] ?? null,
+			'session_id'   => self::cap_property_value( $session_details['session_id'] ?? null ),
+			'landing_page' => self::cap_json_list_value( $session_details['landing_page'] ?? null ),
+			'is_engaged'   => self::cap_property_value( $session_details['is_engaged'] ?? null ),
 		);
 	}
 
@@ -634,48 +644,65 @@ class WC_Analytics_Tracking {
 			$event_properties = array_slice( $event_properties, 0, self::MAX_CLIENT_PROPERTIES_PER_EVENT, true );
 		}
 
-		$budget = self::MAX_CLIENT_PAYLOAD_LENGTH;
+		$values = array();
+		$costs  = array();
 
 		foreach ( $event_properties as $key => $value ) {
 			// Dropped, not truncated: two long names could truncate to the same key.
 			if ( ! self::is_valid_client_name( $key ) || ! Pixel_Builder::prop_name_is_valid( $key ) ) {
-				unset( $event_properties[ $key ] );
 				continue;
 			}
-
-			$was_array = is_array( $value ) && ! empty( $value );
 
 			// Arrays are flattened later by get_properties(); bound their members too.
 			if ( is_array( $value ) ) {
-				if ( count( $value ) > self::MAX_CLIENT_ARRAY_MEMBERS ) {
-					$value = array_slice( $value, 0, self::MAX_CLIENT_ARRAY_MEMBERS, true );
-				}
-
-				// Trimmed to fit rather than dropped: losing a few categories is
-				// easier to notice than the whole property disappearing, and the
-				// member cap alone always exceeds the budget.
-				$value = self::fit_client_array(
-					array_map( array( __CLASS__, 'cap_client_value' ), $value ),
-					$budget - strlen( $key )
+				$value = array_map(
+					array( __CLASS__, 'cap_property_value' ),
+					array_slice( $value, 0, self::MAX_CLIENT_ARRAY_MEMBERS, true )
 				);
 			} else {
-				$value = self::cap_client_value( $value );
+				$value = self::cap_property_value( $value );
 			}
 
-			$cost = strlen( $key ) + self::measure_client_value( $value );
-
-			// The budget is only spent on properties that survive, or one oversized
-			// value would charge its key against everything after it.
-			if ( ( $was_array && array() === $value ) || $cost > $budget ) {
-				unset( $event_properties[ $key ] );
-				continue;
-			}
-
-			$budget                  -= $cost;
-			$event_properties[ $key ] = $value;
+			$values[ $key ] = $value;
+			$costs[ $key ]  = strlen( $key ) + self::measure_client_value( $value );
 		}
 
-		return $event_properties;
+		// Cheapest first, so one long value costs its own tail rather than every
+		// property that happens to follow it. A product name at the value cap can
+		// still outweigh the whole budget once percent-encoded, and in source order
+		// it would take `pi`, `pp` and `pt` down with it.
+		asort( $costs );
+
+		$budget = self::MAX_CLIENT_PAYLOAD_LENGTH;
+		$kept   = array();
+
+		foreach ( $costs as $key => $cost ) {
+			$value = $values[ $key ];
+
+			// Trimmed to fit rather than dropped, the same way arrays already were.
+			// The value cap counts characters and the budget counts encoded bytes, so
+			// a value at the cap can still be nine times its length here; dropping it
+			// would lose a whole property to an encoding difference.
+			if ( $cost > $budget ) {
+				$room = $budget - strlen( $key );
+
+				$value = is_array( $value )
+					? self::fit_client_array( $value, $room )
+					: self::fit_client_string( (string) $value, $room );
+
+				if ( array() === $value || '' === $value ) {
+					continue;
+				}
+
+				$cost = strlen( $key ) + self::measure_client_value( $value );
+			}
+
+			$budget      -= $cost;
+			$kept[ $key ] = $value;
+		}
+
+		// Back into the order the caller sent, so the pixel is not reordered by cost.
+		return array_replace( array_intersect_key( $values, $kept ), $kept );
 	}
 
 	/**
@@ -743,6 +770,40 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
+	 * Trim a string value until it fits the remaining budget.
+	 *
+	 * The scalar counterpart of `fit_client_array()`. Binary search rather than a
+	 * character-at-a-time walk because each step re-encodes the candidate.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param string $value Already-capped value.
+	 * @param int    $budget Bytes still available for this value.
+	 * @return string The longest prefix that fits, with an ellipsis; empty when
+	 *                even one character does not.
+	 */
+	private static function fit_client_string( $value, $budget ) {
+		if ( $budget <= 0 ) {
+			return '';
+		}
+
+		$low  = 0;
+		$high = mb_strlen( $value );
+
+		while ( $low < $high ) {
+			$mid = (int) ceil( ( $low + $high ) / 2 );
+
+			if ( self::measure_client_value( self::truncate_value( $value, $mid ) ) <= $budget ) {
+				$low = $mid;
+			} else {
+				$high = $mid - 1;
+			}
+		}
+
+		return self::truncate_value( $value, $low );
+	}
+
+	/**
 	 * Drop trailing members until an array value fits the remaining budget.
 	 *
 	 * @since 0.18.0
@@ -760,9 +821,53 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
-	 * Bound one client-supplied value on its way to the pixel URL.
+	 * Bound a value that carries a JSON list, without invalidating the JSON.
 	 *
-	 * Nested arrays are collapsed to an empty string rather than capped: the
+	 * `landing_page` is a JSON-encoded breadcrumb trail. Capping it as a plain
+	 * string cuts mid-token and hands the pipeline something that no longer
+	 * parses, so drop whole trailing entries instead and re-encode. The leading
+	 * entries are the ones worth keeping: they are the top of the trail.
+	 *
+	 * Anything that is not a JSON list falls back to the plain cap.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param mixed $value Caller-influenced value.
+	 * @return mixed Bounded value, still valid JSON when it arrived as JSON.
+	 */
+	private static function cap_json_list_value( $value ) {
+		if ( ! is_string( $value ) || mb_strlen( $value ) <= self::MAX_CLIENT_PROPERTY_LENGTH ) {
+			return self::cap_property_value( $value );
+		}
+
+		$decoded = json_decode( $value, true );
+		if ( ! is_array( $decoded ) ) {
+			return self::cap_property_value( $value );
+		}
+
+		while ( ! empty( $decoded ) ) {
+			$encoded = wp_json_encode( $decoded );
+
+			if ( is_string( $encoded ) && mb_strlen( $encoded ) <= self::MAX_CLIENT_PROPERTY_LENGTH ) {
+				return $encoded;
+			}
+
+			array_pop( $decoded );
+		}
+
+		return '[]';
+	}
+
+	/**
+	 * Bound one value on its way to the pixel URL.
+	 *
+	 * Applies to anything a caller can influence, which is not only the properties
+	 * a client posts: the session cookie and the request headers behind
+	 * `get_server_details()` are caller-influenced too, and an uncapped one of
+	 * those pushed the finished URL past MAX_PIXEL_URL_LENGTH, costing the whole
+	 * event rather than the oversized value.
+	 *
+	 * Arrays and objects are collapsed to an empty string rather than capped: the
 	 * flattening in `get_properties()` calls `implode()` on array members, which
 	 * emits an "Array to string conversion" warning for a nested one. Letting an
 	 * unauthenticated caller write warnings into the error log is the actual
@@ -770,10 +875,10 @@ class WC_Analytics_Tracking {
 	 *
 	 * @since 0.18.0
 	 *
-	 * @param mixed $value Client-supplied value.
+	 * @param mixed $value Caller-influenced value.
 	 * @return mixed Bounded value.
 	 */
-	private static function cap_client_value( $value ) {
+	private static function cap_property_value( $value ) {
 		if ( is_array( $value ) || is_object( $value ) ) {
 			return '';
 		}
@@ -786,7 +891,27 @@ class WC_Analytics_Tracking {
 			return $value;
 		}
 
-		return mb_substr( $value, 0, self::MAX_CLIENT_PROPERTY_LENGTH - 1 ) . '…';
+		return self::truncate_value( $value, self::MAX_CLIENT_PROPERTY_LENGTH );
+	}
+
+	/**
+	 * Cut a value to a character count, marking that it was cut.
+	 *
+	 * The ellipsis keeps a truncated value distinguishable downstream from one
+	 * that genuinely ended at the limit, and costs one of the characters.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param string $value  Value to cut.
+	 * @param int    $length Characters the result may occupy, ellipsis included.
+	 * @return string The cut value, or an empty string when nothing fits.
+	 */
+	private static function truncate_value( $value, $length ) {
+		if ( $length <= 0 ) {
+			return '';
+		}
+
+		return mb_substr( $value, 0, $length - 1 ) . '…';
 	}
 
 	/**
@@ -845,6 +970,14 @@ class WC_Analytics_Tracking {
 		// Add _via_ref (referrer) for backward compatibility.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data['_via_ref'] = isset( $_SERVER['HTTP_REFERER'] ) ? $clean( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+
+		// Headers are caller-supplied, and the referer lands here twice. Uncapped, one
+		// long Referer pushes the finished URL past MAX_PIXEL_URL_LENGTH and costs the
+		// whole event; capped, it costs the tail of one value. `_lg` is already bounded
+		// above and `_via_ip` is validated by get_user_ip_address().
+		foreach ( array( '_via_ua', '_dr', '_dl', '_via_ref' ) as $key ) {
+			$data[ $key ] = self::cap_property_value( $data[ $key ] );
+		}
 
 		return $data;
 	}

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -61,9 +61,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum number of events a single client request may record.
 	 *
-	 * Each event becomes an outbound pixel request, so an unbounded batch turns
-	 * the unauthenticated endpoint into an amplifier. The client's own batch size
-	 * is 10 (see `api-client.ts`); the headroom is for retries coalescing.
+	 * Prevents the unauthenticated endpoint from creating unbounded pixel requests.
 	 *
 	 * @since 0.18.0
 	 *
@@ -83,15 +81,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum length of a single property value bound for the pixel URL.
 	 *
-	 * Not the event's size limit — MAX_CLIENT_PAYLOAD_LENGTH is, and it applies
-	 * whatever this is set to. This only stops one value spending the whole
-	 * budget, so it is set well above real values rather than close to them: an
-	 * ad-click landing URL carrying `gclid` and `fbclid` runs past 200
-	 * characters, and truncating it destroys the campaign attribution the event
-	 * exists to record.
-	 *
-	 * Deliberately unlike `Woo_Analytics_Trait::cap_page_string()`, which bounds
-	 * breadcrumb titles and search terms. Those are short by nature; URLs are not.
+	 * The payload limit still caps the full event, while this preserves attribution URLs.
 	 *
 	 * @since 0.18.0
 	 *
@@ -102,7 +92,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum length of a client-supplied event or property name.
 	 *
-	 * `Pixel_Builder` checks a name's characters but not its length.
+	 * `Pixel_Builder` validates characters but not length.
 	 *
 	 * @since 0.18.0
 	 *
@@ -113,11 +103,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum number of members in a client-supplied array value.
 	 *
-	 * Not a size bound: `fit_client_array()` already drops members until the value
-	 * fits the payload budget, whatever the count. This caps the work that costs,
-	 * since fitting re-measures the whole array on every pop, and an array of
-	 * hundreds of thousands of one-character members would otherwise be measured
-	 * that many times.
+	 * Avoids excessive work while fitting an array into the payload budget.
 	 *
 	 * @since 0.18.0
 	 *
@@ -128,14 +114,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum total length of one event's client-supplied properties.
 	 *
-	 * The other caps bound each axis separately and multiply: at their limits one
-	 * event still built a 512KB pixel URL. This bounds the product.
-	 *
-	 * Counted after percent-encoding, in bytes, unlike the per-value cap which
-	 * counts characters. A `%` costs three bytes in the URL and a CJK character
-	 * nine — three UTF-8 bytes, each percent-encoded — so counting characters
-	 * here would under-count by up to 9x and let the budget pass a payload that
-	 * still blows past MAX_PIXEL_URL_LENGTH.
+	 * Counts percent-encoded URL bytes, which can exceed a value's character count.
 	 *
 	 * @since 0.18.0
 	 *
@@ -146,10 +125,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum length of a pixel URL this package will fire.
 	 *
-	 * The backstop for every other cap. It is the only bound that sees the final
-	 * URL, so it is also the only one covering properties a
-	 * `jetpack_woocommerce_analytics_event_props` callback added after the
-	 * client-side caps ran.
+	 * This also bounds properties added after client properties are sanitized.
 	 *
 	 * @since 0.18.0
 	 *
@@ -232,10 +208,7 @@ class WC_Analytics_Tracking {
 		}
 
 		if ( $is_client_supplied ) {
-			// An error rather than a silent skip: the caller sent a name that cannot
-			// be recorded, and reporting success for an event that produced no pixel
-			// is what makes the loss invisible. Telling a client about its own
-			// malformed input leaks nothing.
+			// Report invalid names because they cannot produce an event.
 			if ( ! self::is_valid_client_name( $event_name ) ) {
 				return new WP_Error( 'invalid_event_name', 'the event name is empty, too long, or not a string', 400 );
 			}
@@ -456,9 +429,7 @@ class WC_Analytics_Tracking {
 	private static function get_session_properties() {
 		$session_details = self::get_session_details();
 
-		// Capped here rather than only on the proxy path: the cookie is client-writable
-		// on every request, and first-party events never meet the client caps, so an
-		// oversized cookie would push their pixel past MAX_PIXEL_URL_LENGTH.
+		// The client-writable cookie also affects first-party events.
 		return array(
 			'session_id'   => self::cap_property_value( $session_details['session_id'] ?? null ),
 			'landing_page' => self::cap_json_list_value( $session_details['landing_page'] ?? null ),
@@ -622,15 +593,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Strip and bound a client-supplied property array.
 	 *
-	 * The single place the untrusted-input rules are applied, so that the REST
-	 * controller, the MU-plugin speed module and the stale-template safety net
-	 * cannot drift apart on what "sanitized" means.
-	 *
-	 * Capping is silent and lossy for the same reason stripping is: an
-	 * unauthenticated endpoint that reports which values it rejected is an oracle,
-	 * and analytics should not fail loudly on a malformed client. Truncated values
-	 * keep an ellipsis so they stay distinguishable downstream from a value that
-	 * genuinely ended at the limit, matching `Woo_Analytics_Trait::cap_page_string()`.
+	 * Keep rejected properties silent so the unauthenticated endpoint cannot expose its limits.
 	 *
 	 * @since 0.18.0
 	 *
@@ -667,10 +630,7 @@ class WC_Analytics_Tracking {
 			$costs[ $key ]  = strlen( $key ) + self::measure_client_value( $value );
 		}
 
-		// Cheapest first, so one long value costs its own tail rather than every
-		// property that happens to follow it. A product name at the value cap can
-		// still outweigh the whole budget once percent-encoded, and in source order
-		// it would take `pi`, `pp` and `pt` down with it.
+		// Preserve more properties by fitting the cheapest values first.
 		asort( $costs );
 
 		$budget = self::MAX_CLIENT_PAYLOAD_LENGTH;
@@ -679,10 +639,7 @@ class WC_Analytics_Tracking {
 		foreach ( $costs as $key => $cost ) {
 			$value = $values[ $key ];
 
-			// Trimmed to fit rather than dropped, the same way arrays already were.
-			// The value cap counts characters and the budget counts encoded bytes, so
-			// a value at the cap can still be nine times its length here; dropping it
-			// would lose a whole property to an encoding difference.
+			// Trim values to keep them when their encoded form exceeds the remaining budget.
 			if ( $cost > $budget ) {
 				$room = $budget - strlen( $key );
 
@@ -725,11 +682,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Reduce one property value to the string that goes into the pixel URL.
 	 *
-	 * Array values are joined and encoded for compatibility with the client's
-	 * `encodeURIComponent()`; an associative array becomes JSON, which carries its
-	 * keys. The single definition matters: the payload budget measures a value by
-	 * running it through here, and an approximation that missed the JSON branch
-	 * charged nothing for those keys.
+	 * The payload budget uses this same conversion to measure array values accurately.
 	 *
 	 * @since 0.18.0
 	 *
@@ -762,9 +715,7 @@ class WC_Analytics_Tracking {
 	 *             `http_build_query()` applies on top of it.
 	 */
 	private static function measure_client_value( $value ) {
-		// urlencode(), not rawurlencode(): http_build_query() defaults to RFC1738,
-		// which writes `~` as %7E. Measuring with rawurlencode() under-counted a
-		// tilde threefold, the same way counting characters under-counted a `%`.
+		// Match http_build_query()'s RFC1738 encoding.
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- Deliberate: mirrors http_build_query()'s RFC1738 encoding so the budget measures the bytes the finished URL carries.
 		return strlen( urlencode( (string) self::flatten_property_value( $value ) ) );
 	}
@@ -772,8 +723,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Trim a string value until it fits the remaining budget.
 	 *
-	 * The scalar counterpart of `fit_client_array()`. Binary search rather than a
-	 * character-at-a-time walk because each step re-encodes the candidate.
+	 * Uses binary search because each candidate must be encoded again.
 	 *
 	 * @since 0.18.0
 	 *
@@ -823,12 +773,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Bound a value that carries a JSON list, without invalidating the JSON.
 	 *
-	 * `landing_page` is a JSON-encoded breadcrumb trail. Capping it as a plain
-	 * string cuts mid-token and hands the pipeline something that no longer
-	 * parses, so drop whole trailing entries instead and re-encode. The leading
-	 * entries are the ones worth keeping: they are the top of the trail.
-	 *
-	 * Anything that is not a JSON list falls back to the plain cap.
+	 * Preserve valid JSON by removing trailing list entries instead of cutting text.
 	 *
 	 * @since 0.18.0
 	 *
@@ -861,17 +806,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Bound one value on its way to the pixel URL.
 	 *
-	 * Applies to anything a caller can influence, which is not only the properties
-	 * a client posts: the session cookie and the request headers behind
-	 * `get_server_details()` are caller-influenced too, and an uncapped one of
-	 * those pushed the finished URL past MAX_PIXEL_URL_LENGTH, costing the whole
-	 * event rather than the oversized value.
-	 *
-	 * Arrays and objects are collapsed to an empty string rather than capped: the
-	 * flattening in `get_properties()` calls `implode()` on array members, which
-	 * emits an "Array to string conversion" warning for a nested one. Letting an
-	 * unauthenticated caller write warnings into the error log is the actual
-	 * problem; the value itself is meaningless either way.
+	 * Arrays and objects become empty strings to avoid warnings during flattening.
 	 *
 	 * @since 0.18.0
 	 *
@@ -896,9 +831,6 @@ class WC_Analytics_Tracking {
 
 	/**
 	 * Cut a value to a character count, marking that it was cut.
-	 *
-	 * The ellipsis keeps a truncated value distinguishable downstream from one
-	 * that genuinely ended at the limit, and costs one of the characters.
 	 *
 	 * @since 0.18.0
 	 *

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -128,6 +128,13 @@ class WooCommerceAnalyticsProxySpeed {
 			return false;
 		}
 
+		// Same skew, different symbol: process_proxy_request() reads this constant, and an
+		// older copy throws inside the catch, answering 500 rather than falling back here.
+		if ( ! defined( '\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST' ) ) {
+			error_log( 'WooCommerce Analytics Proxy Speed Module: the loaded WC_Analytics_Tracking predates the client input bounds.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			return false;
+		}
+
 		return true;
 	}
 

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -199,6 +199,14 @@ class WooCommerceAnalyticsProxySpeed {
 			$events = array( $events );
 		}
 
+		// Same bound as the REST controller. The constant lives in the package rather
+		// than being restated here: unlike is_proxy_request(), this runs after the
+		// autoloader, so the class is available.
+		$max_events = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST;
+		if ( count( $events ) > $max_events ) {
+			$events = array_slice( $events, 0, $max_events, true );
+		}
+
 		$results    = array();
 		$has_errors = false;
 

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -128,8 +128,7 @@ class WooCommerceAnalyticsProxySpeed {
 			return false;
 		}
 
-		// Same skew, different symbol: process_proxy_request() reads this constant, and an
-		// older copy throws inside the catch, answering 500 rather than falling back here.
+		// Avoid a 500 when an older package lacks the bound constant.
 		if ( ! defined( '\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST' ) ) {
 			error_log( 'WooCommerce Analytics Proxy Speed Module: the loaded WC_Analytics_Tracking predates the client input bounds.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			return false;
@@ -206,9 +205,7 @@ class WooCommerceAnalyticsProxySpeed {
 			$events = array( $events );
 		}
 
-		// Same bound as the REST controller. The constant lives in the package rather
-		// than being restated here: unlike is_proxy_request(), this runs after the
-		// autoloader, so the class is available.
+		// Use the same batch limit as the REST controller.
 		$max_events = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST;
 		if ( count( $events ) > $max_events ) {
 			$events = array_slice( $events, 0, $max_events, true );

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
@@ -280,4 +280,36 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		$this->assertSame( '2', $props['pi'] ?? null );
 	}
 
+	/**
+	 * Every event becomes an outbound pixel request, so an unauthenticated caller
+	 * must not be able to fan out an unbounded batch.
+	 */
+	public function test_batch_size_is_capped(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::register_rest_routes();
+
+		$events = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST + 10; $i++ ) {
+			$events[] = array(
+				'event_name' => 'add_to_cart',
+				'properties' => array( 'pi' => $i ),
+			);
+		}
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $events ) );
+
+		rest_do_request( $request );
+
+		$this->assertCount(
+			WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST,
+			$this->get_pixel_batch_queue(),
+			'The batch must be truncated to MAX_CLIENT_EVENTS_PER_REQUEST.'
+		);
+	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -365,9 +365,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The third argument tells a callback whether the properties it is looking
-	 * at came from an untrusted client, which is the only way it can know to
-	 * assign unconditionally.
+	 * Pass whether properties came from an untrusted client to filter callbacks.
 	 */
 	public function test_filter_receives_the_client_supplied_flag(): void {
 		$seen     = array();
@@ -392,12 +390,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A callback that defers to an existing value hands a *reserved* property
-	 * straight back to the client that supplied it. The strip runs before the
-	 * filter, so it cannot see this; get_properties() re-asserts the server's
-	 * values afterwards. Contrast with
-	 * test_filter_callback_deferring_to_an_existing_value_loses_to_the_client(),
-	 * which covers a name the filter invents — still the client's to win.
+	 * Reassert server-owned values after filters run on client properties.
 	 */
 	public function test_filter_callback_cannot_hand_a_reserved_property_back_to_the_client(): void {
 		update_option( 'woocommerce_store_id', 'real-store-id' );
@@ -420,9 +413,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The trusted path must keep its escape hatch: a server-side caller can still
-	 * set a property that collides with a common one, and the post-filter
-	 * re-assertion must not take that away.
+	 * Allow trusted callers to override common properties.
 	 */
 	public function test_reserved_properties_are_not_re_asserted_for_trusted_callers(): void {
 		update_option( 'woocommerce_store_id', 'real-store-id' );
@@ -437,8 +428,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `_ts` is in $required_properties and in RESERVED_IDENTITY_PROPERTIES, so a
-	 * client cannot forge the event timestamp at either layer.
+	 * Use the server timestamp for client events.
 	 */
 	public function test_client_cannot_forge_the_event_timestamp(): void {
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
@@ -457,10 +447,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The endpoint is unauthenticated and every property reaches the pixel URL,
-	 * which is rejected outright once it grows too long. Values are truncated
-	 * with an ellipsis so a capped value stays distinguishable from one that
-	 * genuinely ended at the limit.
+	 * Truncate oversized client values.
 	 */
 	public function test_client_property_values_are_capped(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
@@ -476,7 +463,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A client cannot widen its own footprint by sending hundreds of properties.
+	 * Limit client properties per event.
 	 */
 	public function test_client_property_count_is_capped(): void {
 		$properties = array();
@@ -490,10 +477,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * get_properties() flattens array values with implode(), which emits an
-	 * "Array to string conversion" warning for a nested array. Letting an
-	 * unauthenticated caller write warnings into the error log is the problem
-	 * worth closing; the value itself is meaningless either way.
+	 * Prevent nested arrays from generating warnings while flattening values.
 	 */
 	public function test_nested_client_arrays_do_not_reach_the_flattening_step(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
@@ -504,9 +488,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The per-value cap runs on each member, never on the string
-	 * `get_properties()` joins them into: 20,000 ten-character members produced a
-	 * 300KB pixel URL, which nothing downstream rejects.
+	 * Limit client array members before flattening them.
 	 */
 	public function test_client_array_member_count_is_capped(): void {
 		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS + 25, 'abcdefghij' );
@@ -525,8 +507,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Slicing must not turn an indexed array into an associative one:
-	 * `get_properties()` picks `implode()` over `wp_json_encode()` on that test.
+	 * Keep capped indexed arrays indexed so they continue to flatten correctly.
 	 */
 	public function test_capped_arrays_still_flatten_with_implode(): void {
 		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS + 5, 'a' );
@@ -541,9 +522,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The per-axis caps multiply: at their limits one event built a 512KB pixel
-	 * URL, so the product needs its own bound. Properties are dropped from the
-	 * tail once the budget is spent.
+	 * Keep client payloads within the pixel URL limit.
 	 */
 	public function test_client_payload_total_is_capped( string $character = 'a' ): void {
 		$properties = array();
@@ -555,8 +534,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 		$this->assertNotEmpty( $sanitized, 'The budget drops the tail, it does not empty the event.' );
 
-		// The pixel URL is what the budget exists to bound, so assert on it rather
-		// than on the constant.
+		// Verify the final URL, not just the budget constant.
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
 		$props            = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
 
@@ -569,9 +547,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * An ASCII-only fixture hid this: the budget counted characters while the URL
-	 * carries percent-encoded bytes, so `%` costs 3x and CJK and emoji 9x or more
-	 * of what the budget charged, and the same payload built a 12KB URL.
+	 * Measure encoded bytes rather than character counts.
 	 *
 	 * @dataProvider expensive_character_provider
 	 *
@@ -597,9 +573,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * An associative array serializes to JSON, which carries its keys, while an
-	 * indexed one is joined and drops them. Measuring both as a joined list
-	 * charged nothing for the keys, and 50 such properties built a 152KB URL.
+	 * Include associative-array keys when measuring payload size.
 	 */
 	public function test_associative_array_keys_are_charged_to_the_budget(): void {
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
@@ -625,13 +599,10 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * One oversized value used to charge its key against the budget and then be
-	 * dropped anyway, so short properties after it were refused for space that
-	 * nothing occupied.
+	 * Do not charge the budget for properties that are dropped.
 	 */
 	public function test_a_dropped_property_does_not_spend_the_budget(): void {
-		// Long names on purpose: the leak is the key's own cost, so short keys hide
-		// it however many properties are dropped.
+		// Long names ensure this exercises each dropped key's cost.
 		$properties = array();
 		for ( $i = 0; $i < 40; $i++ ) {
 			$name                = str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH - 12 ) . $i;
@@ -645,14 +616,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The cut is made in characters, never in bytes, so a multibyte value comes
-	 * back shorter but never cut mid-sequence.
-	 *
-	 * No equality against the value cap here: a multibyte value at the cap costs
-	 * several times its length once percent-encoded, so the payload budget trims
-	 * it further, and asserting the cap would be asserting which bound won.
-	 * `test_client_property_values_are_capped()` pins the cap on ASCII, where
-	 * nothing else is in play.
+	 * Truncate multibyte values without splitting characters.
 	 *
 	 * @dataProvider multibyte_value_provider
 	 *
@@ -673,7 +637,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Multibyte characters whose byte length differs from their character length.
+	 * Provide multibyte characters for truncation tests.
 	 *
 	 * @return array<string, array{0: string}>
 	 */
@@ -686,7 +650,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The bound is a limit, not an off-by-one rejection of the longest legal value.
+	 * Keep values at the length limit.
 	 */
 	public function test_a_value_at_the_length_limit_is_untouched(): void {
 		$exact = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
@@ -697,8 +661,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * An array that hits the member cap always exceeded the budget, so the whole
-	 * property used to vanish. Losing a few categories is easier to notice.
+	 * Keep oversized arrays by removing trailing members.
 	 */
 	public function test_oversized_arrays_lose_members_not_the_property(): void {
 		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) );
@@ -710,9 +673,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The last bound, and the only one that sees the final URL — so the only one
-	 * covering properties a filter callback added after the client caps ran.
-	 * Driven through the trusted path, where no client cap applies.
+	 * Do not queue pixel URLs that exceed the final URL limit.
 	 */
 	public function test_oversized_pixel_urls_are_not_fired(): void {
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
@@ -732,8 +693,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A realistic event must pass through untouched, or the budget is capping
-	 * first-party analytics rather than an attacker's payload.
+	 * Keep typical client payloads unchanged.
 	 */
 	public function test_a_realistic_client_payload_is_not_capped(): void {
 		$properties = array(
@@ -751,10 +711,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Every other bounds test calls `sanitize_client_properties()` directly, so
-	 * removing its call site in `record_event()` left the suite green while the
-	 * bounds silently stopped applying. This drives one through the real entry
-	 * point instead.
+	 * Apply bounds when recording a client event.
 	 */
 	public function test_record_client_event_actually_applies_the_bounds(): void {
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
@@ -778,8 +735,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Non-string scalars are analytics payload, not text: capping them would
-	 * change their type on the way to the pixel.
+	 * Preserve scalar value types.
 	 */
 	public function test_client_scalar_values_keep_their_type(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
@@ -794,9 +750,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A JSON array survives the consumers' truthiness check and reaches
-	 * `PREFIX . $event_name`, where PHP writes a warning to the log on an
-	 * unauthenticated request. `failOnWarning` makes that warning fail the test.
+	 * Reject unusable client event names.
 	 *
 	 * @dataProvider unusable_client_event_name_provider
 	 *
@@ -828,8 +782,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A name at the limit is still recorded: the bound is a limit, not an
-	 * off-by-one rejection of the longest legal name.
+	 * Keep event names at the length limit.
 	 */
 	public function test_client_event_name_at_the_length_limit_is_recorded(): void {
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
@@ -845,9 +798,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Names are the one axis left unbounded once values and counts are capped.
-	 * The charset check is `Pixel_Builder`'s own, so this drops exactly what it
-	 * would reject — but rejecting there loses the whole event, not one property.
+	 * Drop invalid client property names.
 	 */
 	public function test_unusable_client_property_names_are_dropped(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
@@ -864,8 +815,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A JSON object key that is all digits becomes an integer array key in PHP,
-	 * which `Pixel_Builder` would reject for the whole event.
+	 * Drop numeric client property names.
 	 */
 	public function test_numeric_client_property_names_are_dropped(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
@@ -879,11 +829,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The session cookie is client-writable and decoded with `json_decode`, so
-	 * every value it carries arrives with a type the client chose. `is_engaged`
-	 * was the one field read straight out of it: a nested array reached
-	 * `implode()` in `get_properties()` and wrote an "Array to string conversion"
-	 * warning to the log from an unauthenticated request.
+	 * Do not generate warnings for non-scalar session values.
 	 */
 	public function test_a_non_scalar_session_value_writes_no_warning(): void {
 		$_COOKIE['tk_ai']                        = 'test-visitor-id-1234567890ab';
@@ -905,9 +851,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `landing_page` carries a JSON breadcrumb trail. Cutting it as a plain string
-	 * lands mid-token and hands the pipeline something that no longer parses, so
-	 * whole trailing entries go instead.
+	 * Keep oversized landing-page trails valid JSON.
 	 */
 	public function test_an_oversized_landing_page_stays_valid_json(): void {
 		$trail = array_fill( 0, 200, 'Category' );
@@ -929,10 +873,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The referer reaches the pixel twice, as `_dr` and `_via_ref`, and nothing
-	 * bounds an HTTP header. Uncapped, one long one pushed the finished URL past
-	 * MAX_PIXEL_URL_LENGTH and cost the whole event, silently: the client fires
-	 * with `sendBeacon`, which discards the response.
+	 * Trim long referrers without dropping the event.
 	 */
 	public function test_a_long_referer_costs_its_own_tail_not_the_event(): void {
 		$_COOKIE['tk_ai']        = 'test-visitor-id-1234567890ab';
@@ -952,9 +893,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The fixture is an ordinary paid-traffic landing URL. At the old 200-character
-	 * cap it was truncated, which destroys exactly the campaign attribution the
-	 * event exists to record.
+	 * Preserve common ad-click landing URLs.
 	 */
 	public function test_an_ad_click_landing_url_survives_untouched(): void {
 		$url = 'https://example.com/product-category/clothing/mens-shirts/?utm_source=google&utm_medium=cpc&utm_campaign=spring&gclid=Cj0KCQjw1viWBhD0ARIsAAM_oKnLQ8example1234567890abcdefghij&fbclid=IwAR2example1234567890abcdefghijklmnop';
@@ -967,9 +906,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A value at the character cap can outweigh the whole byte budget once
-	 * percent-encoded. Trimming it keeps the property; dropping it loses a
-	 * product name to an encoding difference.
+	 * Trim values that exceed the encoded payload budget.
 	 */
 	public function test_a_value_the_budget_cannot_fit_is_trimmed_not_dropped(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
@@ -981,9 +918,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The template must record through the untrusted-client entry point. Nothing
-	 * in the suite executes the template, so asserting on its source text is
-	 * crude, but it is the only thing standing behind that requirement.
+	 * Keep the MU-plugin template aligned with the package API.
 	 */
 	public function test_mu_plugin_template_stays_in_step_with_the_package(): void {
 		$template = file_get_contents(
@@ -1018,9 +953,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The bounds are the contract this endpoint is documented with, and every
-	 * other assertion about them compares against the constant itself, so a
-	 * changed number would go unnoticed. These literals are the tripwire.
+	 * Keep the documented bounds in sync with their constants.
 	 */
 	public function test_client_bounds_have_their_documented_values(): void {
 		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST );
@@ -1033,9 +966,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The worst input the per-axis caps allow must still fit the pixel URL. The
-	 * literal 8192 is deliberate: asserting against MAX_PIXEL_URL_LENGTH makes
-	 * the assertion move with the constant and pass whatever it is set to.
+	 * Keep the largest permitted payload below the fixed pixel URL limit.
 	 */
 	public function test_a_maximal_client_payload_stays_under_eight_kilobytes(): void {
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
@@ -1062,8 +993,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Long property names cost budget too. Without charging the key, the budget
-	 * under-counts by up to MAX_CLIENT_PROPERTIES_PER_EVENT x MAX_CLIENT_NAME_LENGTH.
+	 * Include property names in the payload budget.
 	 */
 	public function test_property_names_are_charged_to_the_payload_budget(): void {
 		$short = array();
@@ -1083,8 +1013,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * An array trimmed until nothing fits is dropped rather than sent as an
-	 * empty value, so the pixel does not carry a meaningless parameter.
+	 * Drop arrays that cannot retain a member within the payload budget.
 	 */
 	public function test_an_array_that_cannot_fit_even_one_member_is_dropped(): void {
 		$properties = array();

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -1006,10 +1006,14 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			$template,
 			'The template must cap the batch with the same constant as the REST controller.'
 		);
-		$this->assertStringContainsString(
-			'defined( \'\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST\' )',
-			$template,
-			'The template must check that constant exists before reading it, since the autoloader can resolve an older package.'
+		$this->assertSame(
+			1,
+			preg_match( '/defined\( \'([^\']*::[^\']+)\' \)/', $template, $matches ),
+			'The template must check the constant exists before reading it, since the autoloader can resolve an older package.'
+		);
+		$this->assertTrue(
+			defined( $matches[1] ),
+			"The guarded name must resolve, or load_autoloader() always returns false and the module never serves. Reviewers read the leading backslash in {$matches[1]} as breaking defined(); it does not, on any PHP this package supports."
 		);
 	}
 

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -50,7 +50,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 */
 	public function tear_down(): void {
 		$_SERVER = $this->server_snapshot;
-		unset( $_COOKIE['tk_ai'] );
+		unset( $_COOKIE['tk_ai'], $_COOKIE['woocommerceanalytics_session'] );
 		$this->reset_reserved_property_names();
 		$this->reset_pixel_batch_queue();
 		$this->reset_cached_ip();
@@ -465,7 +465,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	public function test_client_property_values_are_capped(): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
 			array(
-				'pn'    => str_repeat( 'a', 500 ),
+				'pn'    => str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH + 100 ),
 				'short' => 'kept',
 			)
 		);
@@ -570,8 +570,8 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 	/**
 	 * An ASCII-only fixture hid this: the budget counted characters while the URL
-	 * carries percent-encoded bytes, so `%`, CJK and emoji each cost 3x what the
-	 * budget charged and the same payload built a 12KB URL.
+	 * carries percent-encoded bytes, so `%` costs 3x and CJK and emoji 9x or more
+	 * of what the budget charged, and the same payload built a 12KB URL.
 	 *
 	 * @dataProvider expensive_character_provider
 	 *
@@ -645,8 +645,14 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `cap_client_value()` counts characters, so a 250-character CJK value must
-	 * come back at 200 characters rather than being cut mid-sequence at 200 bytes.
+	 * The cut is made in characters, never in bytes, so a multibyte value comes
+	 * back shorter but never cut mid-sequence.
+	 *
+	 * No equality against the value cap here: a multibyte value at the cap costs
+	 * several times its length once percent-encoded, so the payload budget trims
+	 * it further, and asserting the cap would be asserting which bound won.
+	 * `test_client_property_values_are_capped()` pins the cap on ASCII, where
+	 * nothing else is in play.
 	 *
 	 * @dataProvider multibyte_value_provider
 	 *
@@ -654,10 +660,15 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 */
 	public function test_value_cap_counts_characters_not_bytes( string $character ): void {
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
-			array( 'pn' => str_repeat( $character, 250 ) )
+			array( 'pn' => str_repeat( $character, WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH + 50 ) )
 		);
 
-		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $sanitized['pn'] ) );
+		$this->assertLessThan(
+			WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH + 50,
+			mb_strlen( $sanitized['pn'] ),
+			'An over-cap value must come back shorter.'
+		);
+		$this->assertStringEndsWith( '…', $sanitized['pn'] );
 		$this->assertSame( $sanitized['pn'], mb_convert_encoding( $sanitized['pn'], 'UTF-8', 'UTF-8' ), 'The cut must not split a character.' );
 	}
 
@@ -752,7 +763,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		WC_Analytics_Tracking::record_client_event(
 			'add_to_cart',
 			array(
-				'pn'        => str_repeat( 'a', 500 ),
+				'pn'        => str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH + 100 ),
 				'Uppercase' => 'dropped by the name check',
 			)
 		);
@@ -868,6 +879,108 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The session cookie is client-writable and decoded with `json_decode`, so
+	 * every value it carries arrives with a type the client chose. `is_engaged`
+	 * was the one field read straight out of it: a nested array reached
+	 * `implode()` in `get_properties()` and wrote an "Array to string conversion"
+	 * warning to the log from an unauthenticated request.
+	 */
+	public function test_a_non_scalar_session_value_writes_no_warning(): void {
+		$_COOKIE['tk_ai']                        = 'test-visitor-id-1234567890ab';
+		$_COOKIE['woocommerceanalytics_session'] = wp_slash(
+			(string) wp_json_encode( array( 'is_engaged' => array( array( 'nested' ) ) ) )
+		);
+
+		$warnings = array();
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure
+			function ( $errno, $message ) use ( &$warnings ) {
+				$warnings[] = $message;
+				return true;
+			}
+		);
+		WC_Analytics_Tracking::record_client_event( 'product_view', array( 'pi' => 42 ) );
+		restore_error_handler();
+
+		$this->assertSame( array(), $warnings, 'A cookie value must not be able to write PHP warnings.' );
+	}
+
+	/**
+	 * `landing_page` carries a JSON breadcrumb trail. Cutting it as a plain string
+	 * lands mid-token and hands the pipeline something that no longer parses, so
+	 * whole trailing entries go instead.
+	 */
+	public function test_an_oversized_landing_page_stays_valid_json(): void {
+		$trail = array_fill( 0, 200, 'Category' );
+
+		$_COOKIE['woocommerceanalytics_session'] = wp_slash(
+			(string) wp_json_encode( array( 'landing_page' => wp_json_encode( $trail ) ) )
+		);
+
+		$properties = WC_Analytics_Tracking::get_common_properties();
+		$decoded    = json_decode( $properties['landing_page'], true );
+
+		$this->assertLessThanOrEqual(
+			WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH,
+			mb_strlen( $properties['landing_page'] )
+		);
+		$this->assertIsArray( $decoded, 'A trimmed trail must still parse as JSON.' );
+		$this->assertNotEmpty( $decoded );
+		$this->assertSame( 'Category', $decoded[0], 'The leading entries are the ones kept.' );
+	}
+
+	/**
+	 * The referer reaches the pixel twice, as `_dr` and `_via_ref`, and nothing
+	 * bounds an HTTP header. Uncapped, one long one pushed the finished URL past
+	 * MAX_PIXEL_URL_LENGTH and cost the whole event, silently: the client fires
+	 * with `sendBeacon`, which discards the response.
+	 */
+	public function test_a_long_referer_costs_its_own_tail_not_the_event(): void {
+		$_COOKIE['tk_ai']        = 'test-visitor-id-1234567890ab';
+		$_SERVER['HTTP_REFERER'] = 'https://example.com/?q=' . str_repeat( 'a', 5000 );
+		$this->reset_pixel_batch_queue();
+
+		$result = WC_Analytics_Tracking::record_client_event( 'product_view', array( 'pi' => 42 ) );
+
+		$this->assertFalse( is_wp_error( $result ), 'A long request header must not cost the event.' );
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( '42', $props['pi'] ?? null, 'The event payload must survive intact.' );
+		$this->assertStringEndsWith( '…', $props['_dr'] ?? '', 'The referer is what gets trimmed.' );
+
+		$this->reset_pixel_batch_queue();
+	}
+
+	/**
+	 * The fixture is an ordinary paid-traffic landing URL. At the old 200-character
+	 * cap it was truncated, which destroys exactly the campaign attribution the
+	 * event exists to record.
+	 */
+	public function test_an_ad_click_landing_url_survives_untouched(): void {
+		$url = 'https://example.com/product-category/clothing/mens-shirts/?utm_source=google&utm_medium=cpc&utm_campaign=spring&gclid=Cj0KCQjw1viWBhD0ARIsAAM_oKnLQ8example1234567890abcdefghij&fbclid=IwAR2example1234567890abcdefghijklmnop';
+
+		$this->assertGreaterThan( 200, mb_strlen( $url ), 'A fixture under the old cap would prove nothing.' );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( '_dl' => $url ) );
+
+		$this->assertSame( $url, $sanitized['_dl'] ?? null );
+	}
+
+	/**
+	 * A value at the character cap can outweigh the whole byte budget once
+	 * percent-encoded. Trimming it keeps the property; dropping it loses a
+	 * product name to an encoding difference.
+	 */
+	public function test_a_value_the_budget_cannot_fit_is_trimmed_not_dropped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array( 'pn' => str_repeat( '漢', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) )
+		);
+
+		$this->assertArrayHasKey( 'pn', $sanitized, 'An over-budget value must be trimmed, not dropped.' );
+		$this->assertStringEndsWith( '…', $sanitized['pn'] );
+	}
+
+	/**
 	 * The template must record through the untrusted-client entry point. Nothing
 	 * in the suite executes the template, so asserting on its source text is
 	 * crude, but it is the only thing standing behind that requirement.
@@ -909,7 +1022,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST );
 		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT );
 		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS );
-		$this->assertSame( 200, WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		$this->assertSame( 1000, WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
 		$this->assertSame( 100, WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH );
 		$this->assertSame( 4096, WC_Analytics_Tracking::MAX_CLIENT_PAYLOAD_LENGTH );
 		$this->assertSame( 8192, WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH );

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -893,6 +893,11 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			$template,
 			'The template must cap the batch with the same constant as the REST controller.'
 		);
+		$this->assertStringContainsString(
+			'defined( \'\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST\' )',
+			$template,
+			'The template must check that constant exists before reading it, since the autoloader can resolve an older package.'
+		);
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -457,6 +457,332 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The endpoint is unauthenticated and every property reaches the pixel URL,
+	 * which is rejected outright once it grows too long. Values are truncated
+	 * with an ellipsis so a capped value stays distinguishable from one that
+	 * genuinely ended at the limit.
+	 */
+	public function test_client_property_values_are_capped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				'pn'    => str_repeat( 'a', 500 ),
+				'short' => 'kept',
+			)
+		);
+
+		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $sanitized['pn'] ) );
+		$this->assertStringEndsWith( '…', $sanitized['pn'] );
+		$this->assertSame( 'kept', $sanitized['short'], 'Values within the limit must be untouched.' );
+	}
+
+	/**
+	 * A client cannot widen its own footprint by sending hundreds of properties.
+	 */
+	public function test_client_property_count_is_capped(): void {
+		$properties = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT + 25; $i++ ) {
+			$properties[ 'p' . $i ] = $i;
+		}
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertCount( WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT, $sanitized );
+	}
+
+	/**
+	 * get_properties() flattens array values with implode(), which emits an
+	 * "Array to string conversion" warning for a nested array. Letting an
+	 * unauthenticated caller write warnings into the error log is the problem
+	 * worth closing; the value itself is meaningless either way.
+	 */
+	public function test_nested_client_arrays_do_not_reach_the_flattening_step(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array( 'foo' => array( array( 1, 2 ), 'ok' ) )
+		);
+
+		$this->assertSame( array( '', 'ok' ), $sanitized['foo'] );
+	}
+
+	/**
+	 * The per-value cap runs on each member, never on the string
+	 * `get_properties()` joins them into: 20,000 ten-character members produced a
+	 * 300KB pixel URL, which nothing downstream rejects.
+	 */
+	public function test_client_array_member_count_is_capped(): void {
+		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS + 25, 'abcdefghij' );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pc' => $members ) );
+
+		$this->assertCount( WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, $sanitized['pc'] );
+
+		$props = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertLessThan(
+			2000,
+			strlen( $props['pc'] ),
+			'The flattened value is what reaches the pixel URL, so the cap must survive flattening.'
+		);
+	}
+
+	/**
+	 * Slicing must not turn an indexed array into an associative one:
+	 * `get_properties()` picks `implode()` over `wp_json_encode()` on that test.
+	 */
+	public function test_capped_arrays_still_flatten_with_implode(): void {
+		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS + 5, 'a' );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pc' => $members ) );
+		$props     = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertSame(
+			rawurlencode( implode( ',', array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, 'a' ) ) ),
+			$props['pc']
+		);
+	}
+
+	/**
+	 * The per-axis caps multiply: at their limits one event built a 512KB pixel
+	 * URL, so the product needs its own bound. Properties are dropped from the
+	 * tail once the budget is spent.
+	 */
+	public function test_client_payload_total_is_capped( string $character = 'a' ): void {
+		$properties = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $i++ ) {
+			$properties[ 'p' . $i ] = str_repeat( $character, WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		}
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertNotEmpty( $sanitized, 'The budget drops the tail, it does not empty the event.' );
+
+		// The pixel URL is what the budget exists to bound, so assert on it rather
+		// than on the constant.
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$props            = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertLessThanOrEqual(
+			WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH,
+			strlen( Pixel_Builder::build_tracks_url( $props ) )
+		);
+
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * An ASCII-only fixture hid this: the budget counted characters while the URL
+	 * carries percent-encoded bytes, so `%`, CJK and emoji each cost 3x what the
+	 * budget charged and the same payload built a 12KB URL.
+	 *
+	 * @dataProvider expensive_character_provider
+	 *
+	 * @param string $character One character whose encoded form is longer than itself.
+	 */
+	public function test_client_payload_budget_counts_encoded_bytes( string $character ): void {
+		$this->test_client_payload_total_is_capped( $character );
+	}
+
+	/**
+	 * Characters that cost more in the URL than they do in the payload.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function expensive_character_provider(): array {
+		return array(
+			'percent' => array( '%' ),
+			'CJK'     => array( '漢' ),
+			'emoji'   => array( '😀' ),
+			'space'   => array( ' ' ),
+			'tilde'   => array( '~' ),
+		);
+	}
+
+	/**
+	 * An associative array serializes to JSON, which carries its keys, while an
+	 * indexed one is joined and drops them. Measuring both as a joined list
+	 * charged nothing for the keys, and 50 such properties built a 152KB URL.
+	 */
+	public function test_associative_array_keys_are_charged_to_the_budget(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+
+		$properties = array();
+		for ( $p = 0; $p < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $p++ ) {
+			$members = array();
+			for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS; $i++ ) {
+				$members[ str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) . $i ] = 'v';
+			}
+			$properties[ 'p' . $p ] = $members;
+		}
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+		$props     = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertLessThanOrEqual(
+			WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH,
+			strlen( Pixel_Builder::build_tracks_url( $props ) )
+		);
+
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * One oversized value used to charge its key against the budget and then be
+	 * dropped anyway, so short properties after it were refused for space that
+	 * nothing occupied.
+	 */
+	public function test_a_dropped_property_does_not_spend_the_budget(): void {
+		// Long names on purpose: the leak is the key's own cost, so short keys hide
+		// it however many properties are dropped.
+		$properties = array();
+		for ( $i = 0; $i < 40; $i++ ) {
+			$name                = str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH - 12 ) . $i;
+			$properties[ $name ] = str_repeat( 'y', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		}
+		$properties['last'] = 'short';
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertSame( 'short', $sanitized['last'] ?? null, 'A property that fits must not be refused for a dropped one.' );
+	}
+
+	/**
+	 * `cap_client_value()` counts characters, so a 250-character CJK value must
+	 * come back at 200 characters rather than being cut mid-sequence at 200 bytes.
+	 *
+	 * @dataProvider multibyte_value_provider
+	 *
+	 * @param string $character One multibyte character.
+	 */
+	public function test_value_cap_counts_characters_not_bytes( string $character ): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array( 'pn' => str_repeat( $character, 250 ) )
+		);
+
+		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $sanitized['pn'] ) );
+		$this->assertSame( $sanitized['pn'], mb_convert_encoding( $sanitized['pn'], 'UTF-8', 'UTF-8' ), 'The cut must not split a character.' );
+	}
+
+	/**
+	 * Multibyte characters whose byte length differs from their character length.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function multibyte_value_provider(): array {
+		return array(
+			'CJK'    => array( '漢' ),
+			'emoji'  => array( '😀' ),
+			'accent' => array( 'é' ),
+		);
+	}
+
+	/**
+	 * The bound is a limit, not an off-by-one rejection of the longest legal value.
+	 */
+	public function test_a_value_at_the_length_limit_is_untouched(): void {
+		$exact = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pn' => $exact ) );
+
+		$this->assertSame( $exact, $sanitized['pn'] );
+	}
+
+	/**
+	 * An array that hits the member cap always exceeded the budget, so the whole
+	 * property used to vanish. Losing a few categories is easier to notice.
+	 */
+	public function test_oversized_arrays_lose_members_not_the_property(): void {
+		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pc' => $members ) );
+
+		$this->assertArrayHasKey( 'pc', $sanitized, 'The property must survive with fewer members.' );
+		$this->assertLessThan( count( $members ), count( $sanitized['pc'] ) );
+	}
+
+	/**
+	 * The last bound, and the only one that sees the final URL — so the only one
+	 * covering properties a filter callback added after the client caps ran.
+	 * Driven through the trusted path, where no client cap applies.
+	 */
+	public function test_oversized_pixel_urls_are_not_fired(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		$result = WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'pn' => str_repeat( 'a', WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH * 2 ) )
+		);
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'pixel_too_long', $result->get_error_code() );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'Nothing may be queued.' );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * A realistic event must pass through untouched, or the budget is capping
+	 * first-party analytics rather than an attacker's payload.
+	 */
+	public function test_a_realistic_client_payload_is_not_capped(): void {
+		$properties = array(
+			'pi'  => 731,
+			'pn'  => 'Some Reasonably Long Product Name With Words',
+			'pt'  => 'simple',
+			'pc'  => array( 'Clothing', 'Shirts', 'Sale' ),
+			'pp'  => 115.81,
+			'_lg' => 'en-GB',
+			'_dl' => 'https://example.com/product/some-reasonably-long-product-slug/?utm_source=x',
+			'_dr' => 'https://example.com/shop/page/3/',
+		);
+
+		$this->assertSame( $properties, WC_Analytics_Tracking::sanitize_client_properties( $properties ) );
+	}
+
+	/**
+	 * Every other bounds test calls `sanitize_client_properties()` directly, so
+	 * removing its call site in `record_event()` left the suite green while the
+	 * bounds silently stopped applying. This drives one through the real entry
+	 * point instead.
+	 */
+	public function test_record_client_event_actually_applies_the_bounds(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'pn'        => str_repeat( 'a', 500 ),
+				'Uppercase' => 'dropped by the name check',
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $props['pn'] ?? '' ) );
+		$this->assertArrayNotHasKey( 'Uppercase', $props );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * Non-string scalars are analytics payload, not text: capping them would
+	 * change their type on the way to the pixel.
+	 */
+	public function test_client_scalar_values_keep_their_type(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				'pi' => 42,
+				'ch' => true,
+			)
+		);
+
+		$this->assertSame( 42, $sanitized['pi'] );
+		$this->assertTrue( $sanitized['ch'] );
+	}
+
+	/**
 	 * A JSON array survives the consumers' truthiness check and reaches
 	 * `PREFIX . $event_name`, where PHP writes a warning to the log on an
 	 * unauthenticated request. `failOnWarning` makes that warning fail the test.
@@ -486,7 +812,59 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			'array'      => array( array( 'product_view' ) ),
 			'nested map' => array( array( 'name' => 'product_view' ) ),
 			'empty'      => array( '' ),
+			'oversized'  => array( str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH + 1 ) ),
 		);
+	}
+
+	/**
+	 * A name at the limit is still recorded: the bound is a limit, not an
+	 * off-by-one rejection of the longest legal name.
+	 */
+	public function test_client_event_name_at_the_length_limit_is_recorded(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		$name = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH );
+
+		WC_Analytics_Tracking::record_client_event( $name, array() );
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( WC_Analytics_Tracking::PREFIX . $name, $props['_en'] ?? null );
+	}
+
+	/**
+	 * Names are the one axis left unbounded once values and counts are capped.
+	 * The charset check is `Pixel_Builder`'s own, so this drops exactly what it
+	 * would reject — but rejecting there loses the whole event, not one property.
+	 */
+	public function test_unusable_client_property_names_are_dropped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH + 1 ) => 'oversized',
+				'Uppercase' => 'bad charset',
+				'has space' => 'bad charset',
+				'pi'        => 42,
+				'_lg'       => 'en-GB',
+			)
+		);
+
+		$this->assertSame( array( 'pi' => 42, '_lg' => 'en-GB' ), $sanitized );
+	}
+
+	/**
+	 * A JSON object key that is all digits becomes an integer array key in PHP,
+	 * which `Pixel_Builder` would reject for the whole event.
+	 */
+	public function test_numeric_client_property_names_are_dropped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				'0'  => 'dropped',
+				'pi' => 42,
+			)
+		);
+
+		$this->assertSame( array( 'pi' => 42 ), $sanitized );
 	}
 
 	/**
@@ -509,5 +887,92 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			$template,
 			'The template must not call the trusted entry point.'
 		);
+
+		$this->assertStringContainsString(
+			'MAX_CLIENT_EVENTS_PER_REQUEST',
+			$template,
+			'The template must cap the batch with the same constant as the REST controller.'
+		);
+	}
+
+	/**
+	 * The bounds are the contract this endpoint is documented with, and every
+	 * other assertion about them compares against the constant itself, so a
+	 * changed number would go unnoticed. These literals are the tripwire.
+	 */
+	public function test_client_bounds_have_their_documented_values(): void {
+		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST );
+		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT );
+		$this->assertSame( 50, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS );
+		$this->assertSame( 200, WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		$this->assertSame( 100, WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH );
+		$this->assertSame( 4096, WC_Analytics_Tracking::MAX_CLIENT_PAYLOAD_LENGTH );
+		$this->assertSame( 8192, WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH );
+	}
+
+	/**
+	 * The worst input the per-axis caps allow must still fit the pixel URL. The
+	 * literal 8192 is deliberate: asserting against MAX_PIXEL_URL_LENGTH makes
+	 * the assertion move with the constant and pass whatever it is set to.
+	 */
+	public function test_a_maximal_client_payload_stays_under_eight_kilobytes(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+
+		$properties = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $i++ ) {
+			$key                = str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH - 3 ) . sprintf( '%03d', $i );
+			$properties[ $key ] = str_repeat( '漢', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		}
+
+		$all = WC_Analytics_Tracking::get_properties(
+			WC_Analytics_Tracking::PREFIX . 'bounds_probe',
+			WC_Analytics_Tracking::sanitize_client_properties( $properties ),
+			true
+		);
+
+		$this->assertLessThanOrEqual(
+			8192,
+			strlen( Pixel_Builder::build_tracks_url( $all ) ),
+			'The per-axis caps must not multiply past the pixel URL ceiling.'
+		);
+
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * Long property names cost budget too. Without charging the key, the budget
+	 * under-counts by up to MAX_CLIENT_PROPERTIES_PER_EVENT x MAX_CLIENT_NAME_LENGTH.
+	 */
+	public function test_property_names_are_charged_to_the_payload_budget(): void {
+		$short = array();
+		$long  = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $i++ ) {
+			$value                = str_repeat( 'v', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+			$short[ 's' . $i ]    = $value;
+			$key                  = str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH - 3 ) . sprintf( '%03d', $i );
+			$long[ $key ]         = $value;
+		}
+
+		$this->assertLessThan(
+			count( WC_Analytics_Tracking::sanitize_client_properties( $short ) ),
+			count( WC_Analytics_Tracking::sanitize_client_properties( $long ) ),
+			'Long property names must consume budget, or the cap under-counts the URL.'
+		);
+	}
+
+	/**
+	 * An array trimmed until nothing fits is dropped rather than sent as an
+	 * empty value, so the pixel does not carry a meaningless parameter.
+	 */
+	public function test_an_array_that_cannot_fit_even_one_member_is_dropped(): void {
+		$properties = array();
+		for ( $i = 0; $i < 20; $i++ ) {
+			$properties[ 'p' . $i ] = str_repeat( 'v', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		}
+		$properties['pc'] = array( str_repeat( 'm', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertArrayNotHasKey( 'pc', $sanitized, 'An emptied array must be dropped, not sent as an empty value.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:


-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

> [!IMPORTANT]
> **PR 2 of 3.** PR 1 (#68313) has landed, so this now targets `trunk` directly and the diff is just the increment. It builds on PR 1's `record_client_event()` entry point. PR 3 is #68315.

**The problem**

PR 1 stops a client of `POST /wp-json/woocommerce-analytics/v1/track` overwriting server-derived properties. It does not bound how much a client can send.

Every accepted event becomes one outbound pixel request built by `Pixel_Builder::build_tracks_url()`, and nothing limited the number of events per request, properties per event, members in an array property, or the length of a value or a name. `record_pixel_url()` only checked the URL for emptiness.

The axes are independent and they multiply. At their limits one event built a **512KB pixel URL** and one request **24.5MB of outbound traffic**, from an unauthenticated caller. One property of 20,000 ten-character members produced a 300KB URL on its own, because the per-value cap runs on each member and never on the string `get_properties()` joins them into.

**The fix**

| Limit                     | Constant                          | Value |
| ------------------------- | --------------------------------- | ----- |
| Events per request        | `MAX_CLIENT_EVENTS_PER_REQUEST`   | 50    |
| Properties per event      | `MAX_CLIENT_PROPERTIES_PER_EVENT` | 50    |
| Members per array value   | `MAX_CLIENT_ARRAY_MEMBERS`        | 50    |
| Characters per value      | `MAX_CLIENT_PROPERTY_LENGTH`      | 1000  |
| Characters per name       | `MAX_CLIENT_NAME_LENGTH`          | 100   |
| Encoded payload per event | `MAX_CLIENT_PAYLOAD_LENGTH`       | 4096  |
| Pixel URL bytes           | `MAX_PIXEL_URL_LENGTH`            | 8192  |

-   Add `sanitize_client_properties()`, replacing the `strip_reserved_properties()` call on `record_event()`'s client path. It strips reserved names, then caps the property count, the names, the values, the array members and the per-event payload. One place, so the REST controller, the MU-plugin speed module and the stale-template safety net cannot drift on what "sanitized" means.
-   Cap the batch in the REST controller and in the MU-plugin template. The client's own batch size is 10; the headroom is for retries coalescing.
-   `MAX_CLIENT_PAYLOAD_LENGTH` bounds the product rather than each axis. It is counted **after percent-encoding, in bytes**, unlike the per-value cap which counts characters: a `%`, a CJK character or an emoji is one character and three bytes in the URL, so a character count under-charges by 3x and the same 50 x 200 payload built a 12KB URL.
-   Measure a value through the same `flatten_property_value()` that `get_properties()` uses, rather than approximating it. The approximation missed the JSON branch, so the keys of an associative array cost nothing, and it used `rawurlencode()` while `http_build_query()` defaults to RFC1738, which writes `~` as `%7E`.
-   Add the `MAX_PIXEL_URL_LENGTH` backstop in `record_pixel_url()`. It is the only bound that sees the finished URL, so the only one covering properties a `jetpack_woocommerce_analytics_event_props` callback added after the client caps ran. It **logs** when it drops a pixel, since no call site checks the return value.
-   Cap `session_id` and `landing_page` in `get_session_properties()`. They come from the client-writable `woocommerceanalytics_session` cookie and first-party events never meet the client caps, so an oversized cookie would push a first-party pixel past the backstop and drop the event.

Over-limit properties are dropped and the event still records; events past the batch limit are not recorded at all. Both are silent on purpose, for the reason stripping is: an unauthenticated endpoint that reports which values it rejected is an oracle. Truncated values keep a trailing `…` so they stay distinguishable from a value that genuinely ended at the limit.

Part of WOOA7S-1803. The issue is closed by #68313, not by this PR.

(For Bug Fixes) Not a regression from a specific PR: the endpoint has been unbounded since proxy tracking was introduced.

### Screenshots or screen recordings:


<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable: no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

Step 1 covers the whole change. Steps 2 onwards are the manual pass, because the bounds exist to keep an unauthenticated request from producing a large outbound pixel URL and the suite can only assert on the URL it builds in-process. Step 5 (the MU-plugin speed module) and step 7 (first-party events under a large session cookie) are the paths the suite does not execute at all.

Test the branch, not the diff: it contains PR 1's commit, and none of this works without it.

#### 1. Package suite

```bash
cd packages/php/woocommerce-analytics
composer install
XDEBUG_MODE=off ./vendor/bin/phpunit --colors=never
```

Expect `OK (150 tests, 303 assertions)`.

#### 2. Setup

Follow **step 2 of #68313** for the store requirements, the `00-wca-probe.php` version probe, the `rsync` deploy into the vendored copy, and the harness that logs recorded properties. Everything there applies unchanged.

Then add this to the harness file, since the bounds exist to bound the pixel URL rather than the response body:

```php
add_action( 'shutdown', function () {
	$p = new ReflectionProperty( '\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking', 'pixel_batch_queue' );
	$p->setAccessible( true );
	foreach ( (array) $p->getValue() as $url ) {
		error_log( 'WCA-PIXEL ' . strlen( $url ) . ' ' . substr( $url, 0, 200 ) );
	}
}, 19 );
```

```bash
wp option update wca_proxy_on yes
TRACK="$SITE/wp-json/woocommerce-analytics/v1/track"
UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36'
tail -f wp-content/debug.log

# Baseline, so the later numbers mean something.
curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":"product_view","properties":{"pi":42}}]'
```

Expect `200`, one `WCA … client=true` line, and **two** `WCA-PIXEL` lines. Each event produces two pixel URLs (`t.gif` and `w.gif`), so every pixel-line count below is twice the event count. The measured baseline was 563 and 568 bytes; yours will differ with user agent length.

> [!IMPORTANT]
> If the host plugin runs Jetpack's bot check, `curl/` is on its bot list and `record_event()` skips silently: every request returns `{"success":true}` and records nothing. Pass `-A "$UA"` on every request below.

#### 3. Each axis is bounded

Run these one at a time and read the `WCA-PIXEL` byte count after each.

```bash
# a) 500-member array value -> 50 members, tail dropped.
python3 -c "import json;print(json.dumps([{'event_name':'a','properties':{'cats':['c%d'%i for i in range(500)]}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# b) 20,000 ten-character members -> the 300KB case, also 50 members.
python3 -c "import json;print(json.dumps([{'event_name':'b','properties':{'cats':['abcdefghij']*20000}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# c) 1000-character value -> 199 characters plus a trailing ellipsis.
python3 -c "import json;print(json.dumps([{'event_name':'c','properties':{'pn':'z'*1000,'ok':'kept'}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# d) 300-character property name dropped, the short one kept.
python3 -c "import json;print(json.dumps([{'event_name':'d','properties':{'x'*300:'dropped','ok':'kept'}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# e) 300-character event name -> 207, that event errors, the good one records.
python3 -c "import json;print(json.dumps([{'event_name':'x'*300,'properties':{}},{'event_name':'good','properties':{'ok':'1'}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# f) 100 events -> 50 results.
python3 -c "import json;print(json.dumps([{'event_name':'batch_%d'%i,'properties':{}} for i in range(100)]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-
```

Expected:

-   (a) and (b): the logged `cats` value carries exactly 50 members, `c0` to `c49` in (a). Both stay a few hundred bytes over baseline. On PR 1, (b) produces a single URL of roughly 300KB.
-   (c): `pn` is 200 characters ending in `…`; `ok` is still `kept`.
-   (d): no 300-character key in the logged properties, `ok` still there, and the event still records. `Pixel_Builder` would have rejected the whole event for that name, so dropping the one property is the more forgiving outcome.
-   (e): `207` with `"the event name is empty, too long, or not a string"` for the first event and `{"success":true}` for the second. Two `WCA-PIXEL` lines, not four.
-   (f): 50 result objects and 100 `WCA-PIXEL` lines. On PR 1, 100 result objects and 200 pixel lines.
-   Throughout: **no `Array to string conversion` warning** anywhere in `debug.log`.

#### 4. The per-event budget counts encoded bytes

This is the axis that makes the others safe, and the one an ASCII fixture hides.

```bash
# ~24KB of CJK, emoji and '%', 50 properties x 200 characters.
python3 -c "import json;print(json.dumps([{'event_name':'e','properties':{'p%02d'%i:('測試%🎉'*60)[:200] for i in range(50)}}],ensure_ascii=False))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# The same shape in ASCII, for comparison.
python3 -c "import json;print(json.dumps([{'event_name':'f','properties':{'p%02d'%i:'a'*200 for i in range(50)}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# 50 associative array values, whose keys JSON carries into the URL.
python3 -c "import json;print(json.dumps([{'event_name':'g','properties':{'p%02d'%p:{('k'*200)+str(i):'v' for i in range(50)} for p in range(50)}}]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-
```

Expected: every `WCA-PIXEL` line **at or under 8192**, and in practice a few thousand bytes, since only the properties that fit the 4096-byte budget survive. The point is the ceiling, not the count. On PR 1 these are roughly 90KB, 12KB and 152KB. Each request must still log a `WCA` line with at least one client property: the budget drops the tail, not the event.

#### 5. The MU-plugin speed module

**This path has no execution coverage in the suite.** It bypasses the REST stack and runs before plugins load, so a mistake here is a fatal on every proxy POST. This PR adds the batch cap to it.

```bash
wp option update wca_module_on yes
wp transient delete woocommerce_analytics_proxy_speed_module_version_check
# visit $SITE/wp-admin/ as an admin, which runs the admin_init installer
grep -m1 Version wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php          # Version: 0.18.0
grep -c MAX_CLIENT_EVENTS_PER_REQUEST wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php   # 1

python3 -c "import json;print(json.dumps([{'event_name':'fast_%d'%i,'properties':{}} for i in range(100)]))" \
  | curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' --data @-
```

Expected: `"is_proxy_speed_module":true` and 50 result objects. **No `WCA-PIXEL` lines appear on this path**, because the module calls `send_batched_pixels()` and exits before `shutdown` runs, so the probe cannot see the queue. Use the response code instead: an over-length pixel comes back as `207` with `pixel_too_long`. Re-run step 3 (d) and step 4's first request through this path too, since the module calls the same `record_client_event()`.

Turn it back off when done: `wp option update wca_module_on no`, delete the transient, visit `/wp-admin/` again, confirm the file is gone.

#### 6. The pixel backstop, and its log line

`MAX_PIXEL_URL_LENGTH` is the only bound that sees the finished URL, so the only one covering properties a filter callback adds **after** the client caps have run. Add to the harness:

```php
add_filter( 'jetpack_woocommerce_analytics_event_props', function ( $props ) {
	if ( 'yes' === get_option( 'wca_bloat' ) ) {
		$props['bloat'] = str_repeat( 'q', 20000 );
	}
	return $props;
}, 1 );
```

```bash
wp option update wca_bloat yes
curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":"product_view","properties":{"pi":42}}]'
wp option update wca_bloat no
```

Expected: `207` with `"tracks pixel URL exceeds the maximum length"`, **no** `WCA-PIXEL` line, and a warning in **WooCommerce > Status > Logs**, source `woocommerce-analytics`:

```
WooCommerce Analytics: dropped a 20xxx byte tracks pixel, over the 8192 byte limit.
```

That log line is the point of this step: no call site checks `record_pixel_url()`'s return value, so on a first-party event the log is the only trace. Confirm it comes from `wc_get_logger()` and not the `error_log()` fallback, which applies only at MU-plugin stage.

#### 7. First-party events under an oversized session cookie

**The behaviour this PR newly changes.** `session_id` and `landing_page` come from the client-writable `woocommerceanalytics_session` cookie, and first-party events never pass through the client caps, so without the new cap an oversized cookie would push a first-party pixel past the 8192 backstop and drop the event.

```bash
wp option update wca_proxy_on no   # first-party path: record_event(), client=false

COOKIE=$(python3 -c "import json,urllib.parse;print(urllib.parse.quote(json.dumps({'session_id':'s'*1000,'landing_page':'https://example.com/'+'p'*1000,'is_engaged':True})))")

# Any product id on the store. add_to_cart fires server-side.
curl -s -o /dev/null -A "$UA" \
  -b "woocommerceanalytics_session=$COOKIE; tk_ai=<your tk_ai value>" \
  "$SITE/?add-to-cart=<product-id>"
```

> [!IMPORTANT]
> Two things make this step look like a failure when it is not.
> Keep the cookie around 1000 characters per field. At 5000 the encoded `Cookie` header goes over 10KB and the web server drops the whole header, taking `tk_ai` with it, so the event never appears at all rather than appearing capped.
> And pass `tk_ai` explicitly. On the first-party path `get_visitor_id()` has no IP-based fallback, so without that cookie `record_event()` skips silently and `debug.log` stays empty. Copy the value from a browser session on the store.

Expected in `debug.log`: a `WCA woocommerceanalytics_add_to_cart client=false` line whose `session_id` and `landing_page` are each 200 characters ending in `…`, and a `WCA-PIXEL` line comfortably under 8192. **The event must still be recorded.** If it is missing and the Logs screen shows `dropped a … byte tracks pixel`, the cap in `get_session_properties()` is not applying.

Then repeat with a normal-sized cookie (browse the shop in a browser and add to cart) and confirm both values pass through untouched.

#### 8. A realistic event is untouched

The failure mode worth ruling out is the budget capping ordinary analytics rather than an attacker's payload.

```bash
wp option update wca_proxy_on yes
curl -s -A "$UA" -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":"product_view","properties":{
    "pi":731,"pn":"Some Reasonably Long Product Name With Words","pt":"simple",
    "pc":["Clothing","Shirts","Sale"],"pp":115.81,"_lg":"en-GB",
    "_dl":"https://example.com/product/some-reasonably-long-product-slug/?utm_source=x",
    "_dr":"https://example.com/shop/page/3/"}}]'
```

Expected: every property appears in the logged event byte-identical to what was sent, with no truncation, no dropped key and no `…`. Then browse the shop in a real browser with proxy tracking on and confirm `page_view` and `product_view` still carry intact `pi`, `pn`, `pc`, `pp`, `pt` and page-accurate `_dl`, `_dr`, `_lg`, with no console errors and no PHP warnings.

Afterwards delete both harness files, reset the `wca_*` options, and reactivate anything you deactivated.

<!-- End testing instructions -->
### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

**Automated**

-   Package PHPUnit suite under WorDBless (PHP 8.1, PHPUnit 9.6.34): `OK (150 tests, 303 assertions)`.
-   `composer phpcs`: only the 5 pre-existing findings in `src/class-universal.php`, nothing new.

**Manual.** Local store: WooCommerce 11.1.0-dev, WordPress 7.0, Jetpack 16.1-a.5 connected, `premium-analytics` active, storefront over HTTPS via a tunnel, this branch's `src/` deployed into the vendored copy and confirmed loaded over HTTP as `PACKAGE_VERSION=0.18.0`.

-   **Every axis bounded.** 500-member array to exactly `c0`-`c49`; 20,000 members to 50; a 1000-character value to 200 ending in `…` with the sibling property kept; a 300-character property name dropped while the event still recorded; a 300-character event name rejected with `207` while the good event went through; 100 events truncated to 50 results and 100 pixel lines, highest `batch_49`.
-   **Worst case measured 3856 and 4646 bytes** against the 8192 ceiling: 50 multi-byte properties of 200 characters kept 2 properties, the ASCII equivalent kept 20, and 50 associative arrays with long keys kept 1. Baseline was 563 bytes.
-   **Zero** `Array to string conversion` lines across the whole run.
-   **Pixel backstop fires and logs.** A callback adding 20,000 characters returned `207` with `"tracks pixel URL exceeds the maximum length"`, produced no pixel, and wrote `dropped a 20570 byte tracks pixel, over the 8192 byte limit.` through `wc_get_logger()` rather than the `error_log()` fallback.
-   **Real events untouched.** `pi`, `pn`, `pt`, `pc`, `pp`, `_lg`, `_dl` and `_dr` on a browsed product passed through character for character.
-   **First-party events survive an oversized session cookie.** With 3000-character fields, both values capped to 200, the event still recorded, and the pixel came to 1419 bytes with no dropped-pixel warning. With a normal cookie both passed through untouched.
-   The MU-plugin fast path was re-run against the same bounds and behaved identically.

### Milestone


<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry


<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Neither box is checked: the entry is already committed as a file at `packages/php/woocommerce-analytics/changelog/wooa7s-client-input-bounds`, with `Significance: minor` and `Type: security`. `security` is not one of the checkbox options in this template's Type list, which is the other reason the automatic job is not used here. Minor rather than patch because the change adds public API: seven `MAX_*` constants and `sanitize_client_properties()`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

(Type is `Security`, matching the committed file and the 0.16.7 entry for WOOA7S-1800. It is not offered as a checkbox above.)

#### Message <!-- Add a changelog message here -->

Bound what the unauthenticated tracking proxy endpoint accepts: events per request, properties per event, array members, value and name lengths, an encoded payload budget per event, and a ceiling on the pixel URL that is fired.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

N/A: entry already committed as a file (see above).

</details>

### Release Communication


<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools


<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code: the caps, the encoding fix and the tests were drafted with AI assistance and reviewed line by line before commit.

---

### Review requirement

This is **High-Impact** under `docs/contribution/contributing/deciding-pr-high-impact.md`: it changes an unauthenticated public endpoint and adds public API. It needs an approving review from an independent human. The automated reviews on this PR, and any AI analysis the author ran, do not satisfy that.

### Backward compatibility


All signature changes are additive. Four behavioural changes need review.

1.  **Seven new public constants** on `WC_Analytics_Tracking`, plus the public `sanitize_client_properties()`. Public constants are permanent aliases for their values once shipped, and the MU-plugin template already reads one across the package boundary, so lowering any of them later is a behaviour change for anyone at the limit. They are deliberately not filterable: a filter would let a site raise its own outbound traffic ceiling from an unauthenticated request path.

2.  **A client that sends too much has it trimmed, silently.** An over-long value is cut rather than dropped, and the payload budget is spent on the cheapest properties first, so one long value costs its own tail instead of every property after it. Events past the 50-event batch limit produce no result entry. An unauthenticated endpoint that reports which values it rejected is an oracle for probing the limits. Truncated values keep a trailing `…`, so a capped value stays distinguishable downstream from one that genuinely ended at the limit.

    An unusable **event** name is the exception and does return an error, since an event that produced no pixel reported as a success is what makes the loss invisible.

3.  **Server-derived values are capped on first-party events too.** The session cookie (`session_id`, `landing_page`, `is_engaged`) and the request headers behind `get_server_details()` (`_via_ua`, `_dr`, `_via_ref`, `_dl`) are all caller-influenced, and neither path goes through the client caps. Ordinary lengths see no change. The alternative was worse: uncapped, one long `Referer` reaches the pixel twice and pushes it past the ceiling, costing the whole event.

    `landing_page` carries a JSON breadcrumb trail, so it loses whole trailing entries and is re-encoded rather than cut mid-token, which would have made it unparseable. `is_engaged` is now type-checked: a nested array in the cookie reached `implode()` and wrote an `Array to string conversion` warning from an unauthenticated request.

4.  **`record_pixel_url()` now refuses any URL over 8192 bytes**, returning a `pixel_too_long` `WP_Error`. This applies to first-party events too, so a `jetpack_woocommerce_analytics_event_props` callback that adds a large property can now cost the event. **No first-party call site checks the return value**, so it writes a `warning` through `wc_get_logger()` with source `woocommerce-analytics`, falling back to `error_log()` at MU-plugin stage. Extensions adding large properties should expect that log line rather than a silent gap.

**Not covered:** the per-axis caps apply to client-supplied properties only. Properties introduced by a filter callback are bounded solely by the 8192-byte backstop, which drops the whole event rather than the offending property.

### Follow-ups this PR deliberately leaves alone


-   **Five of the seven values are pinned only by the new tripwire test.** The individual behaviour tests compare against the constants themselves, so raising one to 5000 keeps every assertion but the tripwire green. Only `MAX_CLIENT_PAYLOAD_LENGTH` and `MAX_PIXEL_URL_LENGTH` are pinned by assertions on the resulting pixel URL, which is the shape all of them should have.
-   **The MU-plugin template's batch cap is covered by string matching only.** No test loads the template, so nothing checks that the slice runs. Its version guard is executed now, but only through the constant name the template names.
-   **An already-installed module is unprotected by the batch cap until it is rewritten.** The rewrite triggers on `PACKAGE_VERSION` changing, so the module copy lags the REST route until an admin page load runs the installer.
-   **A truncated batch does not say how many events were dropped.** The count is something the client already knows, so returning it would not be an oracle.
-   **The 8192-byte backstop drops the event rather than the property.** Dropping the offending property instead means deciding whose property to drop, which needs a rule this PR does not have.



