### PR TITLE
Prevent selecting a variation in the Single Product block

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/edit/shared-product-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/edit/shared-product-control.tsx
@@ -21,7 +21,6 @@ const SharedProductControl = ( {
 }: SharedProductControlProps ) => (
 	<ProductControl
 		selected={ attributes.productId || 0 }
-		showVariations
 		onChange={ ( value = [] ) => {
 			const id = value[ 0 ] ? value[ 0 ].id : 0;
 			setAttributes( {

--- a/plugins/woocommerce/client/blocks/changelog/fix-60860-single-product-variation-product-title
+++ b/plugins/woocommerce/client/blocks/changelog/fix-60860-single-product-variation-product-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent selecting a product variation in the Single Product block, which caused the Product Title block to render empty in the editor.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a product variation is selected in the Single Product block, the Product Title block renders an empty string in the editor. The Single Product block passes the variation ID to its inner `core/post-title` block, which reads the title through `useEntityProp()` with `postType: 'product'`. Variations are not `product` posts, so that entity request fails in the editor and the title comes back empty, while the frontend (which reads product context via the Store API) renders correctly.

Variations are not the primary use case for the Single Product block, so this change stops offering them in the block's product picker (`SharedProductControl`), matching the short-term mitigation proposed in the issue.

Closes #60860.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a variable product with a few variations in WooCommerce.
2. Add the Single Product block to a page or template. In the block's product picker, search for the variable product and confirm only the top-level product can be selected — variations are no longer listed/expandable for selection.
3. Select the variable product and confirm the Product Title inner block renders the product title in the editor (not an empty string).
4. Confirm the frontend renders the Single Product block and Product Title correctly for the selected product.

### Testing that has already taken place:

-   Ran the existing Single Product block integration test (`assets/js/blocks/single-product/test/block.ts`): 2 tests pass.
-   Ran ESLint on the changed file: clean.
-   This is a deliberate scoping change: pre-existing saved variations remain as the stored `productId` (unchanged frontend behavior); only new selection is restricted. A more complete fix for rendering already-saved variations is tracked separately in the issue.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually at `plugins/woocommerce/client/blocks/changelog/fix-60860-single-product-variation-product-title`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->