### PR TITLE
fix: register WooCommerce user REST fields before building currentUserData

### DIFF
--- a/plugins/woocommerce/changelog/fix-current-user-data-rest-fields
+++ b/plugins/woocommerce/changelog/fix-current-user-data-rest-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Include WooCommerce user fields in currentUserData when the REST API has not been initialized.

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -24,7 +24,7 @@ class WCAdminUser {
 	/**
 	 * Get class instance.
 	 *
-	 * @return object Instance.
+	 * @return WCAdminUser Instance.
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -160,6 +160,12 @@ class WCAdminUser {
 	 * @return array User data.
 	 */
 	public static function get_user_data() {
+		// The controller below reads $wp_rest_additional_fields, which is only filled once
+		// rest_api_init has fired. On a wp-admin request it has not, so register our fields
+		// explicitly instead of relying on something else having booted the REST server first.
+		// register_rest_field() only writes to that global, so this does not build the server.
+		self::get_instance()->register_user_data();
+
 		$user_controller = new \WP_REST_Users_Controller();
 		$request         = new \WP_REST_Request();
 		$request->set_query_params( array( 'context' => 'edit' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/WCAdminUserTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/WCAdminUserTest.php
@@ -1,0 +1,58 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\WCAdminUser;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the WCAdminUser class.
+ */
+class WCAdminUserTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Value of $wp_rest_additional_fields before the test ran.
+	 *
+	 * @var array
+	 */
+	private $additional_fields_backup = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// No base class snapshots this global, so keep our own copy.
+		$this->additional_fields_backup = $GLOBALS['wp_rest_additional_fields'] ?? array();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		try {
+			$GLOBALS['wp_rest_additional_fields'] = $this->additional_fields_backup;
+		} finally {
+			parent::tearDown();
+		}
+	}
+
+	/**
+	 * @testdox Should include the WooCommerce user fields even when rest_api_init has not fired.
+	 */
+	public function test_get_user_data_includes_woocommerce_fields_without_rest_api_init(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		// A wp-admin request never fires rest_api_init, so the global the users controller
+		// reads its extra fields from is empty.
+		$GLOBALS['wp_rest_additional_fields'] = array();
+
+		$user_data = WCAdminUser::get_user_data();
+
+		$this->assertArrayHasKey( 'woocommerce_meta', $user_data, 'currentUserData should carry woocommerce_meta.' );
+		$this->assertArrayHasKey( 'is_super_admin', $user_data, 'currentUserData should carry is_super_admin.' );
+		$this->assertArrayHasKey( 'variable_product_tour_shown', $user_data['woocommerce_meta'], 'woocommerce_meta should carry the registered user data fields.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

Since 11.0, user preferences in wc-admin look like they don't stick.
Column visibility, dismissed notices, saved view shapes all come back empty on page load.
They do save; they just never come back.

Reasoning: 

- Every wc-admin page prints a `currentUserData` blob. The JS reads it once and never asks the server again.
- We build that blob by calling the REST users endpoint by hand.
- WooCommerce adds two extra fields to it (`woocommerce_meta`, `is_super_admin`) - but only after the REST API has started up.
- On a normal admin page the REST API never starts up. So the two fields aren't there yet, and the blob ships without them.

It used to work by accident. Until 11.0 we preloaded a Jetpack endpoint on every admin page, which started the REST API early enough. #65505 removed that preload for performance, and the accident went with it.

The fix: add the two fields ourselves, right before building the blob - which should be sufficient.
Registering a field just writes to an array (it doesn't start the REST API) so #65505's performance win stays.

Bug introduced in PR #65505.

I noticed this while working on https://github.com/Automattic/woocommerce-payments/pull/12090 and noticing that WooPayments column visibility preferences no longer worked.

### Backward compatibility

No hook added, removed, renamed, or retimed. No signature changed. No overridable method skipped.
This changes restores a path that was being skipped. `register_user_data()` was already public. The `woocommerce_admin_get_user_data_fields` filter now fires on admin page loads again, as it did before 11.0.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a clean site, go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and turn "Analytics" off.
<img width="1186" height="81" alt="645096272-daacec45-eef4-4c95-b5a1-69cf8e81fbaa" src="https://github.com/user-attachments/assets/d41ad8e9-f53d-4004-bd01-e34c8864ca62" />

2. Visit `/wp-admin/admin.php?page=wc-admin` and run `wcSettings.admin.currentUserData` in the browser console.
3. On WC 11: no `woocommerce_meta`. On this branch: it's there.
Before:
<img width="364" height="62" alt="Screenshot 2026-09-03 at 10 52 13 AM" src="https://github.com/user-attachments/assets/e0c5bd90-b78a-4ee7-8e15-2506f6fd93b6" />

After:
<img width="522" height="45" alt="Screenshot 2026-09-03 at 10 47 39 AM" src="https://github.com/user-attachments/assets/cd05ebfa-5d9b-4187-847a-c09d32aa1f74" />

4. Other surface areas where the symptoms are visible (this is not a complete list, just an example):
  - On the home screen ( `/wp-admin/admin.php?page=wc-admin` ), changing the layout column and refreshing the page doesn't get persisted 
<img width="344" height="227" alt="Screenshot 2026-09-03 at 11 19 15 AM" src="https://github.com/user-attachments/assets/652776da-ae41-486a-93ad-d9095facb8ab" />

  - On a brand new site (you _need_ to create a new site - I tested on JN), tutorials are continuously proposed (like "variable product" tutorial displayed when selecting "Variable product" on the product edit screen)
<img width="494" height="482" alt="Screenshot 2026-09-03 at 11 21 19 AM" src="https://github.com/user-attachments/assets/c0de4095-4e9f-433d-a5a3-82ec8bd72a50" />

<!-- End testing instructions -->

### Testing that has already taken place:

- Unit tests
- Manual organic-life-form-performed tests acting on mouse and keyboard on both brand new and pre-existing JN sites

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added manually in `plugins/woocommerce/changelog/`.

### Use of AI Tools

Written with Claude Code: the fix, the test, and this description. Reviewed by an adversarial agent, then by me. I take responsibility for the result.


