### PR TITLE
Fix: preserve percent-encoded custom variation attribute values

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1242,7 +1242,7 @@ class WC_Cart extends WC_Legacy_Cart {
 							// Don't use wc_clean as it destroys sanitized characters.
 							$value = sanitize_title( wp_unslash( $variation[ $attribute_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						} else {
-							$value = html_entity_decode( wc_clean( wp_unslash( $variation[ $attribute_key ] ) ), ENT_QUOTES, get_bloginfo( 'charset' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+							$value = html_entity_decode( wc_sanitize_term_text_based( $variation[ $attribute_key ] ), ENT_QUOTES, get_bloginfo( 'charset' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						}
 
 						// Don't include if it's empty.

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php
@@ -2208,6 +2208,44 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should accept a percent-encoded custom variation attribute value.
+	 */
+	public function test_add_to_cart_preserves_percent_encoded_custom_variation_attribute(): void {
+		$product = new WC_Product_Variable();
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( 'color' );
+		$attribute->set_options( array( 'Black%20White' ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE ENCODED COLOR',
+			10,
+			array( 'color' => 'Black%20White' )
+		);
+
+		$cart_item_key = WC()->cart->add_to_cart(
+			$product->get_id(),
+			1,
+			$variation->get_id(),
+			array( 'attribute_color' => 'Black%20White' )
+		);
+
+		$this->assertNotFalse( $cart_item_key, 'The variation should be added to the cart.' );
+		$this->assertSame(
+			'Black%20White',
+			WC()->cart->get_cart_item( $cart_item_key )['variation']['attribute_color'],
+			'The cart item should preserve the percent-encoded attribute value.'
+		);
+	}
+
+	/**
 	 * Test that adding a variation via URL parameter fails when specifying a value for the attribute
 	 * that differs from a value belonging to that variant.
 	 */


### PR DESCRIPTION
Fixes #68250.

`WC_Cart::add_to_cart()` sanitizes a posted custom (non-taxonomy) variation attribute value with `wc_clean()`, which calls `sanitize_text_field()` and strips percent-encoded sequences -- e.g. `Black%20White` becomes `BlackWhite`, no longer matching the configured option, so the variation is rejected as invalid even though the product editor accepts and stores the value fine.

The taxonomy branch immediately above already avoids the identical problem via `sanitize_title()`, with a comment noting `wc_clean`'s character-destroying behavior. This uses `wc_sanitize_term_text_based()` instead for the custom-attribute branch -- it's the existing purpose-built sanitizer for exactly this case (`trim( wp_strip_all_tags( wp_unslash( $term ) ) )`: strips tags, doesn't touch percent-encoded characters), rather than introducing a third, different sanitization approach alongside the two already in this function.

## Testing

Added `test_add_to_cart_preserves_percent_encoded_custom_variation_attribute` to `plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php`, covering the exact reported scenario (a custom attribute with a `%20`-containing option value added to the cart).

I wasn't able to run PHPUnit locally (no PHP toolchain in my environment) -- read the test closely against the existing suite's conventions and `WC_Helper_Product::create_product_variation_object`'s real signature to be as confident as I can without running it, but would appreciate CI's read.