### PR TITLE
Update PR review routing for Kirigami

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -9,12 +9,12 @@ when:
         - rubik
   - author:
       teamIs:
-        - woo-fse
+        - kirigami
       ignore:
         nameIs:
     assign:
       teams:
-        - woo-fse
+        - kirigami
   - author:
       teamIs:
         - ballade

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -28,60 +28,60 @@
 'plugins/woocommerce/tests/{Tools,bin,cli,e2e,metrics,performance}/**/*':
     - team: monorepo
 
-# Blocks, patterns, products, inventory, search, and storefront (Woo FSE / Kirigami).
+# Blocks, patterns, products, inventory, search, and storefront (Kirigami).
 'packages/js/{block-templates,components,experimental,expression-evaluation,sanitize}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/{.wordpress-org,i18n}/**/*':
     - team: developer-advocacy
 
 'plugins/woocommerce-beta-tester/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/patterns/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/client/blocks/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/client/admin/client/{components,error-boundary,hooks,lib,stylesheets,typings,utils,wp-admin-scripts}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/client/admin/client/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/client/admin/docs/**/*':
     - team: developer-advocacy
 
 'plugins/woocommerce/client/legacy/**/*{attribute,product,variation}*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/src/{Blocks,LayoutTemplates}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/src/Admin/BlockTemplates/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/src/Internal/{CostOfGoodsSold,Customers,ProductAttributes,ProductAttributesLookup,ProductDownloads,ProductFeed,ProductFilters,ProductGallery,ProductImage,VariationGallery}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/includes/{blocks,customizer,shortcodes,theme-support,walkers,widgets}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/includes/{class-wc-customer*,class-wc-product*,wc-customer*,wc-product*,wc-stock-functions.php}':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/includes/data-stores/class-wc-{customer,product}*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/templates/{auth,block-notices,brands,global,loop,myaccount,notices,parts,product-form,single-product,templates}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/templates/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/packages/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 # Cart, checkout, orders, onboarding, Store API, and shared backend (Rubik).
 'packages/js/{currency,customer-effort-score,date,extend-cart-checkout-block,number,onboarding}/**/*':
@@ -106,7 +106,7 @@
     - team: rubik
 
 'plugins/woocommerce/src/Internal/{AddressProvider,POS}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/src/Internal/Admin/{Logging,Onboarding,Orders,Schedulers}/**/*':
     - team: rubik
@@ -115,7 +115,7 @@
     - team: rubik
 
 'plugins/woocommerce/src/Internal/Admin/{ProductForm,ProductReviews}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/includes/*':
     - team: rubik
@@ -435,27 +435,27 @@
 'packages/js/remote-logging/**/*':
     - team: rubik
 
-# Product and storefront tests mirror the Woo FSE-owned source areas.
+# Product and storefront tests mirror the Kirigami-owned source areas.
 'plugins/woocommerce/tests/php/src/Blocks/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/tests/php/src/Blocks/StoreApi/**/*':
     - team: rubik
 
 'plugins/woocommerce/tests/php/src/Internal/{AddressProvider,CostOfGoodsSold,Customers,POS,ProductAttributes,ProductAttributesLookup,ProductDownloads,ProductFeed,ProductFilters,ProductGallery,VariationGallery}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/tests/php/src/Internal/Admin/{ProductForm,ProductReviews}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/tests/php/src/Internal/{AssignDefaultCategoryTest.php,DownloadPermissionsAdjusterTest.php}':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/tests/legacy/unit-tests/{account,attributes,blocks,customer,product,shortcodes,templates,widgets}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/tests/php/includes/data-stores/class-wc-{customer,product}*':
-    - team: woo-fse
+    - team: kirigami
 
 # Legacy client assets are routed only when their product area is identifiable.
 'plugins/woocommerce/client/legacy/**/*{cart,checkout,order}*':
@@ -500,19 +500,19 @@
     - team: ballade
 
 'plugins/woocommerce/assets/images/{pattern-placeholders,product_data,template-placeholders}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/client/legacy/css/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/client/legacy/js/frontend/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/assets/{client,fonts}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/assets/images/{icons,pinata,previews}/**/*':
-    - team: woo-fse
+    - team: kirigami
 
 'plugins/woocommerce/tests/php/src/{AutoloaderTest.php,CLAUDE.md}':
     - team: monorepo


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Woo FSE GitHub team has been replaced by Kirigami, so PR reviewer automation must use the new team slug. This updates both internal team-authored PR assignment and file-based community PR routing from `woo-fse` to `kirigami`.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; this PR only changes GitHub reviewer automation configuration.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Confirm `.github/automate-team-review-assignment-config.yml` matches Kirigami-authored PRs and assigns the `kirigami` team.
2. Confirm every formerly Woo FSE-owned path in `.github/project-community-pr-assigner.yml` now assigns the `kirigami` team.
3. Confirm no `woo-fse` or Woo FSE references remain under `.github`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Parsed both modified configuration files successfully with Ruby's YAML parser.
- Confirmed no Woo FSE references remain under `.github`.
- Ran `git diff --check` successfully.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Administrative GitHub configuration change; not shipped to merchants.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to update the configuration, validate the YAML, and prepare this pull request.
