### PR TITLE
Revert "Give woocommercebot PRs a larger e2e timeout"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,9 +405,7 @@ jobs:
           path: '${{ runner.temp }}/last-run-info'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        # `woocommercebot` PRs run on the `WooCommerce Release Checks` group (see `runs-on` above),
-        # which is slower than `ubuntu-latest`, so they need a larger e2e budget than other PRs.
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && ( github.event.pull_request.user.login == 'woocommercebot' && 30 || 20 ) ) || ( matrix.testType == 'unit:php' && 20 ) ) ) || 360 }}
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && 20 ) || ( matrix.testType == 'unit:php' && 20 ) ) ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }} # required by Metrics tests


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Reverts #67178.

That PR gave `woocommercebot` PRs a 30-minute e2e budget because the `WooCommerce Release Checks` runner group was about 1.45× slower than `ubuntu-latest`, and Blocks e2e shard 10/10 timed out at the 20-minute cap on every package-release PR.

That gap is gone. Since late August the slowest Blocks shard on that group finishes in 17 minutes, the same as on `ubuntu-latest`. 

Bot PRs no longer need their own budget, so this restores the single 20-minute e2e cap for all PRs. Human PRs, `unit:php`, and trunk pushes are unchanged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

`.github/**` is excluded from `needs-code-validation`, so this PR runs no test jobs. Green here proves nothing.

1. After merge, on the next `woocommercebot` package-release PR, confirm every Blocks e2e shard finishes under 20 minutes.
2. On any non-bot PR, confirm e2e is still capped at 20 minutes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Blocks e2e shard durations for the `Run tests (e2e)` step, taken from the GitHub Actions API. Shards 6/10 and 10/10 are the slowest.

| Run | Branch | Runner | 6/10 | 10/10 |
| --- | --- | --- | --- | --- |
| `32337632407` (bot PR #67869, 20 Aug) | `release/11.1` | Release Checks | 21 min | 25 min |
| `32505820875` (bot PR #67915, 21 Aug) | `release/11.1` | Release Checks | 22 min | 26 min |
| `33083663625` (bot PR #68103, 27 Aug) | `release/11.1` | Release Checks | 14 min | 16 min |
| `33381784052` (bot PR #68144, 31 Aug) | `release/11.1` | Release Checks | 14 min | 17 min |
| `33499493777` (bot PR #68219, 1 Sep) | `release/11.1` | Release Checks | 14 min | 15 min |
| `33634084761` (push, 2 Sep) | `release/11.1` | `ubuntu-latest` | 14 min | 16 min |
| `33741842812` (push, 3 Sep) | `trunk` | `ubuntu-latest` | 13 min | 10 min |
| `33744345222` (push, 3 Sep) | `trunk` | `ubuntu-latest` | 13 min | 9 min |

The revert applies cleanly with `git revert` and the workflow YAML parses.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

CI configuration only; nothing shipped to merchants.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code): the revert, the timing data collection, and this description. Reviewed by the author.