### PR TITLE
Email Editor: Restrict email preview sending to registered email post types

### DIFF
--- a/packages/php/email-editor/changelog/stomail-8437-security-email-editor-preview-route-sends-arbitrary-mail-as
+++ b/packages/php/email-editor/changelog/stomail-8437-security-email-editor-preview-route-sends-arbitrary-mail-as
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restrict the send preview email endpoint to posts of registered email post types.

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -183,8 +183,14 @@ class Email_Editor {
 	 * @phpstan-return EmailPostType[]
 	 */
 	private static function get_post_types(): array {
-		$post_types = array();
-		return apply_filters( 'woocommerce_email_editor_post_types', $post_types );
+		$post_types = apply_filters( 'woocommerce_email_editor_post_types', array() );
+		/**
+		 * Non-array filter results mean no email post types.
+		 *
+		 * @var EmailPostType[] $post_types
+		 */
+		$post_types = is_array( $post_types ) ? $post_types : array();
+		return $post_types;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -137,7 +137,7 @@ class Email_Editor {
 			$request_uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 		}
 		if ( strstr( $request_uri, 'site-editor.php' ) === false ) {
-			$post_types = array_column( $this->get_post_types(), 'name' );
+			$post_types = array_column( self::get_post_types(), 'name' );
 			$this->templates->initialize( $post_types );
 		}
 	}
@@ -158,7 +158,7 @@ class Email_Editor {
 	 * @return void
 	 */
 	private function register_email_post_types(): void {
-		foreach ( $this->get_post_types() as $post_type ) {
+		foreach ( self::get_post_types() as $post_type ) {
 			register_post_type(
 				$post_type['name'],
 				array_merge( $this->get_default_email_post_args(), $post_type['args'] )
@@ -182,7 +182,7 @@ class Email_Editor {
 	 * @return array
 	 * @phpstan-return EmailPostType[]
 	 */
-	private function get_post_types(): array {
+	private static function get_post_types(): array {
 		$post_types = array();
 		return apply_filters( 'woocommerce_email_editor_post_types', $post_types );
 	}
@@ -240,7 +240,7 @@ class Email_Editor {
 	 * @return void
 	 */
 	public function extend_email_post_api() {
-		$email_post_types = array_column( $this->get_post_types(), 'name' );
+		$email_post_types = array_column( self::get_post_types(), 'name' );
 		register_rest_field(
 			$email_post_types,
 			'email_data',
@@ -270,7 +270,7 @@ class Email_Editor {
 					}
 					$post_id = $request->get_param( 'postId' );
 					if ( is_numeric( $post_id ) && (int) $post_id > 0 ) {
-						return current_user_can( 'edit_post', (int) $post_id );
+						return self::is_email_post_type( get_post_type( (int) $post_id ) ) && current_user_can( 'edit_post', (int) $post_id );
 					}
 
 					/**
@@ -355,17 +355,17 @@ class Email_Editor {
 	}
 
 	/**
-	 * Check if the current post type is an email post type.
+	 * Check if the post type is registered for the email editor.
 	 *
-	 * @param string $current_post_type The current post type.
+	 * @param string|false $post_type The post type to check.
 	 * @return bool
 	 */
-	private function current_post_is_email_post_type( $current_post_type ): bool {
-		if ( ! $current_post_type ) {
+	public static function is_email_post_type( $post_type ): bool {
+		if ( ! $post_type ) {
 			return false;
 		}
-		$email_post_types = array_column( $this->get_post_types(), 'name' );
-		return in_array( $current_post_type, $email_post_types, true );
+		$email_post_types = array_column( self::get_post_types(), 'name' );
+		return in_array( $post_type, $email_post_types, true );
 	}
 
 	/**
@@ -381,7 +381,7 @@ class Email_Editor {
 			return $template;
 		}
 
-		if ( ! $this->current_post_is_email_post_type( $post->post_type ) ) {
+		if ( ! self::is_email_post_type( $post->post_type ) ) {
 			return $template;
 		}
 
@@ -413,7 +413,7 @@ class Email_Editor {
 			return $preview_link;
 		}
 
-		if ( ! $this->current_post_is_email_post_type( $post->post_type ) ) {
+		if ( ! self::is_email_post_type( $post->post_type ) ) {
 			return $preview_link;
 		}
 

--- a/packages/php/email-editor/src/Engine/class-send-preview-email.php
+++ b/packages/php/email-editor/src/Engine/class-send-preview-email.php
@@ -219,7 +219,7 @@ class Send_Preview_Email {
 	 */
 	private function fetch_post( $post_id ): \WP_Post {
 		$post = get_post( intval( $post_id ) );
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof \WP_Post || ! Email_Editor::is_email_post_type( $post->post_type ) ) {
 			throw new \Exception( esc_html__( 'Invalid post', 'woocommerce' ) );
 		}
 		return $post;

--- a/packages/php/email-editor/tests/integration/Engine/Send_Preview_Email_Permission_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Send_Preview_Email_Permission_Test.php
@@ -35,6 +35,20 @@ class Send_Preview_Email_Permission_Test extends \Email_Editor_Integration_Test_
 	private const ROUTE = '/woocommerce-email-editor/v1/send_preview_email';
 
 	/**
+	 * Post type registered for the email editor in these tests.
+	 *
+	 * @var string
+	 */
+	private const EMAIL_POST_TYPE = 'custom_email_type';
+
+	/**
+	 * Callback to register the test email post type.
+	 *
+	 * @var callable
+	 */
+	private $post_register_callback;
+
+	/**
 	 * Creates a user and returns an integer ID.
 	 *
 	 * @param array $args Arguments for user creation.
@@ -47,13 +61,13 @@ class Send_Preview_Email_Permission_Test extends \Email_Editor_Integration_Test_
 	}
 
 	/**
-	 * Creates a post and returns an integer ID.
+	 * Creates an email post and returns an integer ID.
 	 *
 	 * @param array $args Arguments for post creation.
 	 * @return int
 	 */
 	private function create_post( array $args = array() ): int {
-		$result = self::factory()->post->create( $args );
+		$result = self::factory()->post->create( array_merge( array( 'post_type' => self::EMAIL_POST_TYPE ), $args ) );
 		$this->assertIsInt( $result );
 		return $result;
 	}
@@ -63,7 +77,17 @@ class Send_Preview_Email_Permission_Test extends \Email_Editor_Integration_Test_
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->email_editor = $this->di_container->get( Email_Editor::class );
+		$this->email_editor           = $this->di_container->get( Email_Editor::class );
+		$this->post_register_callback = function ( $post_types ) {
+			$post_types[] = array(
+				'name' => self::EMAIL_POST_TYPE,
+				'args' => array(),
+				'meta' => array(),
+			);
+			return $post_types;
+		};
+		add_filter( 'woocommerce_email_editor_post_types', $this->post_register_callback );
+		$this->email_editor->initialize();
 
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server();
@@ -78,8 +102,85 @@ class Send_Preview_Email_Permission_Test extends \Email_Editor_Integration_Test_
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
+		remove_filter( 'woocommerce_email_editor_post_types', $this->post_register_callback );
 		global $wp_rest_server;
 		$wp_rest_server = null;
+	}
+
+	/**
+	 * Test that an author can send a preview email for their own email post.
+	 */
+	public function testAuthorCanSendPreviewForOwnEmailPost(): void {
+		$author_id = $this->create_user( array( 'role' => 'author' ) );
+		$post_id   = $this->create_post( array( 'post_author' => $author_id ) );
+
+		wp_set_current_user( $author_id );
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_body_params(
+			array(
+				'email'  => 'test@example.com',
+				'postId' => $post_id,
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 403, $response->get_status(), 'Author should be allowed to send preview for own email post' );
+	}
+
+	/**
+	 * Test that an author cannot send a preview email for their own post of a non-email post type.
+	 */
+	public function testAuthorCannotSendPreviewForOwnNonEmailPost(): void {
+		$author_id = $this->create_user( array( 'role' => 'author' ) );
+		$post_id   = $this->create_post(
+			array(
+				'post_author' => $author_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		wp_set_current_user( $author_id );
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_body_params(
+			array(
+				'email'  => 'test@example.com',
+				'postId' => $post_id,
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status(), 'Author should not be allowed to send preview for a non-email post' );
+	}
+
+	/**
+	 * Test that an admin cannot send a preview email for a post of a non-email post type.
+	 */
+	public function testAdminCannotSendPreviewForNonEmailPost(): void {
+		$admin_id = $this->create_user( array( 'role' => 'administrator' ) );
+		$post_id  = $this->create_post(
+			array(
+				'post_author' => $admin_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		wp_set_current_user( $admin_id );
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_body_params(
+			array(
+				'email'  => 'test@example.com',
+				'postId' => $post_id,
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status(), 'Admin should not be allowed to send preview for a non-email post' );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Engine/Send_Preview_Email_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Send_Preview_Email_Test.php
@@ -241,7 +241,7 @@ class Send_Preview_Email_Test extends \Email_Editor_Integration_Test_Case {
 	 * Clean up after each test
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
 		remove_filter( 'woocommerce_email_editor_post_types', $this->post_register_callback );
+		parent::tearDown();
 	}
 }

--- a/packages/php/email-editor/tests/integration/Engine/Send_Preview_Email_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Send_Preview_Email_Test.php
@@ -33,10 +33,27 @@ class Send_Preview_Email_Test extends \Email_Editor_Integration_Test_Case {
 	private $renderer_mock;
 
 	/**
+	 * Callback to register the test email post type.
+	 *
+	 * @var callable
+	 */
+	private $post_register_callback;
+
+	/**
 	 * Set up before each test
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->post_register_callback = function ( $post_types ) {
+			$post_types[] = array(
+				'name' => 'custom_email_type',
+				'args' => array(),
+				'meta' => array(),
+			);
+			return $post_types;
+		};
+		add_filter( 'woocommerce_email_editor_post_types', $this->post_register_callback );
 
 		$this->renderer_mock = $this->createMock( Renderer::class );
 		$this->renderer_mock->method( 'render' )->willReturn(
@@ -70,6 +87,7 @@ class Send_Preview_Email_Test extends \Email_Editor_Integration_Test_Case {
 
 		$email_post_id = $this->factory->post->create(
 			array(
+				'post_type'    => 'custom_email_type',
 				'post_content' => '<!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
 			)
 		);
@@ -104,6 +122,7 @@ class Send_Preview_Email_Test extends \Email_Editor_Integration_Test_Case {
 
 		$email_post_id = $this->factory->post->create(
 			array(
+				'post_type'    => 'custom_email_type',
 				'post_content' => '<!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
 			)
 		);
@@ -189,6 +208,22 @@ class Send_Preview_Email_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it throws an exception when the post is not of an email post type
+	 */
+	public function testItThrowsAnExceptionWhenPostIsNotAnEmailPostType(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+		$this->assertIsInt( $post_id );
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Invalid post' );
+		$post_data = array(
+			'email'  => 'hello@example.com',
+			'postId' => $post_id,
+		);
+		$this->send_preview_email->send_preview_email( $post_data );
+	}
+
+	/**
 	 * Test it throws an exception when the post cannot be found
 	 */
 	public function testItThrowsAnExceptionWhenPostCannotBeFound(): void {
@@ -200,5 +235,13 @@ class Send_Preview_Email_Test extends \Email_Editor_Integration_Test_Case {
 			'postId'       => 100,
 		);
 		$this->send_preview_email->send_preview_email( $post_data );
+	}
+
+	/**
+	 * Clean up after each test
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_filter( 'woocommerce_email_editor_post_types', $this->post_register_callback );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `POST /woocommerce-email-editor/v1/send_preview_email` route and the fallback `Send_Preview_Email::send_preview_email()` handler accepted any post ID the current user could edit. Both now also require the post to be of a type registered through the `woocommerce_email_editor_post_types` filter.

**Backward compatibility:** The preview endpoint now only sends previews for email posts. Email posts are the post types that plugins register with the `woocommerce_email_editor_post_types` filter, like WooCommerce's own emails. Previews for other post types, such as regular blog posts, are now refused. The endpoint URL, its parameters, its response, and the `woocommerce_email_editor_send_preview_email` filter did not change.

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to WooCommerce > Settings > Emails and open any email in the block editor.
2. Use "Send a test email" and confirm the preview still arrives.
3. Use a user with the `Author` role, create a regular blog post and note its ID.
4. As the same user, send `POST /wp-json/woocommerce-email-editor/v1/send_preview_email` with `{"email": "you@example.com", "postId": <blog post ID>}`.
```JS
wp.apiFetch({
	path: '/woocommerce-email-editor/v1/send_preview_email',
	method: 'POST',
	data: { email: 'you@example.com', postId: 123 },
}).then(console.log).catch(console.error);
```
5. Confirm the response is HTTP 403 and no email is sent.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
