### PR TITLE
Require a push notifications role on the status endpoint

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestController.php
@@ -97,7 +97,7 @@ class PushNotificationStatusRestController extends RestApiControllerBase {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'get_status' ),
-					'permission_callback' => array( $this, 'authorize_as_from_wpcom_or_authenticated' ),
+					'permission_callback' => array( $this, 'authorize_as_from_wpcom_or_allowed_user' ),
 				),
 				// A sibling of the endpoint array, not a key inside it. WP_REST_Server
 				// promotes only non-numeric top-level keys into its route options, and

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestController.php
@@ -97,7 +97,7 @@ class PushNotificationStatusRestController extends RestApiControllerBase {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'get_status' ),
-					'permission_callback' => array( $this, 'authorize_as_from_wpcom_or_logged_in_user' ),
+					'permission_callback' => array( $this, 'authorize_as_from_wpcom_or_authenticated' ),
 				),
 				// A sibling of the endpoint array, not a key inside it. WP_REST_Server
 				// promotes only non-numeric top-level keys into its route options, and

--- a/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md
+++ b/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md
@@ -151,7 +151,7 @@ This library will be in the `src/Internal` directory and is not intended to be u
 
 - **Get driver status:**
     - Endpoint: `GET /wp-json/wc-push-notifications/status`
-    - Auth: Jetpack blog token, or any logged in user. No role is required, because WPCOM reads this endpoint and signs those requests with the blog token, which identifies no user.
+    - Auth: Jetpack blog token, or a user holding one of the roles allowed to use push notifications. The blog token identifies no user, so a role check on its own would reject the requests WPCOM makes to this endpoint.
     - Returns the installed notification drivers, each with `connected` (its underlying connection is present), `enabled` (the driver itself isn't disabled), and `available` (`connected && enabled`, i.e. configured and usable, which is not a statement about delivery) flags, plus the `preferred_driver`, the first available driver in precedence order. `preferred_driver` is the site's preference, not a statement about what is delivering notifications to a given app, which also depends on the app version and on whether its token registered successfully. The `jetpack-sync` driver is listed only when the Jetpack Sync package is installed; the `remote-push-notification-proxy` driver ships with core and is always listed. Stays reachable even when push notifications are disabled, so clients can read the driver state and fall back to Jetpack Sync when the proxy isn't available.
 
     ```json

--- a/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
@@ -30,6 +30,7 @@ trait AuthorizesPushNotificationRequests {
 	 */
 	public function authorize_as_authenticated( WP_REST_Request $request ) {
 		$authorized = $this->authorize_as_authenticated_ignoring_enablement( $request );
+
 		if ( true !== $authorized ) {
 			return $authorized;
 		}
@@ -38,7 +39,7 @@ trait AuthorizesPushNotificationRequests {
 	}
 
 	/**
-	 * Checks the caller is either WPCOM or an authorized user, without requiring
+	 * Checks the caller is either WPCOM or an allowed user, without requiring
 	 * the module to be enabled.
 	 *
 	 * WPCOM reads this endpoint to decide how to reach a store, and signs those
@@ -51,7 +52,7 @@ trait AuthorizesPushNotificationRequests {
 	 *
 	 * @since 11.2.0
 	 */
-	public function authorize_as_from_wpcom_or_authenticated( WP_REST_Request $request ) {
+	public function authorize_as_from_wpcom_or_allowed_user( WP_REST_Request $request ) {
 		if ( $this->is_signed_with_blog_token() ) {
 			return true;
 		}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
@@ -29,6 +29,45 @@ trait AuthorizesPushNotificationRequests {
 	 * @return bool|WP_Error
 	 */
 	public function authorize_as_authenticated( WP_REST_Request $request ) {
+		$authorized = $this->authorize_as_authenticated_ignoring_enablement( $request );
+		if ( true !== $authorized ) {
+			return $authorized;
+		}
+
+		return wc_get_container()->get( PushNotifications::class )->should_be_enabled();
+	}
+
+	/**
+	 * Checks the caller is either WPCOM or an authorized user, without requiring
+	 * the module to be enabled.
+	 *
+	 * WPCOM reads this endpoint to decide how to reach a store, and signs those
+	 * requests with the Jetpack blog token, which identifies no user. Requiring a
+	 * role would reject them.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return bool|WP_Error
+	 *
+	 * @since 11.2.0
+	 */
+	public function authorize_as_from_wpcom_or_authenticated( WP_REST_Request $request ) {
+		if ( $this->is_signed_with_blog_token() ) {
+			return true;
+		}
+
+		return $this->authorize_as_authenticated_ignoring_enablement( $request );
+	}
+
+	/**
+	 * Checks the user is authenticated and holds at least one role allowed to
+	 * interact with push notifications.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return bool|WP_Error
+	 */
+	private function authorize_as_authenticated_ignoring_enablement( WP_REST_Request $request ) {
 		if ( ! get_current_user_id() ) {
 			return new WP_Error(
 				'woocommerce_rest_cannot_view',
@@ -37,41 +76,10 @@ trait AuthorizesPushNotificationRequests {
 			);
 		}
 
-		$has_valid_role = array_reduce(
+		return array_reduce(
 			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
 			fn ( $carry, $role ) => $this->check_permission( $request, $role ) === true ? true : $carry,
 			false
-		);
-
-		if ( ! $has_valid_role ) {
-			return false;
-		}
-
-		return wc_get_container()->get( PushNotifications::class )->should_be_enabled();
-	}
-
-	/**
-	 * Checks the caller is either WPCOM or a logged in user, with no role
-	 * requirement and without requiring the module to be enabled.
-	 *
-	 * WPCOM reads this endpoint to decide how to reach a store, and signs those
-	 * requests with the Jetpack blog token, which identifies no user. Requiring a
-	 * role would reject them. The response describes driver configuration only,
-	 * so it carries nothing specific to the calling user or to the merchant.
-	 *
-	 * @return bool|WP_Error
-	 *
-	 * @since 11.2.0
-	 */
-	public function authorize_as_from_wpcom_or_logged_in_user() {
-		if ( $this->is_signed_with_blog_token() || get_current_user_id() ) {
-			return true;
-		}
-
-		return new WP_Error(
-			'woocommerce_rest_cannot_view',
-			__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
-			array( 'status' => rest_authorization_required_code() )
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
@@ -44,6 +44,13 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 	private static $fixture_subscriber_id;
 
 	/**
+	 * Administrator fixture user ID.
+	 *
+	 * @var int
+	 */
+	private static $fixture_administrator_id;
+
+	/**
 	 * Shop manager user ID for testing.
 	 *
 	 * @var int
@@ -58,13 +65,21 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 	private $subscriber_id;
 
 	/**
+	 * Administrator user ID for testing.
+	 *
+	 * @var int
+	 */
+	private $administrator_id;
+
+	/**
 	 * Create immutable users shared by the test class.
 	 *
 	 * @param WP_UnitTest_Factory $factory WordPress unit test factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ): void {
-		self::$fixture_user_id       = $factory->user->create( array( 'role' => 'shop_manager' ) );
-		self::$fixture_subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$fixture_user_id          = $factory->user->create( array( 'role' => 'shop_manager' ) );
+		self::$fixture_subscriber_id    = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$fixture_administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
 	/**
@@ -75,20 +90,47 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 
 		$this->reset_push_notifications_cache();
 
-		$this->user_id       = self::$fixture_user_id;
-		$this->subscriber_id = self::$fixture_subscriber_id;
+		$this->user_id          = self::$fixture_user_id;
+		$this->subscriber_id    = self::$fixture_subscriber_id;
+		$this->administrator_id = self::$fixture_administrator_id;
 	}
 
 	/**
-	 * Register the controller's routes using the container so init() auto-wires
-	 * the push-notifications dependencies.
+	 * Register the controller's routes, defaulting to the container instance so
+	 * init() auto-wires the push-notifications dependencies.
+	 *
+	 * @param PushNotificationStatusRestController|null $controller Controller to register, or null for the container instance.
 	 */
-	private function register_routes(): void {
-		$controller   = wc_get_container()->get( PushNotificationStatusRestController::class );
+	private function register_routes( ?PushNotificationStatusRestController $controller = null ): void {
+		$controller ??= wc_get_container()->get( PushNotificationStatusRestController::class );
 		$this->server = $this->create_rest_server_with_routes(
 			array( array( $controller, 'register_routes' ) ),
 			true
 		);
+	}
+
+	/**
+	 * Builds a controller that reports every request as signed with the Jetpack
+	 * blog token, wired up by hand because the container cannot resolve a
+	 * subclass declared here.
+	 *
+	 * @return PushNotificationStatusRestController
+	 */
+	private function create_blog_token_signed_controller(): PushNotificationStatusRestController {
+		$controller = new class() extends PushNotificationStatusRestController {
+			/**
+			 * Stands in for a request WPCOM signed with the Jetpack blog token.
+			 *
+			 * @return bool
+			 */
+			protected function is_signed_with_blog_token(): bool {
+				return true;
+			}
+		};
+
+		$controller->init( wc_get_container()->get( DriverAvailabilityService::class ) );
+
+		return $controller;
 	}
 
 	/**
@@ -130,31 +172,45 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( rest_authorization_required_code(), $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayNotHasKey( 'installed_drivers', $data );
+		$this->assertArrayNotHasKey( 'preferred_driver', $data );
+	}
+
+	/**
+	 * @testdox GET should accept an administrator.
+	 */
+	public function test_get_status_accepts_administrators() {
+		wp_set_current_user( $this->administrator_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
+
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertArrayHasKey( 'installed_drivers', $response->get_data() );
 	}
 
 	/**
 	 * WPCOM signs its requests with the Jetpack blog token, which identifies no
-	 * user, so the endpoint has to authorize them without one.
+	 * user, so the endpoint has to authorize them without one. Dispatched through
+	 * the registered route so that the route's permission callback is the one
+	 * under test.
 	 *
 	 * @testdox GET should accept a blog token signed request that carries no user.
 	 */
 	public function test_get_status_accepts_a_blog_token_signed_request_without_a_user() {
 		wp_set_current_user( 0 );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes( $this->create_blog_token_signed_controller() );
 
-		$controller = new class() extends PushNotificationStatusRestController {
-			/**
-			 * Stands in for a request WPCOM signed with the Jetpack blog token.
-			 *
-			 * @return bool
-			 */
-			protected function is_signed_with_blog_token(): bool {
-				return true;
-			}
-		};
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
+		$response = $this->server->dispatch( $request );
 
-		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
-
-		$this->assertTrue( $controller->authorize_as_from_wpcom_or_allowed_user( $request ) );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertArrayHasKey( 'installed_drivers', $response->get_data() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
@@ -119,9 +119,9 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox GET should accept a logged in user who holds no push-notifications role.
+	 * @testdox GET should reject a logged in user who holds no push-notifications role.
 	 */
-	public function test_get_status_accepts_users_without_role() {
+	public function test_get_status_rejects_users_without_role() {
 		wp_set_current_user( $this->subscriber_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
 		$this->register_routes();
@@ -129,7 +129,7 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( rest_authorization_required_code(), $response->get_status() );
 	}
 
 	/**
@@ -152,7 +152,9 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 			}
 		};
 
-		$this->assertTrue( $controller->authorize_as_from_wpcom_or_logged_in_user() );
+		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
+
+		$this->assertTrue( $controller->authorize_as_from_wpcom_or_authenticated( $request ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
@@ -154,7 +154,7 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 
 		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
 
-		$this->assertTrue( $controller->authorize_as_from_wpcom_or_authenticated( $request ) );
+		$this->assertTrue( $controller->authorize_as_from_wpcom_or_allowed_user( $request ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushNotificationStatusRestControllerTest.php
@@ -157,7 +157,7 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertSame( rest_authorization_required_code(), $response->get_status() );
+		$this->assertSame( WP_Http::UNAUTHORIZED, $response->get_status() );
 	}
 
 	/**
@@ -171,7 +171,7 @@ class PushNotificationStatusRestControllerTest extends WC_Unit_Test_Case {
 		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/status' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertSame( rest_authorization_required_code(), $response->get_status() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertArrayNotHasKey( 'installed_drivers', $data );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`GET /wp-json/wc-push-notifications/status` accepted any logged in user. On a store with open customer registration, a subscriber or customer could read whether the store is connected to Jetpack, whether Jetpack Sync is installed and enabled, and whether push notifications were filtered off. That is merchant configuration, and accounts that cannot use push notifications do not need to read it.

This reinstates the role check, so the endpoint now requires an administrator or shop manager. Requests signed with the Jetpack blog token still pass, since WPCOM reads this endpoint to decide how to reach a store and that token identifies no user. The endpoint also stays reachable while push notifications are disabled, so the role check is applied without the enablement check that the other push notification endpoints use.

Closes WOO6-138

(For Bug Fixes) Bug introduced in PR #67315.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Prerequisites

Before testing, ensure:

-   You have a WooCommerce site running this branch.
-   You have an administrator account and a separate subscriber account. To create the subscriber, go to **Users > Add New User**, fill in a username and email, set **Role** to **Subscriber**, and click **Add New User**.
-   You have an application password for each of the two accounts. To create one, go to **Users > All Users**, click the account, scroll to **Application Passwords**, enter a name, and click **Add New Application Password**. Copy the generated password, which is shown only once.

Application passwords are only offered over HTTPS, or on a site WordPress treats as a local environment. If the **Application Passwords** section is missing, the site is served over plain HTTP and the section will not appear.

#### Steps

1. Request the endpoint without authenticating, replacing the capitalised part with your site address:

    ```bash
    curl -s -o /dev/null -w "%{http_code}\n" \
      "https://YOUR_TEST_SITE_HERE/wp-json/wc-push-notifications/status"
    ```

    Expected result: `401`

2. Request the endpoint as the subscriber, replacing the capitalised parts:

    ```bash
    curl -s -o /dev/null -w "%{http_code}\n" \
      -u "SUBSCRIBER_USERNAME:SUBSCRIBER_APPLICATION_PASSWORD" \
      "https://YOUR_TEST_SITE_HERE/wp-json/wc-push-notifications/status"
    ```

    Expected result: `403`

3. Request the endpoint as the administrator, replacing the capitalised parts:

    ```bash
    curl -s -w "\n%{http_code}\n" \
      -u "ADMIN_USERNAME:ADMIN_APPLICATION_PASSWORD" \
      "https://YOUR_TEST_SITE_HERE/wp-json/wc-push-notifications/status"
    ```

    Expected result: `200`, and a body listing the installed drivers, for example:

    ```json
    {
        "installed_drivers": {
            "remote-push-notification-proxy": { "connected": false, "enabled": true, "available": false }
        },
        "preferred_driver": null
    }
    ```

4. Change the subscriber account's role to **Shop manager** under **Users > All Users**, then repeat the request from step 2.

    Expected result: `200`, and the same body as step 3.

<!-- End testing instructions -->

### Testing that has already taken place:

I have run through the testing instructions above.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

The endpoint this changes was added in an unreleased version and has not shipped, so there is no released behaviour to record. The pull request that added it, #67315, also carried no changelog entry.

</details>

### Use of AI Tools

Authored with Claude Code (Opus 5). The change was specified, reviewed and verified by me.
