### PR TITLE
Harden wcAnalytics config global and webpack public path assignment

### DIFF
--- a/packages/php/woocommerce-analytics/changelog/wooa7s-2042-config-global-hardening
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-2042-config-global-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Always initialize the front-end `window.wcAnalytics` object from scratch and only accept a string as the webpack public path.

--- a/packages/php/woocommerce-analytics/src/class-universal.php
+++ b/packages/php/woocommerce-analytics/src/class-universal.php
@@ -82,7 +82,8 @@ class Universal {
 		?>
 		<script type="text/javascript">
 			(function() {
-				window.wcAnalytics = window.wcAnalytics || {};
+				// Always start from a fresh object: a `||` fallback would keep a same-named DOM element alive.
+				window.wcAnalytics = {};
 				const wcAnalytics = window.wcAnalytics;
 
 				// Set the assets URL for webpack to find the split assets.

--- a/packages/php/woocommerce-analytics/src/client/public-path.ts
+++ b/packages/php/woocommerce-analytics/src/client/public-path.ts
@@ -6,8 +6,11 @@
  * Unfortunately we can't set `publicPath: 'auto'` because WordPress.com Simple's JS concatenation breaks it (and other plugins that do JS concatenation probably would too).
  * @see https://webpack.js.org/guides/public-path/#on-the-fly
  */
-if ( typeof window === 'object' && window.wcAnalytics?.assets_url ) {
+const assetsUrl = typeof window === 'object' ? window.wcAnalytics?.assets_url : undefined;
+
+// Only a string may become the public path: a same-named DOM element is truthy and stringifies to its href.
+if ( typeof assetsUrl === 'string' ) {
 	// @ts-expect-error: __webpack_public_path__ is set globally by webpack, ignore TS2304
 	// eslint-disable-next-line no-global-assign
-	__webpack_public_path__ = window.wcAnalytics.assets_url;
+	__webpack_public_path__ = assetsUrl;
 }

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -313,6 +313,18 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that the page output always starts `window.wcAnalytics` from a fresh
+	 * object. A `window.wcAnalytics || {}` fallback keeps a same-named DOM element
+	 * alive, and the assignments that follow silently fail to land on it.
+	 */
+	public function test_page_output_initializes_config_from_a_fresh_object(): void {
+		$output = $this->render_analytics_data();
+
+		$this->assertStringContainsString( 'window.wcAnalytics = {};', $output );
+		$this->assertStringNotContainsString( 'window.wcAnalytics ||', $output );
+	}
+
+	/**
 	 * Test that the server-fired pixel path keeps its request-derived
 	 * properties. That path runs on uncached requests and is the only place
 	 * where pixel.wp.com can learn the visitor's real IP, user agent and


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

Hardens how the `woocommerce-analytics` front-end bootstrap reads its config global.

- `class-universal.php`: initialize `window.wcAnalytics` from a fresh object instead of `window.wcAnalytics || {}`. Nothing writes to the global before this script runs, so the fallback only served to keep a pre-existing same-named value alive.
- `public-path.ts`: assign `__webpack_public_path__` only when `assets_url` is a string, matching webpack's own guard for this value.
- Adds a test for the emitted bootstrap.

Closes WOOA7S-2042.

### How to test the changes in this Pull Request:

1. On a store with the analytics tracker active, load any front-end page and confirm `window.wcAnalytics.assets_url` is a string ending in `/build/` and that the tracker still fires (events appear in the network tab).
2. Add a published post containing `<a id="wcAnalytics"></a><a id="wcAnalytics" name="assets_url" href="https://example.com/x/"></a>` and reload it. `window.wcAnalytics.assets_url` must still be the store's own build URL, and no request to `example.com` should appear.
3. Run the package tests: `pnpm --filter @automattic/woocommerce-analytics test:php`.

### Testing that has already taken place:

- Package PHPUnit suite passes locally (151 tests).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Entry added manually in `packages/php/woocommerce-analytics/changelog/`.
