### PR TITLE
Add a parity test between src/Enums and src/Api/Enums

### DIFF
--- a/plugins/woocommerce/changelog/add-api-enum-parity-test
+++ b/plugins/woocommerce/changelog/add-api-enum-parity-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a test that keeps the enums in src/Api/Enums and their src/Enums counterparts from drifting apart.

--- a/plugins/woocommerce/phpunit.xml
+++ b/plugins/woocommerce/phpunit.xml
@@ -24,6 +24,7 @@
 			     ./tests/php/src/Api/<X>/ subdir is never silently picked up by
 			     this suite. A new GraphQL test subdir must be added to the
 			     wc-phpunit-graphql testsuite AND excluded here. -->
+			<exclude>./tests/php/src/Api/Enums</exclude>
 			<exclude>./tests/php/src/Api/Infrastructure</exclude>
 			<exclude>./tests/php/src/Api/Queries</exclude>
 			<exclude>./tests/php/src/Api/Mutations</exclude>
@@ -35,6 +36,7 @@
 		     the public command classes under src/Api/Queries/ and
 		     src/Api/Mutations/ (products, coupons, …). -->
 		<testsuite name="wc-phpunit-graphql">
+			<directory suffix=".php">./tests/php/src/Api/Enums</directory>
 			<directory suffix=".php">./tests/php/src/Api/Infrastructure</directory>
 			<directory suffix=".php">./tests/php/src/Internal/Api</directory>
 			<directory suffix=".php">./tests/php/src/Api/Queries</directory>

--- a/plugins/woocommerce/tests/php/src/Api/Enums/EnumParityTest.php
+++ b/plugins/woocommerce/tests/php/src/Api/Enums/EnumParityTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Api\Enums;
+
+use Automattic\WooCommerce\Api\Enums\Coupons\CouponStatus as ApiCouponStatus;
+use Automattic\WooCommerce\Api\Enums\Coupons\DiscountType as ApiDiscountType;
+use Automattic\WooCommerce\Api\Enums\Products\ProductStatus as ApiProductStatus;
+use Automattic\WooCommerce\Api\Enums\Products\ProductType as ApiProductType;
+use Automattic\WooCommerce\Api\Enums\Products\StockStatus as ApiStockStatus;
+use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Enums\ProductType;
+use ReflectionClass;
+use WC_Unit_Test_Case;
+
+/**
+ * Guards the two enum systems in the plugin against silent drift.
+ *
+ * `src/Enums/` holds `final` classes of string constants usable from PHP 7.4 code, and
+ * `src/Api/Enums/` holds native backed enums for the PHP 8.1+ Code API. Several concepts
+ * are declared in both, so a value added to one and forgotten in the other means the Code
+ * API and the rest of the plugin disagree about a string that is persisted in the database.
+ *
+ * Each API enum below declares, case by case, the `src/Enums/` value it represents (or
+ * `null` when it has no equivalent, such as the `Other` fallbacks). Adding or removing a
+ * case on either side fails these tests until the map is updated deliberately.
+ */
+class EnumParityTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Every enum under `src/Api/Enums/`, mapped to its `src/Enums/` counterpart.
+	 *
+	 * Keys are API enum class names. Each entry holds:
+	 *  - `legacy`: the counterpart class in `src/Enums/`, or `null` when the concept only
+	 *    exists in the Code API.
+	 *  - `cases`: every case name of the API enum mapped to the `src/Enums/` value it
+	 *    represents, or `null` for a case with no counterpart.
+	 *  - `legacy_only`: counterpart values the API deliberately does not expose.
+	 *
+	 * @var array<class-string, array{legacy: class-string|null, cases: array<string, string|null>, legacy_only: array<int, string>}>
+	 */
+	private const API_ENUMS = array(
+		ApiProductStatus::class => array(
+			'legacy'      => ProductStatus::class,
+			'cases'       => array(
+				'Draft'     => ProductStatus::DRAFT,
+				'Pending'   => ProductStatus::PENDING,
+				'Published' => ProductStatus::PUBLISH,
+				'Private'   => ProductStatus::PRIVATE,
+				'Future'    => ProductStatus::FUTURE,
+				'Trash'     => ProductStatus::TRASH,
+				'Other'     => null,
+			),
+			// A product is never created through the Code API in the intermediate
+			// auto-draft state WordPress assigns before a first save.
+			'legacy_only' => array( ProductStatus::AUTO_DRAFT ),
+		),
+		ApiProductType::class   => array(
+			'legacy'      => ProductType::class,
+			'cases'       => array(
+				'Simple'    => ProductType::SIMPLE,
+				'Grouped'   => ProductType::GROUPED,
+				'External'  => ProductType::EXTERNAL,
+				'Variable'  => ProductType::VARIABLE,
+				'Variation' => ProductType::VARIATION,
+				'Other'     => null,
+			),
+			'legacy_only' => array(),
+		),
+		ApiStockStatus::class   => array(
+			'legacy'      => ProductStockStatus::class,
+			'cases'       => array(
+				'InStock'     => ProductStockStatus::IN_STOCK,
+				'OutOfStock'  => ProductStockStatus::OUT_OF_STOCK,
+				'OnBackorder' => ProductStockStatus::ON_BACKORDER,
+				'Other'       => null,
+			),
+			// `lowstock` is a reporting threshold rather than a stored stock status.
+			'legacy_only' => array( ProductStockStatus::LOW_STOCK ),
+		),
+		ApiCouponStatus::class  => array(
+			'legacy'      => null,
+			'cases'       => array(
+				'Published' => null,
+				'Draft'     => null,
+				'Pending'   => null,
+				'Private'   => null,
+				'Future'    => null,
+				'Trash'     => null,
+				'Other'     => null,
+			),
+			'legacy_only' => array(),
+		),
+		ApiDiscountType::class  => array(
+			'legacy'      => null,
+			'cases'       => array(
+				'Percent'      => null,
+				'FixedCart'    => null,
+				'FixedProduct' => null,
+				'Other'        => null,
+			),
+			'legacy_only' => array(),
+		),
+	);
+
+	/**
+	 * Provides one entry per mapped API enum.
+	 *
+	 * @return array<string, array{0: class-string}>
+	 */
+	public function api_enum_provider(): array {
+		$data = array();
+		foreach ( array_keys( self::API_ENUMS ) as $api_enum ) {
+			$data[ $api_enum ] = array( $api_enum );
+		}
+		return $data;
+	}
+
+	/**
+	 * @testdox Every enum file under src/Api/Enums is accounted for by this test.
+	 */
+	public function test_all_api_enums_are_mapped(): void {
+		$declared = array();
+		foreach ( array_keys( self::API_ENUMS ) as $api_enum ) {
+			$declared[] = ( new ReflectionClass( $api_enum ) )->getShortName();
+		}
+
+		$found = array();
+		foreach ( glob( WC_ABSPATH . 'src/Api/Enums/*/*.php' ) ?: array() as $file ) {
+			$found[] = basename( $file, '.php' );
+		}
+
+		sort( $declared );
+		sort( $found );
+
+		$this->assertSame(
+			$declared,
+			$found,
+			'A new enum under src/Api/Enums must be added to EnumParityTest::API_ENUMS, declaring whether it has a src/Enums counterpart.'
+		);
+	}
+
+	/**
+	 * @testdox An API enum declares exactly the cases this test maps.
+	 *
+	 * @dataProvider api_enum_provider
+	 *
+	 * @param class-string $api_enum The API enum under test.
+	 */
+	public function test_api_enum_cases_match_the_map( string $api_enum ): void {
+		$expected = array_keys( self::API_ENUMS[ $api_enum ]['cases'] );
+		$actual   = array_column( $api_enum::cases(), 'name' );
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame(
+			$expected,
+			$actual,
+			"Cases of {$api_enum} changed. Update EnumParityTest::API_ENUMS, and check whether its src/Enums counterpart needs the same change."
+		);
+	}
+
+	/**
+	 * @testdox A string-backed API case carries the same value as its src/Enums counterpart.
+	 *
+	 * @dataProvider api_enum_provider
+	 *
+	 * @param class-string $api_enum The API enum under test.
+	 */
+	public function test_string_backed_case_values_match_the_counterpart( string $api_enum ): void {
+		$cases = self::API_ENUMS[ $api_enum ]['cases'];
+
+		$checked = 0;
+		foreach ( $api_enum::cases() as $case ) {
+			$legacy_value = $cases[ $case->name ];
+
+			if ( null === $legacy_value || ! is_string( $case->value ) ) {
+				continue;
+			}
+
+			$this->assertSame(
+				$legacy_value,
+				$case->value,
+				"{$api_enum}::{$case->name} and its src/Enums counterpart disagree on the stored value."
+			);
+			++$checked;
+		}
+
+		if ( 0 === $checked ) {
+			$this->assertTrue( true, "{$api_enum} has no string-backed case with a src/Enums counterpart." );
+		}
+	}
+
+	/**
+	 * @testdox A src/Enums counterpart declares exactly the values the API enum covers.
+	 *
+	 * @dataProvider api_enum_provider
+	 *
+	 * @param class-string $api_enum The API enum under test.
+	 */
+	public function test_counterpart_constants_are_covered( string $api_enum ): void {
+		$legacy = self::API_ENUMS[ $api_enum ]['legacy'];
+
+		if ( null === $legacy ) {
+			$this->assertTrue( true, "{$api_enum} has no src/Enums counterpart." );
+			return;
+		}
+
+		$expected = array_merge(
+			array_filter( array_values( self::API_ENUMS[ $api_enum ]['cases'] ) ),
+			self::API_ENUMS[ $api_enum ]['legacy_only']
+		);
+		$actual   = array_values( ( new ReflectionClass( $legacy ) )->getConstants() );
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame(
+			$expected,
+			$actual,
+			"Constants of {$legacy} changed. Update EnumParityTest::API_ENUMS, and check whether {$api_enum} needs the same change."
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

The plugin now declares enumerated vocabularies in **two** systems:

- `src/Enums/` — `final` classes of string constants, usable from PHP 7.4 code.
- `src/Api/Enums/` — native PHP 8.1 backed enums for the Code API.

Several concepts are declared in both, nothing links them, and they have **already diverged**:

| Concept | `src/Enums/` | `src/Api/Enums/` |
| ------- | ------------ | ---------------- |
| Product status | has `auto-draft` | no `auto-draft`; adds `other`; `publish` exposed as `ACTIVE` |
| Stock status | string-backed (`instock`) | **int-backed** (`InStock = 1`), mapped in `src/Api/Utils/Products/ProductMapper.php` |
| Product type | 5 values | same 5 plus `other` |

These strings are persisted, so a value added on one side and forgotten on the other means the Code API and the rest of the plugin disagree about what is stored.

This PR adds `tests/php/src/Api/Enums/EnumParityTest.php`, which maps every API enum case to the `src/Enums` value it represents and fails when either side gains or loses a value. Four checks:

1. Every file under `src/Api/Enums/` is declared in the map, so a **new** API enum fails the test until someone decides whether it has a counterpart.
2. Each API enum declares exactly the cases the map lists.
3. Each string-backed case carries the same value as its counterpart constant.
4. Each counterpart class declares exactly the values the API covers, plus an explicit `legacy_only` list.

Intentional differences are declared rather than ignored: `Other` fallbacks map to `null`, `auto-draft` and `lowstock` are listed as `legacy_only` with a comment saying why, and `CouponStatus`/`DiscountType` are declared as having no counterpart.

`phpunit.xml` puts the new directory in `wc-phpunit-graphql` and excludes it from `wc-phpunit-main`, exactly as the comment in that file requires for anything under `tests/php/src/Api` — the PHP 7.4 matrix entry cannot parse native enums.

**Note on test conventions:** `tests/php/src/AGENTS.md` prefers targeted assertions over full equality. This test deliberately uses whole-set equality, because detecting an *added* value is the entire point. The assertion messages say what to do when they fail.

#### Backward compatibility

No production code changes. Test-only plus a `phpunit.xml` suite assignment.

### How to test the changes in this Pull Request:

1. `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --testsuite=wc-phpunit-graphql --filter EnumParityTest` — passes.
2. Add a case to `src/Api/Enums/Products/ProductType.php` (e.g. `case Bundle = 'bundle';`) and re-run — `test_api_enum_cases_match_the_map` fails, naming the enum.
3. Add a constant to `src/Enums/ProductType.php` and re-run — `test_counterpart_constants_are_covered` fails.
4. Change a backing value on a string-backed API case and re-run — `test_string_backed_case_values_match_the_counterpart` fails.
5. Add a new file under `src/Api/Enums/` and re-run — `test_all_api_enums_are_mapped` fails.
6. Confirm the PHP 7.4 matrix entry still passes: the new directory is excluded from `wc-phpunit-main`.

### Testing that has already taken place:

The full dev dependencies could not be installed in the environment this was written in (`composer install` fails authenticating to github.com for several packages) and Docker was unavailable, so **PHPUnit, PHPCS and PHPStan were not run**. Please treat CI as the first real verification.

What was verified instead:

- `php -l` on the new file: clean.
- The map was checked against the real enum files by a standalone script that loads `src/Api/Enums/*` and `src/Enums/*` directly and runs the same four comparisons the test makes. All 20 checks pass, so the test should be green as written rather than needing the map corrected.

Not verified: PHPCS/PHPStan conformance, and behavior inside the PHPUnit harness (`WC_ABSPATH` resolution — used the same way as several existing tests in `tests/php/src/`).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually: `plugins/woocommerce/changelog/add-api-enum-parity-test` (patch / dev).

### Use of AI Tools

This pull request was authored by Claude Code (Claude Opus 5) end to end: the analysis of the two enum systems, the test, and this description. The parity map was verified against the real enum files as described above; the PHPUnit, PHPCS and PHPStan runs were not possible in that environment and remain unverified. Please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACXHNtYNFFVCy4SvQS3yBz

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACXHNtYNFFVCy4SvQS3yBz)_