### PR TITLE
Keep the src/Enums README in step with the directory

### DIFF
--- a/plugins/woocommerce/changelog/enums-readme-index-test
+++ b/plugins/woocommerce/changelog/enums-readme-index-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document where a new enumerator belongs and add a test that keeps src/Enums/README.md in step with the classes in that directory.

--- a/plugins/woocommerce/src/Enums/README.md
+++ b/plugins/woocommerce/src/Enums/README.md
@@ -11,17 +11,38 @@ The enum classes make it easier to reference string values and avoid typos. They
 - [CurrencyPosition](./CurrencyPosition.php) - Enumerates the possible values of the `woocommerce_currency_pos` option.
 - [DefaultCustomerAddress](./DefaultCustomerAddress.php) - Enumerates the possible values of the `woocommerce_default_customer_address` option.
 - [DimensionUnit](./DimensionUnit.php) - Enumerates the possible values of the `woocommerce_dimension_unit` option.
+- [FeaturePluginCompatibility](./FeaturePluginCompatibility.php) - Enumerates the possible default compatibility values between a plugin and a feature.
 - [OrderInternalStatus](./OrderInternalStatus.php) - Enumerates the possible internal statuses of an order (when stored in the database).
 - [OrderItemType](./OrderItemType.php) - Enumerates the possible types of an order line item.
 - [OrderStatus](./OrderStatus.php) - Enumerates the possible statuses of an order.
-- [PaymentGatewayFeatures](./PaymentGatewayFeatures.php) - Enumerates the possible features of a payment gateway.
+- [PaymentGatewayFeature](./PaymentGatewayFeature.php) - Enumerates the possible features of a payment gateway.
 - [ProductStatus](./ProductStatus.php) - Enumerates the possible statuses of a product.
 - [ProductStockStatus](./ProductStockStatus.php) - Enumerates the possible stock statuses of a product.
+- [ProductTaxStatus](./ProductTaxStatus.php) - Enumerates the possible tax statuses of a product.
 - [ProductType](./ProductType.php) - Enumerates the possible types of a product.
 - [StockDisplayFormat](./StockDisplayFormat.php) - Enumerates the possible values of the `woocommerce_stock_format` option.
 - [TaxBasedOn](./TaxBasedOn.php) - Enumerates the possible values of the `woocommerce_tax_based_on` option.
 - [TaxDisplayMode](./TaxDisplayMode.php) - Enumerates the possible values of the `woocommerce_tax_display_shop` and `woocommerce_tax_display_cart` options.
 - [WeightUnit](./WeightUnit.php) - Enumerates the possible values of the `woocommerce_weight_unit` option.
+
+## Where an enumerator belongs
+
+The plugin declares enumerated vocabularies in three places. Which one to use depends on who consumes the values.
+
+- **`src/Enums/` (this directory)** is the default. Use it for any vocabulary that is persisted, passed through a hook, or referenced from more than one module — order statuses, product types, settings option values.
+- **A module-local `Enums/` sub-namespace** is acceptable when the vocabulary belongs to a single internal module and nothing outside it consumes the values, as in `src/Internal/StockNotifications/Enums/`. Move it here once a second module needs it.
+- **`src/Api/Enums/`** holds native PHP 8.1 backed enums for the Code API, which requires PHP 8.1 and so cannot be referenced from the rest of the plugin. When a concept exists both there and here, the two must stay in step; `EnumParityTest` fails when they drift.
+
+## Conventions for a new enumerator
+
+- One `final` class per concept, no behavior, in this directory's namespace.
+- Explicit `public` visibility and a docblock on every constant.
+- Add it to the list above. `EnumsReadmeTest` fails when a class in this directory is missing from it.
+- Native PHP enums are not an option here: the minimum supported PHP version is 7.4, and the raw string values are the contract persisted in databases and consumed by extensions.
+
+## Constants name values; they never change them
+
+The string is the contract and the constant is a permanent alias for it. Never change a constant's value, and never rename or remove one — these constants are public API that extensions rely on. Deprecate instead, and introduce the replacement alongside.
 
 ## Contributing
 

--- a/plugins/woocommerce/tests/php/src/Enums/EnumsReadmeTest.php
+++ b/plugins/woocommerce/tests/php/src/Enums/EnumsReadmeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Enums;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Keeps `src/Enums/README.md` in step with the classes in that directory.
+ *
+ * The README is the index contributors and agents read to find out whether a vocabulary
+ * already has an enumerator, so a class missing from it gets re-invented as raw string
+ * literals, and a stale entry sends readers to a file that does not exist.
+ */
+class EnumsReadmeTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Enumerator class names found in the directory, sorted.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_enum_class_names(): array {
+		$names = array();
+
+		foreach ( glob( WC_ABSPATH . 'src/Enums/*.php' ) ?: array() as $file ) {
+			$names[] = basename( $file, '.php' );
+		}
+
+		sort( $names );
+
+		return $names;
+	}
+
+	/**
+	 * Enumerator names linked from the README's list, sorted.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_readme_entry_names(): array {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$readme = (string) file_get_contents( WC_ABSPATH . 'src/Enums/README.md' );
+
+		preg_match_all( '/^- \[(\w+)\]\(\.\/(\w+)\.php\)/m', $readme, $matches );
+
+		$names = $matches[1];
+		sort( $names );
+
+		return $names;
+	}
+
+	/**
+	 * @testdox The README lists every enumerator class in src/Enums, and no others.
+	 */
+	public function test_readme_lists_every_enum_class(): void {
+		$this->assertSame(
+			$this->get_enum_class_names(),
+			$this->get_readme_entry_names(),
+			'src/Enums/README.md is out of date: add an entry for each new enumerator, and remove entries for classes that no longer exist.'
+		);
+	}
+
+	/**
+	 * @testdox Every file the README links to exists, and matches its link text.
+	 */
+	public function test_readme_links_resolve(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$readme = (string) file_get_contents( WC_ABSPATH . 'src/Enums/README.md' );
+
+		preg_match_all( '/^- \[(\w+)\]\(\.\/(\w+)\.php\)/m', $readme, $matches, PREG_SET_ORDER );
+
+		$this->assertNotEmpty( $matches, 'No enumerator entries were found in src/Enums/README.md.' );
+
+		foreach ( $matches as $match ) {
+			list( , $label, $target ) = $match;
+
+			$this->assertSame( $label, $target, "README entry [{$label}] links to {$target}.php." );
+			$this->assertFileExists(
+				WC_ABSPATH . "src/Enums/{$target}.php",
+				"README entry [{$label}] links to a file that does not exist."
+			);
+		}
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

`src/Enums/README.md` is the index used to check whether a vocabulary already has an enumerator. It had drifted from the directory: **18 classes, 15 correct entries.**

- Missing: `FeaturePluginCompatibility`, `ProductTaxStatus`, `PaymentGatewayFeature`.
- Broken: one entry linked to `PaymentGatewayFeatures.php` (plural), which does not exist.

A class missing from the index tends to get re-invented as raw string literals, which is the problem the directory exists to solve. So this PR:

1. **Adds the three missing entries and corrects the broken link.**
2. **Adds `tests/php/src/Enums/EnumsReadmeTest.php`**, which fails when a class in the directory is absent from the list, when an entry names a class that no longer exists, or when a link's text and target disagree (the exact failure above).
3. **Documents where a new enumerator belongs.** Vocabularies are currently declared in three places with nothing saying which to reach for:
   - `src/Enums/` — the default, for anything persisted, passed through a hook, or shared between modules.
   - A module-local `Enums/` sub-namespace — acceptable for a single internal module, as in `src/Internal/StockNotifications/Enums/`.
   - `src/Api/Enums/` — native PHP 8.1 enums for the Code API, which cannot be referenced from the rest of the plugin.

   Plus the conventions a new class follows (`final`, documented constants, listed in the README) and a restatement that a constant's value is a permanent alias, never changed or removed.

#### Deliberately not done

`src/Enums/ProductTaxStatus` is the only class in the directory that is not `final`. Making it `final` is a backward-incompatible change for any extension that subclasses it, so it is left alone here and the README states the rule for *new* classes only. Worth a separate decision if the team wants it aligned.

#### Backward compatibility

No production code changes. Documentation plus one new test.

### How to test the changes in this Pull Request:

1. `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter EnumsReadmeTest` — passes.
2. Remove any `- [X](./X.php)` line from `src/Enums/README.md` and re-run — `test_readme_lists_every_enum_class` fails.
3. Change a link target to a file that does not exist (e.g. back to `PaymentGatewayFeatures.php`) and re-run — `test_readme_links_resolve` fails.
4. Add a new class to `src/Enums/` without a README entry and re-run — the first test fails.
5. Read the new README sections and confirm they match how the three locations are actually used.

### Testing that has already taken place:

The full dev dependencies could not be installed in the environment this was written in (`composer install` fails authenticating to github.com for several packages) and Docker was unavailable, so **PHPUnit, PHPCS, PHPStan and markdownlint were not run**. Please treat CI as the first real verification.

What was verified instead:

- `php -l` on the new test: clean.
- The test's parsing logic was run standalone against the updated README: 18 entries matched against 18 files, no diff, and every link resolves. So both assertions should be green as written.

Not verified: PHPCS conformance (the `file_get_contents` calls carry the same `phpcs:ignore` that existing tests in `tests/php/src/Internal/Api/` use), and markdownlint on the README prose.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually: `plugins/woocommerce/changelog/enums-readme-index-test` (patch / dev).

### Note on merge order

This touches the same region of `src/Enums/README.md` as the `ProductVisibility` PR from the same batch. Whichever merges second will need a one-line conflict resolution in the list.

### Use of AI Tools

This pull request was authored by Claude Code (Claude Opus 5) end to end: finding the README drift, the test, the documented rule, and this description. The test logic was verified against the real README as described above; PHPUnit, PHPCS and markdownlint runs were not possible in that environment. Please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACXHNtYNFFVCy4SvQS3yBz

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACXHNtYNFFVCy4SvQS3yBz)_