### PR TITLE
Add a ProductVisibility enum for the product_visibility taxonomy

### DIFF
--- a/plugins/woocommerce/changelog/add-product-visibility-enum
+++ b/plugins/woocommerce/changelog/add-product-visibility-enum
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a ProductVisibility enum class for the product_visibility taxonomy terms and use it in place of raw string literals in src.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -5,6 +5,7 @@ use Automattic\WooCommerce\Blocks\Utils\BlocksWpQuery;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Enums\ProductVisibility;
 
 /**
  * AbstractProductGrid class.
@@ -290,7 +291,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 */
 	protected function set_visibility_query_args( &$query_args ) {
 		$product_visibility_terms  = wc_get_product_visibility_term_ids();
-		$product_visibility_not_in = array( $product_visibility_terms['exclude-from-catalog'] );
+		$product_visibility_not_in = array( $product_visibility_terms[ ProductVisibility::EXCLUDE_FROM_CATALOG ] );
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$product_visibility_not_in[] = $product_visibility_terms[ ProductStockStatus::OUT_OF_STOCK ];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -11,6 +11,7 @@ use WP_Query;
 use WC_Tax;
 use Automattic\WooCommerce\Enums\CatalogSortOrder;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Enums\ProductVisibility;
 use Automattic\WooCommerce\Enums\TaxDisplayMode;
 
 /**
@@ -451,7 +452,7 @@ class QueryBuilder {
 				array(
 					'taxonomy' => 'product_visibility',
 					'field'    => 'name',
-					'terms'    => 'featured',
+					'terms'    => ProductVisibility::FEATURED,
 					'operator' => 'IN',
 				),
 			),
@@ -810,7 +811,7 @@ class QueryBuilder {
 	 */
 	private function get_product_visibility_query( $stock_query, $stock_status ) {
 		$product_visibility_terms  = wc_get_product_visibility_term_ids();
-		$product_visibility_not_in = array( is_search() ? $product_visibility_terms['exclude-from-search'] : $product_visibility_terms['exclude-from-catalog'] );
+		$product_visibility_not_in = array( is_search() ? $product_visibility_terms[ ProductVisibility::EXCLUDE_FROM_SEARCH ] : $product_visibility_terms[ ProductVisibility::EXCLUDE_FROM_CATALOG ] );
 
 		// Hide out of stock products.
 		if ( empty( $stock_query ) && ! in_array( ProductStockStatus::OUT_OF_STOCK, $stock_status, true ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Enums\ProductStatus;
 use WP_Query;
 use Automattic\WooCommerce\Blocks\Utils\Utils;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Enums\ProductVisibility;
 
 // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -569,7 +570,7 @@ class ProductQuery extends AbstractBlock {
 	 */
 	private function get_product_visibility_query( $stock_query ) {
 		$product_visibility_terms  = wc_get_product_visibility_term_ids();
-		$product_visibility_not_in = array( is_search() ? $product_visibility_terms['exclude-from-search'] : $product_visibility_terms['exclude-from-catalog'] );
+		$product_visibility_not_in = array( is_search() ? $product_visibility_terms[ ProductVisibility::EXCLUDE_FROM_SEARCH ] : $product_visibility_terms[ ProductVisibility::EXCLUDE_FROM_CATALOG ] );
 
 		// Hide out of stock products.
 		if ( empty( $stock_query ) && 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {

--- a/plugins/woocommerce/src/Enums/ProductVisibility.php
+++ b/plugins/woocommerce/src/Enums/ProductVisibility.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Enums;
+
+/**
+ * Enum class for the terms of the `product_visibility` taxonomy.
+ *
+ * Two members of that taxonomy are deliberately absent. The `outofstock` term is referenced
+ * through {@see ProductStockStatus::OUT_OF_STOCK}, which is the value already used for it
+ * across the plugin, and the per-rating `rated-1` to `rated-5` terms are built from a number
+ * at runtime rather than being a fixed vocabulary.
+ *
+ * @since 11.2.0
+ */
+final class ProductVisibility {
+	/**
+	 * The product is hidden from the shop catalog.
+	 *
+	 * @var string
+	 */
+	public const EXCLUDE_FROM_CATALOG = 'exclude-from-catalog';
+
+	/**
+	 * The product is hidden from search results.
+	 *
+	 * @var string
+	 */
+	public const EXCLUDE_FROM_SEARCH = 'exclude-from-search';
+
+	/**
+	 * The product is marked as featured.
+	 *
+	 * @var string
+	 */
+	public const FEATURED = 'featured';
+}

--- a/plugins/woocommerce/src/Enums/README.md
+++ b/plugins/woocommerce/src/Enums/README.md
@@ -18,6 +18,7 @@ The enum classes make it easier to reference string values and avoid typos. They
 - [ProductStatus](./ProductStatus.php) - Enumerates the possible statuses of a product.
 - [ProductStockStatus](./ProductStockStatus.php) - Enumerates the possible stock statuses of a product.
 - [ProductType](./ProductType.php) - Enumerates the possible types of a product.
+- [ProductVisibility](./ProductVisibility.php) - Enumerates the terms of the `product_visibility` taxonomy.
 - [StockDisplayFormat](./StockDisplayFormat.php) - Enumerates the possible values of the `woocommerce_stock_format` option.
 - [TaxBasedOn](./TaxBasedOn.php) - Enumerates the possible values of the `woocommerce_tax_based_on` option.
 - [TaxDisplayMode](./TaxDisplayMode.php) - Enumerates the possible values of the `woocommerce_tax_display_shop` and `woocommerce_tax_display_cart` options.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Enums\ProductVisibility;
 use Automattic\WooCommerce\Enums\WeightUnit;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareRestControllerTrait;
 use Automattic\WooCommerce\Internal\RestApi\ProductRequestPreparationTrait;
@@ -466,7 +467,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 			$args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
 				'field'    => 'name',
-				'terms'    => 'featured',
+				'terms'    => ProductVisibility::FEATURED,
 				'operator' => true === $request['featured'] ? 'IN' : 'NOT IN',
 			);
 		}

--- a/plugins/woocommerce/src/Internal/TermCount.php
+++ b/plugins/woocommerce/src/Internal/TermCount.php
@@ -8,6 +8,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal;
 
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Enums\ProductVisibility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -122,7 +123,7 @@ class TermCount {
 		 * @var array $visibility_term_ids
 		 */
 		$visibility_term_ids = wc_get_product_visibility_term_ids();
-		$counting_tt_ids     = array( $visibility_term_ids['exclude-from-catalog'] ?? 0 );
+		$counting_tt_ids     = array( $visibility_term_ids[ ProductVisibility::EXCLUDE_FROM_CATALOG ] ?? 0 );
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$counting_tt_ids[] = $visibility_term_ids[ ProductStockStatus::OUT_OF_STOCK ] ?? 0;

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Enums\ProductVisibility;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
 use Automattic\WooCommerce\Enums\TaxDisplayMode;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
@@ -191,7 +192,7 @@ class ProductQuery implements QueryClausesGenerator {
 			$args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
 				'field'    => 'name',
-				'terms'    => 'featured',
+				'terms'    => ProductVisibility::FEATURED,
 				'operator' => true === $request['featured'] ? 'IN' : 'NOT IN',
 			);
 		}
@@ -212,8 +213,8 @@ class ProductQuery implements QueryClausesGenerator {
 		$visibility_options = wc_get_product_visibility_options();
 
 		if ( in_array( $catalog_visibility, array_keys( $visibility_options ), true ) ) {
-			$exclude_from_catalog = CatalogVisibility::SEARCH === $catalog_visibility ? '' : 'exclude-from-catalog';
-			$exclude_from_search  = CatalogVisibility::CATALOG === $catalog_visibility ? '' : 'exclude-from-search';
+			$exclude_from_catalog = CatalogVisibility::SEARCH === $catalog_visibility ? '' : ProductVisibility::EXCLUDE_FROM_CATALOG;
+			$exclude_from_search  = CatalogVisibility::CATALOG === $catalog_visibility ? '' : ProductVisibility::EXCLUDE_FROM_SEARCH;
 
 			$args['tax_query'][] = array(
 				'taxonomy'      => 'product_visibility',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

The terms of the `product_visibility` taxonomy were written as raw strings at every call site, while the `outofstock` term of the *same taxonomy* already went through `ProductStockStatus::OUT_OF_STOCK`. The result was lines mixing a constant and a literal for two terms of one vocabulary:

```php
$product_visibility_not_in = array( is_search() ? $product_visibility_terms['exclude-from-search'] : $product_visibility_terms['exclude-from-catalog'] );

if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
    $product_visibility_not_in[] = $product_visibility_terms[ ProductStockStatus::OUT_OF_STOCK ];
}
```

This PR adds `src/Enums/ProductVisibility.php` with `EXCLUDE_FROM_CATALOG`, `EXCLUDE_FROM_SEARCH` and `FEATURED`, and adopts it at 9 sites across 6 files:

| File | Sites |
| ---- | ----- |
| `src/StoreApi/Utilities/ProductQuery.php` | 3 |
| `src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php` | 2 |
| `src/Blocks/BlockTypes/ProductQuery.php` | 1 |
| `src/Blocks/BlockTypes/AbstractProductGrid.php` | 1 |
| `src/Internal/RestApi/Routes/V4/Products/Controller.php` | 1 |
| `src/Internal/TermCount.php` | 1 |

The constant values are identical to the strings they replace, so every query built is unchanged.

#### Scope decisions

Two members of the taxonomy are deliberately left out, and both are documented in the class docblock:

- **`outofstock`** keeps pointing at `ProductStockStatus::OUT_OF_STOCK`, which is what the plugin already uses for this term (e.g. `TermCount.php`). Adding a second constant for the same string would give the value two names.
- **`rated-1` … `rated-5`** are built from a number at runtime (`'rated-' . $value`), so they are not a fixed vocabulary.

One literal is left in place: `src/Internal/ProductAttributesLookup/LookupDataStore.php:892` names `exclude-from-search` inside a raw SQL string, where interpolating a constant adds risk without making anything clearer.

#### Backward compatibility

`ProductVisibility` is a new public symbol — additive, nothing renamed or removed. All 9 changed sites are internal call sites; no signature, hook, or stored value changes. The taxonomy term slugs themselves are untouched, so no migration is involved.

### How to test the changes in this Pull Request:

1. Confirm the values match the taxonomy: `wp term list product_visibility --field=name` lists `exclude-from-catalog`, `exclude-from-search`, `featured`, `outofstock`, `rated-1`…`rated-5`.
2. Set a product's catalog visibility to **Hidden**, then to **Search results only**, then **Shop only**. Confirm it appears/disappears from the shop page and from search as before.
3. Mark a product as **Featured**. Confirm a Featured Products block and `/wc/store/v1/products?featured=true` both return it, and `featured=false` excludes it.
4. Enable *Hide out of stock items* and confirm out-of-stock products drop out of the shop, a Product Collection block, and a Product Grid block.
5. `GET /wc/v4/products?featured=true` returns the same set as before the change.
6. Confirm product category counts still exclude catalog-hidden products (`TermCount`).

### Testing that has already taken place:

The full dev dependencies could not be installed in the environment this was written in (`composer install` fails authenticating to github.com for several packages) and Docker was unavailable, so **PHPUnit, PHPCS and PHPStan were not run**, and none of the manual steps above were performed. Please treat CI and a manual pass as the first real verification.

What was verified instead:

- `php -l` on all 7 changed/added files: clean.
- Each replacement was applied as an exact-string substitution with an asserted occurrence count, then the diff was read line by line. Every replaced literal is byte-identical to its constant's value, so the change is mechanically behavior-preserving.
- A repository-wide grep confirms no `exclude-from-catalog` / `exclude-from-search` / `=> 'featured',` literals remain in `src/` outside the SQL string noted above.

Not verified: PHPCS/PHPStan conformance, and runtime behavior in a store.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually: `plugins/woocommerce/changelog/add-product-visibility-enum` (patch / dev).

### Note on merge order

This touches the same region of `src/Enums/README.md` as the README PR from the same batch. Whichever merges second will need a one-line conflict resolution in the list.

### Use of AI Tools

This pull request was authored by Claude Code (Claude Opus 5) end to end: identifying the call sites, the new enum class, the adoption edits, and this description. Verification was limited to syntax checks, asserted-count substitutions and diff review as described above — no tests were run and no store behavior was exercised. Please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACXHNtYNFFVCy4SvQS3yBz

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACXHNtYNFFVCy4SvQS3yBz)_