### PR TITLE
Fix BIS duplicate signup detection across guest and logged-in signups

### DIFF
--- a/plugins/woocommerce/changelog/fix-bis-duplicate-signup-cross-state
+++ b/plugins/woocommerce/changelog/fix-bis-duplicate-signup-cross-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Back in Stock duplicate signup detection missing existing guest signups when the same email later signs up as a logged-in user.

--- a/plugins/woocommerce/changelog/fix-bis-duplicate-signup-cross-state
+++ b/plugins/woocommerce/changelog/fix-bis-duplicate-signup-cross-state
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix Back in Stock duplicate signup detection missing existing guest signups when the same email later signs up as a logged-in user.
+Fix Back in Stock duplicate signup detection: match guest and logged-in signups with the same email, ignore cancelled and sent notifications, and keep signups for different variation attributes separate.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -66583,18 +66583,6 @@ parameters:
 			path: src/Internal/StockNotifications/Frontend/SignupService.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\StockNotifications\\Frontend\\SignupService\:\:is_already_signed_up\(\) should return Automattic\\WooCommerce\\Internal\\StockNotifications\\Notification\|null but returns Automattic\\WooCommerce\\Internal\\StockNotifications\\Notification\|true\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Internal/StockNotifications/Frontend/SignupService.php
-
-		-
-			message: '#^Parameter \#1 \$notification_id of static method Automattic\\WooCommerce\\Internal\\StockNotifications\\Factory\:\:get_notification\(\) expects int, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/StockNotifications/Frontend/SignupService.php
-
-		-
 			message: '#^Parameter \#1 \$object_or_string of function is_a expects object, int\|WP_Error given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
@@ -443,7 +443,9 @@ CREATE TABLE $meta_table_name (
 		if ( ! empty( $args['status'] ) ) {
 			$statuses = array_values( array_filter( array_map( 'strval', (array) $args['status'] ) ) );
 			if ( ! empty( $statuses ) ) {
-				$where[]      = 'status IN (' . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ')';
+				$where[]      = 1 === count( $statuses )
+					? 'status = %s'
+					: 'status IN (' . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ')';
 				$where_values = array_merge( $where_values, $statuses );
 			}
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
@@ -440,14 +440,17 @@ CREATE TABLE $meta_table_name (
 		$where        = array();
 		$where_values = array();
 
-		if ( ! empty( $args['status'] ) ) {
-			$statuses = array_values( array_filter( array_map( 'strval', (array) $args['status'] ) ) );
-			if ( ! empty( $statuses ) ) {
-				$where[]      = 1 === count( $statuses )
-					? 'status = %s'
-					: 'status IN (' . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ')';
-				$where_values = array_merge( $where_values, $statuses );
+		$statuses = array_filter(
+			array_map( 'strval', (array) $args['status'] ),
+			static function ( string $status ): bool {
+				return '' !== $status;
 			}
+		);
+		if ( ! empty( $statuses ) ) {
+			$where[]      = 1 === count( $statuses )
+				? 'status = %s'
+				: 'status IN (' . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ')';
+			$where_values = array_merge( $where_values, array_values( $statuses ) );
 		}
 
 		if ( ! empty( $args['product_id'] ) ) {

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -191,7 +191,7 @@ class SignupService {
 	}
 
 	/**
-	 * Get the active notification for the request data.
+	 * Get the active or pending notification for the request data.
 	 *
 	 * @param int    $product_id The product ID.
 	 * @param int    $user_id The user ID.
@@ -211,39 +211,66 @@ class SignupService {
 
 		// A customer may have signed up as a guest (user_id 0) before creating an account with the same
 		// email, or vice versa. Match on user ID first, then fall back to the email so both states are found.
-		$query_args = array( 'product_id' => $product_id );
-		if ( ! empty( $user_id ) && NotificationQuery::notification_exists_by_user_id( $product_id, $user_id ) ) {
-			$query_args['user_id'] = $user_id;
-		} elseif ( ! empty( $user_email ) && NotificationQuery::notification_exists_by_email( $product_id, $user_email ) ) {
-			$query_args['user_email'] = $user_email;
-		} else {
-			return null;
+		$identities = array();
+		if ( ! empty( $user_id ) ) {
+			$identities[] = array( 'user_id' => $user_id );
+		}
+		if ( ! empty( $user_email ) ) {
+			$identities[] = array( 'user_email' => $user_email );
 		}
 
-		$query_args['return'] = 'ids';
-		$query_args['limit']  = 1;
-		if ( ! empty( $posted_attributes ) ) {
-			// Hint: We need to compare the posted attributes with the stored attributes to handle variations with "any" attributes.
-			$query_args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				array(
-					'key'     => 'posted_attributes',
-					'value'   => maybe_serialize( $posted_attributes ),
-					'compare' => '=',
-				),
+		foreach ( $identities as $identity ) {
+			$notifications = NotificationQuery::get_notifications(
+				array_merge(
+					$identity,
+					array(
+						'product_id' => $product_id,
+						'status'     => array( NotificationStatus::ACTIVE, NotificationStatus::PENDING ),
+						'order_by'   => array( 'id' => 'DESC' ),
+						'return'     => 'objects',
+					)
+				)
 			);
+
+			foreach ( $notifications as $notification ) {
+				if ( $notification instanceof Notification && $this->matches_posted_attributes( $notification, $posted_attributes ) ) {
+					return $notification;
+				}
+			}
 		}
 
-		$ids = NotificationQuery::get_notifications( $query_args );
-		if ( empty( $ids ) || ! is_numeric( $ids[0] ) ) {
-			return null;
+		return null;
+	}
+
+	/**
+	 * Check whether a notification was signed up for with the posted attributes.
+	 *
+	 * A variation with "any" attributes can be signed up for more than once with different
+	 * attribute values, so the stored attributes have to match the posted ones. An empty set
+	 * of posted attributes matches any notification.
+	 *
+	 * @param Notification $notification The notification.
+	 * @param array        $posted_attributes The posted attributes.
+	 * @return bool True if the notification matches the posted attributes.
+	 */
+	private function matches_posted_attributes( Notification $notification, array $posted_attributes ): bool {
+
+		if ( empty( $posted_attributes ) ) {
+			return true;
 		}
 
-		$notification = Factory::get_notification( $ids[0] );
-		if ( ! $notification ) {
-			return null;
+		$stored_attributes = $notification->get_meta( 'posted_attributes' );
+		if ( ! is_array( $stored_attributes ) || count( $stored_attributes ) !== count( $posted_attributes ) ) {
+			return false;
 		}
 
-		return $notification;
+		foreach ( $posted_attributes as $key => $value ) {
+			if ( ! array_key_exists( $key, $stored_attributes ) || (string) $stored_attributes[ $key ] !== (string) $value ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -209,22 +209,15 @@ class SignupService {
 			return null;
 		}
 
-		$found = false;
-		if ( ! empty( $user_id ) ) {
-			$found = NotificationQuery::notification_exists_by_user_id( $product_id, $user_id );
-		} else {
-			$found = NotificationQuery::notification_exists_by_email( $product_id, $user_email );
-		}
-
-		if ( ! $found ) {
-			return null;
-		}
-
+		// A customer may have signed up as a guest (user_id 0) before creating an account with the same
+		// email, or vice versa. Match on user ID first, then fall back to the email so both states are found.
 		$query_args = array( 'product_id' => $product_id );
-		if ( ! empty( $user_id ) ) {
+		if ( ! empty( $user_id ) && NotificationQuery::notification_exists_by_user_id( $product_id, $user_id ) ) {
 			$query_args['user_id'] = $user_id;
-		} else {
+		} elseif ( ! empty( $user_email ) && NotificationQuery::notification_exists_by_email( $product_id, $user_email ) ) {
 			$query_args['user_email'] = $user_email;
+		} else {
+			return null;
 		}
 
 		$query_args['return'] = 'ids';

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -111,6 +111,58 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should detect an existing guest signup when the same email later signs up as a logged-in user.
+	 */
+	public function test_guest_signup_detected_for_logged_in_user_with_same_email() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $guest_result->get_code() );
+
+		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $user_result->get_code() );
+		$this->assertSame( $guest_result->get_notification()->get_id(), $user_result->get_notification()->get_id() );
+
+		$found = $this->sut->is_already_signed_up( $product->get_id(), $user_id, 'customer@example.com' );
+		$this->assertInstanceOf( Notification::class, $found );
+		$this->assertSame( $guest_result->get_notification()->get_id(), $found->get_id() );
+	}
+
+	/**
+	 * @testdox Should detect an existing logged-in signup when the same email later signs up as a guest.
+	 */
+	public function test_logged_in_signup_detected_for_guest_with_same_email() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $user_result->get_code() );
+
+		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $guest_result->get_code() );
+		$this->assertSame( $user_result->get_notification()->get_id(), $guest_result->get_notification()->get_id() );
+	}
+
+	/**
+	 * @testdox Should not treat a different email as a duplicate when the user ID has no signup.
+	 */
+	public function test_no_false_duplicate_for_different_email() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$this->sut->signup( $product->get_id(), 0, 'guest@example.com' );
+
+		$this->assertNull( $this->sut->is_already_signed_up( $product->get_id(), $user_id, 'customer@example.com' ) );
+	}
+
+	/**
 	 * Create an out-of-stock simple product for signup.
 	 *
 	 * @return \WC_Product_Simple

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -149,6 +149,23 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should detect an existing guest signup when the same email later signs up as a logged-in user with different attributes.
+	 */
+	public function test_guest_signup_detected_for_logged_in_user_with_different_attributes() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com', array( 'attribute_pa_color' => 'blue' ) );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $guest_result->get_code() );
+
+		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com', array( 'attribute_pa_color' => 'red' ) );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $user_result->get_code() );
+		$this->assertSame( $guest_result->get_notification()->get_id(), $user_result->get_notification()->get_id() );
+	}
+
+	/**
 	 * @testdox Should not treat a different email as a duplicate when the user ID has no signup.
 	 */
 	public function test_no_false_duplicate_for_different_email() {

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -133,6 +133,24 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should detect an existing pending guest signup when the same email later signs up as a logged-in user with double opt-in enabled.
+	 */
+	public function test_pending_guest_signup_detected_for_logged_in_user_with_double_opt_in() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'yes' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS_DOUBLE_OPT_IN, $guest_result->get_code() );
+		$this->assertSame( NotificationStatus::PENDING, $guest_result->get_notification()->get_status() );
+
+		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED_DOUBLE_OPT_IN, $user_result->get_code() );
+		$this->assertSame( $guest_result->get_notification()->get_id(), $user_result->get_notification()->get_id() );
+	}
+
+	/**
 	 * @testdox Should detect an existing logged-in signup when the same email later signs up as a guest.
 	 */
 	public function test_logged_in_signup_detected_for_guest_with_same_email() {

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -121,6 +121,7 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 
 		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com' );
 		$this->assertSame( SignupService::SIGNUP_SUCCESS, $guest_result->get_code() );
+		$this->assertSame( 0, $guest_result->get_notification()->get_user_id() );
 
 		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' );
 		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $user_result->get_code() );
@@ -159,6 +160,7 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 
 		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com', array( 'attribute_pa_color' => 'blue' ) );
 		$this->assertSame( SignupService::SIGNUP_SUCCESS, $guest_result->get_code() );
+		$this->assertSame( 0, $guest_result->get_notification()->get_user_id() );
 
 		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com', array( 'attribute_pa_color' => 'red' ) );
 		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $user_result->get_code() );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -150,9 +150,27 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should detect an existing guest signup when the same email later signs up as a logged-in user with different attributes.
+	 * @testdox Should detect an existing guest signup when the same email later signs up as a logged-in user with the same attributes.
 	 */
-	public function test_guest_signup_detected_for_logged_in_user_with_different_attributes() {
+	public function test_guest_signup_detected_for_logged_in_user_with_same_attributes() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$guest_result = $this->sut->signup( $product->get_id(), 0, 'customer@example.com', array( 'attribute_pa_color' => 'blue' ) );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $guest_result->get_code() );
+		$this->assertSame( 0, $guest_result->get_notification()->get_user_id() );
+
+		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com', array( 'attribute_pa_color' => 'blue' ) );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $user_result->get_code() );
+		$this->assertSame( $guest_result->get_notification()->get_id(), $user_result->get_notification()->get_id() );
+	}
+
+	/**
+	 * @testdox Should allow a second signup for the same variation with different posted attributes.
+	 */
+	public function test_different_posted_attributes_are_not_a_duplicate() {
 		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
 
 		$product = $this->create_out_of_stock_product();
@@ -163,8 +181,35 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 		$this->assertSame( 0, $guest_result->get_notification()->get_user_id() );
 
 		$user_result = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com', array( 'attribute_pa_color' => 'red' ) );
-		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $user_result->get_code() );
-		$this->assertSame( $guest_result->get_notification()->get_id(), $user_result->get_notification()->get_id() );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $user_result->get_code() );
+		$this->assertNotSame( $guest_result->get_notification()->get_id(), $user_result->get_notification()->get_id() );
+
+		$found = $this->sut->is_already_signed_up( $product->get_id(), $user_id, 'customer@example.com', array( 'attribute_pa_color' => 'blue' ) );
+		$this->assertInstanceOf( Notification::class, $found );
+		$this->assertSame( $guest_result->get_notification()->get_id(), $found->get_id() );
+	}
+
+	/**
+	 * @testdox Should not let a cancelled notification hide a later active one.
+	 */
+	public function test_cancelled_notification_does_not_hide_active_one() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'user_email' => 'customer@example.com' ) );
+
+		$first = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' )->get_notification();
+		$first->set_status( NotificationStatus::CANCELLED );
+		$first->save();
+
+		$second = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $second->get_code() );
+		$this->assertNotSame( $first->get_id(), $second->get_notification()->get_id() );
+
+		// The cancelled notification is older, so it must not be the one the third signup finds.
+		$third = $this->sut->signup( $product->get_id(), $user_id, 'customer@example.com' );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $third->get_code() );
+		$this->assertSame( $second->get_notification()->get_id(), $third->get_notification()->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`SignupService::is_already_signed_up()` only checked by user ID when a user ID was available. A guest signup is stored with `user_id = 0`, so once that customer creates an account with the same email and signs up again, the existing notification is not found: a duplicate is created and the product page does not show the "already joined" message.

This PR matches by user ID first and falls back to the email, so the same email is detected across guest and logged-in signups.

Fixes WOOPLUG-7664.

### How to test the changes in this Pull Request:

1. Enable Back in Stock Notifications (Settings > Products > Stock notifications), allow signups, disable "require account" and double opt-in.
2. Logged out, join the waitlist for an out-of-stock product using `test@example.com`.
3. Register an account with `test@example.com` and log in.
4. Visit the same product. Expected: the "already joined the waitlist" message is shown instead of the form.
5. Submit the signup form for the same product anyway (e.g. via the form on another product page or by re-posting). Expected: "You have already joined this waitlist" notice, no second notification under WooCommerce > Stock notifications.

### Testing that has already taken place:

Unit tests added in `SignupServiceTests` covering guest then logged-in, logged-in then guest, and a non-matching email. The guest then logged-in test fails on trunk and passes with this change. PHPCS and PHPStan clean.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually.

### Use of AI Tools

Written with Claude Code; reviewed and tested by the author.

