### PR TITLE
Fix back-in-stock email CTA dropping the selected "Any" attribute

### DIFF
--- a/plugins/woocommerce/changelog/fix-bis-email-cta-drops-attribute
+++ b/plugins/woocommerce/changelog/fix-bis-email-cta-drops-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the back-in-stock notification email CTA dropping the selected "Any" attribute from the product link.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -66931,12 +66931,6 @@ parameters:
 			path: src/Internal/StockNotifications/Notification.php
 
 		-
-			message: '#^Method WC_Product\:\:get_permalink\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Internal/StockNotifications/Notification.php
-
-		-
 			message: '#^Property Automattic\\WooCommerce\\Internal\\StockNotifications\\Notification\:\:\$product \(WC_Product\) does not accept null\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
@@ -428,11 +428,15 @@ class Notification extends \WC_Data {
 			return '';
 		}
 
-		if ( $product->is_type( 'variation' ) && ! empty( $this->get_meta( 'posted_attributes' ) ) ) {
-			return $product->get_permalink( array( 'item_meta_array' => $this->get_meta( 'posted_attributes' ) ) );
-		} else {
+		$posted_attributes = $this->get_meta( 'posted_attributes' );
+		if ( ! $product instanceof \WC_Product_Variation || empty( $posted_attributes ) || ! is_array( $posted_attributes ) ) {
 			return $product->get_permalink();
 		}
+
+		// Posted attributes hold only the values chosen for "Any" attributes, so merge them over the variation's own attributes to build a complete link.
+		$attributes = array_merge( $product->get_variation_attributes(), $posted_attributes );
+
+		return $product->get_permalink( array( 'variation' => $attributes ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
@@ -434,7 +434,9 @@ class Notification extends \WC_Data {
 		}
 
 		// Posted attributes hold only the values chosen for "Any" attributes, so merge them over the variation's own attributes to build a complete link.
-		$attributes = array_merge( $product->get_variation_attributes(), $posted_attributes );
+		// Keys that no longer belong to the variation (e.g. a removed attribute) are dropped so they don't leak into the URL.
+		$variation_attributes = $product->get_variation_attributes();
+		$attributes           = array_merge( $variation_attributes, array_intersect_key( $posted_attributes, $variation_attributes ) );
 
 		return $product->get_permalink( array( 'variation' => $attributes ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
@@ -115,7 +115,14 @@ class NotificationTests extends \WC_Unit_Test_Case {
 		$notification = new Notification();
 		$notification->set_product_id( $variation_id );
 		$notification->set_user_email( 'test@example.com' );
-		$notification->update_meta_data( 'posted_attributes', array( 'attribute_pa_colour' => 'red' ) );
+		// "attribute_pa_stale" is not a variation attribute and must not end up in the URL.
+		$notification->update_meta_data(
+			'posted_attributes',
+			array(
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_stale'  => 'gone',
+			)
+		);
 		$notification->save();
 
 		$expected = add_query_arg(
@@ -126,7 +133,7 @@ class NotificationTests extends \WC_Unit_Test_Case {
 			get_permalink( $variable_product->get_id() )
 		);
 
-		$this->assertSame( $expected, $notification->get_product_permalink(), 'Permalink should carry both the variation attribute and the posted "Any" attribute' );
+		$this->assertSame( $expected, $notification->get_product_permalink(), 'Permalink should carry the variation attribute and the posted "Any" attribute, and nothing else' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
@@ -105,6 +105,31 @@ class NotificationTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should include both the variation's own attributes and the posted "Any" attributes in the permalink.
+	 */
+	public function test_get_product_permalink_with_posted_attributes(): void {
+		$variable_product = \WC_Helper_Product::create_variation_product();
+		// The first variation only sets "size"; "colour" is left as "Any".
+		$variation_id = $variable_product->get_children()[0];
+
+		$notification = new Notification();
+		$notification->set_product_id( $variation_id );
+		$notification->set_user_email( 'test@example.com' );
+		$notification->update_meta_data( 'posted_attributes', array( 'attribute_pa_colour' => 'red' ) );
+		$notification->save();
+
+		$expected = add_query_arg(
+			array(
+				'attribute_pa_size'   => 'small',
+				'attribute_pa_colour' => 'red',
+			),
+			get_permalink( $variable_product->get_id() )
+		);
+
+		$this->assertSame( $expected, $notification->get_product_permalink(), 'Permalink should carry both the variation attribute and the posted "Any" attribute' );
+	}
+
+	/**
 	 * Test the get_product_name method.
 	 */
 	public function test_get_product_name() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When a customer signs up for a variation with an "Any…" attribute, the back-in-stock email CTA linked to the bare parent product, losing the selected attribute. `Notification::get_product_permalink()` passed the stored `posted_attributes` (a flat `attribute_* => value` array) to `WC_Product_Variation::get_permalink()` under the `item_meta_array` key, which expects order-item meta rows, so the attributes were discarded.

This switches to the `variation` key (the one the Back In Stock Notifications extension uses) and merges the variation's own attributes under the posted ones, since core only stores the "Any" values. The link now preselects the full variation.

(For Bug Fixes) Bug introduced in PR #59947.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable Back In Stock Notifications (WooCommerce > Settings > Products > Back in stock).
2. Create a variable product with two attributes used for variations, e.g. Size and Colour. Create a variation with Size = Small and Colour = Any, set it out of stock.
3. On the frontend, select Small / Red and sign up for a notification.
4. Set the variation back in stock so the notification email is sent (or trigger it from WooCommerce > Stock Notifications).
5. Open the email and check the CTA link: it should include `attribute_pa_size=small&attribute_pa_colour=red` and land on the product page with both selected. Before this PR the link had no attributes.

<!-- End testing instructions -->

### Testing that has already taken place:

- Added `test_get_product_permalink_with_posted_attributes` to `NotificationTests`; it fails on trunk and passes with this change.
- `NotificationTests` green, phpcs and PHPStan clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

Claude Code assisted with the investigation, fix, and tests; all changes reviewed by the author.