### PR TITLE
Dispatch new order push notifications before the rest of the batch

### DIFF
--- a/plugins/woocommerce/changelog/fix-push-notification-order-first
+++ b/plugins/woocommerce/changelog/fix-push-notification-order-first
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Send the new order push notification before the stock ones queued by the same order, so devices play the new order sound.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 
@@ -153,10 +154,37 @@ class PendingNotificationStore {
 			return;
 		}
 
-		$this->dispatcher->dispatch( array_values( $this->pending ) );
+		$this->dispatcher->dispatch( $this->sort_with_new_orders_first( array_values( $this->pending ) ) );
 
 		$this->enabled = false;
 		$this->pending = array();
+	}
+
+	/**
+	 * Moves new order notifications to the front of the batch.
+	 *
+	 * Android only plays a sound for the first notification of a burst, and
+	 * stock is reduced before the order notification is queued, so the order
+	 * must go first for its sound to play.
+	 *
+	 * @param Notification[] $notifications The notifications about to be dispatched.
+	 * @return Notification[]
+	 *
+	 * @since 11.2.0
+	 */
+	private function sort_with_new_orders_first( array $notifications ): array {
+		$new_orders = array();
+		$others     = array();
+
+		foreach ( $notifications as $notification ) {
+			if ( NewOrderNotification::TYPE === $notification->get_type() ) {
+				$new_orders[] = $notification;
+			} else {
+				$others[] = $notification;
+			}
+		}
+
+		return array_merge( $new_orders, $others );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
@@ -151,6 +151,48 @@ class PendingNotificationStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should dispatch new order notifications before the rest of the batch.
+	 */
+	public function test_dispatch_all_sends_new_orders_first(): void {
+		$dispatched = array();
+		$dispatcher = $this->createMock( InternalNotificationDispatcher::class );
+		$dispatcher->expects( $this->once() )
+			->method( 'dispatch' )
+			->willReturnCallback(
+				function ( array $notifications ) use ( &$dispatched ) {
+					$dispatched = $notifications;
+				}
+			);
+
+		$store = new PendingNotificationStore();
+		$store->init( $dispatcher );
+		$store->register();
+		$store->add( $this->create_stock_mock( 42, StockNotification::EVENT_LOW_STOCK ) );
+		$store->add( $this->create_stock_mock( 43, StockNotification::EVENT_LOW_STOCK ) );
+		$store->add( $this->create_order_mock( 1 ) );
+
+		$store->dispatch_all();
+
+		remove_action( 'shutdown', array( $store, 'dispatch_all' ) );
+
+		$dispatched_order = array_map(
+			function ( $notification ) {
+				return $notification->get_type() . ':' . $notification->get_resource_id();
+			},
+			$dispatched
+		);
+
+		$this->assertSame(
+			array(
+				NewOrderNotification::TYPE . ':1',
+				StockNotification::TYPE . ':42',
+				StockNotification::TYPE . ':43',
+			),
+			$dispatched_order
+		);
+	}
+
+	/**
 	 * @testdox Should not call the dispatcher when there are no pending notifications.
 	 */
 	public function test_dispatch_all_does_not_call_dispatcher_when_empty(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR only changes the order push notifications are sent in: the new order one now goes out before the stock ones. Nothing else changes.

When an order drops products to low stock, the store queues the stock notifications before the order one, because stock is reduced earlier in the status transition. Android only plays a sound for the first notification of a burst, so the new order sound is lost whenever an order also triggers stock notifications.

This does not close the gap completely. The two notifications leave the store as independent pushes and nothing guarantees the delivery order, so the sound can still be lost. It fixes the common case, and sending the new order first is the right order regardless of the Android behaviour: it is the event the merchant is waiting for, and the stock notifications are a consequence of that same order.

References: WOOMOB-3968

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Connect a store to Jetpack and log into the WooCommerce Android app with the WordPress.com account that owns it, so the device registers for push notifications.
2. Go to WooCommerce > Settings > Products > Inventory and set the low stock threshold to 2.
3. Open a simple product, enable stock management and set its stock quantity to 3.
4. In the app, open Settings > Notifications and confirm new order and stock notifications are enabled.
5. Place an order for 1 unit of that product from the storefront, so the remaining stock reaches the threshold.
6. Confirm the new order notification arrives before the low stock one.
7. Confirm the new order notification plays the cha-ching sound.

### Testing that has already taken place:

Unit test added for the send order. The dispatched payload was also captured end to end in wp-env, on a real order that reduced stock: the batch is queued as stock then order, and dispatched as order then stock.

Measured on a WordPress.com Atomic store with the Android app on a Pixel emulator, placing storefront orders that drop a product to its low stock threshold.

|                   | Orders placed | New order notification first | Cha-ching |
| ----------------- | ------------- | ---------------------------- | --------- |
| Before the change | 15            | 0                            | never played |
| After the change  | 29            | 23                           | played |

The six remaining cases are the delivery race between two independent pushes, which this change does not control.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually.

### Use of AI Tools

Written with Claude Code. The change, the test and the measurements above were reviewed by me.




