### PR TITLE
[tests] Stop sales report tests leaking HPOS state across the PHPUnit suite

### DIFF
--- a/plugins/woocommerce/changelog/fix-analytics-hpos-state-leak-cpt-coverage
+++ b/plugins/woocommerce/changelog/fix-analytics-hpos-state-leak-cpt-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stop the sales report tests leaking HPOS storage state into the rest of the PHPUnit suite, and pin the long-custom-status Analytics tests to the storage they actually exercise.

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/reports-sales.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/reports-sales.php
@@ -47,11 +47,15 @@ class WC_Tests_API_Reports_Sales extends WC_REST_Unit_Test_Case {
 	public function tearDown(): void {
 		global $wpdb;
 
+		// DELETE rather than TRUNCATE, which is DDL: its implicit commit persisted the
+		// HPOS switch setup_cot() makes, while the restore below landed in a fresh
+		// transaction the parent rollback discarded. Every test after this class then
+		// ran against HPOS, including in the HPOS-off job. See #68358.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE {$wpdb->prefix}wc_orders" );
-		$wpdb->query( "TRUNCATE {$wpdb->prefix}wc_orders_meta" );
-		$wpdb->query( "TRUNCATE {$wpdb->prefix}wc_order_operational_data" );
-		$wpdb->query( "TRUNCATE {$wpdb->prefix}wc_order_addresses" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_orders" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_orders_meta" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_order_operational_data" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_order_addresses" );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery
 
 		remove_all_actions( 'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION );

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Admin\API\Reports\Orders\Stats;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Helper_Order;
 use WC_Unit_Test_Case;
@@ -15,6 +16,15 @@ use WP_Error;
  * Tests for Orders Stats DataStore.
  */
 class DataStoreTest extends WC_Unit_Test_Case {
+
+	use HPOSToggleTrait;
+
+	/**
+	 * Whether the store used HPOS before a test pinned it.
+	 *
+	 * @var bool
+	 */
+	private $original_hpos_usage;
 
 	/**
 	 * Previous woocommerce_db_version for restore.
@@ -35,6 +45,9 @@ class DataStoreTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+
+		$this->original_hpos_usage           = OrderUtil::custom_orders_table_usage_is_enabled();
 		$this->previous_db_version           = get_option( 'woocommerce_db_version' );
 		$this->previous_old_full_refund_flag = get_option( 'woocommerce_analytics_uses_old_full_refund_data' );
 	}
@@ -53,6 +66,7 @@ class DataStoreTest extends WC_Unit_Test_Case {
 		} else {
 			delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
 		}
+		$this->toggle_cot_authoritative( $this->original_hpos_usage );
 		parent::tearDown();
 	}
 
@@ -569,6 +583,12 @@ class DataStoreTest extends WC_Unit_Test_Case {
 	 */
 	public function test_returning_customer_recalculated_for_long_excluded_status(): void {
 		global $wpdb;
+
+		// A slug this long only survives a save under HPOS, which truncates it to fit the
+		// 20-char status column. The CPT store discards the change and leaves the order in
+		// its previous status instead, so pin the store rather than inherit whichever one
+		// the suite is running. See #68358.
+		$this->toggle_cot_authoritative( true );
 
 		$long_status = 'competition-completed';
 		register_post_status( 'wc-' . $long_status, array( 'public' => true ) );

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Products/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Products/DataStoreTest.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\Tests\Admin\API\Reports\Products;
 use Automattic\WooCommerce\Admin\API\Reports\Cache;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
@@ -13,6 +15,8 @@ use WC_Unit_Test_Case;
  * Tests for Products report DataStore.
  */
 class DataStoreTest extends WC_Unit_Test_Case {
+
+	use HPOSToggleTrait;
 
 	/**
 	 * Custom status slug that exceeds the 20-char status column once 'wc-' prefixed.
@@ -22,10 +26,26 @@ class DataStoreTest extends WC_Unit_Test_Case {
 	private $long_status = 'competition-completed';
 
 	/**
+	 * Whether the store used HPOS before these tests pinned it.
+	 *
+	 * @var bool
+	 */
+	private $original_hpos_usage;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		// A slug this long only survives a save under HPOS, which truncates it to fit the
+		// 20-char status column. The CPT store discards the change and leaves the order in
+		// its previous status instead, so these tests pin the store rather than inherit
+		// whichever one the suite is running. See #68358.
+		$this->original_hpos_usage = OrderUtil::custom_orders_table_usage_is_enabled();
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		$this->toggle_cot_authoritative( true );
+
 		register_post_status( 'wc-' . $this->long_status, array( 'public' => true ) );
 		add_filter( 'wc_order_statuses', array( $this, 'add_custom_status' ) );
 	}
@@ -37,6 +57,7 @@ class DataStoreTest extends WC_Unit_Test_Case {
 		remove_filter( 'wc_order_statuses', array( $this, 'add_custom_status' ) );
 		delete_option( 'woocommerce_excluded_report_order_statuses' );
 		unset( $GLOBALS['wp_post_statuses'][ 'wc-' . $this->long_status ] );
+		$this->toggle_cot_authoritative( $this->original_hpos_usage );
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Two test classes committed order-storage switches that outlived their own tests, leaving later classes on the wrong store. This closes both leaks and pins the three tests that quietly depended on one of them.

**Sales report leak — HPOS left on.** `WC_Tests_API_Reports_Sales::tearDown()` emptied four HPOS tables with `TRUNCATE`, which is DDL: it commits the per-test transaction `WP_UnitTestCase` opens. So the setup switch to HPOS stuck, while the restore after it landed in a fresh transaction the rollback discarded. The legacy suite runs before `tests/php`, so every later test ran against HPOS — including in the job meant to run without it. `DELETE FROM`, which `tests/README.md` requires, lets the restore survive.

**Page controller leak — HPOS left off.** `Orders/PageControllerTest` switches storage to CPT for the class; its tests switch back inside their transactions. The rollback undid that in the database but not the object cache, so the teardown read a stale `yes`, decided nothing needed restoring, and left the option at `no` for every later class — `OrdersSchedulerTest` then skipped three tests instead of two. It now flushes the cache and restores unconditionally.

**Three Analytics tests now pin themselves to HPOS.** They build an order whose custom status exceeds the 20-character status column. Only HPOS keeps it, by truncating the slug; CPT discards the write and leaves the previous status. The first leak had been handing these tests HPOS all along, so they never ran against CPT to notice.

**Not fixed here.** The silent status drop in the CPT data store is a real defect, written up in #68358 with both stores' measured behaviour.

Closes #68358.

One call worth a second opinion: pinning those three tests to HPOS leaves long custom statuses uncovered under CPT — say the word if you'd rather skip them there instead.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Everything here is a PHPUnit run. No store setup, products or orders are needed — the tests build their own fixtures.

**Prerequisites**

1. Check out this branch and run `pnpm install --frozen-lockfile` from the monorepo root.
2. Make sure Docker is running.
3. From `plugins/woocommerce`, run `pnpm env:test` and wait for it to report that the test environment is ready.

**Scenario 1 — the sales report class no longer hands HPOS to later tests**

4. From `plugins/woocommerce`, run `pnpm test:php:env:hpos-off -- --filter '(WC_Tests_API_Reports_Sales|test_returning_customer_recalculated_for_long_excluded_status|test_non_excluded_long_custom_status_is_counted|test_excluded_long_custom_status_is_not_counted)'`.
5. Confirm the last line reads `OK (4 tests, 14 assertions)`.

**Scenario 2 — the page controller class hands storage back**

6. From `plugins/woocommerce`, run `pnpm test:php:env -- --testsuite=wc-phpunit-main --filter '(PageControllerTest|OrdersSchedulerTest)'`. Both classes have to run in one process, which is why they are filtered together.
7. Confirm the summary reports **2 skipped**. Those two are `OrdersSchedulerTest`'s CPT-only cases. On `trunk` the same command reports 3 skipped, because a third test is skipped for the wrong reason: storage was left switched off.

**Scenario 3 — nothing else moved**

8. From `plugins/woocommerce`, run `pnpm test:php:env:hpos-off -- --filter 'DataStoreTest'` and confirm 340 passing tests.
9. From `plugins/woocommerce`, run `pnpm test:php:env -- --filter 'DataStoreTest'` and confirm 340 passing tests.

<!-- End testing instructions -->

### Testing that has already taken place:

Full HPOS-off suite on this branch: `14535 tests, 56145 assertions, 4 failures`. All four are pre-existing local-environment artifacts (`WC_Tests_Notes_Run_Db_Update`, `WC_Install_Test`, two `SavedForLaterTests`) that fail the same way on an unmodified `trunk` checkout in the same environment. Both affected classes pass with HPOS on and off, 340 tests each way. `phpcs` and `lint:changes:branch` are clean on all three changed files.

<details>

<summary>Each claim above was measured against its counterfactual, not inferred</summary>

- **The leak is real.** With `trunk`'s teardown restored, a probe test running after the class reports `hpos_usage=true`, `woocommerce_custom_orders_table_enabled='yes'`, `OrdersTableDataStore`. With this change it reports `false`, `'no'`, `WC_Order_Data_Store_CPT`.
- **The CPT behaviour is real.** Saving an order with `wc-competition-completed` (24 characters) under CPT passes the full slug to `wp_insert_post_data`, sets no `$wpdb->last_error`, and leaves `post_status` at its previous `wc-pending`; the reloaded order reports `pending`. The same save under HPOS stores `wc-competition-compl` and reloads as `competition-compl`.
- **One test was passing vacuously.** `Reports\Products\DataStoreTest::test_excluded_long_custom_status_is_not_counted` asserts `0` and got `0` under CPT only because the order was still `pending`.
- **The cache flush is the load-bearing part.** Running `PageControllerTest` then `OrdersSchedulerTest` in one process, HPOS on at boot, moved `OrdersSchedulerTest` from 42 executed and 3 skipped to 43 executed and 2 skipped. Dropping the stale-cache condition alone was not enough: `update_option()` also compares against the cached value and skips the write.

</details>

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually: `plugins/woocommerce/changelog/fix-analytics-hpos-state-leak-cpt-coverage` (patch, dev).

</details>

### Use of AI Tools

Claude Code found this while addressing review feedback on #68285, ran the bisection and the probes that produced the evidence above, and drafted the change. I reviewed the diagnosis and the diff and take responsibility for the change.
