### PR TITLE
Fix fatal generating receipt when variation parent product was deleted

### DIFF
--- a/plugins/woocommerce/changelog/68368-fix-receipt-deleted-variation-parent
+++ b/plugins/woocommerce/changelog/68368-fix-receipt-deleted-variation-parent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error when generating a receipt for an order containing a variation item whose parent product was deleted. The receipt now falls back to the line item name.

--- a/plugins/woocommerce/changelog/68368-fix-receipt-deleted-variation-parent
+++ b/plugins/woocommerce/changelog/68368-fix-receipt-deleted-variation-parent
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent a fatal error when generating a receipt for an order containing a variation item whose parent product was deleted. The receipt now falls back to the line item name.
+Fix a fatal error generating receipts for orders with a deleted variation parent.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -63121,12 +63121,6 @@ parameters:
 			path: src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
 
 		-
-			message: '#^Cannot call method get_name\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
-
-		-
 			message: '#^Constant Automattic\\WooCommerce\\Internal\\ReceiptRendering\\ReceiptRenderingEngine\:\:KNOWN_CARD_TYPES is unused\.$#'
 			identifier: classConstant.unused
 			count: 1

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -302,7 +302,7 @@ class ReceiptRenderingEngine {
 			if ( false === $line_item_product ) {
 				$line_item_title = $line_item->get_name();
 			} elseif ( $line_item_product instanceof \WC_Product_Variation ) {
-				$parent_product = wc_get_product( $line_item_product->get_parent_id() );
+				$parent_product   = wc_get_product( $line_item_product->get_parent_id() );
 				$line_item_title = $parent_product instanceof \WC_Product
 					? $parent_product->get_name() . '. ' . $line_item_product->get_attribute_summary()
 					: $line_item->get_name();

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -301,11 +301,13 @@ class ReceiptRenderingEngine {
 			$line_item_product = $line_item->get_product();
 			if ( false === $line_item_product ) {
 				$line_item_title = $line_item->get_name();
+			} elseif ( $line_item_product instanceof \WC_Product_Variation ) {
+				$parent_product = wc_get_product( $line_item_product->get_parent_id() );
+				$line_item_title = $parent_product instanceof \WC_Product
+					? $parent_product->get_name() . '. ' . $line_item_product->get_attribute_summary()
+					: $line_item->get_name();
 			} else {
-				$line_item_title =
-					( $line_item_product instanceof \WC_Product_Variation ) ?
-						( wc_get_product( $line_item_product->get_parent_id() )->get_name() ) . '. ' . $line_item_product->get_attribute_summary() :
-						$line_item_product->get_name();
+				$line_item_title = $line_item_product->get_name();
 			}
 			$line_items_info[] = array(
 				'type'     => 'product',

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -302,7 +302,7 @@ class ReceiptRenderingEngine {
 			if ( false === $line_item_product ) {
 				$line_item_title = $line_item->get_name();
 			} elseif ( $line_item_product instanceof \WC_Product_Variation ) {
-				$parent_product   = wc_get_product( $line_item_product->get_parent_id() );
+				$parent_product  = wc_get_product( $line_item_product->get_parent_id() );
 				$line_item_title = $parent_product instanceof \WC_Product
 					? $parent_product->get_name() . '. ' . $line_item_product->get_attribute_summary()
 					: $line_item->get_name();

--- a/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
@@ -319,4 +319,24 @@ class ReceiptRenderingEngineTest extends \WC_Unit_Test_Case {
 
 		$this->assertStringNotContainsString( 'payment_method_section_title', $rendered );
 	}
+
+	/**
+	 * @testdox 'generate_receipt' falls back to the line item name when the variation parent product was deleted.
+	 */
+	public function test_generate_receipt_falls_back_to_item_name_when_variation_parent_is_deleted() {
+		// Arrange - an order holding a variation item whose parent product no longer exists.
+		$parent    = \WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( current( $parent->get_children() ) );
+
+		$order = OrderHelper::create_order( 1, $variation );
+
+		$parent->delete( true );
+
+		// Act - rendering must not fatal on the dangling parent lookup.
+		$rendered = $this->render_receipt( $order );
+
+		// Assert - the line item name is used as the title fallback.
+		$item = current( $order->get_items() );
+		$this->assertStringContainsString( $item->get_name(), $rendered );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
@@ -321,16 +321,25 @@ class ReceiptRenderingEngineTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'generate_receipt' falls back to the line item name when the variation parent product was deleted.
+	 * @testdox 'generate_receipt' falls back to the line item name when the variation parent lookup dangles.
 	 */
 	public function test_generate_receipt_falls_back_to_item_name_when_variation_parent_is_deleted() {
-		// Arrange - an order holding a variation item whose parent product no longer exists.
+		global $wpdb;
+		// Arrange - an order holding a variation item whose parent product
+		// lookup dangles (failed cleanup, out-of-band delete, stale cache
+		// serving the variation after its parent is gone). The orphan is
+		// built at the row level on purpose: deleting through the API
+		// cascades to the children, so it cannot produce this state.
 		$parent    = \WC_Helper_Product::create_variation_product();
 		$variation = wc_get_product( current( $parent->get_children() ) );
 
 		$order = OrderHelper::create_order( 1, $variation );
 
-		$parent->delete( true );
+		$wpdb->delete( $wpdb->posts, array( 'ID' => $parent->get_id() ) );
+		clean_post_cache( $parent->get_id() );
+		$this->assertFalse( wc_get_product( $parent->get_id() ) );
+		$items = $order->get_items();
+		$this->assertInstanceOf( \WC_Product_Variation::class, current( $items )->get_product() );
 
 		// Act - rendering must not fatal on the dangling parent lookup.
 		$rendered = $this->render_receipt( $order );

--- a/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
@@ -325,11 +325,7 @@ class ReceiptRenderingEngineTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_generate_receipt_falls_back_to_item_name_when_variation_parent_is_deleted() {
 		global $wpdb;
-		// Arrange - an order holding a variation item whose parent product
-		// lookup dangles (failed cleanup, out-of-band delete, stale cache
-		// serving the variation after its parent is gone). The orphan is
-		// built at the row level on purpose: deleting through the API
-		// cascades to the children, so it cannot produce this state.
+		// Arrange - orphan the variation at the row level: deleting through the API cascades to the children, so it cannot produce this state.
 		$parent    = \WC_Helper_Product::create_variation_product();
 		$variation = wc_get_product( current( $parent->get_children() ) );
 
@@ -345,7 +341,7 @@ class ReceiptRenderingEngineTest extends \WC_Unit_Test_Case {
 		$rendered = $this->render_receipt( $order );
 
 		// Assert - the line item name is used as the title fallback.
-		$item = current( $order->get_items() );
+		$item = current( $items );
 		$this->assertStringContainsString( $item->get_name(), $rendered );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
-   I have checked to ensure there aren't other open Pull Requests for the same update/change.
-   I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

Closes #68368.

`ReceiptRenderingEngine` called `->get_name()` on the result of `wc_get_product( parent_id )` with no guard. When the parent variable product was deleted the factory returns `false` and receipt generation fatals. Now falls back to the line item name, mirroring the existing `false` branch for a missing item product.

### How to test the changes in this Pull Request:

End-to-end via the REST receipt endpoint (verified live on wp-env, PHP 8.1 — not just the unit test):

1. Build the broken state with WP-CLI (one paste via `wp eval-file`). This creates a variable product + variation + order, then deletes ONLY the parent row — the same shape as failed cleanups / out-of-band deletes (deleting from the UI cascades to variations, so no click path can build this):
```php
$parent = new WC_Product_Variable();
$parent->set_name( 'Receipt Repro Shirt' );
$parent->set_status( 'publish' );
$parent_id = $parent->save();
$variation = new WC_Product_Variation();
$variation->set_parent_id( $parent_id );
$variation->set_attributes( array( 'size' => 'M' ) );
$variation->set_regular_price( '10' );
$variation->set_status( 'publish' );
$variation_id = $variation->save();
$order = wc_create_order();
$order->add_product( wc_get_product( $variation_id ), 1 );
$order->calculate_totals();
$order_id = $order->get_id();
global $wpdb;
$wpdb->delete( $wpdb->posts, array( 'ID' => $parent_id ) );
clean_post_cache( $parent_id );
echo "order_id=$order_id parent lookup: " . var_export( wc_get_product( $parent_id ), true );
```
It prints something like `order_id=14 parent lookup: false` while the variation stays readable.
2. Make an admin Application Password (Users → Profile → Application Passwords, or `wp user application-password create admin repro --porcelain`).
3. Generate the receipt through REST:
```
curl -u admin:PASS -X POST "https://<host>/wp-json/wc/v3/orders/<order_id>/receipt?force_new=1"
```
(If permalinks are plain, use `index.php?rest_route=/wc/v3/orders/<order_id>/receipt&force_new=1` instead.)
- Without the fix: HTTP 500, "There has been a critical error on this website" (`Error: Call to a member function get_name() on bool`).
- With the fix: HTTP 200 with `{"receipt_url": "...", "expiration_date": "..."}`.
4. Automated cover: `pnpm test:php:env -- --filter test_generate_receipt_falls_back_to_item_name_when_variation_parent_is_deleted` (errors without the fix, passes with it; full `ReceiptRenderingEngineTest` class 17/17 green).

### Testing that has already taken place:

wp-env locally (PHP 8.1): new test ERRORS without the fix (`Call to a member function get_name() on bool`) and passes with it; full `ReceiptRenderingEngineTest` class 17/17 green; `phpcs-changed` on the branch diff clean; `php -l` clean on both files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
