### PR TITLE
Load WooCommerce notice functions in all request contexts

### DIFF
--- a/plugins/woocommerce/changelog/fix-54681-wc-print-notice-cron-fatal
+++ b/plugins/woocommerce/changelog/fix-54681-wc-print-notice-cron-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error (Call to undefined function wc_print_notice) when a plugin renders WooCommerce templates during wp-cron or admin requests where the notice functions were not loaded.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -979,10 +979,18 @@ final class WooCommerce {
 	/**
 	 * Function used to Init WooCommerce Template Functions - This makes them pluggable by plugins and themes.
 	 *
+	 * Notice functions are loaded here too: templates loaded through the
+	 * template functions (for example `checkout/form-login.php`, which calls
+	 * `wc_print_notice()`) assume they exist, but they were previously only
+	 * included for frontend/REST requests. Requests such as wp-cron or plain
+	 * wp-admin loads could therefore fatal when a plugin rendered a template
+	 * in a context where the notice functions had not been loaded.
+	 *
 	 * @return void
 	 */
 	public function include_template_functions() {
 		include_once WC_ABSPATH . 'includes/wc-template-functions.php';
+		include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Third-party plugins can render WooCommerce templates during wp-cron or plain wp-admin requests (for example JetWooBuilder's checkout widgets rendered by Elementor while Yoast SEO background-indexes a Checkout page). Those templates call notice functions such as `wc_print_notice()` (see `templates/checkout/form-login.php`), but `includes/wc-notice-functions.php` was only loaded for frontend/REST requests — via `frontend_includes()` and `wc_load_cart()`, both gated by `is_request( 'frontend' )`, which hard-excludes `DOING_CRON`. The result is a fatal: `Call to undefined function wc_print_notice()`.

This change loads `wc-notice-functions.php` unconditionally in `include_template_functions()`, alongside `wc-template-functions.php`. Both files are registered on `after_setup_theme` and fire in every request context, so the template functions and the notice functions they (indirectly) depend on always travel together. The existing frontend include becomes a harmless no-op via `include_once`.

Closes #54681.

Related issues fixed by the same root cause: #52342 (same fatal via `no-products-found.php`), #66272 / #65402 (admin-context `wc_set_notices()` / `wc_get_notices()` fatals on the widgets screen, previously worked around in `Blocks/Domain/Services/Hydration.php`).

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Confirm `wc_print_notice()` is now defined in a context where it previously was not: run a `wp cron` request (or `wp cron event run --due-now` via WP-CLI) and verify no "Call to undefined function wc_print_notice" fatal occurs when a template that calls it is rendered. A direct check is to load any non-frontend request (for example a wp-admin page or `wp-cron.php`) and confirm `function_exists( 'wc_print_notice' )` returns `true`.
2. Verify normal storefront behavior is unchanged: load a frontend page, add a product to the cart, and confirm the "added to cart" success notice still displays; check the Checkout login reminder notice on the Checkout page when the "Enable checkout login reminder" option is on.
3. Confirm notices are not emitted prematurely in bare cron/admin: call `wc_add_notice()` or `wc_print_notices()` during a non-frontend request and confirm they no-op safely (guarded by `did_action( 'woocommerce_init' )` / `WC()->session`), with no PHP warnings or fatal errors.

### Testing that has already taken place:

-   Reviewed the load paths in `includes/class-woocommerce.php`: `include_template_functions()` is registered on `after_setup_theme` (priority 11) and fires in every request context; `frontend_includes()` and `wc_load_cart()` — the previous load sites of `wc-notice-functions.php` — are gated behind `is_request( 'frontend' )`, which returns `false` when `DOING_CRON` is defined.
-   Confirmed `includes/wc-notice-functions.php` contains only function definitions (plus the `ABSPATH` guard), with no top-level side effects.
-   Confirmed the notice functions that touch the session (`wc_add_notice`, `wc_get_notices`, `wc_set_notices`, `wc_print_notices`, `wc_notice_count`) already self-guard with `did_action( 'woocommerce_init' )` and `WC()->session` checks, and `wc_print_notice()` itself has no session dependency.
-   Checked existing tests (`tests/php/includes/class-woocommerce-test.php`, `tests/php/src/Blocks/Domain/Services/HydrationTest.php`) — none assert the notice functions are absent outside frontend/REST contexts, and the Hydration seam overrides availability explicitly, so it remains valid.
-   Ran the WooCommerce PHPCS lint on the changed files: clean. PHPUnit tests require the wp-env Docker environment and were not run locally.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually at `plugins/woocommerce/changelog/fix-54681-wc-print-notice-cron-fatal`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
