### PR TITLE
Exclude password-protected product reviews from the Store API

### DIFF
--- a/docs/apis/store-api/resources-endpoints/product-reviews.md
+++ b/docs/apis/store-api/resources-endpoints/product-reviews.md
@@ -58,3 +58,11 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?cal
 	}
 ]
 ```
+
+### Password-protected products
+
+Reviews of password-protected products are excluded until the visitor has submitted the correct password. They are omitted from both the collection and the pagination totals.
+
+Password verification uses WordPress's native `wp-postpass_*` cookie, set when a user submits the password form on the frontend. The Store API does not accept passwords directly.
+
+A request that targets a locked product via `product_id` returns an empty collection with status `200`.

--- a/plugins/woocommerce/changelog/fix-WOO6-151-exclude-password-protected-product-reviews-from-rest-api
+++ b/plugins/woocommerce/changelog/fix-WOO6-151-exclude-password-protected-product-reviews-from-rest-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude password-protected product reviews from the Store API

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -160,12 +160,16 @@ class ProductReviews extends AbstractRoute {
 	 * WP_Comment_Query already joins posts because of post_status. Filter on that
 	 * join instead of building a post__not_in list of every protected product.
 	 *
-	 * @param array $clauses              Comment query clauses.
-	 * @param int[] $unlocked_product_ids Password-protected product IDs the visitor has unlocked.
-	 * @return array
+	 * @param array|mixed $clauses              Comment query clauses from comments_clauses.
+	 * @param int[]       $unlocked_product_ids Password-protected product IDs the visitor has unlocked.
+	 * @return array|mixed
 	 */
 	private function exclude_password_protected_product_reviews( $clauses, $unlocked_product_ids ) {
 		global $wpdb;
+
+		if ( ! is_array( $clauses ) ) {
+			return $clauses;
+		}
 
 		$where = " {$wpdb->posts}.post_password = '' ";
 		if ( ! empty( $unlocked_product_ids ) ) {
@@ -173,6 +177,7 @@ class ProductReviews extends AbstractRoute {
 			$where = " ( {$wpdb->posts}.post_password = '' OR {$wpdb->posts}.ID IN ({$ids}) ) ";
 		}
 
+		$clauses['where']  = is_string( $clauses['where'] ?? null ) ? $clauses['where'] : '';
 		$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . $where;
 
 		return $clauses;

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -111,7 +111,7 @@ class ProductReviews extends AbstractRoute {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
-		$inaccessible_product_ids = $this->get_inaccessible_password_protected_product_ids();
+		$inaccessible_product_ids = $this->get_inaccessible_password_protected_product_ids( $request );
 		if ( ! empty( $inaccessible_product_ids ) ) {
 			$prepared_args['post__not_in'] = $inaccessible_product_ids;
 		}
@@ -148,24 +148,34 @@ class ProductReviews extends AbstractRoute {
 	/**
 	 * Product IDs whose reviews should stay hidden from this request.
 	 *
+	 * @param \WP_REST_Request $request Request object.
 	 * @return int[]
 	 */
-	private function get_inaccessible_password_protected_product_ids() {
-		$protected_products = get_posts(
-			array(
-				'post_type'              => 'product',
-				'post_status'            => ProductStatus::PUBLISH,
-				'has_password'           => true,
-				'posts_per_page'         => -1,
-				'no_found_rows'          => true,
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			)
+	private function get_inaccessible_password_protected_product_ids( $request ) {
+		$protected_products_query = array(
+			'post_type'              => 'product',
+			'post_status'            => ProductStatus::PUBLISH,
+			'has_password'           => true,
+			'comment_count'          => array(
+				'value'   => 0,
+				'compare' => '!=',
+			),
+			'posts_per_page'         => -1,
+			'orderby'                => 'none',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
 		);
+
+		if ( ! empty( $request['product_id'] ) ) {
+			$protected_products_query['post__in'] = $request['product_id'];
+		}
+
+		$protected_products = get_posts( $protected_products_query );
 
 		$inaccessible_ids = array();
 		foreach ( $protected_products as $product_post ) {
-			if ( $product_post->comment_count > 0 && post_password_required( $product_post ) ) {
+			if ( post_password_required( $product_post ) ) {
 				$inaccessible_ids[] = (int) $product_post->ID;
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -165,7 +165,7 @@ class ProductReviews extends AbstractRoute {
 
 		$inaccessible_ids = array();
 		foreach ( $protected_products as $product_post ) {
-			if ( post_password_required( $product_post ) ) {
+			if ( $product_post->comment_count > 0 && post_password_required( $product_post ) ) {
 				$inaccessible_ids[] = (int) $product_post->ID;
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -116,6 +116,10 @@ class ProductReviews extends AbstractRoute {
 		$response_objects = array();
 
 		foreach ( $query_result as $review ) {
+			if ( post_password_required( (int) $review->comment_post_ID ) ) {
+				continue;
+			}
+
 			$data               = $this->prepare_item_for_response( $review, $request );
 			$response_objects[] = $this->prepare_response_for_collection( $data );
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -111,32 +111,41 @@ class ProductReviews extends AbstractRoute {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
-		$inaccessible_product_ids = $this->get_inaccessible_password_protected_product_ids( $request );
-		if ( ! empty( $inaccessible_product_ids ) ) {
-			$prepared_args['post__not_in'] = $inaccessible_product_ids;
+		$unlocked_product_ids               = $this->get_unlocked_password_protected_product_ids( $prepared_args['post__in'] ?? array() );
+		$exclude_password_protected_reviews = function ( $clauses ) use ( $unlocked_product_ids ) {
+			return $this->exclude_password_protected_product_reviews( $clauses, $unlocked_product_ids );
+		};
+
+		$query_result  = array();
+		$total_reviews = 0;
+		$max_pages     = 0;
+
+		add_filter( 'comments_clauses', $exclude_password_protected_reviews );
+		try {
+			$query        = new WP_Comment_Query();
+			$query_result = $query->query( $prepared_args );
+
+			$total_reviews = (int) $query->found_comments;
+			$max_pages     = (int) $query->max_num_pages;
+
+			if ( $total_reviews < 1 ) {
+				// Out-of-bounds, run the query again without LIMIT for total count.
+				unset( $prepared_args['number'], $prepared_args['offset'] );
+
+				$query                  = new WP_Comment_Query();
+				$prepared_args['count'] = true;
+
+				$total_reviews = $query->query( $prepared_args );
+				$max_pages     = $request['per_page'] ? ceil( $total_reviews / $request['per_page'] ) : 1;
+			}
+		} finally {
+			remove_filter( 'comments_clauses', $exclude_password_protected_reviews );
 		}
 
-		$query            = new WP_Comment_Query();
-		$query_result     = $query->query( $prepared_args );
 		$response_objects = array();
-
 		foreach ( $query_result as $review ) {
 			$data               = $this->prepare_item_for_response( $review, $request );
 			$response_objects[] = $this->prepare_response_for_collection( $data );
-		}
-
-		$total_reviews = (int) $query->found_comments;
-		$max_pages     = (int) $query->max_num_pages;
-
-		if ( $total_reviews < 1 ) {
-			// Out-of-bounds, run the query again without LIMIT for total count.
-			unset( $prepared_args['number'], $prepared_args['offset'] );
-
-			$query                  = new WP_Comment_Query();
-			$prepared_args['count'] = true;
-
-			$total_reviews = $query->query( $prepared_args );
-			$max_pages     = $request['per_page'] ? ceil( $total_reviews / $request['per_page'] ) : 1;
 		}
 
 		$response = rest_ensure_response( $response_objects );
@@ -146,13 +155,37 @@ class ProductReviews extends AbstractRoute {
 	}
 
 	/**
-	 * Product IDs whose reviews should stay hidden from this request.
+	 * Restrict the comment query to products the visitor can access.
 	 *
-	 * @param \WP_REST_Request $request Request object.
+	 * WP_Comment_Query already joins posts because of post_status. Filter on that
+	 * join instead of building a post__not_in list of every protected product.
+	 *
+	 * @param array $clauses              Comment query clauses.
+	 * @param int[] $unlocked_product_ids Password-protected product IDs the visitor has unlocked.
+	 * @return array
+	 */
+	private function exclude_password_protected_product_reviews( $clauses, $unlocked_product_ids ) {
+		global $wpdb;
+
+		$where = " {$wpdb->posts}.post_password = '' ";
+		if ( ! empty( $unlocked_product_ids ) ) {
+			$ids   = implode( ',', array_map( 'absint', $unlocked_product_ids ) );
+			$where = " ( {$wpdb->posts}.post_password = '' OR {$wpdb->posts}.ID IN ({$ids}) ) ";
+		}
+
+		$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . $where;
+
+		return $clauses;
+	}
+
+	/**
+	 * Password-protected product IDs the visitor has unlocked.
+	 *
+	 * @param int[] $candidate_product_ids Product IDs already limiting the review query, if any.
 	 * @return int[]
 	 */
-	private function get_inaccessible_password_protected_product_ids( $request ) {
-		$protected_products_query = array(
+	private function get_unlocked_password_protected_product_ids( $candidate_product_ids = array() ) {
+		$query_args = array(
 			'post_type'              => 'product',
 			'post_status'            => ProductStatus::PUBLISH,
 			'has_password'           => true,
@@ -165,22 +198,22 @@ class ProductReviews extends AbstractRoute {
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
+			'fields'                 => 'ids',
 		);
 
-		if ( ! empty( $request['product_id'] ) ) {
-			$protected_products_query['post__in'] = $request['product_id'];
+		if ( ! empty( $candidate_product_ids ) ) {
+			$query_args['post__in'] = $candidate_product_ids;
 		}
 
-		$protected_products = get_posts( $protected_products_query );
-
-		$inaccessible_ids = array();
-		foreach ( $protected_products as $product_post ) {
-			if ( post_password_required( $product_post ) ) {
-				$inaccessible_ids[] = (int) $product_post->ID;
+		$unlocked_ids = array();
+		foreach ( get_posts( $query_args ) as $product_id ) {
+			$product_id = absint( $product_id );
+			if ( $product_id && ! post_password_required( $product_id ) ) {
+				$unlocked_ids[] = $product_id;
 			}
 		}
 
-		return $inaccessible_ids;
+		return $unlocked_ids;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -198,7 +198,6 @@ class ProductReviews extends AbstractRoute {
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
-			'fields'                 => 'ids',
 		);
 
 		if ( ! empty( $candidate_product_ids ) ) {
@@ -206,10 +205,9 @@ class ProductReviews extends AbstractRoute {
 		}
 
 		$unlocked_ids = array();
-		foreach ( get_posts( $query_args ) as $product_id ) {
-			$product_id = absint( $product_id );
-			if ( $product_id && ! post_password_required( $product_id ) ) {
-				$unlocked_ids[] = $product_id;
+		foreach ( get_posts( $query_args ) as $product ) {
+			if ( $product instanceof \WP_Post && ! post_password_required( $product ) ) {
+				$unlocked_ids[] = (int) $product->ID;
 			}
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -111,15 +111,16 @@ class ProductReviews extends AbstractRoute {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
+		$inaccessible_product_ids = $this->get_inaccessible_password_protected_product_ids();
+		if ( ! empty( $inaccessible_product_ids ) ) {
+			$prepared_args['post__not_in'] = $inaccessible_product_ids;
+		}
+
 		$query            = new WP_Comment_Query();
 		$query_result     = $query->query( $prepared_args );
 		$response_objects = array();
 
 		foreach ( $query_result as $review ) {
-			if ( post_password_required( (int) $review->comment_post_ID ) ) {
-				continue;
-			}
-
 			$data               = $this->prepare_item_for_response( $review, $request );
 			$response_objects[] = $this->prepare_response_for_collection( $data );
 		}
@@ -142,6 +143,34 @@ class ProductReviews extends AbstractRoute {
 		$response = ( new Pagination() )->add_headers( $response, $request, $total_reviews, $max_pages );
 
 		return $response;
+	}
+
+	/**
+	 * Product IDs whose reviews should stay hidden from this request.
+	 *
+	 * @return int[]
+	 */
+	private function get_inaccessible_password_protected_product_ids() {
+		$protected_products = get_posts(
+			array(
+				'post_type'              => 'product',
+				'post_status'            => ProductStatus::PUBLISH,
+				'has_password'           => true,
+				'posts_per_page'         => -1,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		$inaccessible_ids = array();
+		foreach ( $protected_products as $product_post ) {
+			if ( post_password_required( $product_post ) ) {
+				$inaccessible_ids[] = (int) $product_post->ID;
+			}
+		}
+
+		return $inaccessible_ids;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -185,6 +185,11 @@ class ProductReviews extends AbstractRoute {
 	 * @return int[]
 	 */
 	private function get_unlocked_password_protected_product_ids( $candidate_product_ids = array() ) {
+		// Return early if the visitor has not submitted the password form and there is no filter in `post_password_required`.
+		if ( ( ! defined( 'COOKIEHASH' ) || ! isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) && ! has_filter( 'post_password_required' ) ) {
+			return array();
+		}
+
 		$query_args = array(
 			'post_type'              => 'product',
 			'post_status'            => ProductStatus::PUBLISH,

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -141,6 +141,8 @@ class ProductReviews extends ControllerTestCase {
 		$product_ids = wp_list_pluck( $response->get_data(), 'product_id' );
 
 		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 2, $product_ids );
+		$this->assertSame( 2, (int) $response->get_headers()['X-WP-Total'] );
 		$this->assertContains( $this->products[0]->get_id(), $product_ids );
 		$this->assertContains( $this->products[1]->get_id(), $product_ids );
 		$this->assertNotContains( $protected_product->get_id(), $product_ids );
@@ -151,6 +153,7 @@ class ProductReviews extends ControllerTestCase {
 
 		$this->assertSame( 200, $targeted->get_status() );
 		$this->assertCount( 0, $targeted->get_data() );
+		$this->assertSame( 0, (int) $targeted->get_headers()['X-WP-Total'] );
 	}
 
 	/**
@@ -174,21 +177,26 @@ class ProductReviews extends ControllerTestCase {
 		$hasher                                 = new \PasswordHash( 8, true );
 		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( $password );
 
-		$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' ) );
-		$product_ids = wp_list_pluck( $response->get_data(), 'product_id' );
+		try {
+			$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' ) );
+			$product_ids = wp_list_pluck( $response->get_data(), 'product_id' );
 
-		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
-		$request->set_param( 'product_id', (string) $protected_product->get_id() );
-		$targeted = rest_get_server()->dispatch( $request );
-		$data     = $targeted->get_data();
-
-		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+			$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+			$request->set_param( 'product_id', (string) $protected_product->get_id() );
+			$targeted = rest_get_server()->dispatch( $request );
+			$data     = $targeted->get_data();
+		} finally {
+			unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+		}
 
 		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 3, $product_ids );
+		$this->assertSame( 3, (int) $response->get_headers()['X-WP-Total'] );
 		$this->assertContains( $protected_product->get_id(), $product_ids );
 
 		$this->assertSame( 200, $targeted->get_status() );
 		$this->assertCount( 1, $data );
+		$this->assertSame( 1, (int) $targeted->get_headers()['X-WP-Total'] );
 		$this->assertSame( $protected_product->get_id(), $data[0]['product_id'] );
 		$this->assertSame( 3, $data[0]['rating'] );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -122,6 +122,78 @@ class ProductReviews extends ControllerTestCase {
 	}
 
 	/**
+	 * @testdox Reviews are not returned for password-protected products.
+	 */
+	public function test_reviews_are_excluded_for_password_protected_products(): void {
+		$fixtures          = new FixtureData();
+		$protected_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Password Protected Review Product',
+				'regular_price' => 10,
+			)
+		);
+		$fixtures->add_product_review( $protected_product->get_id(), 5, 'Hidden review' );
+
+		$protected_product->set_post_password( 'secret' );
+		$protected_product->save();
+
+		$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' ) );
+		$product_ids = wp_list_pluck( $response->get_data(), 'product_id' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertContains( $this->products[0]->get_id(), $product_ids );
+		$this->assertContains( $this->products[1]->get_id(), $product_ids );
+		$this->assertNotContains( $protected_product->get_id(), $product_ids );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$request->set_param( 'product_id', (string) $protected_product->get_id() );
+		$targeted = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $targeted->get_status() );
+		$this->assertCount( 0, $targeted->get_data() );
+	}
+
+	/**
+	 * @testdox Reviews of password-protected products are returned when the visitor has the password.
+	 */
+	public function test_reviews_are_returned_for_password_protected_products_when_password_is_known(): void {
+		$fixtures          = new FixtureData();
+		$password          = 'secret';
+		$protected_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Password Protected Review Product',
+				'regular_price' => 10,
+			)
+		);
+		$fixtures->add_product_review( $protected_product->get_id(), 3, 'Visible with password' );
+
+		$protected_product->set_post_password( $password );
+		$protected_product->save();
+
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher                                 = new \PasswordHash( 8, true );
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( $password );
+
+		$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' ) );
+		$product_ids = wp_list_pluck( $response->get_data(), 'product_id' );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$request->set_param( 'product_id', (string) $protected_product->get_id() );
+		$targeted = rest_get_server()->dispatch( $request );
+		$data     = $targeted->get_data();
+
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertContains( $protected_product->get_id(), $product_ids );
+
+		$this->assertSame( 200, $targeted->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertSame( $protected_product->get_id(), $data[0]['product_id'] );
+		$this->assertSame( 3, $data[0]['rating'] );
+	}
+
+	/**
 	 * Test getting reviews with specific order and per_page parameters.
 	 */
 	public function test_get_items_with_order_params() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOO6-151.

Make it so `/wp-json/wc/store/v1/products/reviews` returns reviews of password-protected products only if the user has the password.

Note: the way WP core handles comments in private posts is by filtering them after doing the SQL query. That has the issue that `X-WP-Total` might not be correct. WP accepts that trade-off, but in our case [the Reviews blocks depend on the `X-WP-Total` value](https://github.com/woocommerce/woocommerce/blob/1512be0ff427f8d2a6cda13a2171288d9de6a1ad/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/utils.js#L43), that's why in this implementation reviews are filtered in the SQL query instead of afterwards.

### How to test the changes in this Pull Request:

1. Create three products: one without password, one with a password and another one with different password.
2. Add a different review to each of the three products.
3. Being logged out, visit the page of one of the password-protected products and introduce the password.
4. Make a GET request to `/wp-json/wc/store/v1/products/reviews`. (Alternatively, you can test the _All Reviews_ block in a post or page)
5. Verify you see the reviews of the product without password and the product that you introduced the password. You shouldn't see the review of the product that you hadn't introduced the password.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->