### PR TITLE
Treat array-valued remove_coupon as empty instead of fataling

### DIFF
--- a/plugins/woocommerce/changelog/68376-fix-remove-coupon-array-guard
+++ b/plugins/woocommerce/changelog/68376-fix-remove-coupon-array-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Treat an array-valued remove_coupon request parameter as empty instead of raising a PHP error on the cart page.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -730,7 +730,7 @@ class WC_Form_Handler {
 			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		} elseif ( isset( $_GET['remove_coupon'] ) ) {
-			WC()->cart->remove_coupon( wc_format_coupon_code( urldecode( wp_unslash( $_GET['remove_coupon'] ) ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			WC()->cart->remove_coupon( wc_format_coupon_code( urldecode( is_string( $_GET['remove_coupon'] ) ? wp_unslash( $_GET['remove_coupon'] ) : '' ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		} elseif ( ! empty( $_GET['remove_item'] ) && wp_verify_nonce( $nonce_value, 'woocommerce-cart' ) ) {
 			$cart_item_key = sanitize_text_field( wp_unslash( $_GET['remove_item'] ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -668,4 +668,42 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 
 		$this->fail( 'Expected save_account_details() to redirect after a successful save.' );
 	}
+
+	/**
+	 * @testdox update_cart_action() ignores array-valued remove_coupon instead of fataling.
+	 *
+	 * @covers WC_Form_Handler::update_cart_action()
+	 */
+	public function test_update_cart_action_ignores_array_remove_coupon(): void {
+		$coupon = WC_Helper_Coupon::create_coupon( 'tenoff', array( 'coupon_amount' => 10 ) );
+		WC()->cart->empty_cart();
+		WC()->cart->add_discount( $coupon->get_code() );
+		$this->assertTrue( WC()->cart->has_discount( $coupon->get_code() ) );
+
+		$_GET['remove_coupon']     = array( 'tenoff' );
+		$_REQUEST['remove_coupon'] = array( 'tenoff' );
+
+		WC_Form_Handler::update_cart_action();
+
+		$this->assertTrue( WC()->cart->has_discount( $coupon->get_code() ), 'Array remove_coupon must not remove the coupon.' );
+	}
+
+	/**
+	 * @testdox update_cart_action() still removes the coupon for a string remove_coupon.
+	 *
+	 * @covers WC_Form_Handler::update_cart_action()
+	 */
+	public function test_update_cart_action_removes_coupon_for_string_remove_coupon(): void {
+		$coupon = WC_Helper_Coupon::create_coupon( 'tenoff', array( 'coupon_amount' => 10 ) );
+		WC()->cart->empty_cart();
+		WC()->cart->add_discount( $coupon->get_code() );
+		$this->assertTrue( WC()->cart->has_discount( $coupon->get_code() ) );
+
+		$_GET['remove_coupon']     = $coupon->get_code();
+		$_REQUEST['remove_coupon'] = $coupon->get_code();
+
+		WC_Form_Handler::update_cart_action();
+
+		$this->assertFalse( WC()->cart->has_discount( $coupon->get_code() ), 'String remove_coupon must remove the coupon.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
-   I have checked to ensure there aren't other open Pull Requests for the same update/change.
-   I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

Closes #68376.

`update_cart_action()` passed `$_GET['remove_coupon']` straight into `urldecode()`, so an array value (`?remove_coupon[]=x`, no login needed) fataled with a `TypeError` on PHP 8+. Non-string values are now treated as empty, using the exact `is_string ? ... : ''` idiom from the merged #68307 (which fixed the same bug class on the order pay/cancel/PayPal paths but missed this line). Array input degrades to a no-op redirect instead of a 500; string coupons behave exactly as before.

### How to test the changes in this Pull Request:

1. As a guest, open the cart page with `?remove_coupon[]=SAVE10` — the page redirects normally instead of a 500.
2. Remove a real coupon with `?remove_coupon=SAVE10` — still works.
3. Run the form-handler suite (`pnpm test:php:env -- --filter WC_Form_Handler_Test`).

### Testing that has already taken place:

wp-env locally (PHP 8.1): new `WC_Form_Handler_Test` cases — array `remove_coupon` completes without error and keeps the coupon, string `remove_coupon` still removes it. RED without the fix (`TypeError: urldecode(): Argument #1 ($string) must be of type string, array given`), GREEN with it. `php -l` clean; `phpcs-changed` on the branch diff clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

