### PR TITLE
Revert "Move tokenization form script to footer with defer strategy"

### DIFF
--- a/plugins/woocommerce/changelog/68036-woopmnt-6354-tokenization-form-footer
+++ b/plugins/woocommerce/changelog/68036-woopmnt-6354-tokenization-form-footer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Load `woocommerce-tokenization-form` in the footer with a `defer` strategy so the script no longer sits in the blocking `<head>` on checkout pages.

--- a/plugins/woocommerce/changelog/revert-pr-68036
+++ b/plugins/woocommerce/changelog/revert-pr-68036
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Revert PR #68036, see WOOAIRR-226

--- a/plugins/woocommerce/client/legacy/js/frontend/tokenization-form.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/tokenization-form.js
@@ -1,5 +1,5 @@
 /*global wc_tokenization_form_params */
-( function( $ ) {
+jQuery( function( $ ) {
 
 	/**
 	 * WCTokenizationForm class.
@@ -105,12 +105,6 @@
 
 	/**
 	 * Initialize.
-	 *
-	 * Register the listener synchronously (outside jQuery(fn)) so it is bound before
-	 * any DOM-ready callback runs. With this script loaded in the footer with a
-	 * defer strategy, wc-credit-card-form-init is fired from another script's
-	 * DOM-ready callback and would otherwise be missed if we deferred registration
-	 * until our own DOM-ready callback ran later in the queue.
 	 */
 	$( document.body ).on( 'updated_checkout wc-credit-card-form-init', function() {
 		// Loop over gateways with saved payment methods
@@ -120,4 +114,4 @@
 			$( this ).wc_tokenization_form();
 		} );
 	} );
-} )( jQuery );
+} );

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -566,10 +566,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			plugins_url( '/assets/js/frontend/tokenization-form' . ( Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min' ) . '.js', WC_PLUGIN_FILE ),
 			array( 'jquery' ),
 			WC()->version,
-			array(
-				'in_footer' => true,
-				'strategy'  => 'defer',
-			)
+			false
 		);
 
 		wp_localize_script(


### PR DESCRIPTION
Fixes WOOAIRR-226

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Reverts PR #68036 to fix a regression where the tokenization is moved to `footer` and `deferred`. 
- WooPayments happens to register its dependent script in the footer so it is unaffected. 
- But `woocommerce-tokenization-form` is a public script handle and out-of-tree consumers can enqueue in the head. For example, changing this param from `true` to `false` in https://github.com/Automattic/woocommerce-payments/blob/754c0809f08a234fb292656c4c8f2cc4241224d4/includes/class-wc-payments.php#L1253 - the credit card fields will not display.

Though this is theoretical, with Woo core as the platform, I think the gain does not outweight the risk. So I think it would be better to revert and do not chase to move this important script to the footer anymore.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Regression discovered by an internal AI regression-review pipeline. PR description drafted with Claude Code and reviewed by the author.