### PR TITLE
Limit WooCommerce user fields in the users REST endpoint to the edit context

### DIFF
--- a/plugins/woocommerce/changelog/pr-402-users-endpoint-field-permissions
+++ b/plugins/woocommerce/changelog/pr-402-users-endpoint-field-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return is_super_admin and woocommerce_meta fields in users REST endpoint only for requests in 'edit' context, and only when requesting own user or with 'list_users' capability.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -59122,12 +59122,6 @@ parameters:
 			path: src/Internal/Admin/WCAdminAssets.php
 
 		-
-			message: '#^Access to offset ''id'' on an unknown class Automattic\\WooCommerce\\Internal\\Admin\\WP_User\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/Admin/WCAdminUser.php
-
-		-
 			message: '#^Access to property \$ID on an unknown class Automattic\\WooCommerce\\Internal\\Admin\\WP_User\.$#'
 			identifier: class.notFound
 			count: 1
@@ -59154,12 +59148,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\WCAdminUser\:\:update_user_data_values\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/WCAdminUser.php
-
-		-
-			message: '#^Parameter \$user of method Automattic\\WooCommerce\\Internal\\Admin\\WCAdminUser\:\:get_user_data_values\(\) has invalid type Automattic\\WooCommerce\\Internal\\Admin\\WP_User\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Internal/Admin/WCAdminUser.php
 

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -41,14 +41,22 @@ class WCAdminUser {
 			'user',
 			'is_super_admin',
 			array(
-				'get_callback' => function( $user ) {
-					if ( ! isset( $user['id'] ) || 0 === $user['id'] ) {
+				'get_callback' => function ( $user, $attr, $request ) {
+					if ( 'edit' !== ( $request['context'] ?? null ) ) {
+						return false;
+					}
+
+					if ( ! $this->current_user_can_read_user_data( $user['id'] ?? 0 ) ) {
 						return false;
 					}
 
 					return is_super_admin( $user['id'] );
 				},
-				'schema'       => null,
+				'schema'       => array(
+					'type'     => 'boolean',
+					'context'  => array( 'edit' ),
+					'readonly' => true,
+				),
 			)
 		);
 		register_rest_field(
@@ -57,7 +65,10 @@ class WCAdminUser {
 			array(
 				'get_callback'    => array( $this, 'get_user_data_values' ),
 				'update_callback' => array( $this, 'update_user_data_values' ),
-				'schema'          => null,
+				'schema'          => array(
+					'type'    => 'object',
+					'context' => array( 'edit' ),
+				),
 			)
 		);
 	}
@@ -66,14 +77,45 @@ class WCAdminUser {
 	 * For all the registered user data fields (  Loader::get_user_data_fields ), fetch the data
 	 * for returning via the REST API.
 	 *
-	 * @param WP_User $user Current user.
+	 * Returns an empty array unless the request has the 'edit' context and the current user
+	 * is either the requested user or has the 'list_users' capability.
+	 *
+	 * @param array                  $user The prepared user data from the users endpoint response.
+	 * @param mixed                  $attr The name of the requested field.
+	 * @param \WP_REST_Request|array $request The current request.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>>|array $request
 	 */
-	public function get_user_data_values( $user ) {
+	public function get_user_data_values( $user, $attr = null, $request = array() ) {
+		if ( 'edit' !== ( $request['context'] ?? null ) ) {
+			return array();
+		}
+
+		if ( ! $this->current_user_can_read_user_data( $user['id'] ?? 0 ) ) {
+			return array();
+		}
+
 		$values = array();
 		foreach ( $this->get_user_data_fields() as $field ) {
 			$values[ $field ] = self::get_user_data_field( $user['id'], $field );
 		}
 		return $values;
+	}
+
+	/**
+	 * Checks whether the current user is allowed to read the extra data registered by
+	 * WooCommerce for a given user.
+	 *
+	 * @param int $user_id The id of the user whose data is being read.
+	 * @return bool True if the current user can read the extra data for the given user.
+	 */
+	private function current_user_can_read_user_data( $user_id ) {
+		$user_id = (int) $user_id;
+		if ( 0 === $user_id ) {
+			return false;
+		}
+
+		return get_current_user_id() === $user_id || current_user_can( 'list_users' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce-admin/pull/7489 added an `is_super_admin` field, alongside a `woocommerce_meta` field, to the standard WordPress users endpoint. Both fields were registered without a schema, so they were included in every response of the endpoint regardless of the request context.

This pull request makes both fields part of the `edit` context only, so they are returned when a `context=edit` parameter is added to the request _and_ either the user has the `list_users` capability, or is requesting their own data (`/users/me` endpoint). `context=edit` already implies that the endpoint returns data only when the user either is querying their own information or has the `list_users` capability, but the conditions are explicitly checked in code too (including the `get_user_data_values` method) for extra safety.

Additionally, both fields now declare a proper schema: `is_super_admin` is a read-only boolean, and `woocommerce_meta` is an object. The latter is an associative array, and since the schema now feeds the argument validation of the users endpoint, declaring it as `array` would make every `woocommerce_meta` update fail with a 400 error. Two related entries are removed from the PHPStan baseline.

**Backward compatibility:** the `is_super_admin` and `woocommerce_meta` fields are no longer present in the default (`view`) context responses of the `wp/v2/users` endpoint. Consumers that need them must request `context=edit`, which is what the WooCommerce admin client already does.

Bug introduced in PR https://github.com/woocommerce/woocommerce-admin/pull/7489.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. If you are testing in a non-HTTPS environment (e.g. a development machine), make sure you have the following line in `wp-config.php`: `define ('WP_ENVIRONMENT_TYPE', 'local');`
2. Create, if you don't have any, an user with the customer role, or any other role that can't edit users.
3. Edit the superadmin user and create an application password ("Application Passwords" section in the user edit screen), take note of the generated password. Repeat for the user with the customer role.
4. Run the following in the command line, it should return the user information without `is_super_admin` or `woocommerce_meta` fields:

```bash
curl http://localhost/wp-json/wp/v2/users/<admin user id>
```

5. Now try this, it will return a 401 error:

```bash
curl http://localhost/wp-json/wp/v2/users/<admin user id>?context=edit
```

6. Try now authenticating as the superadmin user: try with their own user id, the customer user id and the fixed string `me` in `<user id>`; again it will *not* return the `is_super_admin` or `woocommerce_meta` fields:

```bash
curl -u "<admin user id>:<admin password>" http://localhost/wp-json/wp/v2/users/<user id>
```

7. Repeat the previous step but with `context=edit`, this time you'll get the extra fields:

```bash
curl -u "<admin user id>:<admin password>" http://localhost/wp-json/wp/v2/users/<user id>?context=edit
```

8. Now let's repeat step 6 with the customer credentials, it should work in the same way (with the extra fields *not* included in the response):

```bash
curl -u "<customer user id>:<customer password>" http://localhost/wp-json/wp/v2/users/<user id>
```

9. Use the customer credentials for the `me` user and with `context=edit`, it works and the response includes the extra fields this time:

```bash
curl -u "<customer user id>:<customer password>" http://localhost/wp-json/wp/v2/users/me?context=edit
```

10. Finally, verify that the customer credentials with `context=edit` and any user id that's not `me` returns a 403 error:

```bash
curl -u "<customer user id>:<customer password>" http://localhost/wp-json/wp/v2/users/<any user id>?context=edit
```

11. Using the customer credentials, save a preference and confirm it round-trips. The response must include the saved value, not a `rest_invalid_param` error:

```bash
curl -u "<customer user id>:<customer password>" -X POST 'http://localhost/wp-json/wp/v2/users/me?context=edit' -H 'Content-Type: application/json' -d '{"woocommerce_meta":{"variable_product_tour_shown":"\"yes\""}}'
```

If you want to verify the extra check in the callbacks:

12. Temporarily revert the changes made to the `schema` property of the array passed to both calls to `register_rest_field` (so they are set as null again).
13. Repeat step 6 (passing an admin user id) and you should get `is_super_admin` equal to false and `woocommerce_meta` equal to an empty array in the response.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested manually following the instructions above on a local `wp-env` site. PHPStan and PHPCS pass for the modified file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

The changelog entry has been added manually to the branch (`plugins/woocommerce/changelog/pr-402-users-endpoint-field-permissions`).

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)
