### PR TITLE
Restrict Claude Code tool set in User-Facing Documentation Check workflow

### DIFF
--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -36,6 +36,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >
             --allowedTools "Bash(gh pr diff *),Bash(gh pr view *)"
+            --disallowedTools "Read,Glob,Grep,WebFetch,WebSearch,Edit,Write"
             --json-schema '{"type":"object","properties":{"needs_docs":{"type":"boolean"},"confidence":{"type":"string","enum":["high","medium","low"]},"reason":{"type":"string"}},"required":["needs_docs","confidence","reason"]}'
           prompt: |
             Docs update detection for WooCommerce


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR explicitly limits the tools available to the Claude analysis step in the User-Facing Documentation Check workflow.

The step already allows the two Bash commands required by its prompt, `gh pr view` and `gh pr diff`. Adding `--disallowedTools "Read,Glob,Grep,WebFetch,WebSearch,Edit,Write"` aligns the available tool set with that task, follows the principle of least privilege, and keeps the job's behavior predictable.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Parse `.github/workflows/docs-needed-detection.yml` with `js-yaml` and print `jobs.detect-docs-needed.steps[1].with.claude_args`. Confirm that YAML folds `claude_args` into a single argument string containing both `--allowedTools` and `--disallowedTools`.
2. Extract the workflow's prompt block into `prompt.txt`, substitute `${{ github.repository }}` with `woocommerce/woocommerce`, and substitute the PR number with merged PR `66417`, which does not have the `needs: documentation` label. Run:

   ```sh
   claude -p --permission-mode default --setting-sources "" --allowedTools "Bash(gh pr diff *),Bash(gh pr view *)" --disallowedTools "Read,Glob,Grep,WebFetch,WebSearch,Edit,Write" --json-schema '<schema from workflow>' "$(cat prompt.txt)"
   ```

   Expect a JSON object containing `needs_docs`, `confidence`, and `reason`, with no permission denials. Add `--verbose --output-format stream-json` to inspect `permission_denials`.
3. Repeat step 2 with merged PR `66899`, which already has the `needs: documentation` label. Expect `{"needs_docs":false,"confidence":"high","reason":"Already labeled"}`.
4. After merge, check the next run of the User-Facing Documentation Check workflow on a merged PR. Confirm that it completes successfully and that the Analyze Pull Request step produces structured output.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Ran steps 1–3 locally with Claude Code 2.1.260.

- PR #66417 ran `gh pr view` followed by `gh pr diff` and returned `needs_docs=false` with `confidence=low`, a sensible reason, and zero permission denials.
- PR #66899 followed the `Already labeled` skip path.
- Only the Bash and StructuredOutput tools were invoked.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

CI workflow change only; no package code is affected.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to validate the workflow behavior. Codex was used to help draft this pull request description. The resulting changes and description were reviewed by the author.