### PR TITLE
Skip the Back in Stock form inside the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-bis-form-add-to-cart-with-options-legacy-mode
+++ b/plugins/woocommerce/changelog/fix-bis-form-add-to-cart-with-options-legacy-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop the Back in Stock form from rendering inside the Add to Cart + Options block, which forced the block into a legacy HTML form.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
@@ -75,8 +75,8 @@ class ProductPageIntegration {
 		}
 
 		// Add to Cart + Options buffers this hook inside its <form> and falls back to a
-		// legacy HTML form when the buffer contains form elements. Block themes are
-		// handled separately with an Interactivity API native form.
+		// legacy HTML form when the buffer contains form elements. Block-theme support
+		// will ship separately.
 		if ( $this->is_rendering_inside_add_to_cart_with_options() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
@@ -17,6 +17,11 @@ use WC_Product;
 class ProductPageIntegration {
 
 	/**
+	 * Name of the Add to Cart + Options block.
+	 */
+	private const ADD_TO_CART_WITH_OPTIONS_BLOCK = 'woocommerce/add-to-cart-with-options';
+
+	/**
 	 * Runtime cache for preventing double rendering.
 	 *
 	 * @var array<int, bool>
@@ -69,6 +74,13 @@ class ProductPageIntegration {
 			return;
 		}
 
+		// Add to Cart + Options buffers this hook inside its <form> and falls back to a
+		// legacy HTML form when the buffer contains form elements. Block themes are
+		// handled separately with an Interactivity API native form.
+		if ( $this->is_rendering_inside_add_to_cart_with_options() ) {
+			return;
+		}
+
 		global $product;
 		if ( ! is_product() || ! is_a( $product, 'WC_Product' ) ) {
 			return;
@@ -100,6 +112,19 @@ class ProductPageIntegration {
 		wp_enqueue_script( 'wc-back-in-stock-form' );
 
 		$this->render_form( $product );
+	}
+
+	/**
+	 * Whether the hook is firing from inside the Add to Cart + Options render callback.
+	 *
+	 * WP_Block::render() sets WP_Block_Supports::$block_to_render around the callback,
+	 * and the block fires its buffered template hooks before rendering inner blocks.
+	 *
+	 * @return bool
+	 */
+	private function is_rendering_inside_add_to_cart_with_options(): bool {
+		return isset( \WP_Block_Supports::$block_to_render['blockName'] )
+			&& self::ADD_TO_CART_WITH_OPTIONS_BLOCK === \WP_Block_Supports::$block_to_render['blockName'];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
@@ -1,0 +1,115 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Frontend;
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Frontend\ProductPageIntegration;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsQuantitySelectorMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeNameMock;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ProductPageIntegration class.
+ */
+class ProductPageIntegrationTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ProductPageIntegration
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// The blocks are not registered on `init` because `init` runs with a classic theme.
+		// Other test classes may have registered them already.
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'woocommerce/add-to-cart-with-options' ) ) {
+			new AddToCartWithOptionsMock();
+			new AddToCartWithOptionsQuantitySelectorMock();
+			new AddToCartWithOptionsVariationSelectorMock();
+			new AddToCartWithOptionsVariationSelectorAttributeMock();
+			new AddToCartWithOptionsVariationSelectorAttributeNameMock();
+		}
+
+		update_option( 'woocommerce_customer_stock_notifications_allow_signups', 'yes' );
+
+		$this->sut = wc_get_container()->get( ProductPageIntegration::class );
+	}
+
+	/**
+	 * Create a variable product with an out of stock variation and load its single product page.
+	 *
+	 * @return int The product ID.
+	 */
+	private function create_and_visit_variable_product(): int {
+		$fixtures         = new FixtureData();
+		$variable_product = $fixtures->get_variable_product(
+			array(),
+			array( $fixtures->get_product_attribute( 'color', array( 'red', 'blue' ) ) )
+		);
+		$product_id       = $variable_product->get_id();
+
+		// Keep one variation purchasable so the block fires its template hooks.
+		$fixtures->get_variation_product(
+			$product_id,
+			array( 'pa_color' => 'red-slug' ),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$fixtures->get_variation_product(
+			$product_id,
+			array( 'pa_color' => 'blue-slug' ),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::OUT_OF_STOCK,
+			)
+		);
+
+		// Sync the parent stock status from its variations so the block treats it as purchasable.
+		\WC_Product_Variable::sync( $product_id );
+
+		$this->go_to( get_permalink( $product_id ) );
+
+		// `go_to()` overwrites the global with the query var, so set it again for the hook callbacks.
+		$GLOBALS['product'] = wc_get_product( $product_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $product_id;
+	}
+
+	/**
+	 * @testdox Should not render the form inside the Add to Cart + Options block so it keeps its Interactivity API form.
+	 */
+	public function test_form_is_not_rendered_inside_add_to_cart_with_options_block(): void {
+		$product_id = $this->create_and_visit_variable_product();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'data-wp-on--submit', $markup, 'The Add to Cart + Options block should keep its Interactivity API form when sign-ups are enabled.' );
+		$this->assertStringNotContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should not render inside the Add to Cart + Options block.' );
+	}
+
+	/**
+	 * @testdox Should render the form when the classic template hook fires outside the Add to Cart + Options block.
+	 */
+	public function test_form_is_rendered_by_classic_template_hook(): void {
+		$this->create_and_visit_variable_product();
+
+		ob_start();
+		do_action( 'woocommerce_after_add_to_cart_form' );
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should render when the hook fires from a classic template.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
@@ -162,19 +162,14 @@ class ProductPageIntegrationTest extends WC_Unit_Test_Case {
 	 * @testdox Should render the form inside the legacy Add to Cart Form block.
 	 */
 	public function test_form_is_rendered_inside_legacy_add_to_cart_form_block(): void {
-		$product_ids = array(
-			'variable' => $this->create_and_visit_variable_product(),
-			'simple'   => $this->create_and_visit_out_of_stock_simple_product(),
-		);
+		$variable_product_id = $this->create_and_visit_variable_product();
+		$markup              = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product_id . '} --><!-- wp:woocommerce/add-to-cart-form /--><!-- /wp:woocommerce/single-product -->' );
 
-		foreach ( $product_ids as $type => $product_id ) {
-			// Reset the per-product render cache guard state by visiting the product again.
-			$this->go_to( get_permalink( $product_id ) );
-			$GLOBALS['product'] = wc_get_product( $product_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$this->assertStringContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should render inside the legacy Add to Cart Form block for a variable product.' );
 
-			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-form /--><!-- /wp:woocommerce/single-product -->' );
+		$simple_product_id = $this->create_and_visit_out_of_stock_simple_product();
+		$markup            = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $simple_product_id . '} --><!-- wp:woocommerce/add-to-cart-form /--><!-- /wp:woocommerce/single-product -->' );
 
-			$this->assertStringContainsString( 'wc_bis_form', $markup, "The Back in Stock form should render inside the legacy Add to Cart Form block for a {$type} product." );
-		}
+		$this->assertStringContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should render inside the legacy Add to Cart Form block for an out of stock simple product.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
@@ -11,12 +11,15 @@ use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsQuantitySelect
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeNameMock;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Unit_Test_Case;
 
 /**
  * Tests for the ProductPageIntegration class.
  */
 class ProductPageIntegrationTest extends WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The System Under Test.
@@ -43,7 +46,23 @@ class ProductPageIntegrationTest extends WC_Unit_Test_Case {
 
 		update_option( 'woocommerce_customer_stock_notifications_allow_signups', 'yes' );
 
+		// The container caches the instance and the hooks it added in an earlier test are gone
+		// after that test tore down, so re-resolve the services to hook the product page again.
+		$this->enable_stock_notifications_feature();
+		$this->init_stock_notifications_services();
+
 		$this->sut = wc_get_container()->get( ProductPageIntegration::class );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		try {
+			$this->restore_stock_notifications_feature_option();
+		} finally {
+			parent::tearDown();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
@@ -157,4 +157,24 @@ class ProductPageIntegrationTest extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should render when the simple product hook fires from a classic template.' );
 	}
+
+	/**
+	 * @testdox Should render the form inside the legacy Add to Cart Form block.
+	 */
+	public function test_form_is_rendered_inside_legacy_add_to_cart_form_block(): void {
+		$product_ids = array(
+			'variable' => $this->create_and_visit_variable_product(),
+			'simple'   => $this->create_and_visit_out_of_stock_simple_product(),
+		);
+
+		foreach ( $product_ids as $type => $product_id ) {
+			// Reset the per-product render cache guard state by visiting the product again.
+			$this->go_to( get_permalink( $product_id ) );
+			$GLOBALS['product'] = wc_get_product( $product_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-form /--><!-- /wp:woocommerce/single-product -->' );
+
+			$this->assertStringContainsString( 'wc_bis_form', $markup, "The Back in Stock form should render inside the legacy Add to Cart Form block for a {$type} product." );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTest.php
@@ -89,6 +89,26 @@ class ProductPageIntegrationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Create an out of stock simple product and load its single product page.
+	 *
+	 * @return int The product ID.
+	 */
+	private function create_and_visit_out_of_stock_simple_product(): int {
+		$fixtures   = new FixtureData();
+		$product_id = $fixtures->get_simple_product(
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::OUT_OF_STOCK,
+			)
+		)->get_id();
+
+		$this->go_to( get_permalink( $product_id ) );
+		$GLOBALS['product'] = wc_get_product( $product_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $product_id;
+	}
+
+	/**
 	 * @testdox Should not render the form inside the Add to Cart + Options block so it keeps its Interactivity API form.
 	 */
 	public function test_form_is_not_rendered_inside_add_to_cart_with_options_block(): void {
@@ -111,5 +131,30 @@ class ProductPageIntegrationTest extends WC_Unit_Test_Case {
 		$markup = ob_get_clean();
 
 		$this->assertStringContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should render when the hook fires from a classic template.' );
+	}
+
+	/**
+	 * @testdox Should not render the form for an out of stock simple product inside the Add to Cart + Options block.
+	 */
+	public function test_form_is_not_rendered_for_simple_product_inside_add_to_cart_with_options_block(): void {
+		$product_id = $this->create_and_visit_out_of_stock_simple_product();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'data-wp-on--submit', $markup, 'The Add to Cart + Options block should keep its Interactivity API form for an out of stock simple product.' );
+		$this->assertStringNotContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should not render inside the Add to Cart + Options block for a simple product.' );
+	}
+
+	/**
+	 * @testdox Should render the form when the simple product hook fires outside the Add to Cart + Options block.
+	 */
+	public function test_form_is_rendered_by_simple_product_hook(): void {
+		$this->create_and_visit_out_of_stock_simple_product();
+
+		ob_start();
+		do_action( 'woocommerce_simple_add_to_cart' );
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'wc_bis_form', $markup, 'The Back in Stock form should render when the simple product hook fires from a classic template.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With sign-ups enabled, the Back in Stock form prints on `woocommerce_after_add_to_cart_form`. The Add to Cart + Options block buffers that hook inside its own `<form>` and drops to a legacy HTML form whenever the buffer contains form elements, so the block loses its Interactivity API behavior and ships a nested `<form>`. On variable products the Back in Stock form also stays hidden forever, since it waits for a jQuery `found_variation` event the block never fires.

`ProductPageIntegration::maybe_render_form()` now bails when either of its hooks (`woocommerce_after_add_to_cart_form`, `woocommerce_simple_add_to_cart`) fires from inside the block's render callback, detected via `WP_Block_Supports::$block_to_render`. This is deliberate for all product types, including out-of-stock simple products whose form used to print after the block's `</form>`: no legacy Back in Stock markup renders inside Add to Cart + Options. Block-theme support will ship separately.

Outside the block nothing changes. Classic templates and block themes using the legacy `woocommerce/add-to-cart-form` block keep rendering the form for both simple and variable products.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #68362.

(For Bug Fixes) Bug introduced in PR #59317.

### Backward compatibility

With sign-ups enabled, the Back in Stock form no longer renders inside the Add to Cart + Options block, for any product type.

- **Variable products:** previously rendered nested inside the block's `<form>`, forced legacy mode, and never became visible. Nothing working is lost.
- **Simple out-of-stock products:** previously rendered below the block and accepted sign-ups. This is the one intentional regression, until a native Interactivity API form replaces it in a follow-up.
- **Unchanged:** classic themes, `woocommerce/legacy-template`, and block themes using the legacy `woocommerce/add-to-cart-form` block keep the form for both product types.

No hooks, signatures, or script handles change. Both hooks still fire; the callback returns early when `WP_Block_Supports::$block_to_render` is the Add to Cart + Options block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Note: fresh installs currently have sign-ups off because of a wrong option name in `WC_Install` (fixed in #68353). Enable the option manually in step 2.

1. Use a block theme (e.g. Twenty Twenty-Five) and make sure the Single Product template uses the Add to Cart + Options block.
2. Enable customer stock notifications and sign-ups: `wp option update woocommerce_feature_customer_stock_notifications_enabled yes && wp option update woocommerce_customer_stock_notifications_allow_signups yes`.
3. Create a variable product with one in-stock and one out-of-stock variation.
4. Open the product page. Confirm the add-to-cart form has no `action` attribute and selecting a variation updates price and stock without a page reload.
5. Confirm no `.wc_bis_form` markup is present inside the add-to-cart form.
6. Switch to a classic theme (e.g. Storefront), reload the product page and select the out-of-stock variation. The Back in Stock form still appears.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- New PHPUnit tests in `ProductPageIntegrationTest`: block render keeps `data-wp-on--submit` with no `wc_bis_form`; classic hook outside the block still renders the form. Verified failing without the fix.
- Existing `AddToCartWithOptions` block tests pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

Implemented and tested with Claude Code, reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaGGoPfpuYXCz3nuASL28E

