### PR TITLE
Normalize Back in Stock customer emails to a canonical form

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7663-bis-normalize-customer-emails
+++ b/plugins/woocommerce/changelog/wooplug-7663-bis-normalize-customer-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize customer emails in Back in Stock Notifications so signups and lookups match regardless of letter case, and fix lookups for emails containing a single quote.

--- a/plugins/woocommerce/changelog/wooplug-7663-bis-normalize-customer-emails
+++ b/plugins/woocommerce/changelog/wooplug-7663-bis-normalize-customer-emails
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Normalize customer emails in Back in Stock Notifications so signups and lookups match regardless of letter case, and fix lookups for emails containing a single quote.
+Normalize customer emails in Back in Stock Notifications so signups and lookups match regardless of letter case, rewrite existing rows in the same form, and fix lookups for emails containing a single quote.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -359,6 +359,9 @@ class WC_Install {
 			'wc_update_11201_invalidate_analytics_reports_cache',
 			'wc_update_11202_reset_refund_returning_customer_markers',
 		),
+		'11.2.0-3' => array(
+			'wc_update_11203_normalize_stock_notification_emails',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -358,8 +358,6 @@ class WC_Install {
 			'wc_update_11201_migrate_tax_lookup_order_items',
 			'wc_update_11201_invalidate_analytics_reports_cache',
 			'wc_update_11202_reset_refund_returning_customer_markers',
-		),
-		'11.2.0-3' => array(
 			'wc_update_11203_normalize_stock_notification_emails',
 		),
 	);

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3923,7 +3923,9 @@ function wc_update_11202_reset_refund_returning_customer_markers() {
  *
  * Lookups on `user_email` use plain SQL equality, so rows written before emails were
  * normalized would not match on a case-sensitive collation. Processes one batch per
- * call and requeues itself while rows remain.
+ * call and requeues itself while rows remain. A database error stops the migration
+ * and is logged instead of retried: an unnormalized row only keeps the pre-migration
+ * lookup behaviour, and the log names it for manual repair.
  *
  * @since 11.2.0
  *
@@ -3943,6 +3945,15 @@ function wc_update_11203_normalize_stock_notification_emails() {
 			$batch_size
 		)
 	);
+
+	if ( '' !== $wpdb->last_error ) {
+		wc_get_logger()->error(
+			sprintf( 'Stopped normalizing stock notification emails: %s', $wpdb->last_error ),
+			array( 'source' => 'wc-updater' )
+		);
+		delete_option( $last_id_option );
+		return false;
+	}
 
 	// Normalize in PHP rather than with SQL LOWER()/TRIM() so stored values match exactly
 	// what EmailNormalizer produces at lookup time.
@@ -3965,9 +3976,11 @@ function wc_update_11203_normalize_stock_notification_emails() {
 		);
 		if ( false === $updated ) {
 			wc_get_logger()->error(
-				sprintf( 'Failed to normalize the customer email of stock notification #%d: %s', (int) $row->id, $wpdb->last_error ),
+				sprintf( 'Stopped normalizing stock notification emails at notification #%d: %s', (int) $row->id, $wpdb->last_error ),
 				array( 'source' => 'wc-updater' )
 			);
+			delete_option( $last_id_option );
+			return false;
 		}
 	}
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -39,6 +39,7 @@ use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchronize as Download_Directories_Sync;
 use Automattic\WooCommerce\Internal\StockNotifications\StockNotifications;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\VariationGallery\Telemetry as VariationGalleryTelemetry;
 use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
@@ -3915,4 +3916,51 @@ function wc_update_11202_reset_refund_returning_customer_markers() {
 	wc_update_11201_invalidate_analytics_reports_cache();
 
 	return false;
+}
+
+/**
+ * Rewrite stored Back in Stock customer emails in canonical form (trimmed, lowercased).
+ *
+ * Lookups on `user_email` use plain SQL equality, so rows written before emails were
+ * normalized would not match on a case-sensitive collation.
+ *
+ * @since 11.2.0
+ *
+ * @return void
+ */
+function wc_update_11203_normalize_stock_notification_emails() {
+	global $wpdb;
+
+	$table      = $wpdb->prefix . 'wc_stock_notifications';
+	$batch_size = 500;
+	$last_id    = 0;
+
+	// Normalize in PHP rather than with SQL LOWER()/TRIM() so stored values match exactly
+	// what EmailNormalizer produces at lookup time.
+	do {
+		$rows      = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, user_email FROM {$table} WHERE id > %d ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$last_id,
+				$batch_size
+			)
+		);
+		$row_count = count( $rows );
+
+		foreach ( $rows as $row ) {
+			$last_id    = (int) $row->id;
+			$normalized = EmailNormalizer::normalize( (string) $row->user_email );
+			if ( $normalized === $row->user_email ) {
+				continue;
+			}
+
+			$updated = $wpdb->update( $table, array( 'user_email' => $normalized ), array( 'id' => $last_id ), array( '%s' ), array( '%d' ) );
+			if ( false === $updated ) {
+				wc_get_logger()->error(
+					sprintf( 'Failed to normalize the customer email of stock notification #%d: %s', $last_id, $wpdb->last_error ),
+					array( 'source' => 'wc-updater' )
+				);
+			}
+		}
+	} while ( $row_count === $batch_size );
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3922,45 +3922,61 @@ function wc_update_11202_reset_refund_returning_customer_markers() {
  * Rewrite stored Back in Stock customer emails in canonical form (trimmed, lowercased).
  *
  * Lookups on `user_email` use plain SQL equality, so rows written before emails were
- * normalized would not match on a case-sensitive collation.
+ * normalized would not match on a case-sensitive collation. Processes one batch per
+ * call and requeues itself while rows remain.
  *
  * @since 11.2.0
  *
- * @return void
+ * @return bool True when another batch remains, false when done.
  */
 function wc_update_11203_normalize_stock_notification_emails() {
 	global $wpdb;
 
-	$table      = $wpdb->prefix . 'wc_stock_notifications';
-	$batch_size = 500;
-	$last_id    = 0;
+	$last_id_option = 'woocommerce_update_11203_last_stock_notification_id';
+	$table          = $wpdb->prefix . 'wc_stock_notifications';
+	$batch_size     = 500;
+
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT id, user_email FROM {$table} WHERE id > %d ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name cannot be prepared.
+			(int) get_option( $last_id_option, 0 ),
+			$batch_size
+		)
+	);
 
 	// Normalize in PHP rather than with SQL LOWER()/TRIM() so stored values match exactly
 	// what EmailNormalizer produces at lookup time.
-	do {
-		$rows      = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT id, user_email FROM {$table} WHERE id > %d ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$last_id,
-				$batch_size
-			)
-		);
-		$row_count = count( $rows );
-
-		foreach ( $rows as $row ) {
-			$last_id    = (int) $row->id;
-			$normalized = EmailNormalizer::normalize( (string) $row->user_email );
-			if ( $normalized === $row->user_email ) {
-				continue;
-			}
-
-			$updated = $wpdb->update( $table, array( 'user_email' => $normalized ), array( 'id' => $last_id ), array( '%s' ), array( '%d' ) );
-			if ( false === $updated ) {
-				wc_get_logger()->error(
-					sprintf( 'Failed to normalize the customer email of stock notification #%d: %s', $last_id, $wpdb->last_error ),
-					array( 'source' => 'wc-updater' )
-				);
-			}
+	foreach ( $rows as $row ) {
+		$normalized = EmailNormalizer::normalize( (string) $row->user_email );
+		if ( $normalized === $row->user_email ) {
+			continue;
 		}
-	} while ( $row_count === $batch_size );
+
+		// Matching on the value read keeps a concurrent save (e.g. the privacy eraser) from being overwritten.
+		$updated = $wpdb->update(
+			$table,
+			array( 'user_email' => $normalized ),
+			array(
+				'id'         => (int) $row->id,
+				'user_email' => $row->user_email,
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( false === $updated ) {
+			wc_get_logger()->error(
+				sprintf( 'Failed to normalize the customer email of stock notification #%d: %s', (int) $row->id, $wpdb->last_error ),
+				array( 'source' => 'wc-updater' )
+			);
+		}
+	}
+
+	if ( count( $rows ) === $batch_size ) {
+		update_option( $last_id_option, (int) end( $rows )->id, false );
+		return true;
+	}
+
+	delete_option( $last_id_option );
+
+	return false;
 }

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -66313,12 +66313,6 @@ parameters:
 			path: src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
 
 		-
-			message: '#^Cannot call method get_user_email\(\) on bool\|object\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\StockNotifications\\Emails\\CustomerStockNotificationEmail\:\:maybe_restore_notification_locale\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -66362,12 +66356,6 @@ parameters:
 
 		-
 			message: '#^Cannot call method get_unsubscribe_key\(\) on bool\|object\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
-
-		-
-			message: '#^Cannot call method get_user_email\(\) on bool\|object\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php

--- a/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Internal\DataStores\StockNotifications;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -461,7 +462,7 @@ CREATE TABLE $meta_table_name (
 
 		if ( $args['user_email'] ) {
 			$where[]        = 'user_email = %s';
-			$where_values[] = esc_sql( $args['user_email'] );
+			$where_values[] = EmailNormalizer::normalize( (string) $args['user_email'] );
 		}
 
 		if ( $args['last_attempt_limit'] > 0 ) {
@@ -561,6 +562,7 @@ CREATE TABLE $meta_table_name (
 	 */
 	public function notification_exists_by_email( int $product_id, string $email ): bool {
 
+		$email = EmailNormalizer::normalize( $email );
 		if ( ! is_email( $email ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/ListTable.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/ListTable.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Admin\NotificationsPage;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EligibilityService;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 
 /**
  * Notifications list table for Customer Stock Notifications.
@@ -345,7 +346,7 @@ class ListTable extends \WP_List_Table {
 
 		// Search.
 		if ( isset( $_REQUEST['s'] ) && ! empty( $_REQUEST['s'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$query_args['user_email'] = wc_clean( wp_unslash( $_REQUEST['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$query_args['user_email'] = EmailNormalizer::normalize( sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
 		// Views.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationCreatePage.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationCreatePage.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\StockNotifications\Admin;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Admin\NotificationsPage;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 
 /**
  * Notification create page for Customer Stock Notifications.
@@ -58,12 +59,12 @@ class NotificationCreatePage {
 			}
 
 			$user                      = get_user_by( 'id', $posted_data['user_id'] );
-			$posted_data['user_email'] = is_a( $user, 'WP_User' ) ? $user->user_email : '';
+			$posted_data['user_email'] = is_a( $user, 'WP_User' ) ? EmailNormalizer::normalize( $user->user_email ) : '';
 
 		} elseif ( isset( $_POST['user_email'] ) && ! empty( $_POST['user_email'] ) ) {
 
-			$posted_data['user_email'] = sanitize_text_field( wp_unslash( $_POST['user_email'] ) );
-			if ( ! filter_var( $posted_data['user_email'], FILTER_VALIDATE_EMAIL ) ) {
+			$posted_data['user_email'] = EmailNormalizer::sanitize( sanitize_email( wp_unslash( $_POST['user_email'] ) ) );
+			if ( '' === $posted_data['user_email'] ) {
 				NotificationsPage::add_notice( __( 'Please enter a valid email address.', 'woocommerce' ), 'error' );
 				return;
 			}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationCreatePage.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationCreatePage.php
@@ -64,13 +64,16 @@ class NotificationCreatePage {
 		} elseif ( isset( $_POST['user_email'] ) && ! empty( $_POST['user_email'] ) ) {
 
 			$posted_email              = wp_unslash( $_POST['user_email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized below, after the type check.
-			$posted_data['user_email'] = is_string( $posted_email ) ? EmailNormalizer::sanitize( $posted_email ) : '';
+			$posted_email              = is_string( $posted_email ) ? sanitize_email( $posted_email ) : '';
+			$posted_data['user_email'] = is_email( $posted_email ) ? EmailNormalizer::normalize( $posted_email ) : '';
 			if ( '' === $posted_data['user_email'] ) {
 				NotificationsPage::add_notice( __( 'Please enter a valid email address.', 'woocommerce' ), 'error' );
 				return;
 			}
 
-			$user                   = get_user_by( 'email', $posted_data['user_email'] );
+			// Look up the account with the letter case as entered: `wp_users.user_email` is never
+			// normalized, so on a case-sensitive collation the lowercased form would miss it.
+			$user                   = get_user_by( 'email', $posted_email );
 			$posted_data['user_id'] = is_a( $user, 'WP_User' ) ? $user->ID : 0;
 		}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationCreatePage.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationCreatePage.php
@@ -63,7 +63,8 @@ class NotificationCreatePage {
 
 		} elseif ( isset( $_POST['user_email'] ) && ! empty( $_POST['user_email'] ) ) {
 
-			$posted_data['user_email'] = EmailNormalizer::sanitize( sanitize_email( wp_unslash( $_POST['user_email'] ) ) );
+			$posted_email              = wp_unslash( $_POST['user_email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized below, after the type check.
+			$posted_data['user_email'] = is_string( $posted_email ) ? EmailNormalizer::sanitize( $posted_email ) : '';
 			if ( '' === $posted_data['user_email'] ) {
 				NotificationsPage::add_notice( __( 'Please enter a valid email address.', 'woocommerce' ), 'error' );
 				return;

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
@@ -171,7 +171,7 @@ class CustomerStockNotificationEmail extends WC_Email {
 		);
 
 		$unsubscribe_key = $notification->get_unsubscribe_key( true );
-		$user            = get_user_by( 'email', $notification->get_user_email() );
+		$user            = $notification instanceof Notification && $notification->get_user_id() ? get_user_by( 'id', $notification->get_user_id() ) : false;
 		$is_guest        = ! is_a( $user, 'WP_User' );
 
 		return array(

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
@@ -143,7 +143,7 @@ class CustomerStockNotificationVerifiedEmail extends WC_Email {
 	private function get_additional_template_args(): array {
 		$notification    = $this->object;
 		$unsubscribe_key = $notification->get_unsubscribe_key( true );
-		$user            = get_user_by( 'email', $notification->get_user_email() );
+		$user            = $notification instanceof Notification && $notification->get_user_id() ? get_user_by( 'id', $notification->get_user_id() ) : false;
 		$is_guest        = ! is_a( $user, 'WP_User' );
 
 		return array(

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoin
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\NotificationQuery;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EligibilityService;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 
 /**
  * A class for handling the business logic of the signup process.
@@ -87,6 +88,8 @@ class SignupService {
 	 * @return SignupResult|\WP_Error The signup result.
 	 */
 	public function signup( int $product_id, int $user_id, string $user_email, array $posted_attributes = array() ) {
+
+		$user_email = EmailNormalizer::normalize( $user_email );
 
 		// Sanity checks.
 		if ( ! Config::allows_signups() ) {
@@ -200,6 +203,8 @@ class SignupService {
 	 * @return Notification|null The notification, or null if it doesn't exist.
 	 */
 	public function is_already_signed_up( int $product_id, int $user_id, string $user_email, array $posted_attributes = array() ) {
+
+		$user_email = EmailNormalizer::normalize( $user_email );
 
 		if ( empty( $product_id ) ) {
 			return null;
@@ -344,12 +349,8 @@ class SignupService {
 		}
 
 		if ( ! $is_logged_in ) {
-			$email = isset( $source['wc_bis_email'] ) ? sanitize_email( wp_unslash( $source['wc_bis_email'] ) ) : false;
-			if ( ! $email ) {
-				return new \WP_Error( self::ERROR_INVALID_EMAIL );
-			}
-
-			if ( ! is_email( $email ) ) {
+			$email = isset( $source['wc_bis_email'] ) ? EmailNormalizer::sanitize( (string) wp_unslash( $source['wc_bis_email'] ) ) : '';
+			if ( '' === $email ) {
 				return new \WP_Error( self::ERROR_INVALID_EMAIL );
 			}
 
@@ -368,7 +369,7 @@ class SignupService {
 			}
 
 			$data['user_id']    = $user->ID;
-			$data['user_email'] = $user->user_email;
+			$data['user_email'] = EmailNormalizer::normalize( $user->user_email );
 		}
 
 		return $data;

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -349,7 +349,8 @@ class SignupService {
 		}
 
 		if ( ! $is_logged_in ) {
-			$email = isset( $source['wc_bis_email'] ) ? EmailNormalizer::sanitize( (string) wp_unslash( $source['wc_bis_email'] ) ) : '';
+			$posted_email = isset( $source['wc_bis_email'] ) && is_string( $source['wc_bis_email'] ) ? wp_unslash( $source['wc_bis_email'] ) : '';
+			$email        = EmailNormalizer::sanitize( $posted_email );
 			if ( '' === $email ) {
 				return new \WP_Error( self::ERROR_INVALID_EMAIL );
 			}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -349,8 +349,8 @@ class SignupService {
 		}
 
 		if ( ! $is_logged_in ) {
-			$posted_email = isset( $source['wc_bis_email'] ) && is_string( $source['wc_bis_email'] ) ? wp_unslash( $source['wc_bis_email'] ) : '';
-			$email        = EmailNormalizer::sanitize( $posted_email );
+			$posted_email = isset( $source['wc_bis_email'] ) && is_string( $source['wc_bis_email'] ) ? sanitize_email( wp_unslash( $source['wc_bis_email'] ) ) : '';
+			$email        = is_email( $posted_email ) ? EmailNormalizer::normalize( $posted_email ) : '';
 			if ( '' === $email ) {
 				return new \WP_Error( self::ERROR_INVALID_EMAIL );
 			}
@@ -358,8 +358,9 @@ class SignupService {
 			$data['user_id']    = 0;
 			$data['user_email'] = $email;
 
-			// Check if user exists with this email.
-			$user = get_user_by( 'email', $email );
+			// Look up the account with the letter case as entered: `wp_users.user_email` is never
+			// normalized, so on a case-sensitive collation the lowercased form would miss it.
+			$user = get_user_by( 'email', $posted_email );
 			if ( $user ) {
 				$data['user_id'] = $user->ID;
 			}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Internal\StockNotifications;
 
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -236,10 +237,12 @@ class Notification extends \WC_Data {
 	/**
 	 * Set the user email.
 	 *
+	 * The value is stored in canonical form (trimmed, lowercased).
+	 *
 	 * @param string $user_email User email.
 	 */
 	public function set_user_email( string $user_email ) {
-		$this->set_prop( 'user_email', $user_email );
+		$this->set_prop( 'user_email', EmailNormalizer::normalize( $user_email ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Privacy/PrivacyEraser.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Privacy/PrivacyEraser.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\NotificationQuery;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
 
 /**
  * Privacy eraser for WooCommerce Customer Stock Notifications.
@@ -54,6 +55,8 @@ class PrivacyEraser extends \WC_Abstract_Privacy {
 			'messages'       => array(),
 			'done'           => true,
 		);
+
+		$email_address = EmailNormalizer::normalize( $email_address );
 
 		$notifications = NotificationQuery::get_notifications(
 			array(

--- a/plugins/woocommerce/src/Internal/StockNotifications/Utilities/EmailNormalizer.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Utilities/EmailNormalizer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Utilities;
+
+/**
+ * Canonical form for customer emails stored in stock notifications.
+ *
+ * Lookups on `wc_stock_notifications.user_email` use plain SQL equality, so every
+ * write and every query must go through the same normalization or the same customer
+ * can appear more than once under a different letter case.
+ *
+ * @internal
+ */
+final class EmailNormalizer {
+
+	/**
+	 * Normalize an already validated email address.
+	 *
+	 * Trims and lowercases. No validation is performed.
+	 *
+	 * @param string $email The email address.
+	 * @return string
+	 */
+	public static function normalize( string $email ): string {
+		return strtolower( trim( $email ) );
+	}
+
+	/**
+	 * Sanitize and normalize an untrusted email address.
+	 *
+	 * @param string $email The raw email address.
+	 * @return string The normalized address, or an empty string when it is not a valid email.
+	 */
+	public static function sanitize( string $email ): string {
+		$email = self::normalize( sanitize_email( $email ) );
+
+		return is_email( $email ) ? $email : '';
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Utilities/EmailNormalizer.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Utilities/EmailNormalizer.php
@@ -26,16 +26,4 @@ final class EmailNormalizer {
 	public static function normalize( string $email ): string {
 		return strtolower( trim( $email ) );
 	}
-
-	/**
-	 * Sanitize and normalize an untrusted email address.
-	 *
-	 * @param string $email The raw email address.
-	 * @return string The normalized address, or an empty string when it is not a valid email.
-	 */
-	public static function sanitize( string $email ): string {
-		$email = self::normalize( sanitize_email( $email ) );
-
-		return is_email( $email ) ? $email : '';
-	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -651,10 +651,8 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		$db_updates = WC_Install::get_db_update_callbacks();
 
-		// Under its own key, so that a store already on 11.2.0-2 from the batch that shipped beside
-		// it still rewrites its rows.
-		$this->assertArrayHasKey( '11.2.0-3', $db_updates );
-		$this->assertContains( 'wc_update_11203_normalize_stock_notification_emails', $db_updates['11.2.0-3'] );
+		$this->assertArrayHasKey( '11.2.0', $db_updates );
+		$this->assertContains( 'wc_update_11203_normalize_stock_notification_emails', $db_updates['11.2.0'] );
 
 		$table = $wpdb->prefix . 'wc_stock_notifications';
 		foreach ( array( 'Legacy@Example.com', " padded@example.com\t", 'canonical@example.com' ) as $email ) {

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -670,10 +670,44 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 			);
 		}
 
-		wc_update_11203_normalize_stock_notification_emails();
+		$this->assertFalse( wc_update_11203_normalize_stock_notification_emails(), 'A table smaller than one batch should complete in a single run' );
+		$this->assertFalse( get_option( 'woocommerce_update_11203_last_stock_notification_id' ), 'The cursor should be cleared on completion' );
 
 		$emails = $wpdb->get_col( "SELECT user_email FROM {$table} WHERE product_id = 1 ORDER BY id" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$this->assertSame( array( 'legacy@example.com', 'padded@example.com', 'canonical@example.com' ), $emails );
+	}
+
+	/**
+	 * @testdox Migration resumes from the persisted cursor and leaves rows before it untouched.
+	 */
+	public function test_wc_update_11203_normalize_stock_notification_emails_resumes_from_cursor(): void {
+		global $wpdb;
+
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		$table = $wpdb->prefix . 'wc_stock_notifications';
+		$ids   = array();
+		foreach ( array( 'Before@Example.com', 'After@Example.com' ) as $email ) {
+			$wpdb->insert(
+				$table,
+				array(
+					'product_id'       => 1,
+					'user_id'          => 0,
+					'user_email'       => $email,
+					'status'           => 'active',
+					'date_created_gmt' => gmdate( 'Y-m-d H:i:s' ),
+				)
+			);
+			$ids[] = $wpdb->insert_id;
+		}
+
+		update_option( 'woocommerce_update_11203_last_stock_notification_id', $ids[0], false );
+
+		wc_update_11203_normalize_stock_notification_emails();
+
+		$emails = $wpdb->get_col( "SELECT user_email FROM {$table} WHERE product_id = 1 ORDER BY id" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$this->assertSame( array( 'Before@Example.com', 'after@example.com' ), $emails );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -710,4 +710,46 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		$this->assertSame( array( 'Before@Example.com', 'after@example.com' ), $emails );
 	}
+
+	/**
+	 * @testdox Migration stops at the first failed write, clears its cursor and does not request another run.
+	 */
+	public function test_wc_update_11203_normalize_stock_notification_emails_stops_on_failed_write(): void {
+		global $wpdb;
+
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		$table = $wpdb->prefix . 'wc_stock_notifications';
+		foreach ( array( 'First@Example.com', 'Second@Example.com' ) as $email ) {
+			$wpdb->insert(
+				$table,
+				array(
+					'product_id'       => 1,
+					'user_id'          => 0,
+					'user_email'       => $email,
+					'status'           => 'active',
+					'date_created_gmt' => gmdate( 'Y-m-d H:i:s' ),
+				)
+			);
+		}
+
+		$break_update = function ( $query ) use ( $table ) {
+			return 0 === strpos( $query, "UPDATE `{$table}` SET `user_email`" ) ? "UPDATE `{$table}` SET `no_such_column` = 1" : $query;
+		};
+		add_filter( 'query', $break_update );
+		$suppressed = $wpdb->suppress_errors();
+
+		try {
+			$this->assertFalse( wc_update_11203_normalize_stock_notification_emails(), 'A failed write should not request another run' );
+		} finally {
+			$wpdb->suppress_errors( $suppressed );
+			remove_filter( 'query', $break_update );
+		}
+
+		$this->assertFalse( get_option( 'woocommerce_update_11203_last_stock_notification_id' ), 'The cursor should be cleared after a failed write' );
+
+		$emails = $wpdb->get_col( "SELECT user_email FROM {$table} WHERE product_id = 1 ORDER BY id" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$this->assertSame( array( 'First@Example.com', 'Second@Example.com' ), $emails, 'No row should be rewritten after the write fails' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -640,4 +640,40 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		return $variation_id;
 	}
+
+	/**
+	 * @testdox Migration rewrites stored stock notification emails in canonical form and leaves canonical rows alone.
+	 */
+	public function test_wc_update_11203_normalize_stock_notification_emails(): void {
+		global $wpdb;
+
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		$db_updates = WC_Install::get_db_update_callbacks();
+
+		// Under its own key, so that a store already on 11.2.0-2 from the batch that shipped beside
+		// it still rewrites its rows.
+		$this->assertArrayHasKey( '11.2.0-3', $db_updates );
+		$this->assertContains( 'wc_update_11203_normalize_stock_notification_emails', $db_updates['11.2.0-3'] );
+
+		$table = $wpdb->prefix . 'wc_stock_notifications';
+		foreach ( array( 'Legacy@Example.com', " padded@example.com\t", 'canonical@example.com' ) as $email ) {
+			$wpdb->insert(
+				$table,
+				array(
+					'product_id'       => 1,
+					'user_id'          => 0,
+					'user_email'       => $email,
+					'status'           => 'active',
+					'date_created_gmt' => gmdate( 'Y-m-d H:i:s' ),
+				)
+			);
+		}
+
+		wc_update_11203_normalize_stock_notification_emails();
+
+		$emails = $wpdb->get_col( "SELECT user_email FROM {$table} WHERE product_id = 1 ORDER BY id" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$this->assertSame( array( 'legacy@example.com', 'padded@example.com', 'canonical@example.com' ), $emails );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/StockNotifications/StockNotificationsDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/StockNotifications/StockNotificationsDataStoreTests.php
@@ -622,4 +622,53 @@ class StockNotificationsDataStoreTests extends \WC_Unit_Test_Case {
 		$this->assertInstanceOf( Notification::class, $notifications[0] );
 		$this->assertEquals( 'test@test.com', $notifications[0]->get_user_email() );
 	}
+
+	/**
+	 * @testdox notification_exists_by_email() should match a stored lowercase row from mixed-case input.
+	 */
+	public function test_notification_exists_by_email_is_case_insensitive(): void {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_user_email( 'foo@bar.com' );
+		$notification->set_status( NotificationStatus::ACTIVE );
+		$notification->save();
+
+		$this->assertTrue( $this->data_store->notification_exists_by_email( 1, 'FOO@bar.com' ) );
+		$this->assertTrue( $this->data_store->notification_exists_by_email( 1, ' Foo@Bar.COM ' ) );
+		$this->assertFalse( $this->data_store->notification_exists_by_email( 1, 'other@bar.com' ) );
+	}
+
+	/**
+	 * @testdox notification_exists_by_email() should find a legacy mixed-case row from lowercase input.
+	 */
+	public function test_notification_exists_by_email_finds_legacy_mixed_case_row(): void {
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_stock_notifications',
+			array(
+				'product_id'       => 1,
+				'user_id'          => 0,
+				'user_email'       => 'Legacy@Example.com',
+				'status'           => NotificationStatus::ACTIVE,
+				'date_created_gmt' => gmdate( 'Y-m-d H:i:s' ),
+			)
+		);
+
+		$this->assertTrue( $this->data_store->notification_exists_by_email( 1, 'legacy@example.com' ) );
+	}
+
+	/**
+	 * @testdox query() should match an email containing a single quote.
+	 */
+	public function test_query_notifications_with_quoted_user_email(): void {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_user_email( "o'brien@example.com" );
+		$notification->save();
+
+		$notifications = $this->data_store->query( array( 'user_email' => "O'Brien@Example.com" ) );
+
+		$this->assertSame( array( $notification->get_id() ), array_map( 'intval', $notifications ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/StockNotifications/StockNotificationsDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/StockNotifications/StockNotificationsDataStoreTests.php
@@ -639,26 +639,6 @@ class StockNotificationsDataStoreTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox notification_exists_by_email() should find a legacy mixed-case row from lowercase input.
-	 */
-	public function test_notification_exists_by_email_finds_legacy_mixed_case_row(): void {
-		global $wpdb;
-
-		$wpdb->insert(
-			$wpdb->prefix . 'wc_stock_notifications',
-			array(
-				'product_id'       => 1,
-				'user_id'          => 0,
-				'user_email'       => 'Legacy@Example.com',
-				'status'           => NotificationStatus::ACTIVE,
-				'date_created_gmt' => gmdate( 'Y-m-d H:i:s' ),
-			)
-		);
-
-		$this->assertTrue( $this->data_store->notification_exists_by_email( 1, 'legacy@example.com' ) );
-	}
-
-	/**
 	 * @testdox query() should match an email containing a single quote.
 	 */
 	public function test_query_notifications_with_quoted_user_email(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/NotificationCreatePageTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/NotificationCreatePageTests.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Admin;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Admin\NotificationCreatePage;
+use Automattic\WooCommerce\Internal\StockNotifications\Admin\NotificationsPage;
+
+/**
+ * Tests for the admin notification create form handler.
+ */
+class NotificationCreatePageTests extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var NotificationCreatePage
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new NotificationCreatePage();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		$_POST    = array();
+		$_REQUEST = array();
+		delete_option( NotificationsPage::ADMIN_NOTICE_OPTION_NAME );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should reject a posted email that is not a string instead of passing it to the sanitizers.
+	 *
+	 * @testWith [["guest@example.com"]]
+	 *           ["not an email"]
+	 *
+	 * @param mixed $posted_email The submitted email value.
+	 */
+	public function test_create_form_rejects_invalid_email( $posted_email ): void {
+		$_POST = array(
+			'save'       => '1',
+			'product_id' => '1',
+			'user_email' => $posted_email,
+		);
+
+		$_POST['customer_stock_notification_create_security'] = wp_create_nonce( 'woocommerce-customer-stock-notification-create' );
+
+		$_REQUEST = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Simulates the request the handler verifies.
+
+		$this->sut->process_create_form();
+
+		$notice = get_option( NotificationsPage::ADMIN_NOTICE_OPTION_NAME );
+		$this->assertIsArray( $notice, 'An invalid email should produce an admin notice' );
+		$this->assertSame( 'error', $notice['type'] );
+		$this->assertSame( 'Please enter a valid email address.', $notice['message'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -122,4 +122,57 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 
 		return $product;
 	}
+
+	/**
+	 * @testdox A second signup with a different-case email should be reported as already joined.
+	 */
+	public function test_signup_dedupes_case_variants(): void {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'no' );
+
+		$product = $this->create_out_of_stock_product();
+
+		$first = $this->sut->signup( $product->get_id(), 0, 'guest@example.com' );
+		$this->assertSame( SignupService::SIGNUP_SUCCESS, $first->get_code() );
+		$this->assertSame( 'guest@example.com', $first->get_notification()->get_user_email() );
+
+		$second = $this->sut->signup( $product->get_id(), 0, ' Guest@Example.COM ' );
+		$this->assertSame( SignupService::SIGNUP_ALREADY_JOINED, $second->get_code() );
+		$this->assertSame( $first->get_notification()->get_id(), $second->get_notification()->get_id() );
+	}
+
+	/**
+	 * @testdox parse() should return a lowercase email for mixed-case guest input.
+	 */
+	public function test_parse_normalizes_guest_email(): void {
+		$product = $this->create_out_of_stock_product();
+
+		$data = $this->sut->parse(
+			array(
+				'wc_bis_product_id' => $product->get_id(),
+				'wc_bis_email'      => ' Guest@Example.COM ',
+				'wc_bis_opt_in'     => 'on',
+			)
+		);
+
+		$this->assertIsArray( $data );
+		$this->assertSame( 'guest@example.com', $data['user_email'] );
+	}
+
+	/**
+	 * @testdox parse() should reject an invalid guest email.
+	 */
+	public function test_parse_rejects_invalid_guest_email(): void {
+		$product = $this->create_out_of_stock_product();
+
+		$data = $this->sut->parse(
+			array(
+				'wc_bis_product_id' => $product->get_id(),
+				'wc_bis_email'      => 'not an email',
+				'wc_bis_opt_in'     => 'on',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $data );
+		$this->assertSame( SignupService::ERROR_INVALID_EMAIL, $data->get_error_code() );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -159,15 +159,21 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox parse() should reject an invalid guest email.
+	 * @testdox parse() should reject a guest email that is not a valid address.
+	 *
+	 * @testWith ["not an email"]
+	 *           [["guest@example.com"]]
+	 *           [42]
+	 *
+	 * @param mixed $posted_email The submitted email value.
 	 */
-	public function test_parse_rejects_invalid_guest_email(): void {
+	public function test_parse_rejects_invalid_guest_email( $posted_email ): void {
 		$product = $this->create_out_of_stock_product();
 
 		$data = $this->sut->parse(
 			array(
 				'wc_bis_product_id' => $product->get_id(),
-				'wc_bis_email'      => 'not an email',
+				'wc_bis_email'      => $posted_email,
 				'wc_bis_opt_in'     => 'on',
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -159,6 +159,44 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox parse() should resolve a guest email to an existing account stored in mixed case and keep the canonical email.
+	 */
+	public function test_parse_resolves_mixed_case_account_email(): void {
+		global $wpdb;
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory()->user->create( array( 'user_email' => 'Mixed.Case@Example.com' ) );
+
+		// The test database collation is case-insensitive, so capture the value the lookup actually
+		// sends instead of relying on the row being found.
+		$user_queries = array();
+		add_filter(
+			'query',
+			function ( $query ) use ( &$user_queries, $wpdb ) {
+				if ( false !== strpos( $query, "FROM {$wpdb->users} WHERE user_email" ) ) {
+					$user_queries[] = $query;
+				}
+				return $query;
+			}
+		);
+		wp_cache_flush();
+
+		$data = $this->sut->parse(
+			array(
+				'wc_bis_product_id' => $product->get_id(),
+				'wc_bis_email'      => 'Mixed.Case@Example.com',
+				'wc_bis_opt_in'     => 'on',
+			)
+		);
+
+		$this->assertIsArray( $data );
+		$this->assertSame( $user_id, $data['user_id'] );
+		$this->assertSame( 'mixed.case@example.com', $data['user_email'] );
+		$this->assertCount( 1, $user_queries, 'The account lookup should query the users table' );
+		$this->assertStringContainsString( "'Mixed.Case@Example.com'", $user_queries[0], 'The account lookup should keep the letter case as entered' );
+	}
+
+	/**
 	 * @testdox parse() should reject a guest email that is not a valid address.
 	 *
 	 * @testWith ["not an email"]

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
@@ -269,4 +269,31 @@ class NotificationTests extends \WC_Unit_Test_Case {
 
 		$this->assertFalse( $notification->check_verification_key( 'test' ) );
 	}
+
+	/**
+	 * @testdox set_user_email() should store the canonical (trimmed, lowercased) form.
+	 */
+	public function test_set_user_email_stores_canonical_form(): void {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_user_email( ' Foo@Bar.COM ' );
+		$notification->save();
+
+		$this->assertSame( 'foo@bar.com', $notification->get_user_email() );
+		$this->assertSame( 'foo@bar.com', ( new Notification( $notification->get_id() ) )->get_user_email() );
+	}
+
+	/**
+	 * @testdox validate() should still reject an invalid email after normalization.
+	 */
+	public function test_invalid_user_email_fails_validation(): void {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_user_email( 'Not An Email' );
+
+		$result = $notification->save();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'User Email is invalid.', $result->get_error_message() );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Privacy/PrivacyEraserTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Privacy/PrivacyEraserTests.php
@@ -49,4 +49,19 @@ class PrivacyEraserTests extends \WC_Unit_Test_Case {
 		$this->assertEquals( $anonymous_notification->get_user_email(), wp_privacy_anonymize_data( 'email', '' ) );
 		$this->assertEquals( NotificationStatus::CANCELLED, $anonymous_notification->get_status() );
 	}
+
+	/**
+	 * @testdox Should erase a lowercase row when given a mixed-case email.
+	 */
+	public function test_privacy_eraser_matches_case_variants(): void {
+		$notification = new Notification();
+		$notification->set_user_email( 'jon@doe.com' );
+		$notification->set_product_id( 1 );
+		$notification_id = $notification->save();
+
+		$response = PrivacyEraser::erase_notification_data( 'Jon@Doe.COM' );
+
+		$this->assertTrue( $response['items_removed'] );
+		$this->assertEquals( NotificationStatus::CANCELLED, ( new Notification( $notification_id ) )->get_status() );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Utilities/EmailNormalizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Utilities/EmailNormalizerTests.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Utilities;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EmailNormalizer;
+
+/**
+ * Tests for EmailNormalizer.
+ */
+class EmailNormalizerTests extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox normalize() should trim and lowercase while preserving plus tags and dots.
+	 * @testWith [" Foo@Bar.COM ", "foo@bar.com"]
+	 *           ["First.Last+Tag@Example.com", "first.last+tag@example.com"]
+	 *           ["deleted@site.invalid", "deleted@site.invalid"]
+	 *           ["not-an-email", "not-an-email"]
+	 *
+	 * @param string $input    Raw input.
+	 * @param string $expected Expected canonical form.
+	 */
+	public function test_normalize( string $input, string $expected ): void {
+		$this->assertSame( $expected, EmailNormalizer::normalize( $input ) );
+	}
+
+	/**
+	 * @testdox sanitize() should return the canonical form for valid input and an empty string otherwise.
+	 * @testWith [" Foo@Bar.COM ", "foo@bar.com"]
+	 *           ["First.Last+Tag@Example.com", "first.last+tag@example.com"]
+	 *           ["not-an-email", ""]
+	 *           ["", ""]
+	 *
+	 * @param string $input    Raw input.
+	 * @param string $expected Expected result.
+	 */
+	public function test_sanitize( string $input, string $expected ): void {
+		$this->assertSame( $expected, EmailNormalizer::sanitize( $input ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Utilities/EmailNormalizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Utilities/EmailNormalizerTests.php
@@ -23,18 +23,4 @@ class EmailNormalizerTests extends \WC_Unit_Test_Case {
 	public function test_normalize( string $input, string $expected ): void {
 		$this->assertSame( $expected, EmailNormalizer::normalize( $input ) );
 	}
-
-	/**
-	 * @testdox sanitize() should return the canonical form for valid input and an empty string otherwise.
-	 * @testWith [" Foo@Bar.COM ", "foo@bar.com"]
-	 *           ["First.Last+Tag@Example.com", "first.last+tag@example.com"]
-	 *           ["not-an-email", ""]
-	 *           ["", ""]
-	 *
-	 * @param string $input    Raw input.
-	 * @param string $expected Expected result.
-	 */
-	public function test_sanitize( string $input, string $expected ): void {
-		$this->assertSame( $expected, EmailNormalizer::sanitize( $input ) );
-	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Back in Stock Notifications accepted customer emails from several entry points (guest signup form, logged-in user record, admin create page, list table search, privacy eraser) and stored them exactly as received. Duplicate detection relies on SQL equality against `wc_stock_notifications.user_email`, so the same address in a different letter case could be signed up more than once on case-sensitive collations, and nothing outside SQL had a canonical value to key on.

This PR introduces `EmailNormalizer` (`sanitize_email()` → `trim()` → `strtolower()`) and routes every write and lookup through it:

- `Notification::set_user_email()` stores the canonical form, so every save path is covered.
- `SignupService::signup()`, `is_already_signed_up()` and `parse()` normalize their input (guest and logged-in branches).
- Admin create page, list table search and the privacy eraser normalize before querying.
- `StockNotificationsDataStore::query()` normalizes the `user_email` argument and drops the `esc_sql()` call on it. `$wpdb->prepare()` already escapes, and the double escape meant addresses containing a single quote never matched. `notification_exists_by_email()` normalizes before its `is_email()` check.

**Backward compatibility**

- `Notification::set_user_email()` now trims and lowercases its input. Anything reading `get_user_email()` after a save, including the `woocommerce_customer_stock_notifications_signup` action and the outgoing notification emails, receives the lowercased address.
- `wp_users.user_email` is never modified.
- Existing rows are backfilled by a one-shot migration (`wc_update_11203_normalize_stock_notification_emails`, key `11.2.0-3`) that rewrites `wc_stock_notifications.user_email` through the same normalizer, one batch of 500 per Action Scheduler run. Rows that already differ only by letter case on a case-sensitive collation are canonicalized but not merged, so such sites may keep a duplicate active row per customer and product; deduplication is out of scope here.
- The outgoing notification emails now decide `is_guest` from the notification's `user_id` instead of looking the account up by email.
- No hooks, filters or method signatures were added, removed or reordered.

Closes #68324.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

**Setup**

1. Go to WooCommerce → Settings → Products → Inventory and enable customer stock notifications. Leave "Require double opt-in" off and "Require account" off.
2. Create a simple product and set its stock status to "Out of stock".

**Guest signup dedupes across letter case**

1. Log out. Visit the product page and sign up for a back-in-stock notification with `Guest@Example.COM`.
2. Sign up again for the same product with `guest@example.com`.
3. Confirm the second attempt reports that you have already joined the waitlist and no second row is created under WooCommerce → Customer Stock Notifications.
4. Open the notification and confirm the stored email is `guest@example.com`.

**Admin create page**

1. Go to WooCommerce → Customer Stock Notifications → Add New.
2. Pick the product and enter ` Admin@Example.COM ` (with surrounding spaces) as the email. Save.
3. Confirm the stored email is `admin@example.com`.
4. Try to create another notification for the same product with `ADMIN@example.com` and confirm the "already exists" notice appears.

**List table search**

1. On the notifications list, search for `GUEST@EXAMPLE.COM` and confirm the guest notification is found.

**Emails containing a single quote**

1. Sign up as a guest with `o'brien@example.com`.
2. Search the list table for `o'brien@example.com` and confirm the row is returned (this returned nothing before this change).

**Privacy eraser**

1. Go to Tools → Erase Personal Data and submit a request for `GUEST@example.com`.
2. Process the request and confirm the guest notification is cancelled and its email anonymized.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- New unit tests for `EmailNormalizer`, `Notification::set_user_email()`, data store case-insensitive lookups (including a legacy mixed-case row inserted directly and a quoted email), `SignupService` dedupe and `parse()` normalization, and the privacy eraser. Full BIS test suites pass locally in `wp-env` (PHP 8.1, MySQL default collation).
- `lint:php:changes`, `lint:changes:branch` and PHPStan on all touched files are clean.
- Not tested on multisite or on a case-sensitive database collation.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Implementation and tests were drafted with Claude Code from a written plan, then reviewed and verified by the author.

