### PR TITLE
fix: stop order item_data reporting a hidden meta row's id

### DIFF
--- a/docs/apis/store-api/resources-endpoints/order.md
+++ b/docs/apis/store-api/resources-endpoints/order.md
@@ -239,7 +239,7 @@ Each order item carries its metadata in `item_data`, a list of entries:
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `id` | integer \| null | The order item metadata row ID. `null` when an extension added the entry through `woocommerce_order_item_get_formatted_meta_data` without a stored row behind it. |
+| `id` | integer \| null | The order item metadata row ID. `null` when no displayed metadata row backs the entry, which is the case for anything an extension added through `woocommerce_order_item_get_formatted_meta_data`. |
 | `key` | string | Metadata key. |
 | `value` | string | Metadata value. |
 | `display_key` | string | Key, formatted for display. |

--- a/plugins/woocommerce/changelog/fix-store-api-order-item-data-hidden-meta-id
+++ b/plugins/woocommerce/changelog/fix-store-api-order-item-data-hidden-meta-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: the order endpoint no longer reports a hidden metadata row's ID on an item_data entry an extension appended. That entry now correctly reports a null `id`.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -100,9 +100,9 @@ class OrderItemSchema extends ItemSchema {
 		$item_data = [];
 
 		// A callback appending with `$formatted_meta[] =` gets PHP's next integer key, not a row ID.
-		// Mirror what `get_formatted_meta_data()` skips at its default `_` prefix: a row it leaves out
-		// never keys an entry, so counting its ID lets that key land on a hidden row saved right
-		// after the visible ones. Read the rows first, because formatting rewrites keys and values.
+		// Mirror what `get_formatted_meta_data()` skips for this call's `_` prefix and `$include_all`:
+		// a row it leaves out never keys an entry, so counting its ID lets that key land on a hidden
+		// row saved right after the visible ones. Read rows first; formatting rewrites keys and values.
 		$meta_row_ids = [];
 
 		/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -52,7 +52,7 @@ class OrderItemSchema extends ItemSchema {
 				'type'       => 'object',
 				'properties' => [
 					'id'            => [
-						'description' => __( 'Order item metadata ID. Null for entries an extension added that have no stored metadata row.', 'woocommerce' ),
+						'description' => __( 'Order item metadata ID. Null for an entry that no displayed metadata row backs, such as one an extension added.', 'woocommerce' ),
 						'type'        => [ 'integer', 'null' ],
 						'context'     => [ 'view', 'edit' ],
 						'readonly'    => true,
@@ -97,18 +97,36 @@ class OrderItemSchema extends ItemSchema {
 	 * @return array
 	 */
 	private function get_item_data( $order_item ) {
+		$item_data = [];
+
+		// A callback appending with `$formatted_meta[] =` gets PHP's next integer key, not a row ID.
+		// Mirror what `get_formatted_meta_data()` skips at its default `_` prefix: a row it leaves out
+		// never keys an entry, so counting its ID lets that key land on a hidden row saved right
+		// after the visible ones. Read the rows first, because formatting rewrites keys and values.
+		$meta_row_ids = [];
+
+		/**
+		 * `get_meta_data()` is documented as returning bare objects.
+		 *
+		 * @var \WC_Meta_Data[] $meta_rows
+		 */
+		$meta_rows = $order_item->get_meta_data();
+
+		foreach ( $meta_rows as $meta ) {
+			if ( empty( $meta->id ) || '' === $meta->value || ! is_scalar( $meta->value ) || 0 === strpos( (string) $meta->key, '_' ) ) {
+				continue;
+			}
+
+			$meta_row_ids[ $meta->id ] = true;
+		}
+
 		$formatted_meta_data = $order_item->get_all_formatted_meta_data();
-		$item_data           = [];
 
 		// A `woocommerce_order_item_get_formatted_meta_data` callback can return anything, and a bad
 		// one must not take the endpoint down.
 		if ( ! is_array( $formatted_meta_data ) ) {
 			return $item_data;
 		}
-
-		// A callback appending with `$formatted_meta[] =` gets PHP's next integer key, not a row ID.
-		// Same source the formatted metadata is built from, so matching costs no query.
-		$meta_row_ids = array_flip( array_filter( wp_list_pluck( $order_item->get_meta_data(), 'id' ) ) );
 
 		foreach ( $formatted_meta_data as $meta_id => $meta ) {
 			// Only public fields are meant to ship. Casting an object reaches past them and

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Order.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Order.php
@@ -344,6 +344,57 @@ class Order extends ControllerTestCase {
 	}
 
 	/**
+	 * `get_formatted_meta_data()` skips hidden rows, so an appended entry's next-int key can be a
+	 * hidden row's ID: a hidden row saved right after the item's visible ones sits on that number.
+	 *
+	 * @testdox Order item_data does not report a hidden meta row's ID for an appended entry.
+	 */
+	public function test_item_data_ignores_hidden_meta_rows_when_matching_ids(): void {
+		$order = $this->create_guest_order();
+		$item  = current( $order->get_items() );
+		$item->add_meta_data( 'Gift message', 'Happy birthday', true );
+		$item->save();
+
+		// What `wc_reduce_stock_levels()` does once the order is paid.
+		$item->add_meta_data( '_reduced_stock', 1, true );
+		$item->save();
+
+		$row_ids = array_values( wp_list_pluck( $item->get_meta_data(), 'id' ) );
+
+		$this->assertSame(
+			$row_ids[0] + 1,
+			$row_ids[1],
+			'The hidden row must follow the visible one for this to exercise the collision.'
+		);
+
+		add_filter(
+			'woocommerce_order_item_get_formatted_meta_data',
+			function ( $formatted_meta ) {
+				$formatted_meta[] = (object) array(
+					'key'           => 'Appended',
+					'value'         => 'value',
+					'display_key'   => 'Appended',
+					'display_value' => 'value',
+				);
+				return $formatted_meta;
+			}
+		);
+
+		wp_set_current_user( 0 );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/order/' . $order->get_id() );
+		$request->set_param( 'key', $order->get_order_key() );
+		$request->set_param( 'billing_email', $order->get_billing_email() );
+
+		$item_data = rest_get_server()->dispatch( $request )->get_data()['items'][0]['item_data'];
+
+		$this->assertCount( 2, $item_data, 'The hidden row must not become an entry of its own.' );
+		$this->assertSame( $row_ids[0], $item_data[0]['id'] );
+		$this->assertSame( 'Appended', $item_data[1]['key'] );
+		$this->assertNull( $item_data[1]['id'], 'An entry with no stored row has no ID to report.' );
+	}
+
+	/**
 	 * `WC_Meta_Data` keeps its fields protected, so casting one publishes mangled property names.
 	 * Trunk serialized it through `JsonSerializable`, and so must this.
 	 *

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Order.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Order.php
@@ -344,19 +344,25 @@ class Order extends ControllerTestCase {
 	}
 
 	/**
-	 * `get_formatted_meta_data()` skips hidden rows, so an appended entry's next-int key can be a
-	 * hidden row's ID: a hidden row saved right after the item's visible ones sits on that number.
+	 * `get_formatted_meta_data()` skips hidden, empty and non-scalar rows, so an appended entry's
+	 * next-int key can be one of their IDs: a skipped row saved right after the item's visible ones
+	 * sits on exactly that number. On a store that happens when an extension saves a hidden or blank
+	 * field beside a displayed one, and when stock reduction writes `_reduced_stock` after payment.
 	 *
-	 * @testdox Order item_data does not report a hidden meta row's ID for an appended entry.
+	 * @testWith ["_reduced_stock", 1]
+	 *           ["Empty note", ""]
+	 *           ["Options", {"size": "L"}]
+	 *
+	 * @testdox Order item_data does not report a skipped meta row's ID for an appended entry.
+	 *
+	 * @param string $skipped_key   A metadata key the formatter leaves out.
+	 * @param mixed  $skipped_value The value stored against it.
 	 */
-	public function test_item_data_ignores_hidden_meta_rows_when_matching_ids(): void {
+	public function test_item_data_ignores_skipped_meta_rows_when_matching_ids( string $skipped_key, $skipped_value ): void {
 		$order = $this->create_guest_order();
 		$item  = current( $order->get_items() );
 		$item->add_meta_data( 'Gift message', 'Happy birthday', true );
-		$item->save();
-
-		// What `wc_reduce_stock_levels()` does once the order is paid.
-		$item->add_meta_data( '_reduced_stock', 1, true );
+		$item->add_meta_data( $skipped_key, $skipped_value, true );
 		$item->save();
 
 		$row_ids = array_values( wp_list_pluck( $item->get_meta_data(), 'id' ) );
@@ -364,7 +370,7 @@ class Order extends ControllerTestCase {
 		$this->assertSame(
 			$row_ids[0] + 1,
 			$row_ids[1],
-			'The hidden row must follow the visible one for this to exercise the collision.'
+			'The skipped row must follow the visible one for this to exercise the collision.'
 		);
 
 		add_filter(
@@ -388,7 +394,7 @@ class Order extends ControllerTestCase {
 
 		$item_data = rest_get_server()->dispatch( $request )->get_data()['items'][0]['item_data'];
 
-		$this->assertCount( 2, $item_data, 'The hidden row must not become an entry of its own.' );
+		$this->assertCount( 2, $item_data, 'The skipped row must not become an entry of its own.' );
 		$this->assertSame( $row_ids[0], $item_data[0]['id'] );
 		$this->assertSame( 'Appended', $item_data[1]['key'] );
 		$this->assertNull( $item_data[1]['id'], 'An entry with no stored row has no ID to report.' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Every `item_data` entry on the order endpoint carries an `id`: the metadata row it came from, or `null` when an extension added the entry itself.

That `null` was not reliable. PHP gives an appended entry the next free number, one past the item's last visible metadata row. Any hidden row saved right after those sits on exactly that number, and the entry published it as its own ID. An extension that stores a hidden value alongside a displayed one produces exactly that pair, because both rows are written in the same save.

Only rows the displayed metadata could have come from are matched now.

Fixing.

Bug introduced in PR #68161.

Fixes [WOOAIRR-238](https://linear.app/a8c/issue/WOOAIRR-238/).

#### Backwards compatibility

The response shape does not change. One value does: an `id` that pointed at an unrelated row is now `null`, which is what the schema and the docs already promise.

The one trade: a callback that deliberately surfaces a hidden row under its real ID gets `null` too. Nothing can tell that apart from an appended entry, so the schema and the docs now say what `id` really is: the displayed row behind an entry.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Add this snippet. The two `add_meta_data` calls are written in one save, so the hidden row's ID is the visible row's plus one, which is what an appended entry picks up:

```php
add_action( 'woocommerce_checkout_create_order_line_item', function ( $item ) {
	$item->add_meta_data( 'Gift message', 'Happy birthday', true );
	$item->add_meta_data( '_gift_message_token', 'abc123', true );
}, 10, 1 );

add_filter( 'woocommerce_order_item_get_formatted_meta_data', function ( $formatted_meta ) {
	$formatted_meta[] = (object) array(
		'key'           => 'Appended',
		'value'         => 'value',
		'display_key'   => 'Appended',
		'display_value' => 'value',
	);
	return $formatted_meta;
} );
```

- Buy a product and place the order
<img width="1375" height="340" alt="Screenshot 2026-09-04 at 7 47 19 PM" src="https://github.com/user-attachments/assets/49580ade-acda-4e46-b0eb-099a630384de" />

- Run, replacing the order ID:

```
(await wp.apiFetch( {
    path: '/wc/store/v1/order/{order_id}',
    method: 'GET',
} )).items[0].item_data;
```

- The `Appended` entry comes back with `"id": null`. On trunk it reports a number, the ID of the item's hidden `_gift_message_token` row
- The `Gift message` entry keeps its own row ID either way

On `trunk`:
<img width="396" height="354" alt="Screenshot 2026-09-04 at 7 49 01 PM" src="https://github.com/user-attachments/assets/80f74bdf-34a5-416a-a9c6-4e2e3164ba81" />


On this branch:
<img width="370" height="336" alt="Screenshot 2026-09-04 at 7 48 06 PM" src="https://github.com/user-attachments/assets/de2381d2-0c74-4503-afbb-9568c40a43b3" />


Order metadata IDs are not always consecutive, so the collision needs the hidden row to land right after the visible one. On an order with a shipping line, that line's metadata is written in between and there is nothing to collide with.

### Testing that has already taken place:

- Added a test for an appended entry on an item that has a row the formatter skips, one case per skip reason: hidden key, empty value, non-scalar value. It fails on trunk and passes here
- Checked each case against a mutant with its own clause removed. Each fails on that clause and no other, so none of the three is along for the ride
- Verified by hand on a local store, on both branches, using the snippet above. On trunk the appended entry reported the hidden row's ID; on this branch it reports `null`

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Added manually in `plugins/woocommerce/changelog/fix-store-api-order-item-data-hidden-meta-id`.

### Use of AI Tools

Written with Claude Code, from a regression report the AI review pipeline filed against #68161. I reproduced the bug, read the fix and ran the tests myself.

