### PR TITLE
Guard the Orders report export against a missing customer name

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-report-export-customer-name-guard
+++ b/plugins/woocommerce/changelog/fix-orders-report-export-customer-name-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop the Orders Analytics CSV export warning, and writing a lone space, for an order that carries no customer name.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -414,11 +414,14 @@ class Controller extends GenericController implements ExportableInterface {
 	/**
 	 * Get customer name column export value.
 	 *
+	 * An order carries no customer object when its analytics customer record is missing, and a guest
+	 * order carries only the name read off the order itself, so neither key is guaranteed.
+	 *
 	 * @param array $customer Customer from report row.
 	 * @return string
 	 */
 	protected function get_customer_name( $customer ) {
-		return $customer['first_name'] . ' ' . $customer['last_name'];
+		return trim( ( $customer['first_name'] ?? '' ) . ' ' . ( $customer['last_name'] ?? '' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/ControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/ControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\API\Reports\Orders;
+
+use Automattic\WooCommerce\Admin\API\Reports\Orders\Controller;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Orders report export methods.
+ */
+class ControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var Controller
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new Controller();
+	}
+
+	/**
+	 * @testdox The customer name export column should be empty for an order with no customer record.
+	 */
+	public function test_customer_name_is_empty_when_the_order_has_no_customer_record(): void {
+		$export_item = $this->sut->prepare_item_for_export( $this->get_item( array() ) );
+
+		$this->assertSame( '', $export_item['customer_name'] );
+	}
+
+	/**
+	 * @testdox The customer name export column should hold the name a guest order carries on its own.
+	 */
+	public function test_customer_name_is_read_from_a_partial_customer_record(): void {
+		$export_item = $this->sut->prepare_item_for_export(
+			$this->get_item(
+				array(
+					'first_name' => 'Ada',
+					'last_name'  => 'Lovelace',
+				)
+			)
+		);
+
+		$this->assertSame( 'Ada Lovelace', $export_item['customer_name'] );
+	}
+
+	/**
+	 * @testdox The customer name export column should hold a first name on its own.
+	 */
+	public function test_customer_name_holds_a_first_name_on_its_own(): void {
+		$export_item = $this->sut->prepare_item_for_export( $this->get_item( array( 'first_name' => 'Ada' ) ) );
+
+		$this->assertSame( 'Ada', $export_item['customer_name'] );
+	}
+
+	/**
+	 * Build a report row carrying the given customer record.
+	 *
+	 * @param array $customer Customer record for the row.
+	 * @return array
+	 */
+	private function get_item( array $customer ): array {
+		return array(
+			'date'            => '2026-09-04 10:00:00',
+			'order_number'    => '123',
+			'total_formatted' => '10.00',
+			'status'          => 'completed',
+			'customer_type'   => 'new',
+			'num_items_sold'  => 1,
+			'net_total'       => 10.00,
+			'extended_info'   => array(
+				'products'    => array(),
+				'coupons'     => array(),
+				'customer'    => $customer,
+				'attribution' => array( 'origin' => 'Direct' ),
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

`Orders\Controller::prepare_item_for_export()` reads the customer name for every exported row:

```php
'customer_name' => isset( $item['extended_info']['customer'] ) ? $this->get_customer_name( $item['extended_info']['customer'] ) : null,
```

`extended_info['customer']` always exists — `Orders\DataStore::include_extended_info()` defaults it to `array()` — so the `isset()` guard never rejects anything, and `get_customer_name()` then indexed `first_name` and `last_name` unguarded. For an order whose analytics customer record is missing, that raises two `Undefined array key` warnings and exports a lone space where the cell should be blank.

`get_customer_name()` now reads both keys defensively and trims the result. `protected`, so the docblock notes why neither key is guaranteed for anyone overriding it.

#### On the WOOAIRR-234 report itself

The report's two claims do not hold, and this PR deliberately does not act on them:

1. **"A partial `{first_name, last_name}` customer object is a response-shape regression."** The schema declares `extended_info.customer` as `type: object` with no required properties, so the partial object is valid — while the `[]` it replaced serialises to a JSON array and is not. The partial object is the better of the two shapes, and it is what makes the export path above produce a name at all.
2. **"`(int) NULL === 0` wrongly classifies an order with no stored user id as a guest."** That matches WooCommerce's own semantics: `WC_Order::get_customer_id()` returns `0` when `_customer_user` is absent. It cannot arise under HPOS at all, where the query reads the `NOT NULL` `orders.customer_id` column. Writing the order's own billing name over a name borrowed from a shared-email lookup row is precisely the fix #68311 shipped.

What the report did surface is the pre-existing unguarded accessor above, which the partial object made reachable with a name attached rather than with warnings. That is what this PR fixes.

Reported by the AI regression review bot as WOOAIRR-234, against #68311.

Closes WOOAIRR-234

(For Bug Fixes) The unguarded accessor predates #68311; it is not a regression from it.

### Screenshots or screen recordings:

Not applicable — CSV export column value.

### How to test the changes in this Pull Request:

1. Place an order as a guest and leave the billing and shipping name fields empty (or clear them on an existing order), so the order carries no customer name.
2. Let Analytics import it: **WooCommerce → Status → Scheduled Actions**, or **Analytics → Settings → Import historical data**.
3. Go to **Analytics → Orders**, set a date range covering the order, and click **Download**. Check your email for the export.
4. **Expected on this branch:** the row's *Customer* cell is empty, and `wp-content/debug.log` contains no `Undefined array key "first_name"` / `"last_name"` entries for `Orders/Controller.php`. **On `trunk`:** the cell holds a single space and the log gets both warnings per exported row.
5. Regression check: export a range including orders that do have customer names, and confirm those names are unchanged.

Enable `WP_DEBUG` and `WP_DEBUG_LOG` for step 4.

### Testing that has already taken place:

- New `Automattic\WooCommerce\Tests\Admin\API\Reports\Orders\ControllerTest` covers three shapes of `extended_info.customer`: empty, both names, first name only. Two of the three fail on `trunk` with the exact `Undefined array key` errors (verified by reverting the production hunk); all three pass here.
- Read `Orders\Controller::get_item_schema()` and `Orders\DataStore::include_extended_info()` at `trunk` to confirm the `[]` default is reachable and that the schema does not require either key.
- `phpcs` and PHPStan clean on the changed file.
- No REST response shape change: `get_customer_name()` is only used by the CSV export path.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added manually (`plugins/woocommerce/changelog/fix-orders-report-export-customer-name-guard`): `Significance: patch`, `Type: fix`.

**Backward compatibility:** `get_customer_name()` is `protected` on a public controller, so extensions may override or call it. Its signature is unchanged. Its return value changes in two cases that previously also raised warnings: a customer record missing both names now returns `''` instead of `' '`, and one missing a single name loses the trailing space.

### Use of AI Tools

Authored with Claude Code. The finding came from the AI regression review bot; I verified its claims against the code at `trunk`, rejected both as stated, and fixed the real defect they led to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEcWbxtTF4Lmy1uWR8RGYw
