### PR TITLE
Add HPOS order metadata Site Health check

### DIFF
--- a/plugins/woocommerce/changelog/68305-order-meta-site-health
+++ b/plugins/woocommerce/changelog/68305-order-meta-site-health
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a Site Health recommendation for unusually large HPOS order metadata tables.

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 use Automattic\WooCommerce\Enums\DefaultCustomerAddress;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\Utilities\ProductUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
@@ -26,6 +27,16 @@ defined( 'ABSPATH' ) || exit;
  * SiteHealth class.
  */
 class SiteHealth {
+	/**
+	 * Minimum order metadata rows before the table size check can recommend investigation.
+	 */
+	private const ORDER_META_ROW_COUNT_THRESHOLD = 1000000;
+
+	/**
+	 * Minimum metadata rows per order before the table size check can recommend investigation.
+	 */
+	private const ORDER_META_ROWS_PER_ORDER_THRESHOLD = 1000;
+
 	/**
 	 * Class instance.
 	 *
@@ -68,7 +79,7 @@ class SiteHealth {
 				'test'      => function () use ( $test_id ) {
 					return $this->run_test( $test_id );
 				},
-				'skip_cron' => true,
+				'skip_cron' => $test['skip_cron'] ?? true,
 			);
 		}
 
@@ -139,6 +150,7 @@ class SiteHealth {
 	 *   - label: visible test name in Site Health.
 	 *   - badge: 'security' or 'performance'.
 	 *   - check: callable returning bool (true = good) or array (empty = good, otherwise context for description/actions).
+	 *   - skip_cron: whether to exclude the test from scheduled checks (defaults to true).
 	 *   - good: result data when the check passes (label, description).
 	 *   - fail: result data when the check fails (status defaults to 'recommended', label, description, optional actions).
 	 *     Label, status, and description may be callables that receive the check context.
@@ -146,7 +158,7 @@ class SiteHealth {
 	 * @return array<string, array>
 	 */
 	protected function get_woocommerce_site_health_tests(): array {
-		return array(
+		$tests = array(
 			'woocommerce_secure_connection'            => array(
 				'label' => __( 'WooCommerce secure connection', 'woocommerce' ),
 				'badge' => 'security',
@@ -438,6 +450,96 @@ class SiteHealth {
 				),
 			),
 		);
+
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$tests['woocommerce_order_meta_table_size'] = array(
+				'label'     => __( 'WooCommerce order metadata table size', 'woocommerce' ),
+				'badge'     => 'performance',
+				'skip_cron' => false,
+				'check'     => fn() => $this->get_order_meta_table_size_issue(),
+				'good'      => array(
+					'label'       => __( 'WooCommerce order metadata table does not require attention', 'woocommerce' ),
+					'description' => __( 'WooCommerce did not detect an unusually large order metadata table.', 'woocommerce' ),
+				),
+				'fail'      => array(
+					'label'       => __( 'WooCommerce order metadata table is unusually large', 'woocommerce' ),
+					'description' => static fn( array $context ) => sprintf(
+						/* translators: 1: Estimated number of order metadata rows. 2: Estimated number of order rows. */
+						__( 'The order metadata table has an estimated %1$s rows, while the orders table has %2$s. Excess order metadata can slow down checkout and order management. Ask your hosting provider or support team to investigate before deleting data.', 'woocommerce' ),
+						number_format_i18n( $context['meta_rows'] ),
+						number_format_i18n( $context['order_rows'] )
+					),
+				),
+			);
+		}
+
+		return $tests;
+	}
+
+	/**
+	 * Get estimated row counts for the HPOS orders and metadata tables.
+	 *
+	 * @return array{order_rows: int, meta_rows: int}|null
+	 */
+	private function get_hpos_table_statistics(): ?array {
+		if ( ! defined( 'DB_NAME' ) ) {
+			return null;
+		}
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- This bounded query reads database-maintained table statistics during Site Health checks.
+		$statistics = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT
+					(
+						SELECT TABLE_ROWS
+						FROM information_schema.TABLES
+						WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+					) AS order_rows,
+					(
+						SELECT TABLE_ROWS
+						FROM information_schema.TABLES
+						WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+					) AS meta_rows',
+				DB_NAME,
+				OrdersTableDataStore::get_orders_table_name(),
+				DB_NAME,
+				OrdersTableDataStore::get_meta_table_name()
+			)
+		);
+
+		if ( ! is_object( $statistics ) || ! isset( $statistics->order_rows, $statistics->meta_rows ) || ! is_numeric( $statistics->order_rows ) || ! is_numeric( $statistics->meta_rows ) ) {
+			return null;
+		}
+
+		return array(
+			'order_rows' => (int) $statistics->order_rows,
+			'meta_rows'  => (int) $statistics->meta_rows,
+		);
+	}
+
+	/**
+	 * Get context when the order metadata table is unusually large.
+	 *
+	 * @return array{order_rows: int, meta_rows: int}|array{}
+	 */
+	private function get_order_meta_table_size_issue(): array {
+		$table_statistics = $this->get_hpos_table_statistics();
+
+		if ( null === $table_statistics ) {
+			return array();
+		}
+
+		if ( $table_statistics['meta_rows'] < self::ORDER_META_ROW_COUNT_THRESHOLD ) {
+			return array();
+		}
+
+		if ( 0 !== $table_statistics['order_rows'] && intdiv( $table_statistics['meta_rows'], $table_statistics['order_rows'] ) < self::ORDER_META_ROWS_PER_ORDER_THRESHOLD ) {
+			return array();
+		}
+
+		return $table_statistics;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -465,7 +465,7 @@ class SiteHealth {
 					'label'       => __( 'WooCommerce order metadata table is unusually large', 'woocommerce' ),
 					'description' => static fn( array $context ) => sprintf(
 						/* translators: 1: Estimated number of order metadata rows. 2: Estimated number of order rows. */
-						__( 'The order metadata table has an estimated %1$s rows, while the orders table has %2$s. Excess order metadata can slow down checkout and order management. Ask your hosting provider or support team to investigate before deleting data.', 'woocommerce' ),
+						__( 'The estimated row counts are %1$s for the order metadata table and %2$s for the orders table. Excess order metadata can slow down checkout and order management. Ask your hosting provider or support team to investigate before deleting data.', 'woocommerce' ),
 						number_format_i18n( $context['meta_rows'] ),
 						number_format_i18n( $context['order_rows'] )
 					),

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -482,10 +482,6 @@ class SiteHealth {
 	 * @return array{order_rows: int, meta_rows: int}|null
 	 */
 	private function get_hpos_table_statistics(): ?array {
-		if ( ! defined( 'DB_NAME' ) ) {
-			return null;
-		}
-
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- This bounded query reads database-maintained table statistics during Site Health checks.
@@ -495,16 +491,14 @@ class SiteHealth {
 					(
 						SELECT TABLE_ROWS
 						FROM information_schema.TABLES
-						WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+						WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s
 					) AS order_rows,
 					(
 						SELECT TABLE_ROWS
 						FROM information_schema.TABLES
-						WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+						WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s
 					) AS meta_rows',
-				DB_NAME,
 				OrdersTableDataStore::get_orders_table_name(),
-				DB_NAME,
 				OrdersTableDataStore::get_meta_table_name()
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\SiteHealth;
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use WC_Admin_Notices;
 use WC_Unit_Test_Case;
@@ -90,6 +91,91 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'good', $result['status'], 'No completed synchronization should require review.' );
 		$this->assertSame( 'WooCommerce approved download directories do not require review', $result['label'], 'The result should confirm that synchronized directories do not require review.' );
 		$this->assertSame( '<p>There is no completed approved download directory synchronization waiting for review.</p>', $result['description'], 'The result should confirm that no synchronization review is pending.' );
+	}
+
+	/**
+	 * @testdox Order metadata table size check runs during scheduled Site Health checks.
+	 */
+	public function test_order_meta_table_size_check_runs_during_cron(): void {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+
+		$tests = $this->sut->handle_site_status_tests( array() );
+
+		$this->assertFalse( $tests['direct']['woocommerce_order_meta_table_size']['skip_cron'], 'The order metadata table size check should run during scheduled Site Health checks.' );
+	}
+
+	/**
+	 * @testdox Order metadata table size check uses both the absolute and per-order limits.
+	 * @testWith [0, 1000000, "recommended"]
+	 *           [1000, 1000000, "recommended"]
+	 *           [1, 999999, "good"]
+	 *           [1001, 1000000, "good"]
+	 *           [0, 0, "good"]
+	 *
+	 * @param int    $order_rows     Estimated rows in the orders table.
+	 * @param int    $meta_rows      Estimated rows in the order metadata table.
+	 * @param string $expected_status Expected Site Health status.
+	 */
+	public function test_order_meta_table_size_check_thresholds( int $order_rows, int $meta_rows, string $expected_status ): void {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		$this->use_hpos_table_statistics( $order_rows, $meta_rows );
+
+		$result = $this->sut->run_test( 'woocommerce_order_meta_table_size' );
+
+		$this->assertSame( $expected_status, $result['status'], 'The estimated table row counts should determine the Site Health status.' );
+	}
+
+	/**
+	 * @testdox Order metadata table size check explains an unusually large table without recommending deletion.
+	 */
+	public function test_order_meta_table_size_check_explains_unusual_size(): void {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		$this->use_hpos_table_statistics( 44, 49800000 );
+
+		$result = $this->sut->run_test( 'woocommerce_order_meta_table_size' );
+
+		$this->assertSame( 'WooCommerce order metadata table is unusually large', $result['label'], 'The result should describe the table size without claiming duplicate metadata.' );
+		$this->assertSame( 'Performance', $result['badge']['label'], 'The result should use the performance badge.' );
+		$this->assertSame( '<p>The order metadata table has an estimated 49,800,000 rows, while the orders table has 44. Excess order metadata can slow down checkout and order management. Ask your hosting provider or support team to investigate before deleting data.</p>', $result['description'], 'The result should explain the risk and recommend investigation rather than deletion.' );
+		$this->assertSame( '', $result['actions'], 'The result should not link to an unsafe generic cleanup action.' );
+	}
+
+	/**
+	 * @testdox Order metadata table size check is omitted when HPOS is disabled.
+	 */
+	public function test_order_meta_table_size_check_is_omitted_without_hpos(): void {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+		$statistics_queries = 0;
+		$query_filter       = static function ( $query ) use ( &$statistics_queries ) {
+			if ( false !== strpos( $query, 'FROM information_schema.TABLES' ) ) {
+				++$statistics_queries;
+			}
+
+			return $query;
+		};
+		add_filter( 'query', $query_filter );
+
+		try {
+			$tests = $this->sut->handle_site_status_tests( array() );
+		} finally {
+			remove_filter( 'query', $query_filter );
+		}
+
+		$this->assertArrayNotHasKey( 'woocommerce_order_meta_table_size', $tests['direct'], 'The HPOS-specific check should be omitted when HPOS is disabled.' );
+		$this->assertSame( 0, $statistics_queries, 'The HPOS table statistics query should not run when HPOS is disabled.' );
+	}
+
+	/**
+	 * @testdox Order metadata table size check does not require attention when table statistics are unavailable.
+	 */
+	public function test_order_meta_table_size_check_is_good_without_statistics(): void {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		$this->use_hpos_table_statistics( null, null );
+
+		$result = $this->sut->run_test( 'woocommerce_order_meta_table_size' );
+
+		$this->assertSame( 'good', $result['status'], 'Unavailable table statistics should not create a recommendation.' );
+		$this->assertSame( 'WooCommerce order metadata table does not require attention', $result['label'], 'The result should not claim that unavailable statistics were verified.' );
 	}
 
 	/**
@@ -191,5 +277,25 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 		} finally {
 			remove_filter( 'pre_http_request', $filter_callback, 10 );
 		}
+	}
+
+	/**
+	 * Replace HPOS table statistics with predictable estimates.
+	 *
+	 * @param int|null $order_rows Estimated rows in the orders table.
+	 * @param int|null $meta_rows  Estimated rows in the order metadata table.
+	 */
+	private function use_hpos_table_statistics( ?int $order_rows, ?int $meta_rows ): void {
+		$order_rows_sql = null === $order_rows ? 'NULL' : (string) $order_rows;
+		$meta_rows_sql  = null === $meta_rows ? 'NULL' : (string) $meta_rows;
+		$query_filter   = static function ( $query ) use ( $order_rows_sql, $meta_rows_sql ) {
+			if ( false === strpos( $query, 'FROM information_schema.TABLES' ) ) {
+				return $query;
+			}
+
+			return "SELECT {$order_rows_sql} AS order_rows, {$meta_rows_sql} AS meta_rows";
+		};
+
+		add_filter( 'query', $query_filter );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -179,6 +179,20 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Order metadata table size check can read real table statistics.
+	 */
+	public function test_order_meta_table_size_check_can_read_table_statistics(): void {
+		global $wpdb;
+
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+
+		$result = $this->sut->run_test( 'woocommerce_order_meta_table_size' );
+
+		$this->assertSame( '', $wpdb->last_error, 'The table statistics query should be valid for the test database.' );
+		$this->assertSame( 'good', $result['status'], 'The test database should not have an unusually large order metadata table.' );
+	}
+
+	/**
 	 * @testdox Upload directory protection check is inconclusive when the HTTP request fails.
 	 */
 	public function test_uploads_directory_protection_is_inconclusive_for_http_request_error(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -136,7 +136,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'WooCommerce order metadata table is unusually large', $result['label'], 'The result should describe the table size without claiming duplicate metadata.' );
 		$this->assertSame( 'Performance', $result['badge']['label'], 'The result should use the performance badge.' );
-		$this->assertSame( '<p>The order metadata table has an estimated 49,800,000 rows, while the orders table has 44. Excess order metadata can slow down checkout and order management. Ask your hosting provider or support team to investigate before deleting data.</p>', $result['description'], 'The result should explain the risk and recommend investigation rather than deletion.' );
+		$this->assertSame( '<p>The estimated row counts are 49,800,000 for the order metadata table and 44 for the orders table. Excess order metadata can slow down checkout and order management. Ask your hosting provider or support team to investigate before deleting data.</p>', $result['description'], 'The result should explain the risk and recommend investigation rather than deletion.' );
 		$this->assertSame( '', $result['actions'], 'The result should not link to an unsafe generic cleanup action.' );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Run an HPOS-only Site Health check before runaway order metadata becomes an outage. The check uses database-maintained row estimates for the orders and order metadata tables, recommends investigation only above conservative absolute and per-order thresholds, and avoids application-table scans or cleanup actions.

This is additive and does not change public APIs, hooks, or stored data. Multisite was not checked. The check uses the current site's prefixed HPOS table names and the database selected by the routed connection.

Closes #68305, closes WOOPLUG-7660

<img width="893" height="986" alt="Screenshot 2026-09-14 at 15 24 46" src="https://github.com/user-attachments/assets/53097d62-4a86-4a77-b991-f5609d7a4809" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the WooCommerce test environment and run the `SiteHealthTest` PHPUnit class.
2. Confirm all tests pass, including the real `information_schema` query, threshold boundaries, unavailable statistics, HPOS-disabled behavior, and scheduled-check registration.
3. Enable HPOS on a test store, open **Tools > Site Health > Status**, and confirm the WooCommerce order metadata table check appears.
4. Disable HPOS, refresh Site Health, and confirm the HPOS-specific check is omitted.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The focused PHPUnit class passes with 17 tests and 41 assertions on PHP 8.1 in the Docker wp-env environment.
- Changed-file and branch PHP linting pass, and PHPStan reports no errors.
- A non-admin WordPress bootstrap registered and executed the scheduled check successfully. The final query also ran successfully against the wp-env MariaDB database.
- Codex `neo-review` and a separate Claude Code review both returned a shipping verdict after review findings were adjudicated.
- Multisite was not tested. Independent human review is requested because this touches a performance-sensitive database path.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to implement, test, and review this change. Claude Code performed a separate code review.
