### PR TITLE
Use account readiness checks during Test Drive onboarding

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-drive-polling-refresh
+++ b/plugins/woocommerce/changelog/fix-test-drive-polling-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Refresh pending WooPayments Test Drive accounts when webhook updates are delayed.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1236,10 +1236,16 @@ class WooPaymentsService {
 			return;
 		}
 
-		$account_service = $this->proxy->call_static( '\\WC_Payments', 'get_account_service' );
-		if ( is_object( $account_service ) && method_exists( $account_service, 'refresh_test_account_data' ) ) {
-			$account_service->refresh_test_account_data();
-		} else {
+		try {
+			$request = $this->proxy->call_static( '\WCPay\Core\Server\Request', 'get', 'accounts/readiness' );
+			$request->assign_hook( 'wcpay_get_account_readiness_request' );
+			$account = $request->send();
+		} catch ( \Exception $e ) {
+			return;
+		}
+
+		if ( is_array( $account ) && ! empty( $account['payments_enabled'] ) ) {
+			$account_service = $this->proxy->call_static( '\WC_Payments', 'get_account_service' );
 			$account_service->refresh_account_data();
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1207,10 +1207,41 @@ class WooPaymentsService {
 	public function onboarding_step_check( string $step_id, string $location ): array {
 		$this->check_if_onboarding_step_action_is_acceptable( $step_id, $location );
 
+		if ( self::ONBOARDING_STEP_TEST_ACCOUNT === $step_id && $this->has_test_account() && ! $this->has_working_account() ) {
+			$this->maybe_refresh_test_account();
+		}
+
 		return array(
 			'status' => $this->get_onboarding_step_status( $step_id, $location ),
 			'error'  => $this->get_onboarding_step_error( $step_id, $location ),
 		);
+	}
+
+	/**
+	 * Refresh a pending test account while allowing time for webhook updates between requests.
+	 */
+	private function maybe_refresh_test_account(): void {
+		$transient    = 'woocommerce_woopayments_test_account_refresh';
+		$now          = $this->proxy->call_function( 'time' );
+		$next_refresh = $this->proxy->call_function( 'get_transient', $transient );
+
+		if ( false !== $next_refresh && $now < (int) $next_refresh ) {
+			return;
+		}
+
+		$this->proxy->call_function( 'set_transient', $transient, $now + 10, MINUTE_IN_SECONDS );
+
+		// The first poll may have just populated the account cache. Give that data time to change.
+		if ( false === $next_refresh ) {
+			return;
+		}
+
+		$account_service = $this->proxy->call_static( '\\WC_Payments', 'get_account_service' );
+		if ( is_object( $account_service ) && method_exists( $account_service, 'refresh_test_account_data' ) ) {
+			$account_service->refresh_test_account_data();
+		} else {
+			$account_service->refresh_account_data();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -54,6 +54,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 */
 	protected $mock_account_service;
 
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
+	private $mock_readiness_request;
+
 	/**
 	 * The ID of the store admin user.
 	 *
@@ -144,9 +147,22 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		// Arrange the version constant to meet the minimum requirements for the native in-context onboarding.
 		Constants::set_constant( 'WCPAY_VERSION_NUMBER', WooPaymentsService::EXTENSION_MINIMUM_VERSION );
 
+		$this->mock_readiness_request = $this->getMockBuilder( \stdClass::class )->addMethods( array( 'send', 'assign_hook' ) )->getMock();
+
 		$this->mock_account_service = $this->getMockBuilder( \stdClass::class )
 			->addMethods( array( 'is_stripe_account_valid', 'get_account_status_data', 'refresh_account_data' ) )
 			->getMock();
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				'\WCPay\Core\Server\Request' => array(
+					'get' => function ( $route ) {
+						$this->assertSame( 'accounts/readiness', $route );
+						return $this->mock_readiness_request;
+					},
+				),
+			)
+		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
@@ -6845,20 +6861,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should observe a ready test account when its webhook update was delayed.
-	 * @testWith [false]
-	 *           [true]
-	 * @param bool $supports_readiness Whether WooPayments supports lightweight readiness checks.
+	 * @testdox Should fetch full account data only after readiness succeeds.
 	 */
-	public function test_onboarding_step_check_refreshes_stale_test_account( bool $supports_readiness ): void {
-		$refresh_method = 'refresh_account_data';
-		if ( $supports_readiness ) {
-			$this->mock_account_service = $this->getMockBuilder( \stdClass::class )
-				->addMethods( array( 'is_stripe_account_valid', 'get_account_status_data', 'refresh_account_data', 'refresh_test_account_data' ) )
-				->getMock();
-			$this->mock_account_service->expects( $this->never() )->method( 'refresh_account_data' );
-			$refresh_method = 'refresh_test_account_data';
-		}
+	public function test_onboarding_step_check_refreshes_stale_test_account(): void {
+		$this->mock_readiness_request->expects( $this->once() )->method( 'assign_hook' )->with( 'wcpay_get_account_readiness_request' );
+		$this->mock_readiness_request->expects( $this->once() )->method( 'send' )->willReturn( array( 'payments_enabled' => true ) );
 		$this->mock_wpcom_connection_manager->method( 'is_connected' )->willReturn( true );
 		$this->mock_wpcom_connection_manager->method( 'has_connected_owner' )->willReturn( true );
 		$this->mock_provider->method( 'is_account_connected' )->willReturn( true );
@@ -6872,7 +6879,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				);
 			}
 		);
-		$this->mock_account_service->expects( $this->once() )->method( $refresh_method )->willReturnCallback(
+		$this->mock_account_service->expects( $this->once() )->method( 'refresh_account_data' )->willReturnCallback(
 			static function () use ( &$ready ) {
 				$ready = true;
 			}
@@ -6888,9 +6895,12 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should wait between refresh attempts even when the platform is unavailable.
+	 * @testdox Should throttle pending checks and failed requests without refreshing the full account.
+	 * @testWith [false]
+	 *           [true]
+	 * @param bool $fails Whether the readiness request fails.
 	 */
-	public function test_onboarding_step_check_throttles_failed_refreshes(): void {
+	public function test_onboarding_step_check_throttles_failed_refreshes( bool $fails ): void {
 		$this->mock_account_service->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->mock_wpcom_connection_manager->method( 'is_connected' )->willReturn( true );
 		$this->mock_wpcom_connection_manager->method( 'has_connected_owner' )->willReturn( true );
@@ -6901,7 +6911,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				'paymentsEnabled' => false,
 			)
 		);
-		$this->mock_account_service->expects( $this->exactly( 2 ) )->method( 'refresh_account_data' )->willReturn( false );
+		$this->mock_account_service->expects( $this->never() )->method( 'refresh_account_data' );
+		$send = $this->mock_readiness_request->expects( $this->exactly( 2 ) )->method( 'send' );
+		if ( $fails ) {
+			$send->willThrowException( new \Exception( 'Unavailable' ) );
+		} else {
+			$send->willReturn( array( 'payments_enabled' => false ) );
+		}
 
 		foreach ( array( 0, 3, 6, 9, 10, 12, 15, 19, 20 ) as $elapsed ) {
 			$this->current_time = self::TEST_EPOCH + $elapsed;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -145,7 +145,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		Constants::set_constant( 'WCPAY_VERSION_NUMBER', WooPaymentsService::EXTENSION_MINIMUM_VERSION );
 
 		$this->mock_account_service = $this->getMockBuilder( \stdClass::class )
-			->addMethods( array( 'is_stripe_account_valid', 'get_account_status_data' ) )
+			->addMethods( array( 'is_stripe_account_valid', 'get_account_status_data', 'refresh_account_data' ) )
 			->getMock();
 
 		$this->mockable_proxy->register_static_mocks(
@@ -6842,6 +6842,102 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->expectExceptionMessage( 'Onboarding step requirements are not met.' );
 
 		$this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+	}
+
+	/**
+	 * @testdox Should observe a ready test account when its webhook update was delayed.
+	 * @testWith [false]
+	 *           [true]
+	 * @param bool $supports_readiness Whether WooPayments supports lightweight readiness checks.
+	 */
+	public function test_onboarding_step_check_refreshes_stale_test_account( bool $supports_readiness ): void {
+		$refresh_method = 'refresh_account_data';
+		if ( $supports_readiness ) {
+			$this->mock_account_service = $this->getMockBuilder( \stdClass::class )
+				->addMethods( array( 'is_stripe_account_valid', 'get_account_status_data', 'refresh_account_data', 'refresh_test_account_data' ) )
+				->getMock();
+			$this->mock_account_service->expects( $this->never() )->method( 'refresh_account_data' );
+			$refresh_method = 'refresh_test_account_data';
+		}
+		$this->mock_wpcom_connection_manager->method( 'is_connected' )->willReturn( true );
+		$this->mock_wpcom_connection_manager->method( 'has_connected_owner' )->willReturn( true );
+		$this->mock_provider->method( 'is_account_connected' )->willReturn( true );
+		$this->mock_account_service->method( 'is_stripe_account_valid' )->willReturn( true );
+		$ready = false;
+		$this->mock_account_service->method( 'get_account_status_data' )->willReturnCallback(
+			static function () use ( &$ready ) {
+				return array(
+					'testDrive'       => true,
+					'paymentsEnabled' => $ready,
+				);
+			}
+		);
+		$this->mock_account_service->expects( $this->once() )->method( $refresh_method )->willReturnCallback(
+			static function () use ( &$ready ) {
+				$ready = true;
+			}
+		);
+
+		$first = $this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, 'US' );
+		$this->assertNotSame( WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, $first['status'] );
+		$this->current_time += 10;
+		$refreshed           = $this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, 'US' );
+		$this->assertSame( WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, $refreshed['status'] );
+		$this->current_time += 10;
+		$this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, 'US' );
+	}
+
+	/**
+	 * @testdox Should wait between refresh attempts even when the platform is unavailable.
+	 */
+	public function test_onboarding_step_check_throttles_failed_refreshes(): void {
+		$this->mock_account_service->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_wpcom_connection_manager->method( 'is_connected' )->willReturn( true );
+		$this->mock_wpcom_connection_manager->method( 'has_connected_owner' )->willReturn( true );
+		$this->mock_provider->method( 'is_account_connected' )->willReturn( true );
+		$this->mock_account_service->method( 'get_account_status_data' )->willReturn(
+			array(
+				'testDrive'       => true,
+				'paymentsEnabled' => false,
+			)
+		);
+		$this->mock_account_service->expects( $this->exactly( 2 ) )->method( 'refresh_account_data' )->willReturn( false );
+
+		foreach ( array( 0, 3, 6, 9, 10, 12, 15, 19, 20 ) as $elapsed ) {
+			$this->current_time = self::TEST_EPOCH + $elapsed;
+			$result             = $this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, 'US' );
+			$this->assertNotSame( WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, $result['status'] );
+		}
+	}
+
+	/**
+	 * @testdox Should leave other steps and working or non-test-drive accounts cached.
+	 *
+	 * @param string $step The step being checked.
+	 * @param bool   $test_drive Whether this is a test-drive account.
+	 * @param bool   $ready Whether payments are enabled.
+	 *
+	 * @testWith ["payment_methods", true, false]
+	 *           ["test_account", false, false]
+	 *           ["test_account", true, true]
+	 */
+	public function test_onboarding_step_check_does_not_refresh_other_accounts( string $step, bool $test_drive, bool $ready ): void {
+		$this->mock_account_service->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_wpcom_connection_manager->method( 'is_connected' )->willReturn( true );
+		$this->mock_wpcom_connection_manager->method( 'has_connected_owner' )->willReturn( true );
+		$this->mock_provider->method( 'is_account_connected' )->willReturn( true );
+		$this->mock_account_service->method( 'get_account_status_data' )->willReturn(
+			array(
+				'testDrive'       => $test_drive,
+				'isLive'          => ! $test_drive,
+				'paymentsEnabled' => $ready,
+			)
+		);
+		$this->mock_account_service->expects( $this->never() )->method( 'refresh_account_data' );
+
+		$this->sut->onboarding_step_check( $step, 'US' );
+		$this->current_time += 10;
+		$this->sut->onboarding_step_check( $step, 'US' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -6919,6 +6919,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			$send->willReturn( array( 'payments_enabled' => false ) );
 		}
 
+		// Poll between and at the 10-second refresh boundaries; only the checks at 10 and 20 seconds should send a request.
 		foreach ( array( 0, 3, 6, 9, 10, 12, 15, 19, 20 ) as $elapsed ) {
 			$this->current_time = self::TEST_EPOCH + $elapsed;
 			$result             = $this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, 'US' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:



<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Test Drive onboarding can keep polling stale account data when a webhook update is delayed. Refresh pending accounts at most once every ten seconds during polling, after an initial grace period. Call `GET accounts/readiness` through WooPayments' existing request API and refresh the full cached account only when payments are enabled.

Only the pending Test Drive step triggers refreshes. Public signatures and REST responses are unchanged. The request uses the additive `wcpay_get_account_readiness_request` hook; existing account-refresh hooks still receive full account data. The transient is site-scoped and provides best-effort throttling, not an atomic lock. Multisite was not tested.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start Test Drive onboarding on a connected store and delay the account-update webhook so the local account stays pending.
2. Poll the Test Drive step. Confirm the first poll does not force another fetch and refresh attempts are spaced by at least ten seconds within the poll sequence.
3. Make the server account ready. Confirm a subsequent check refreshes the account and completes the step. Further checks must stop refreshing.
4. Use unmodified WooPayments and confirm readiness requests use its existing request API. Simulate a failed readiness request and confirm polling stays pending without refreshing the full account.
5. Confirm live accounts, completed Test Drive accounts and other onboarding steps do not trigger these refreshes. Run `WooPaymentsServiceTest`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

336 service tests passed, covering delayed readiness, throttled pending/error responses and unchanged checks for other account states. Changed-file lint, full-branch lint and PHPStan passed. The new endpoint was called successfully through unmodified WooPayments locally.

Deploy the server endpoint before releasing this change. No WooPayments plugin change is required. Stripe verification time and frontend polling intervals remain unchanged.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-test-drive-polling-refresh`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex authored the code, tests and PR description and ran the checks above. Human review is pending.
