### PR TITLE
Fix reentrant feature definition initialization

### DIFF
--- a/plugins/woocommerce/changelog/fix-features-controller-reentrancy
+++ b/plugins/woocommerce/changelog/fix-features-controller-reentrancy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent recursive feature definition initialization when hooks check WooCommerce features during translation or option callbacks.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -125,6 +125,13 @@ class FeaturesController {
 	private bool $registered_additional_features_via_class_calls = false;
 
 	/**
+	 * Flag indicating if hardcoded feature definitions are currently being initialized.
+	 *
+	 * @var bool
+	 */
+	private bool $initializing_feature_definitions = false;
+
+	/**
 	 * Flag indicating if we are currently delaying plugin normalization.
 	 *
 	 * @var bool
@@ -260,9 +267,7 @@ class FeaturesController {
 	 * @return array[]
 	 */
 	private function get_feature_definitions() {
-		if ( empty( $this->features ) ) {
-			$this->init_feature_definitions();
-		}
+		$this->maybe_init_feature_definitions();
 
 		if ( ! $this->registered_additional_features_via_class_calls ) {
 			// This needs to be set to true *before* additional feature definition calls are made,
@@ -280,6 +285,23 @@ class FeaturesController {
 		}
 
 		return $this->features;
+	}
+
+	/**
+	 * Initialize hardcoded feature definitions if they have not been initialized yet.
+	 */
+	private function maybe_init_feature_definitions(): void {
+		if ( ! empty( $this->features ) || $this->initializing_feature_definitions ) {
+			return;
+		}
+
+		$this->initializing_feature_definitions = true;
+
+		try {
+			$this->init_feature_definitions();
+		} finally {
+			$this->initializing_feature_definitions = false;
+		}
 	}
 
 	/**
@@ -783,9 +805,7 @@ class FeaturesController {
 			return;
 		}
 
-		if ( empty( $this->features ) ) {
-			$this->init_feature_definitions();
-		}
+		$this->maybe_init_feature_definitions();
 
 		/**
 		 * The action for registering features.

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -283,6 +283,48 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Feature definition initialization is safe when a translation callback checks a feature.
+	 */
+	public function test_feature_definition_initialization_is_reentrant_safe() {
+		$reflection_class = new \ReflectionClass( $this->sut );
+
+		$features_property = $reflection_class->getProperty( 'features' );
+		$features_property->setAccessible( true );
+		$features_property->setValue( $this->sut, array() );
+
+		$compat_property = $reflection_class->getProperty( 'compatibility_info_by_feature' );
+		$compat_property->setAccessible( true );
+		$compat_property->setValue( $this->sut, array() );
+
+		$reentrant_feature_enabled = null;
+		$translation_count         = 0;
+
+		$gettext_filter = function ( $translation, $text, $domain ) use ( &$reentrant_feature_enabled, &$translation_count ) {
+			unset( $text, $domain ); // Avoid parameter not used PHPCS errors.
+
+			++$translation_count;
+
+			if ( null === $reentrant_feature_enabled ) {
+				$reentrant_feature_enabled = $this->sut->feature_is_enabled( 'order_withdrawal' );
+			}
+
+			return $translation;
+		};
+
+		add_filter( 'gettext', $gettext_filter, 10, 3 );
+
+		try {
+			$this->sut->get_features( true, false );
+		} finally {
+			remove_filter( 'gettext', $gettext_filter, 10 );
+		}
+
+		$this->assertFalse( $reentrant_feature_enabled );
+		$this->assertGreaterThan( 0, $translation_count );
+		$this->assertNotNull( $this->sut->get_feature_definition( 'order_withdrawal' ) );
+	}
+
+	/**
 	 * @testdox 'change_feature_enable' does nothing and returns false for an invalid feature id.
 	 */
 	public function test_change_feature_enable_for_non_existing_feature() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #68401.

Closes [WOOPLUG-7678](https://linear.app/a8c/issue/WOOPLUG-7678/woocommerce-1110-orderwithdrawalcontrollers-unconditional-woocommerce)

Feature definition initialization was guarded only by whether definitions had already been populated. Hooks fired while building translated feature definitions could call back into feature checks before that population completed, causing initialization to recursively restart until memory exhaustion.

This adds an explicit re-entrancy guard around hardcoded feature definition initialization and reuses it from both initialization call sites. Re-entrant feature checks now see initialization is already in progress and return without restarting the build.

### Screenshots or screen recordings:

Not applicable. This change has no UI impact.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add an mu-plugin with the below code
2. Load the frontend of your store
3. Confirm the request completes without fatals

```php
<?php
/**
 * Plugin Name: WooCommerce Feature Re-entrancy Repro
 * Description: Reproduces recursive feature initialization via gettext and is_wc_endpoint_url().
 */

add_filter(
	'gettext',
	function ( $translated, $text, $domain ) {
		if ( is_admin() || ! function_exists( 'is_wc_endpoint_url' ) ) {
			return $translated;
		}

		is_wc_endpoint_url( 'edit-address' );

		return $translated;
	},
	20,
	3
);
```

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

AI tooling was used to draft the code changes, regression test, and PR description. The author should review before marking the PR ready for review.
