### PR TITLE
[CI] Add external link checks for docs Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
             needs-markdown-validation:
               - '*.md'
               - '!(.github/**)/**/*.md'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/docs-link-check/**'
+              - '.github/workflows/scripts/docs-link-check-policy-test.sh'
+              - '.github/workflows/scripts/install-lychee.sh'
             needs-syncpack-validation:
               - '(.syncpackrc)|(pnpm-lock.yaml)|(pnpm-workspace.yaml)'
 
@@ -747,7 +751,9 @@ jobs:
     name: 'Validate markdown'
     if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'trunk' && needs.identify-jobs-to-run.outputs.needs-markdown-validation == 'true' }}
     needs: [ 'identify-jobs-to-run' ]
-    runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
+    # Always GitHub-hosted: this job requests contributor-authored documentation links
+    # (see the docs link check below) and must never run inside the WooCommerce runner group.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
@@ -766,6 +772,21 @@ jobs:
             needs-docs-build-validation:
               - 'docs/**/*.md'
 
+      # JSON output keeps unusual filenames as data; it is consumed through `env`, never
+      # interpolated into a script.
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: docs-link-changes
+        with:
+          list-files: json
+          filters: |
+            needs-docs-link-check:
+              - added|modified: 'docs/**/*.md'
+            needs-docs-link-policy-check:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/docs-link-check/**'
+              - '.github/workflows/scripts/docs-link-check-policy-test.sh'
+              - '.github/workflows/scripts/install-lychee.sh'
+
       - name: 'Setup - node'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -778,6 +799,29 @@ jobs:
         if: ${{ steps.target-changes.outputs.needs-markdown-linting == 'true' }}
         shell: bash
         run: pnpm dlx markdownlint-cli -- ${{ steps.target-changes.outputs.needs-markdown-linting_files }}
+
+      - name: 'Setup - lychee'
+        if: ${{ !cancelled() && ( steps.docs-link-changes.outputs.needs-docs-link-check == 'true' || steps.docs-link-changes.outputs.needs-docs-link-policy-check == 'true' ) }}
+        shell: bash
+        run: bash .github/workflows/scripts/install-lychee.sh
+
+      - name: 'Validate - docs link-check policy'
+        if: ${{ !cancelled() && steps.docs-link-changes.outputs.needs-docs-link-policy-check == 'true' }}
+        shell: bash
+        run: bash .github/workflows/scripts/docs-link-check-policy-test.sh
+
+      # Requests only approved hosts (docs-link-check/pr.toml) and follows no redirects.
+      # Links to other hosts are skipped here and covered by the weekly crawl in
+      # docs-link-check.yml.
+      - name: 'Validate - approved external doc links'
+        if: ${{ !cancelled() && steps.docs-link-changes.outputs.needs-docs-link-check == 'true' }}
+        timeout-minutes: 2
+        shell: bash
+        env:
+          DOCS_LINK_FILES_JSON: ${{ steps.docs-link-changes.outputs.needs-docs-link-check_files }}
+        run: |
+          jq --raw-output0 '.[]' <<< "$DOCS_LINK_FILES_JSON" | xargs -0 --no-run-if-empty \
+            lychee --config .github/workflows/docs-link-check/pr.toml --root-dir "$PWD" --
 
       - name: 'Validate - lint docs-files'
         if: ${{ always() && steps.target-changes.outputs.needs-docs-build-validation == 'true' }}

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,73 @@
+name: 'Docs external link check'
+
+# Weekly crawl of every external link in docs/**/*.md on trunk. It runs only against
+# reviewed content, so no pull request can choose what this job requests. Broken links
+# fail the run, land in the job summary, and are announced on Slack.
+#
+# The pull-request gate for changed docs lives in ci.yml (`Validate markdown`) and is
+# restricted to approved hosts; see .github/workflows/docs-link-check/pr.toml.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays at 06:00 UTC.
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: 'docs-link-check'
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: 'Check external links in docs'
+    if: ${{ github.repository == 'woocommerce/woocommerce' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # v7.0.0
+        with:
+          ref: trunk
+          persist-credentials: false
+          sparse-checkout: |
+            docs
+            .github/workflows
+            tools/monorepo-utils
+
+      - name: 'Install lychee'
+        run: bash .github/workflows/scripts/install-lychee.sh
+
+      - name: 'Check links'
+        run: |
+          lychee --config .github/workflows/docs-link-check/scheduled.toml \
+            --root-dir "$PWD" \
+            --format markdown --output "$RUNNER_TEMP/docs-link-report.md" \
+            'docs/**/*.md'
+
+      - name: 'Publish report'
+        if: ${{ always() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/docs-link-report.md" ]]; then
+            cat "$RUNNER_TEMP/docs-link-report.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: 'Setup Node'
+        if: ${{ failure() }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: 'Setup PNPM'
+        if: ${{ failure() }}
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: 'Notify Slack on failure'
+        if: ${{ failure() }}
+        env:
+          SLACK_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
+          SLACK_CHANNELS: ${{ secrets.DAILY_CHECKS_CHANNEL }}
+        run: |
+          pnpm utils slack ":link: Docs external link check found broken links or failed.\n<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View the report>"

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -23,7 +23,7 @@ jobs:
     name: 'Check external links in docs'
     if: ${{ github.repository == 'woocommerce/woocommerce' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/docs-link-check/policy-expected.txt
+++ b/.github/workflows/docs-link-check/policy-expected.txt
@@ -1,0 +1,6 @@
+http://wordpress.org/plugins/woocommerce/
+https://developer.woocommerce.com/docs/
+https://github.com/Woo/Repo#frag
+https://github.com/auto/link
+https://github.com/woocommerce/woocommerce
+https://github.com/x?y=1

--- a/.github/workflows/docs-link-check/policy-expected.txt
+++ b/.github/workflows/docs-link-check/policy-expected.txt
@@ -3,4 +3,6 @@ https://developer.woocommerce.com/docs/
 https://github.com/Woo/Repo#frag
 https://github.com/auto/link
 https://github.com/woocommerce/woocommerce
+https://github.com/woocommerce/woocommerce/blob/trunk/README.md#readme
 https://github.com/x?y=1
+https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/README.md

--- a/.github/workflows/docs-link-check/policy-fixture.md
+++ b/.github/workflows/docs-link-check/policy-fixture.md
@@ -10,6 +10,8 @@ This file is input for `.github/workflows/scripts/docs-link-check-policy-test.sh
 - [approved docs host](https://developer.woocommerce.com/docs/)
 - [query string kept](https://github.com/x?y=1)
 - autolink: <https://github.com/auto/link>
+- [raw file host](https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/README.md)
+- [blob link with a fragment](https://github.com/woocommerce/woocommerce/blob/trunk/README.md#readme) is requested from raw.githubusercontent.com at check time (see `pr.toml`); `--dump` shows the original URL
 
 ## Lookalikes and out-of-policy hosts (must not be requested)
 

--- a/.github/workflows/docs-link-check/policy-fixture.md
+++ b/.github/workflows/docs-link-check/policy-fixture.md
@@ -1,0 +1,50 @@
+# Docs link-check policy fixture
+
+This file is input for `.github/workflows/scripts/docs-link-check-policy-test.sh`. It lists URLs that the pull-request link check must request and URLs it must never request. The expected result is `policy-expected.txt`.
+
+## Approved hosts (must be requested)
+
+- [exact host](https://github.com/woocommerce/woocommerce)
+- [plain http](http://wordpress.org/plugins/woocommerce/)
+- [uppercase host is normalized](https://GITHUB.COM/Woo/Repo#frag)
+- [approved docs host](https://developer.woocommerce.com/docs/)
+- [query string kept](https://github.com/x?y=1)
+- autolink: <https://github.com/auto/link>
+
+## Lookalikes and out-of-policy hosts (must not be requested)
+
+- [user info before an approved host](https://github.com@evil.example/x)
+- [credentials](https://user:pw@github.com/x)
+- [non-default port](https://github.com:8443/x)
+- [suffix lookalike](https://github.com.evil.example/x)
+- [approved host in the path](https://evil.example/github.com/)
+- [www subdomain is not approved](https://www.woocommerce.com/)
+- [other subdomain is not approved](https://foo.wordpress.org/)
+- [trailing dot host](https://github.com./x)
+- [homoglyph host](https://gıthub.com/x)
+- [npm is not approved](https://www.npmjs.com/package/x)
+- [example domain](https://example.com/)
+
+## Private, loopback, and link-local (must not be requested)
+
+- [loopback](http://127.0.0.1/)
+- [localhost with port](http://localhost:8080/)
+- [link-local metadata](http://169.254.169.254/latest/meta-data/)
+- [private range](http://10.0.0.1/)
+- [ipv6 loopback](http://[::1]/)
+- [hex loopback](http://0x7f000001/)
+- [decimal loopback](http://2130706433/)
+- [placeholder .local host](http://store.local/)
+- [placeholder .test host](http://local.wordpress.test/)
+
+## Other schemes and non-network links (must not be requested)
+
+- [mail](mailto:docs@example.com)
+- [relative](../README.md)
+- [root-relative](/docs/apis/rest-api/)
+- [fragment](#approved-hosts-must-be-requested)
+- [ftp](ftp://github.com/x)
+
+```md
+[inside a code fence](https://github.com/should/not/appear)
+```

--- a/.github/workflows/docs-link-check/pr.toml
+++ b/.github/workflows/docs-link-check/pr.toml
@@ -1,0 +1,30 @@
+# lychee policy for the pull-request docs link check (`Validate markdown` job in ci.yml).
+#
+# Only URLs whose exact host is listed in `include` are requested. lychee matches the
+# regex against the parsed, normalized URL (lowercased punycode host, default port
+# elided, user info kept), so user info, non-default ports, subdomains, and lookalike
+# hosts never match. Loopback, private, and link-local addresses are rejected before
+# `include` is consulted and cannot be re-included.
+#
+# Adding a host is a policy change: it lets a docs-only pull request make the CI runner
+# contact that host. Keep the list to hosts operated by WooCommerce, WordPress.org, or GitHub.
+#
+# `.github/workflows/scripts/docs-link-check-policy-test.sh` proves this file offline.
+
+no_progress = true
+scheme = ["http", "https"]
+exclude_all_private = true
+include = [
+	'^https?://(github\.com|developer\.woocommerce\.com|woocommerce\.com|developer\.wordpress\.org|woocommerce\.github\.io|wordpress\.org|qit\.woo\.com|user-images\.githubusercontent\.com|codex\.wordpress\.org|make\.wordpress\.org)/',
+]
+
+# Redirects are not followed at pull-request time, so an approved host can never lead the
+# runner elsewhere. A 3xx counts as alive here; the scheduled crawl follows redirects.
+max_redirects = 0
+
+# Only 400, 404, and 410 (plus transport failures) fail the check. Auth challenges, bot
+# blocks, rate limits, and server errors do not prove a link is dead.
+accept = "200..=399,401,403,405..=409,411..=599"
+timeout = 10
+max_retries = 2
+max_concurrency = 4

--- a/.github/workflows/docs-link-check/pr.toml
+++ b/.github/workflows/docs-link-check/pr.toml
@@ -9,13 +9,19 @@
 # Adding a host is a policy change: it lets a docs-only pull request make the CI runner
 # contact that host. Keep the list to hosts operated by WooCommerce, WordPress.org, or GitHub.
 #
+# raw.githubusercontent.com is approved because lychee rewrites approved github.com links
+# of the form `/<owner>/<repo>/blob/<ref>/<file>.md#<fragment>` to that host after the
+# filter has run (lychee-lib `quirks`, "fetch raw GitHub Markdown files"). The rewrite is
+# not a redirect, so `max_redirects = 0` does not stop it, and `--dump` prints the original
+# URL, so the offline policy test cannot observe it either. Both hosts are GitHub-operated.
+#
 # `.github/workflows/scripts/docs-link-check-policy-test.sh` proves this file offline.
 
 no_progress = true
 scheme = ["http", "https"]
 exclude_all_private = true
 include = [
-	'^https?://(github\.com|developer\.woocommerce\.com|woocommerce\.com|developer\.wordpress\.org|woocommerce\.github\.io|wordpress\.org|qit\.woo\.com|user-images\.githubusercontent\.com|codex\.wordpress\.org|make\.wordpress\.org)/',
+	'^https?://(github\.com|developer\.woocommerce\.com|woocommerce\.com|developer\.wordpress\.org|woocommerce\.github\.io|wordpress\.org|qit\.woo\.com|user-images\.githubusercontent\.com|raw\.githubusercontent\.com|codex\.wordpress\.org|make\.wordpress\.org)/',
 ]
 
 # Redirects are not followed at pull-request time, so an approved host can never lead the

--- a/.github/workflows/docs-link-check/scheduled.toml
+++ b/.github/workflows/docs-link-check/scheduled.toml
@@ -1,0 +1,18 @@
+# lychee policy for the scheduled docs external link crawl (docs-link-check.yml).
+#
+# This runs against already-reviewed content on trunk, so it checks every external host
+# and follows redirects. Results are a report, not a merge gate.
+
+no_progress = true
+scheme = ["http", "https"]
+exclude_all_private = true
+exclude_path = ["docs/_docu-tools"]
+
+# Placeholder hosts used in examples.
+exclude = ['^https?://([^/]+\.local|local\.wordpress\.test)/']
+
+# 403 and 429 are bot blocks and rate limits, not dead links.
+accept = "200..=206,403,429"
+timeout = 15
+max_retries = 2
+max_concurrency = 8

--- a/.github/workflows/scripts/docs-link-check-policy-test.sh
+++ b/.github/workflows/scripts/docs-link-check-policy-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Proves the pull-request docs link-check policy without network access.
+# `lychee --dump` applies the same URL filters as a real run and prints only
+# the URLs it would request, so diffing it against the expected list shows
+# exactly which hosts a docs change can make the CI runner contact.
+#
+# Usage: bash .github/workflows/scripts/docs-link-check-policy-test.sh
+# Set LYCHEE to a binary path when lychee is not on PATH.
+
+set -euo pipefail
+
+policy_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../docs-link-check" && pwd )"
+lychee="${LYCHEE:-lychee}"
+
+diff -u "${policy_dir}/policy-expected.txt" <(
+	"${lychee}" --config "${policy_dir}/pr.toml" --dump --root-dir "${policy_dir}" "${policy_dir}/policy-fixture.md" | LC_ALL=C sort
+)
+
+printf 'PASS: docs link-check policy\n'

--- a/.github/workflows/scripts/install-lychee.sh
+++ b/.github/workflows/scripts/install-lychee.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Installs a checksum-pinned lychee release for GitHub-hosted x86_64 Linux runners
+# and adds it to the job PATH. Bump both values together when upgrading.
+
+set -euo pipefail
+
+LYCHEE_VERSION='0.24.2'
+LYCHEE_SHA256='1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a'
+
+target='x86_64-unknown-linux-gnu'
+archive="lychee-${target}.tar.gz"
+download_dir="$( mktemp -d )"
+
+curl --silent --show-error --fail --location --retry 3 \
+	--output "${download_dir}/${archive}" \
+	"https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/${archive}"
+printf '%s  %s\n' "${LYCHEE_SHA256}" "${download_dir}/${archive}" | sha256sum --check --strict --quiet -
+
+tar -xzf "${download_dir}/${archive}" -C "${download_dir}" "lychee-${target}/lychee"
+install -D "${download_dir}/lychee-${target}/lychee" "${RUNNER_TEMP}/lychee/bin/lychee"
+rm -rf "${download_dir}"
+
+printf '%s\n' "${RUNNER_TEMP}/lychee/bin" >> "${GITHUB_PATH}"
+"${RUNNER_TEMP}/lychee/bin/lychee" --version


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds automated checking of external links in `docs/**/*.md` with [lychee](https://github.com/lycheeverse/lychee) 0.24.2, installed from the release tarball pinned by version and SHA-256. Two modes share the installer.

**Weekly crawl** (`docs-link-check.yml`, Mondays 06:00 UTC, also on demand)

- Checks every external link in the docs on `trunk`: all hosts, redirects followed.
- Runs only on reviewed content and holds no token.
- On broken links the run fails, the lychee report goes to the job summary, and the daily-checks Slack channel is notified, like the other scheduled checks.
- A first local run over all 284 docs found 25 dead links in 14 files.

**Pull-request gate** (`Validate markdown` job in `ci.yml`)

- Checks added or modified `docs/**/*.md` files against `docs-link-check/pr.toml`.
- Requests only eleven exact hosts operated by WooCommerce, WordPress.org, or GitHub. lychee matches the allowlist against the parsed, normalized URL and rejects loopback, private, and link-local addresses before consulting it, so user info, ports, subdomains, and lookalike hosts never match.
- Follows no redirects (a 3xx counts as alive) and fails only on 400, 404, 410, and transport errors. Links to other hosts are skipped here and left to the weekly crawl.
- Changed filenames travel from `dorny/paths-filter` as JSON through `env` and reach lychee via `jq --raw-output0 | xargs -0`, never through a shell string.
- The job now always runs on `ubuntu-latest`, including for `woocommercebot`, because it requests contributor-authored URLs and must never run inside the WooCommerce runner group.

**Offline policy proof** (`scripts/docs-link-check-policy-test.sh`)

- Diffs `lychee --dump` over `docs-link-check/policy-fixture.md` against `policy-expected.txt`, so reviewers can see exactly which hosts a docs change can reach without any network access. Runs in CI whenever the workflow, policy, fixture, or scripts change.

**Known limits**

- `developer.woocommerce.com` answers 200 for missing pages, so typos on that host are not caught.
- Redirects that end in a 404 are caught by the weekly crawl only.
- lychee rewrites approved `github.com/…/blob/….md#fragment` links to `raw.githubusercontent.com` after filtering, so that GitHub host is approved explicitly (see `pr.toml`).

**Scope and review.** CI tooling only: nothing ships in the plugin and no public PHP, JS, hook, or REST surface changes. It does change which hosts CI may contact on a pull request, so please give it an independent human review even though it is outside the release package. Supersedes #68407 and is independent of #68413.

**Follow-up.** The crawl currently finds 25 dead links in 14 docs, so the first scheduled run will be red and will post to Slack until they are fixed. A separate docs PR will fix or remove those links so the first run after merge is green.

Closes #43281.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Prerequisites:** lychee 0.24.2 on your PATH (`brew install lychee`, or the tarball from the [release page](https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.24.2)). If it is elsewhere, set `LYCHEE=/path/to/lychee`.

**Policy (offline)**

1. Run `bash .github/workflows/scripts/docs-link-check-policy-test.sh`.
2. - [ ] Confirm it prints `PASS: docs link-check policy`.
3. Run `lychee --config .github/workflows/docs-link-check/pr.toml --dump --root-dir "$PWD" .github/workflows/docs-link-check/policy-fixture.md`.
4. - [ ] Confirm only the eight URLs in `policy-expected.txt` are printed; none of the lookalike, private, or loopback URLs from the fixture appear.
5. Temporarily remove `|wordpress\.org` from `include` in `pr.toml` and rerun step 1.
6. - [ ] Confirm the test fails with a diff. Restore the file.

**Pull-request gate (live)**

7. Create `docs/tmp-dead-link.md` containing `[dead](https://github.com/woocommerce/this-repo-does-not-exist-43281)` and run `lychee --config .github/workflows/docs-link-check/pr.toml --root-dir "$PWD" -- docs/tmp-dead-link.md`.
8. - [ ] Confirm lychee reports `[404]` for that URL and exits non-zero. Delete the file.
9. Open the `Validate markdown` job in this PR's checks.
10. - [ ] Confirm `Setup - lychee` prints `lychee 0.24.2` after the checksum match and `Validate - docs link-check policy` passes. `Validate - approved external doc links` is skipped here because this PR changes no docs; see the hosted evidence below for a run that exercises it.

**Weekly crawl**

11. Run `lychee --config .github/workflows/docs-link-check/scheduled.toml --root-dir "$PWD" 'docs/extensions/**/*.md'`.
12. - [ ] Confirm it completes, reports a few genuine 404s, and lists no `store.local` or `local.wordpress.test` URLs.
13. After merge, trigger `Docs external link check` from the Actions tab (`workflow_dispatch`); a new workflow cannot be dispatched before it exists on `trunk`.
14. - [ ] Confirm the run fails on the currently dead links, the job summary shows the lychee report, and the daily-checks Slack channel receives the notice.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

**Hosted runner** (disposable probe #68423 with two throwaway docs, one with spaces in its filename; closed afterwards)

- Green control, [job 101703678711](https://github.com/woocommerce/woocommerce/actions/runs/34109932419/job/101703678711): all steps passed. The live step reported `11 Total, 10 Unique, 5 OK, 0 Errors, 6 Excluded`: approved-host links were requested; `developer.mozilla.org`, `www.npmjs.com`, `www.woocommerce.com`, `127.0.0.1:8080`, `169.254.169.254`, and `store.local` were excluded without a request. Both filenames arrived intact.
- Red control, [job 101704697682](https://github.com/woocommerce/woocommerce/actions/runs/34110153238/job/101704697682): a dead `github.com` link failed only the link step, with `[404] … Rejected status code: 404 Not Found` and exit code 123. The Docusaurus build after it still ran.

**Local**

- Linux amd64 container (`ubuntu:24.04`, jq 1.7.1): the installer verifies the checksum and a tampered checksum fails; the policy test passes; filenames with a space, a quote, a leading dash, a semicolon, and an embedded newline are opened literally; an empty file selection exits 0.
- Full crawl of all 284 docs with `scheduled.toml`: 60 seconds, 1529 links, 25 errors in 14 files. Two real docs plus a red control with `pr.toml`: 15 OK, 0 errors, 62 excluded.
- Actionlint 1.7.12 on both workflows: no diagnostics beyond the one already on `trunk`.

**Not yet exercised on a hosted runner:** the weekly workflow (see step 13).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

CI and documentation tooling only; nothing ships to merchants.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code wrote the workflow, policy, fixture, and scripts and ran the local, Docker, and hosted-probe verification above. OpenAI Codex ran an independent two-round review before the branch was pushed; its one finding (the `raw.githubusercontent.com` rewrite) was verified and fixed. AI review is supplemental and does not replace independent human review.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

