### PR TITLE
Fix refunds being attributed to user #1 when no user is logged in

### DIFF
--- a/plugins/woocommerce/changelog/36329-fix-refund-attributed-to-user-1
+++ b/plugins/woocommerce/changelog/36329-fix-refund-attributed-to-user-1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Stop attributing a refund to user #1 when no one is logged in; such refunds now show as issued by System.
+Stop attributing refunds to user #1 when no user is logged in. refunded_by is now 0 in REST v1-v3 and null in v4, and the admin labels these refunds as System.

--- a/plugins/woocommerce/changelog/36329-fix-refund-attributed-to-user-1
+++ b/plugins/woocommerce/changelog/36329-fix-refund-attributed-to-user-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop attributing a refund to user #1 when no one is logged in; such refunds now show as issued by System.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-refund.php
@@ -10,25 +10,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$who_refunded = new WP_User( $refund->get_refunded_by() );
+$refunded_by  = $refund->get_refunded_by();
+$who_refunded = new WP_User( $refunded_by );
+
+if ( $who_refunded->exists() ) {
+	$refund_author = sprintf(
+		'<abbr class="refund_by" title="%1$s">%2$s</abbr>',
+		/* translators: 1: ID who refunded */
+		sprintf( esc_attr__( 'ID: %d', 'woocommerce' ), absint( $who_refunded->ID ) ),
+		esc_html( $who_refunded->display_name )
+	);
+} elseif ( ! $refunded_by ) {
+	// Nobody was logged in when the refund was created, so no person can be named.
+	$refund_author = esc_html__( 'System', 'woocommerce' );
+} else {
+	// A user was recorded but their account is gone, so there is no name left to show.
+	$refund_author = '';
+}
 ?>
 <tr class="refund <?php echo ( ! empty( $class ) ) ? esc_attr( $class ) : ''; ?>" data-order_refund_id="<?php echo esc_attr( $refund->get_id() ); ?>">
 	<td class="thumb"><div></div></td>
 
 	<td class="name">
 		<?php
-		if ( $who_refunded->exists() ) {
+		if ( $refund_author ) {
 			printf(
-				/* translators: 1: refund id 2: refund date 3: username */
+				/* translators: 1: refund id 2: refund date 3: username, or "System" when no user issued the refund */
 				esc_html__( 'Refund #%1$s - %2$s by %3$s', 'woocommerce' ),
 				esc_html( $refund->get_id() ),
 				esc_html( wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) ) ),
-				sprintf(
-					'<abbr class="refund_by" title="%1$s">%2$s</abbr>',
-					/* translators: 1: ID who refunded */
-					sprintf( esc_attr__( 'ID: %d', 'woocommerce' ), absint( $who_refunded->ID ) ),
-					esc_html( $who_refunded->display_name )
-				)
+				$refund_author // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above, where it is built.
 			);
 		} else {
 			printf(

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -588,7 +588,9 @@ function wc_create_refund( $args = array() ) {
 		$refund->set_currency( $order->get_currency() );
 		$refund->set_amount( $args['amount'] );
 		$refund->set_parent_id( absint( $args['order_id'] ) );
-		$refund->set_refunded_by( get_current_user_id() ? get_current_user_id() : 1 );
+		// A refund can be created with nobody logged in (gateway webhook, REST, WP-CLI, cron). Record no
+		// user in that case; falling back to user 1 attributes the refund to whoever that happens to be.
+		$refund->set_refunded_by( get_current_user_id() );
 		$refund->set_prices_include_tax( $order->get_prices_include_tax() );
 
 		if ( ! is_null( $args['reason'] ) ) {

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/views/html-order-refund-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/views/html-order-refund-test.php
@@ -1,0 +1,90 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the refund row rendered inside the order items meta box.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+class Html_Order_Refund_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Render the refund row markup for a refund.
+	 *
+	 * @param WC_Order_Refund $refund The refund to render.
+	 * @return string The rendered markup.
+	 */
+	private function render_refund_row( WC_Order_Refund $refund ): string {
+		// Both are read by the view and have no defaults of their own.
+		$order_taxes     = array();
+		$cogs_is_enabled = false;
+
+		ob_start();
+		include WC_ABSPATH . 'includes/admin/meta-boxes/views/html-order-refund.php';
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Create a refund on a throwaway order, attributed to the given user.
+	 *
+	 * @param int $user_id The user to attribute the refund to.
+	 * @return WC_Order_Refund
+	 */
+	private function create_refund_attributed_to( int $user_id ): WC_Order_Refund {
+		$order = WC_Helper_Order::create_order();
+
+		$refund = new WC_Order_Refund();
+		$refund->set_amount( 10 );
+		$refund->set_parent_id( $order->get_id() );
+		$refund->set_refunded_by( $user_id );
+		$refund->save();
+
+		return $refund;
+	}
+
+	/**
+	 * @testdox Should name the user who issued the refund.
+	 */
+	public function test_names_the_refunding_user(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'         => 'administrator',
+				'display_name' => 'Ada Lovelace',
+			)
+		);
+
+		$markup = $this->render_refund_row( $this->create_refund_attributed_to( $user_id ) );
+
+		$this->assertStringContainsString( 'Ada Lovelace', $markup );
+	}
+
+	/**
+	 * @testdox Should attribute a refund with no recorded user to the system.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/36329
+	 */
+	public function test_labels_an_unattributed_refund_as_system(): void {
+		$markup = $this->render_refund_row( $this->create_refund_attributed_to( 0 ) );
+
+		$this->assertStringContainsString( 'by System', $markup );
+	}
+
+	/**
+	 * @testdox Should not attribute a refund to the system when its user was deleted.
+	 */
+	public function test_omits_attribution_when_the_refunding_user_was_deleted(): void {
+		$user_id = self::factory()->user->create();
+		$refund  = $this->create_refund_attributed_to( $user_id );
+		wp_delete_user( $user_id );
+
+		$markup = $this->render_refund_row( $refund );
+
+		$this->assertStringNotContainsString(
+			'by System',
+			$markup,
+			'A deleted user is not the system; the refund was issued by a person whose account is gone.'
+		);
+		$this->assertStringNotContainsString( ' by ', $markup );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller-test.php
@@ -163,4 +163,39 @@ class WC_REST_Order_Refunds_Controller_Test extends WC_REST_Unit_Test_Case {
 
 		$this->assert_incomplete_meta_data_handled_correctly( wc_get_order( $response->get_data()['id'] ) );
 	}
+
+	/**
+	 * @testdox Should report refunded_by as 0 when no user issued the refund.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/36329
+	 */
+	public function test_refunded_by_is_zero_when_no_user_issued_the_refund(): void {
+		wp_set_current_user( 1 );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		// A refund with no recorded user, as a gateway webhook or cron run produces.
+		$refund = new WC_Order_Refund();
+		$refund->set_amount( 5 );
+		$refund->set_parent_id( $order->get_id() );
+		$refund->set_refunded_by( 0 );
+		$refund->save();
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() . '/refunds/' . $refund->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			0,
+			$response->get_data()['refunded_by'],
+			'An unattributed refund reports 0 rather than the id of user 1.'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -298,6 +298,32 @@ class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should report refunded_by as null when no user issued the refund.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/36329
+	 */
+	public function test_refunds_get_endpoint_reports_null_refunded_by_when_no_user_issued_the_refund(): void {
+		$order = $this->create_test_order();
+
+		// A refund with no recorded user, as a gateway webhook or cron run produces.
+		$refund = new WC_Order_Refund();
+		$refund->set_amount( 5 );
+		$refund->set_parent_id( $order->get_id() );
+		$refund->set_refunded_by( 0 );
+		$refund->save();
+		$this->created_refunds[] = $refund->get_id();
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/refunds/' . $refund->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNull(
+			$response->get_data()['refunded_by'],
+			'An unattributed refund reports a null refunded_by rather than an object for user 1.'
+		);
+	}
+
+	/**
 	 * Test POST /wc/v4/refunds endpoint creates refund.
 	 */
 	public function test_refunds_create_endpoint(): void {

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -559,9 +559,9 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that wc_create_refund() records the logged-in user who issued the refund.
+	 * @testdox Should record the logged-in user who issued the refund.
 	 */
-	public function test_wc_create_refund_records_the_current_user() {
+	public function test_wc_create_refund_records_the_current_user(): void {
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 
@@ -573,6 +573,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			)
 		);
 
+		$this->assertNotWPError( $refund );
 		$this->assertSame( $user_id, $refund->get_refunded_by() );
 		$this->assertSame(
 			$user_id,
@@ -582,11 +583,11 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that wc_create_refund() attributes a refund to nobody when no user is logged in, rather than to user 1.
+	 * @testdox Should attribute a refund to nobody when no user is logged in, rather than to user 1.
 	 *
 	 * @see https://github.com/woocommerce/woocommerce/issues/36329
 	 */
-	public function test_wc_create_refund_records_no_user_when_nobody_is_logged_in() {
+	public function test_wc_create_refund_records_no_user_when_nobody_is_logged_in(): void {
 		wp_set_current_user( 0 );
 
 		$order  = WC_Helper_Order::create_order();
@@ -597,6 +598,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			)
 		);
 
+		$this->assertNotWPError( $refund );
 		$this->assertSame( 0, $refund->get_refunded_by() );
 		$this->assertSame(
 			0,

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -557,4 +557,51 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$order->delete();
 		$customer->delete();
 	}
+
+	/**
+	 * Test that wc_create_refund() records the logged-in user who issued the refund.
+	 */
+	public function test_wc_create_refund_records_the_current_user() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$order  = WC_Helper_Order::create_order();
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+			)
+		);
+
+		$this->assertSame( $user_id, $refund->get_refunded_by() );
+		$this->assertSame(
+			$user_id,
+			wc_get_order( $refund->get_id() )->get_refunded_by(),
+			'The refunding user should survive a round trip through the data store.'
+		);
+	}
+
+	/**
+	 * Test that wc_create_refund() attributes a refund to nobody when no user is logged in, rather than to user 1.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/36329
+	 */
+	public function test_wc_create_refund_records_no_user_when_nobody_is_logged_in() {
+		wp_set_current_user( 0 );
+
+		$order  = WC_Helper_Order::create_order();
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+			)
+		);
+
+		$this->assertSame( 0, $refund->get_refunded_by() );
+		$this->assertSame(
+			0,
+			wc_get_order( $refund->get_id() )->get_refunded_by(),
+			'An unattributed refund should stay unattributed after a round trip through the data store.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`wc_create_refund()` fell back to user ID 1 whenever `get_current_user_id()` returned 0. Refunds are routinely created with nobody logged in — a gateway webhook, a REST call, WP-CLI, cron — so each of those was recorded against whoever user 1 happens to be, and the admin refund row named that person. The fallback dates to commit `daf14fc57e` (2014), where it guarded against writing an empty `post_author`; it survived the move to CRUD props and has been unchanged since.

`get_current_user_id()` now passes through unchanged. `WC_Order_Refund` already defaults `refunded_by` to 0 and both the HPOS and CPT stores round-trip a zero, so a refund nobody issued stays unattributed. The admin refund row labels those **System**. A refund whose recorded user has since been *deleted* keeps the existing behaviour and shows no name — that refund did have a human author, so calling it "System" would repeat the misattribution in the other direction.

**Backward compatibility.** `refunded_by` is public REST output, and the break differs by route:

| Route | Before, for a refund nobody issued | After |
| ----- | ----- | ----- |
| `wc/v1`, `wc/v2`, `wc/v3` | `1` | `0` |
| `wc/v4` | a populated user object for user 1 (`id`, `display_name`, `avatar_url`) | `null` |

v4 is the sharper break: consumers received an object and now receive `null`, so code reading `refunded_by.display_name` without a null check will fatal. v1–v3 consumers get an integer either way, but one that no longer resolves to a user.

No hooks, signatures, script handles, template files, or option keys change. This PR carries `impact: high` — it changes a REST response and persisted order data, both on the High-Impact list — so per [the review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements) it needs an independent human review before merge. It has had an AI review; that does not satisfy the requirement.

**Already-stored rows cannot be corrected.** A saved `_refunded_by = 1` is indistinguishable from a genuine refund by user 1, so this is a forward-only fix with no migration.

**Known non-goals.** Three related things are deliberately left alone. All predate this PR:

- `abstract-wc-order-data-store-cpt.php:102` hardcodes `'post_author' => 1` for every order post, refunds included, so under the CPT store an unattributed refund still has post author 1 while its `_refunded_by` is 0. Nothing in WooCommerce reads that author for refunds — the fallback at `class-wc-order-refund-data-store-cpt.php:89` applies only when the meta row is absent, and new refunds always write it — but third-party code querying `post_author` on `shop_order_refund` posts still sees 1.
- The v2/v3 schema does not mark `refunded_by` `readonly` the way it marks `id`, so it reads as writable. The create path calls `wc_create_refund()` without it and the value always comes from the current user, so a client-supplied `refunded_by` is silently ignored, before and after this PR.
- v4 cannot tell "no user issued this" from "the issuing user was deleted" — both serialise to `null`. The admin UI does distinguish them; the REST schema has no shape for it.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->

Closes #36329.

### Screenshots or screen recordings:

Rendered strings from the order items meta box, on an order carrying one refund created with no logged-in user and one created by an administrator:

| Before | After |
| ------ | ----- |
|<img width="1406" height="449" alt="Screenshot 2026-09-07 at 12 56 28" src="https://github.com/user-attachments/assets/0c5ef01d-730b-42ab-aaab-d58dff54c91e" />|<img width="1410" height="504" alt="Screenshot 2026-09-07 at 12 45 33" src="https://github.com/user-attachments/assets/caa1d4b9-1ca2-462a-8030-877c7c2d546d" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store running this branch, create a product and an order for it, and set the order to Processing.
2. In WP-CLI, create a refund with no logged-in user, as a payment gateway webhook would:
   ```
   wp eval '$o = wc_get_order( ORDER_ID ); wp_set_current_user( 0 ); $r = wc_create_refund( array( "amount" => 10, "reason" => "Gateway-initiated refund", "order_id" => $o->get_id() ) ); echo $r->get_refunded_by();'
   ```
   It prints `0`. On `trunk` it prints `1`.
3. Create a second refund from the order edit screen in wp-admin, as an administrator.
4. Reload the order edit screen. The first refund reads `Refund #n - <date> by System`; the second reads `Refund #n - <date> by <your display name>`, with the user ID still in its tooltip.
5. Delete the administrator account used in step 3 (reassigning its content), then reload the order. That refund now shows no attribution — not "System" — because it was issued by a person whose account is gone.
6. `GET /wp-json/wc/v3/orders/<id>/refunds` reports `refunded_by: 0` for the first refund. On `/wc/v4/` it reports `refunded_by: null`.

<!-- End testing instructions -->

### Testing that has already taken place:

- Verified by hand on a `wp-env` store (WooCommerce trunk, PHP 8.1, Storefront-less default admin) on an order carrying both kinds of refund; the rendered markup is quoted in the table above.
- Unit tests cover `wc_create_refund()` with and without a logged-in user, and all three branches of the admin refund row (named user, System, deleted user). The no-user test fails on `trunk` with `Failed asserting that 1 is identical to 0`.
- Two REST tests pin the contract in the table above: `0` on `wc/v3` and `null` on `wc/v4`. They lock the documented shape rather than reproduce the bug, since both endpoints require an authenticated user and so cannot create an unattributed refund themselves.
- The refund-related suite (556 tests) passes under HPOS and again with `DISABLE_HPOS=1`. That second run matters: the CPT fallback resolves to user 1, so a dropped meta write would fail these tests rather than pass quietly.
- Not tested: multisite, and stores running a non-English locale.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually: `plugins/woocommerce/changelog/36329-fix-refund-attributed-to-user-1`.

</details>

### Use of AI Tools

Authored with Claude Code (Claude Opus 5): issue investigation, implementation, unit tests, and this description.
