### PR TITLE
Prevent password-protected product reviews from showing up to wrong users when they were cached

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOO6-159-shared-cached-product-reviews
+++ b/plugins/woocommerce/changelog/fix-WOO6-159-shared-cached-product-reviews
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent password-protected product reviews from showing up to wrong users when they were cached
+
+

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -114,7 +114,7 @@ class ProductReviews extends AbstractRoute {
 		$unlocked_product_ids = $this->get_unlocked_password_protected_product_ids( $prepared_args['post__in'] ?? array() );
 		sort( $unlocked_product_ids, SORT_NUMERIC );
 		// We need to set a cache domain to prevent the comment query from being cached across different sets of unlocked products.
-		$prepared_args['cache_domain'] = 'wc_store_api_product_reviews_' . md5( implode( ',', $unlocked_product_ids ) );
+		$prepared_args['cache_domain'] = 'wc_store_api_product_reviews_' . implode( ',', $unlocked_product_ids );
 
 		$exclude_password_protected_reviews = function ( $clauses ) use ( $unlocked_product_ids ) {
 			return $this->exclude_password_protected_product_reviews( $clauses, $unlocked_product_ids );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -111,7 +111,11 @@ class ProductReviews extends AbstractRoute {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
-		$unlocked_product_ids               = $this->get_unlocked_password_protected_product_ids( $prepared_args['post__in'] ?? array() );
+		$unlocked_product_ids = $this->get_unlocked_password_protected_product_ids( $prepared_args['post__in'] ?? array() );
+		sort( $unlocked_product_ids, SORT_NUMERIC );
+		// We need to set a cache domain to prevent the comment query from being cached across different sets of unlocked products.
+		$prepared_args['cache_domain'] = 'wc_store_api_product_reviews_' . md5( implode( ',', $unlocked_product_ids ) );
+
 		$exclude_password_protected_reviews = function ( $clauses ) use ( $unlocked_product_ids ) {
 			return $this->exclude_password_protected_product_reviews( $clauses, $unlocked_product_ids );
 		};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOO6-159.

Follow-up from #68375.

In #68375, we made it so users without the password, couldn't retrieve reviews from password-protected products. However, if a store had object cache enabled, the reviews seen by one user could leak into another user. This PR fixes that.

### How to test the changes in this Pull Request:

To reproduce the issue, you will need [Redis](https://wordpress.org/plugins/redis-cache/) enabled. Heads-up that depending on the environment and how you have set it up, the plugin might not be enough. Happy to pair if you have trouble setting it up. :slightly_smiling_face: 

1. Create a post or page with the All Reviews block.
2. Update a product so it's password-protected, add some reviews.
3. Visit the post created in 1 with a user that has introduced the password. Verify the reviews from the password-protected product show up.
4. Visit the post created in 1 with a user that has not introduced the password. Verify the reviews from the password-protected product are not visible.