### PR TITLE
Add collection parameters filter to REST term endpoints

### DIFF
--- a/plugins/woocommerce/changelog/add-38898-rest-terms-collection-params-filter
+++ b/plugins/woocommerce/changelog/add-38898-rest-terms-collection-params-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `rest_{$taxonomy}_collection_params` filter to the REST terms controller.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -806,6 +806,9 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		 * Shares its name with the WordPress core hook, so a callback added for a taxonomy served by
 		 * both /wp/v2 and /wc/v3 runs for both.
 		 *
+		 * This filter only registers parameters; use `woocommerce_rest_{$taxonomy}_query`
+		 * to map them to `WP_Term_Query` arguments.
+		 *
 		 * @since 11.2.0
 		 *
 		 * @param array       $params   JSON Schema-formatted collection parameters.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -792,7 +792,26 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		return $params;
+		$taxonomy_obj = get_taxonomy( $this->taxonomy );
+
+		// Empty for the attribute terms route, which serves every pa_* taxonomy from one registration.
+		if ( ! $taxonomy_obj ) {
+			return $params;
+		}
+
+		/**
+		 * Filter collection parameters for the terms controller.
+		 *
+		 * The dynamic portion of the hook name, `$this->taxonomy`, refers to the taxonomy slug.
+		 * Shares its name with the WordPress core hook, so a callback added for a taxonomy served by
+		 * both /wp/v2 and /wc/v3 runs for both.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param array       $params   JSON Schema-formatted collection parameters.
+		 * @param WP_Taxonomy $taxonomy Taxonomy object.
+		 */
+		return apply_filters( "rest_{$this->taxonomy}_collection_params", $params, $taxonomy_obj );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
@@ -42,4 +42,47 @@ class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
 		$this->assertEquals( 'taxonomy_1', $value1 );
 		$this->assertEquals( 'taxonomy_2', $value2 );
 	}
+
+	/**
+	 * @testdox 'get_collection_params' passes params and the taxonomy object through the filter.
+	 */
+	public function test_get_collection_params_is_filterable() {
+		$received = null;
+
+		add_filter(
+			'rest_product_cat_collection_params',
+			function ( $params, $taxonomy ) use ( &$received ) {
+				$received         = $taxonomy;
+				$params['custom'] = array( 'type' => 'string' );
+				return $params;
+			},
+			10,
+			2
+		);
+
+		$params = ( new WC_REST_Product_Categories_Controller() )->get_collection_params();
+
+		$this->assertArrayHasKey( 'custom', $params );
+		$this->assertInstanceOf( WP_Taxonomy::class, $received );
+		$this->assertSame( 'product_cat', $received->name );
+	}
+
+	/**
+	 * @testdox 'get_collection_params' does not filter when the controller has no taxonomy.
+	 */
+	public function test_get_collection_params_skips_filter_without_taxonomy() {
+		$fired = false;
+
+		add_filter(
+			'rest__collection_params',
+			function ( $params ) use ( &$fired ) {
+				$fired = true;
+				return $params;
+			}
+		);
+
+		$this->sut->get_collection_params();
+
+		$this->assertFalse( $fired );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce term controllers lack the extension point that WordPress core and WooCommerce post-type controllers provide for registering or altering collection parameters. This adds `rest_{$this->taxonomy}_collection_params` with the resolved `WP_Taxonomy` object, while preserving the attribute route that has no concrete taxonomy during registration.

Backward compatibility: this is additive and has no default behavior change. The shared WordPress hook name means callbacks for `product_cat` and `product_tag` can run for both `/wp/v2/...` and `/wc/v3/...`, matching `rest_product_collection_params`; `product_shipping_class` has no overlap because it is not exposed through the WordPress REST API.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #38898.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Set up a test site with this branch of WooCommerce active and create REST API credentials with read access.
2. Send an authenticated `GET` request to `/wp-json/wc/v3/products/categories?orderby=menu_order`.
3. Confirm the response is HTTP 400 with the `rest_invalid_param` error code because `menu_order` is not an allowed `orderby` value by default.
4. Add this snippet to a test-only plugin, mu-plugin, or another location that loads before `rest_api_init`:

    ```php
    add_filter( 'rest_product_cat_collection_params', function ( $params ) {
        $params['orderby']['enum'][] = 'menu_order';
        return $params;
    } );
    ```

5. Repeat the same authenticated request.
6. Confirm the response is HTTP 200 and contains the product-category collection, demonstrating that the filtered schema is used for real REST request validation.
7. Remove the test snippet.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm test:php:env -- --filter WC_REST_Terms_Controller_Tests` on PHP 8.1.34: 3 tests and 6 assertions passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed.
- PHPStan passed for `class-wc-rest-terms-controller.php` with no errors.
- A real REST request in the isolated test environment returned `400 rest_invalid_param` without the callback and HTTP 200 with the callback loaded before `rest_api_init`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex implemented the change and ran the listed checks. Claude cross-checked the implementation, test coverage, and PR description. Neither AI-assisted review replaces the independent human approval required for this High-Impact change.
