### PR TITLE
Fix password protection flag for variations so it follows parent product

### DIFF
--- a/docs/apis/store-api/resources-endpoints/products.md
+++ b/docs/apis/store-api/resources-endpoints/products.md
@@ -10,7 +10,9 @@ Only published products are accessible via the Store API. Requesting a draft, pe
 
 ### Password-protected products
 
-Password-protected products are visible in the API, but their `description` and `short_description` fields are redacted (returned as empty strings) until the correct password has been submitted. The response includes an `is_password_protected` boolean field so clients can detect this state and prompt the user.
+Password-protected products, including variations whose parent product is password-protected, are visible in the API, but their `description` and `short_description` fields are redacted (returned as empty strings) until the correct password has been submitted.
+
+The `is_password_protected` field indicates whether the product or its parent has a configured password. It remains `true` after the current visitor has submitted the correct password and the descriptions become accessible.
 
 Password verification uses WordPress's native `wp-postpass_*` cookie, set when a user submits the password form on the frontend. The Store API does not accept passwords directly.
 

--- a/plugins/woocommerce/changelog/fix-variation-password-protection-flag
+++ b/plugins/woocommerce/changelog/fix-variation-password-protection-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Report inherited password protection correctly for product variations in Store API responses.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -578,7 +578,7 @@ class ProductSchema extends AbstractSchema {
 				],
 			],
 			'is_password_protected' => [
-				'description' => __( 'Whether the product requires a password to access its content.', 'woocommerce' ),
+				'description' => __( 'Whether the product or its parent requires a password to access its content.', 'woocommerce' ),
 				'type'        => 'boolean',
 				'context'     => [ 'view', 'edit', 'embed' ],
 				'readonly'    => true,
@@ -662,10 +662,26 @@ class ProductSchema extends AbstractSchema {
 				],
 				( new QuantityLimits() )->get_add_to_cart_limits( $product )
 			),
-			'is_password_protected' => '' !== $product->get_post_password(),
+			'is_password_protected' => $this->is_password_protected( $product ),
 			self::EXTENDING_KEY     => $this->get_extended_data( self::IDENTIFIER, $product ),
 
 		];
+	}
+
+	/**
+	 * Whether the product or its parent is password-protected.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return bool
+	 */
+	private function is_password_protected( $product ) {
+		if ( '' !== $product->get_post_password() ) {
+			return true;
+		}
+
+		$parent_id = $product->get_parent_id();
+
+		return $parent_id && '' !== get_post_field( 'post_password', $parent_id, 'raw' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -857,6 +857,50 @@ class Products extends ControllerTestCase {
 	}
 
 	/**
+	 * @testdox Variations should inherit the parent product's password-protected flag regardless of access.
+	 */
+	public function test_variation_inherits_parent_password_protected_flag(): void {
+		$password     = 'secret';
+		$product      = \WC_Helper_Product::create_variation_product();
+		$variation_id = $product->get_children()[0];
+		$variation    = wc_get_product( $variation_id );
+		$variation->set_description( 'Protected variation description' );
+		$variation->save();
+		$product->set_post_password( $password );
+		$product->save();
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_query_params(
+			array(
+				'include' => array( $variation_id ),
+				'parent'  => array( $product->get_id() ),
+				'type'    => 'variation',
+			)
+		);
+
+		$protected_response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $protected_response->get_status() );
+		$protected_data = $protected_response->get_data()[0];
+		$this->assertTrue( $protected_data['is_password_protected'] );
+		$this->assertSame( '', $protected_data['description'] );
+
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher                                 = new \PasswordHash( 8, true );
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( $password );
+
+		try {
+			$accessible_response = rest_get_server()->dispatch( $request );
+		} finally {
+			unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+		}
+
+		$this->assertSame( 200, $accessible_response->get_status() );
+		$accessible_data = $accessible_response->get_data()[0];
+		$this->assertTrue( $accessible_data['is_password_protected'] );
+		$this->assertStringContainsString( 'Protected variation description', $accessible_data['description'] );
+	}
+
+	/**
 	 * @testdox Related query parameter returns empty when no related products exist.
 	 */
 	public function test_related_query_parameter_returns_empty_when_no_related() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PR #68371 made variation descriptions inherit password protection from their parent product, but the Store API's `is_password_protected` field continued checking only the variation itself. In this PR, I make variation inherit the flag from parent.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #68371.

Closes WOOAIRR-246.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a variable product with a variation description, then password-protect the parent product.
2. Without the password cookie, request `/wc/store/v1/products?parent[]=<parent_id>&type=variation` and confirm the variation has `is_password_protected: true` with an empty description.
3. Enter the parent product password and repeat the request in the same session. Confirm the variation description is visible while `is_password_protected` remains `true`.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually set the milestone to the first milestone that is not in the past.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs created from forks under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to analyze the Store API behavior, draft the focused fix and regression test, and run the listed checks. The author reviewed the resulting code and PR content.
