### PR TITLE
Update Mini-Cart drawer header style to use smaller font size and align it with the close button

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOTHME-462-make-mini-cart-header-smaller
+++ b/plugins/woocommerce/changelog/fix-WOOTHME-462-make-mini-cart-header-smaller
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update Mini-Cart drawer header style to use smaller font size and align it with the close button

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
@@ -115,7 +115,6 @@ $drawer-animation-duration: 0.3s;
 	position: absolute !important;
 	top: $gap-small + $gap-smallest;
 	inset-inline-end: $gap-small;
-	line-height: 1rem;
 	opacity: 0.6;
 	z-index: 2;
 	// Increase clickable area.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
@@ -113,8 +113,9 @@ $drawer-animation-duration: 0.3s;
 	background: transparent !important;
 	color: inherit !important;
 	position: absolute !important;
-	top: $gap-small;
+	top: $gap-small + $gap-smallest;
 	inset-inline-end: $gap-small;
+	line-height: 1rem;
 	opacity: 0.6;
 	z-index: 2;
 	// Increase clickable area.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -46,13 +46,12 @@
 		margin-top: $gap;
 	}
 
-	h2.wc-block-mini-cart__title {
-		@include font-size(larger);
+	h2.wc-block-mini-cart__title .block-editor-block-list__layout {
+		display: flex;
+		align-items: baseline;
 
-		.block-editor-block-list__layout {
-			display: flex;
-			align-items: baseline;
-		}
+		// Simulate the space taken by notifications in the frontend.
+		margin-top: $gap;
 	}
 
 	table.wc-block-cart-items {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -53,7 +53,7 @@
 		.block-editor-block-list__layout {
 			display: flex;
 			align-items: baseline;
-	
+
 			// Simulate the space taken by notifications in the frontend.
 			margin-top: $gap;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -46,12 +46,16 @@
 		margin-top: $gap;
 	}
 
-	h2.wc-block-mini-cart__title .block-editor-block-list__layout {
-		display: flex;
-		align-items: baseline;
+	h2.wc-block-mini-cart__title {
+		font-size: 1.5rem;
 
-		// Simulate the space taken by notifications in the frontend.
-		margin-top: $gap;
+		.block-editor-block-list__layout {
+			display: flex;
+			align-items: baseline;
+	
+			// Simulate the space taken by notifications in the frontend.
+			margin-top: $gap;
+		}
 	}
 
 	table.wc-block-cart-items {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -48,6 +48,7 @@
 
 	h2.wc-block-mini-cart__title {
 		font-size: 1.5rem;
+		mask-image: none;
 
 		.block-editor-block-list__layout {
 			display: flex;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -142,10 +142,10 @@ h2.wc-block-mini-cart__title {
 	align-items: baseline;
 	background: inherit;
 	padding-bottom: $gap * 2;
-	mask-image: linear-gradient(#000 calc(100% - #{$gap * 1.5}), transparent);
 	z-index: 1;
-	margin: $gap $gap $gap * -2;
-	@include font-size(larger);
+	margin: $gap-smallest $gap $gap * -2;
+	font-size: 1.5rem;
+	line-height: 1rem;
 
 	span:first-child {
 		margin-right: $gap-smaller;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -143,9 +143,8 @@ h2.wc-block-mini-cart__title {
 	background: inherit;
 	padding-bottom: $gap * 2;
 	z-index: 1;
-	margin: $gap-smallest $gap $gap * -2;
+	margin: (-$gap-smallest / 2) $gap $gap * -2;
 	font-size: 1.5rem;
-	line-height: 1rem;
 
 	span:first-child {
 		margin-right: $gap-smaller;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -138,18 +138,12 @@
 }
 
 h2.wc-block-mini-cart__title {
-	display: flex;
-	align-items: baseline;
 	background: inherit;
 	padding-bottom: $gap * 2;
 	mask-image: linear-gradient(#000 calc(100% - #{$gap * 1.5}), transparent);
 	z-index: 1;
 	margin: $gap-smallest * -0.5 $gap $gap * -2;
 	font-size: 1.5rem;
-
-	span:first-child {
-		margin-right: $gap-smaller;
-	}
 }
 
 .wc-block-mini-cart__items {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -142,6 +142,7 @@ h2.wc-block-mini-cart__title {
 	align-items: baseline;
 	background: inherit;
 	padding-bottom: $gap * 2;
+	mask-image: linear-gradient(#000 calc(100% - #{$gap * 1.5}), transparent);
 	z-index: 1;
 	margin: (-$gap-smallest / 2) $gap $gap * -2;
 	font-size: 1.5rem;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -144,7 +144,7 @@ h2.wc-block-mini-cart__title {
 	padding-bottom: $gap * 2;
 	mask-image: linear-gradient(#000 calc(100% - #{$gap * 1.5}), transparent);
 	z-index: 1;
-	margin: (-$gap-smallest / 2) $gap $gap * -2;
+	margin: $gap-smallest * -0.5 $gap $gap * -2;
 	font-size: 1.5rem;
 
 	span:first-child {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of WOOTHME-462.

Update the Mini-Cart header style according to the new designs.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="982" height="1494" alt="imatge" src="https://github.com/user-attachments/assets/3cb3dc0d-215d-4a8a-b69c-672197d27e94" /> | <img width="982" height="1494" alt="imatge" src="https://github.com/user-attachments/assets/a248ae2c-5fe6-4b5d-8131-41a2629ac6cc" /> |

### How to test the changes in this Pull Request:

1. Check the Mini-Cart drawer header in the frontend and verify it matches the new designs.
2. Check also the editor view.
3. Make some edits to the _Mini-Cart Title Label_ and _Mini-Cart Title Items Counter_ styles and verify they still get applied in the frontend and the editor.
4. Test different themes.
5. Test adding many products to the cart so the products list overlaps the viewport.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->