### PR TITLE
Fix variation attribute selectors truncating long values in the header

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-attribute-header-width
+++ b/plugins/woocommerce/changelog/fix-variation-attribute-header-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow variation attribute selectors to use available header space and wrap on narrow screens.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -6758,6 +6758,16 @@ img.help_tip {
 		}
 
 		&.woocommerce_variation h3 {
+			> select[name^="attribute_"] {
+				max-width: min(100%, 25rem);
+				margin-inline: 0;
+
+				@media only screen and (max-width: 782px) {
+					width: 100%;
+					max-width: 100%;
+				}
+			}
+
 			a.delete,
 			a.edit,
 			.sort {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the classic product editor, every select in a metabox heading is capped at 20% of the heading width. In the variations list that clips attribute values such as licence tiers to a few characters, so merchants cannot tell variations apart without expanding each row.

This PR lets the built-in attribute selectors in the variation header size to their content, bounded by the available heading width and by `25rem`, the ceiling WordPress core already applies to admin selects. At 782px and below each selector fills its own row so stacked fields share an aligned edge. The rule targets only the direct-child `select[name^="attribute_"]` controls; other metabox heading selects keep the generic cap, and controls printed through `woocommerce_variation_header` are untouched.

Trade-offs: values longer than roughly 56 characters are still clipped in the closed desktop control (the opened list shows the full text), and headers with many long attributes wrap onto more rows than before.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #43566.

The 20% cap was introduced in commit fa9c5480a92d8e1d3f95e50f9272566f8d437e85 (2015, for #8946), before the action links in the header were made always visible in #34948.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

**One long attribute (original issue scenario), desktop 1440px**

| Before | After |
| ------ | ----- |
| <img width="1440" height="1100" alt="single-attribute-desktop-before" src="https://github.com/user-attachments/assets/b2da401b-7b92-4d68-9d32-bc1bee8613fe" /> | <img width="1440" height="1100" alt="single-attribute-desktop-after" src="https://github.com/user-attachments/assets/57659699-eb69-4818-9fea-363d4b63ff27" /> |

**Three long attributes, desktop 1440px**

| Before | After |
| ------ | ----- |
| <img width="1440" height="1100" alt="three-attributes-desktop-before" src="https://github.com/user-attachments/assets/f97e1b80-0fc4-42dd-a6d2-0341dc8f1936" /> | <img width="1440" height="1100" alt="three-attributes-desktop-after" src="https://github.com/user-attachments/assets/bd18685e-0fff-4a0b-8c4a-c0626fb1dc48" /> |

**Three long attributes, mobile 375px**

| Before | After |
| ------ | ----- |
| <img width="375" height="1100" alt="three-attributes-mobile-before" src="https://github.com/user-attachments/assets/0a6fb701-167d-40ec-8b65-73686bc54afd" /> | <img width="375" height="1100" alt="three-attributes-mobile-after" src="https://github.com/user-attachments/assets/b79cebd8-c803-42bb-b218-b7f9239d4e6e" /> |

**Short selected value with one very long unselected option, desktop 1440px**

| Before | After |
| ------ | ----- |
| <img width="751" height="101" alt="outlier3-1440-trunk" src="https://github.com/user-attachments/assets/ef96357c-8774-45e5-b88a-5b89bfacf961" /> | <img width="751" height="108" alt="outlier3-1440-altA" src="https://github.com/user-attachments/assets/edef5003-7bc4-4074-bf57-c38edd5e7d69" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a variable product with one attribute used for variations whose options are long, for example `199 educational / disabled use licence`, `1999 educational / disabled use licence`, `199 private sector use`. Generate variations and open **Product data → Variations**.
2. At a desktop width (above 782px), confirm each variation header shows the full attribute value in the selector instead of a clipped prefix, and that the sort handle, **Remove** and **Edit** stay on the right without overlapping.
3. Add two more attributes with long options, regenerate variations, and confirm the selectors wrap onto a second row when they no longer fit, still without overlap.
4. Narrow the browser to 782px or less. Confirm every selector fills its own row with aligned right edges. Widen back to 783px and confirm intrinsic widths return.
5. Add an attribute with one very long option (60+ characters) and a short one (`S`), create a variation selecting `S`. Confirm the selector is capped at about 400px on desktop rather than filling the whole row, and that opening it shows the full long option.
6. Open the **Attributes** tab and any other metabox with selects in its heading (for example a shipping class or a product bundle extension) and confirm they are unchanged.
7. Optional: switch **Settings → General → Site Language** to an RTL language and repeat steps 2 and 4.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Local wp-env (WordPress 7.1, PHP 8.1, single site), Chromium. Compared trunk and this branch with Playwright-driven measurements over forty fixture cases per version: one, three and eight attributes with short and long values, one extreme unselected option, real `woocommerce_variation_header` output (text, input, button), long action labels, LTR and RTL, at 375, 600, 782, 783, 1440 and 2160px. No header or document overflow, no overlap between selectors, actions and hook output, and no geometry change on hover in any case. Saving, Edit, drag reorder and Remove behave the same on both versions. The `25rem` ceiling was chosen after comparing it against no ceiling and a 50% ceiling on the same fixtures; a percentage bound clips more on narrow desktops and bounds less on wide ones.

Not covered: browsers other than Chromium, physical devices, official translation packs.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code (Claude) was used to investigate the issue history, run the browser measurements described above, draft the CSS change and write this description. The change and the evidence were reviewed by the author.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
