### PR TITLE
Show "Free!" in order emails only for Free Shipping

### DIFF
--- a/plugins/woocommerce/changelog/fix-68306-free-shipping-label-in-order-emails
+++ b/plugins/woocommerce/changelog/fix-68306-free-shipping-label-in-order-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only show "Free!" for Free Shipping in order emails, so zero cost Flat Rate and Local Pickup methods keep their titles, and add the woocommerce_email_order_shipping_show_free_label filter to override it

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 11.1.0
+ * @version 11.2.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -152,9 +152,21 @@ endif;
 			foreach ( $item_totals as $total ) {
 				++$i;
 				$last_class = ( $i === $item_totals_count ) ? ' order-totals-last' : '';
-				// The shipping method name is already shown in the row header, so avoid duplicating it in the value cell.
 				if ( $email_improvements_enabled && 'shipping' === ( $total['type'] ?? '' ) && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
-					$total['value'] = __( 'Free!', 'woocommerce' );
+					/**
+					 * Filters whether a zero cost shipping row shows 'Free!' in place of the repeated method name.
+					 *
+					 * Defaults to true only for Free Shipping. Other methods can cost nothing yet still use the
+					 * name to tell the customer something, such as 'Shipping TBD'.
+					 *
+					 * @since 11.2.0
+					 *
+					 * @param bool     $show_free_label Whether to replace the value with 'Free!'.
+					 * @param WC_Order $order           The order being emailed.
+					 */
+					if ( (bool) apply_filters( 'woocommerce_email_order_shipping_show_free_label', $order->has_shipping_method( 'free_shipping' ), $order ) ) {
+						$total['value'] = __( 'Free!', 'woocommerce' );
+					}
 				}
 				?>
 				<tr class="order-totals order-totals-<?php echo esc_attr( $total['type'] ?? 'unknown' ); ?><?php echo esc_attr( $last_class ); ?>">

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 11.1.0
+ * @version 11.2.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -64,9 +64,21 @@ $item_totals = $order->get_order_item_totals();
 if ( $item_totals ) {
 	foreach ( $item_totals as $total ) {
 		if ( $email_improvements_enabled ) {
-			// The shipping method name is already shown in the row header, so avoid duplicating it in the value cell.
 			if ( 'shipping' === ( $total['type'] ?? '' ) && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
-				$total['value'] = __( 'Free!', 'woocommerce' );
+				/**
+				 * Filters whether a zero cost shipping row shows 'Free!' in place of the repeated method name.
+				 *
+				 * Defaults to true only for Free Shipping. Other methods can cost nothing yet still use the
+				 * name to tell the customer something, such as 'Shipping TBD'.
+				 *
+				 * @since 11.2.0
+				 *
+				 * @param bool     $show_free_label Whether to replace the value with 'Free!'.
+				 * @param WC_Order $order           The order being emailed.
+				 */
+				if ( (bool) apply_filters( 'woocommerce_email_order_shipping_show_free_label', $order->has_shipping_method( 'free_shipping' ), $order ) ) {
+					$total['value'] = __( 'Free!', 'woocommerce' );
+				}
 			}
 			$label = $total['label'];
 			if ( isset( $total['meta'] ) ) {

--- a/plugins/woocommerce/tests/e2e/tests/email/order-emails.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/order-emails.spec.ts
@@ -118,3 +118,50 @@ test( 'Merchant can resend order details to customer', async ( {
 		new RegExp( `Details for order #${ order.id }` )
 	);
 } );
+
+test( 'Zero cost shipping method keeps its title in the order email', async ( {
+	baseURL,
+	page,
+	restApi,
+} ) => {
+	const methodName = 'Shipping TBD';
+	const billingEmail = faker.internet.exampleEmail();
+
+	await setFeatureEmailImprovementsFlag( baseURL, 'yes' );
+
+	const { data: order } = await restApi.post( `${ WC_API_PATH }/orders`, {
+		status: 'processing',
+		billing: { email: billingEmail },
+		shipping_lines: [
+			{
+				method_id: 'flat_rate',
+				method_title: methodName,
+				total: '0.00',
+			},
+		],
+	} );
+
+	try {
+		const emailRow = await expectEmail(
+			page,
+			billingEmail,
+			/order has been received/
+		);
+		await emailRow.getByRole( 'button', { name: 'View log' } ).click();
+
+		const shippingRow = page
+			.locator( '#wp-mail-logging-modal-content-body-content' )
+			.locator( 'iframe' )
+			.contentFrame()
+			.locator( 'tr.order-totals-shipping' );
+
+		await expect( shippingRow.locator( 'td' ) ).toContainText( methodName );
+		await expect( shippingRow.locator( 'td' ) ).not.toContainText(
+			'Free!'
+		);
+	} finally {
+		await restApi.delete( `${ WC_API_PATH }/orders/${ order.id }`, {
+			force: true,
+		} );
+	}
+} );

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-order-details-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-order-details-shipping-test.php
@@ -1,0 +1,274 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Shipping row tests for the `email-order-details.php` templates.
+ *
+ * @covers `email-order-details.php` template
+ */
+class WC_Email_Order_Details_Shipping_Test extends \WC_Unit_Test_Case {
+
+	private const METHOD_NAME = 'Shipping TBD';
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'no' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Shipping methods that cost nothing, paired with what the value cell should then say.
+	 *
+	 * Every case uses the same method name so the shipping method id is the only thing that varies.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string, 3: string}>
+	 */
+	public function provide_shipping_methods(): array {
+		return array(
+			'free shipping'          => array( 'free_shipping', '0', 'Free!', self::METHOD_NAME ),
+			'zero cost flat rate'    => array( 'flat_rate', '0', self::METHOD_NAME, 'Free!' ),
+			'zero cost local pickup' => array( 'local_pickup', '0', self::METHOD_NAME, 'Free!' ),
+			'paid flat rate'         => array( 'flat_rate', '5.00', '5.00', 'Free!' ),
+		);
+	}
+
+	/**
+	 * @testdox HTML email shows the right shipping value for the method and cost.
+	 * @dataProvider provide_shipping_methods
+	 *
+	 * @param string $method_id    Shipping method id on the order.
+	 * @param string $total        Shipping cost.
+	 * @param string $expected     Text the value cell should contain.
+	 * @param string $not_expected Text the value cell should not contain.
+	 */
+	public function test_html_shipping_value( string $method_id, string $total, string $expected, string $not_expected ): void {
+		$order = $this->create_order_with_shipping( $method_id, $total );
+
+		$value = $this->get_html_shipping_value( $this->render( 'emails/email-order-details.php', $order, false ) );
+
+		$this->assertStringContainsString( $expected, $value, "Shipping value cell for a {$method_id} costing {$total} should say '{$expected}'" );
+		$this->assertStringNotContainsString( $not_expected, $value, "Shipping value cell for a {$method_id} costing {$total} should not say '{$not_expected}'" );
+	}
+
+	/**
+	 * @testdox Plain text email shows the right shipping value for the method and cost.
+	 * @dataProvider provide_shipping_methods
+	 *
+	 * @param string $method_id    Shipping method id on the order.
+	 * @param string $total        Shipping cost.
+	 * @param string $expected     Text the value column should contain.
+	 * @param string $not_expected Text the value column should not contain.
+	 */
+	public function test_plain_shipping_value( string $method_id, string $total, string $expected, string $not_expected ): void {
+		$order = $this->create_order_with_shipping( $method_id, $total );
+
+		$value = $this->get_plain_shipping_value( $this->render( 'emails/plain/email-order-details.php', $order, true ) );
+
+		$this->assertStringContainsString( $expected, $value, "Shipping value for a {$method_id} costing {$total} should say '{$expected}'" );
+		$this->assertStringNotContainsString( $not_expected, $value, "Shipping value for a {$method_id} costing {$total} should not say '{$not_expected}'" );
+	}
+
+	/**
+	 * @testdox Method name stays in the row header even when the value cell says 'Free!'.
+	 */
+	public function test_free_shipping_keeps_method_name_in_header(): void {
+		$order = $this->create_order_with_shipping( 'free_shipping', '0' );
+
+		$header = $this->get_html_shipping_header( $this->render( 'emails/email-order-details.php', $order, false ) );
+
+		$this->assertStringContainsString( self::METHOD_NAME, $header, 'Replacing the value cell must not cost the customer the method name' );
+	}
+
+	/**
+	 * @testdox A filter can force the free label on for a method that is not free shipping.
+	 */
+	public function test_filter_can_force_free_label_on(): void {
+		add_filter( 'woocommerce_email_order_shipping_show_free_label', '__return_true' );
+		$order = $this->create_order_with_shipping( 'flat_rate', '0' );
+
+		$value = $this->get_html_shipping_value( $this->render( 'emails/email-order-details.php', $order, false ) );
+
+		$this->assertSame( 'Free!', $value, 'A store that means a zero cost Flat Rate as free should be able to say so' );
+	}
+
+	/**
+	 * @testdox A filter can force the free label off for free shipping.
+	 */
+	public function test_filter_can_force_free_label_off(): void {
+		add_filter( 'woocommerce_email_order_shipping_show_free_label', '__return_false' );
+		$order = $this->create_order_with_shipping( 'free_shipping', '0' );
+
+		$value = $this->get_html_shipping_value( $this->render( 'emails/email-order-details.php', $order, false ) );
+
+		$this->assertSame( self::METHOD_NAME, $value, 'Turning the label off should restore the method name as the value' );
+	}
+
+	/**
+	 * @testdox The filter receives the order and the default for the method on it.
+	 */
+	public function test_filter_receives_order_and_default(): void {
+		$received = array();
+		add_filter(
+			'woocommerce_email_order_shipping_show_free_label',
+			function ( $show_free_label, $order ) use ( &$received ) {
+				$received[] = array( $show_free_label, $order->get_id() );
+				return $show_free_label;
+			},
+			10,
+			2
+		);
+		$order = $this->create_order_with_shipping( 'flat_rate', '0' );
+
+		$this->render( 'emails/email-order-details.php', $order, false );
+
+		$this->assertSame( array( array( false, $order->get_id() ) ), $received );
+	}
+
+	/**
+	 * @testdox The filter also applies to plain text emails.
+	 */
+	public function test_filter_applies_to_plain_text(): void {
+		add_filter( 'woocommerce_email_order_shipping_show_free_label', '__return_true' );
+		$order = $this->create_order_with_shipping( 'flat_rate', '0' );
+
+		$value = $this->get_plain_shipping_value( $this->render( 'emails/plain/email-order-details.php', $order, true ) );
+
+		$this->assertSame( 'Free!', $value );
+	}
+
+	/**
+	 * @testdox The filter does not run for a paid shipping method.
+	 */
+	public function test_filter_does_not_run_for_paid_shipping(): void {
+		add_filter( 'woocommerce_email_order_shipping_show_free_label', '__return_true' );
+		$order = $this->create_order_with_shipping( 'flat_rate', '5.00' );
+
+		$value = $this->get_html_shipping_value( $this->render( 'emails/email-order-details.php', $order, false ) );
+
+		$this->assertStringNotContainsString( 'Free!', $value, 'A paid method must stay out of reach of the filter' );
+	}
+
+	/**
+	 * @testdox The 'Free!' label is off when the email improvements feature is disabled.
+	 */
+	public function test_no_free_label_without_email_improvements(): void {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'no' );
+		$order = $this->create_order_with_shipping( 'free_shipping', '0' );
+
+		$content = $this->render( 'emails/email-order-details.php', $order, false );
+
+		$this->assertStringNotContainsString( 'Free!', $content );
+	}
+
+	/**
+	 * Builds an order carrying a single shipping line.
+	 *
+	 * @param string $method_id Shipping method id, such as `flat_rate`.
+	 * @param string $total     Shipping cost.
+	 * @return WC_Order
+	 */
+	private function create_order_with_shipping( string $method_id, string $total ): WC_Order {
+		$item = new WC_Order_Item_Shipping();
+		$item->set_props(
+			array(
+				'method_title' => self::METHOD_NAME,
+				'method_id'    => $method_id,
+				'total'        => wc_format_decimal( $total ),
+			)
+		);
+
+		$order = wc_create_order();
+		$order->add_item( $item );
+		$order->calculate_totals( false );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Renders an order details template.
+	 *
+	 * @param string   $template   Template path.
+	 * @param WC_Order $order      Order to render.
+	 * @param bool     $plain_text Whether the template is the plain text one.
+	 * @return string
+	 */
+	private function render( string $template, WC_Order $order, bool $plain_text ): string {
+		return wc_get_template_html(
+			$template,
+			array(
+				'order'         => $order,
+				'sent_to_admin' => false,
+				'plain_text'    => $plain_text,
+				'email'         => new WC_Email(),
+			)
+		);
+	}
+
+	/**
+	 * Reads the value cell out of the shipping row of a rendered HTML email.
+	 *
+	 * @param string $content Rendered template.
+	 * @return string
+	 */
+	private function get_html_shipping_value( string $content ): string {
+		return $this->match_html_shipping_row( $content, 2 );
+	}
+
+	/**
+	 * Reads the row header out of the shipping row of a rendered HTML email.
+	 *
+	 * @param string $content Rendered template.
+	 * @return string
+	 */
+	private function get_html_shipping_header( string $content ): string {
+		return $this->match_html_shipping_row( $content, 1 );
+	}
+
+	/**
+	 * Reads one cell out of the shipping row of a rendered HTML email.
+	 *
+	 * @param string $content Rendered template.
+	 * @param int    $group   1 for the row header, 2 for the value cell.
+	 * @return string
+	 */
+	private function match_html_shipping_row( string $content, int $group ): string {
+		$matched = preg_match(
+			'#<tr class="order-totals order-totals-shipping[^"]*">\s*<th[^>]*>(.*?)</th>\s*<td[^>]*>(.*?)</td>#s',
+			$content,
+			$matches
+		);
+
+		$this->assertSame( 1, $matched, 'Rendered email should contain a shipping totals row' );
+
+		return trim( wp_strip_all_tags( $matches[ $group ] ) );
+	}
+
+	/**
+	 * Reads the value column out of the shipping line of a rendered plain text email.
+	 *
+	 * The template pads the label to 40 characters, then a space, then the value.
+	 *
+	 * @param string $content Rendered template.
+	 * @return string
+	 */
+	private function get_plain_shipping_value( string $content ): string {
+		foreach ( explode( "\n", $content ) as $line ) {
+			if ( 0 === strpos( $line, 'Shipping:' ) ) {
+				return trim( substr( $line, 40 ) );
+			}
+		}
+
+		$this->fail( 'Rendered plain text email should contain a shipping line' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

With Email Improvements on, a shipping method that costs nothing shows its own name twice in the order email: once in the row header, once in the value cell. #66034 fixed that by replacing the value with "Free!".

The check it used was string equality alone:

```php
$total['value'] === $total['meta']
```

That is true for **any** method costing nothing, because `WC_Abstract_Order::get_shipping_to_display()` returns the method name instead of a price whenever the shipping total is zero. So a $0 Flat Rate or a $0 Local Pickup also gets relabelled "Free!".

That matters because those methods often use the name to tell the customer something. A merchant who bills shipping after the order names the method "Shipping TBD". The email now tells their customer shipping is free, and they cannot turn it off without code. The order confirmation page still shows the name, so the page and the email disagree.

This adds a test of the actual method, so only orders with Free Shipping get the label, and adds a filter so a store can override the default either way:

```php
apply_filters( 'woocommerce_email_order_shipping_show_free_label', $order->has_shipping_method( 'free_shipping' ), $order )
```

The filter matters because the two cases are identical in the data. A $0 Flat Rate named "Standard Delivery" looks the same whether the merchant means "free" or "price not decided yet". The default picks the safer reading, and the filter covers the rest, including a Flat Rate that computes to zero through per-class costs and so cannot switch to Free Shipping.

**Known limitation:** `has_shipping_method( 'free_shipping' )` answers for the whole order, so an order whose shipping lines are all zero cost and include one Free Shipping line still shows `Free!`. That case already behaves this way on trunk, so nothing gets worse here, and reaching it needs multi-package or split shipping with every line at zero cost. Stores that want the stricter rule can get it through the filter above.

Closes #68306.

(For Bug Fixes) Bug introduced in PR #66034.

### Screenshots or screen recordings:

Shipping row in the customer order email, for a Flat Rate costing 0 named "Shipping TBD":

| Before | After |
| ------ | ----- |
| `Shipping: Shipping TBD` &nbsp;&nbsp; `Free!` | `Shipping: Shipping TBD` &nbsp;&nbsp; `Shipping TBD` |

Free Shipping is unchanged and still shows `Free!`, with the method name kept in the row header.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable **Email improvements** at **WooCommerce → Settings → Advanced → Features** ("Enable modern email design for transactional emails"). Save.
2. Go to **WooCommerce → Settings → Shipping** and open a zone that matches your test address ("Locations not covered by your other zones" is fine). Add:
    - **Flat rate** named `Shipping TBD`. Leave Cost at `0.00`.
    - **Free shipping** named `Royal Mail 1st Class`. Leave "Free shipping requires" as "No requirement".
3. Add a physical (non-virtual) product to the cart and go to Checkout.
4. Choose **Shipping TBD**, leave payment as **Direct bank transfer**, and place the order.

> Note: at checkout both methods show "FREE" in Shipping options and the order summary. That is existing cart and checkout behaviour and is not what this PR changes. This PR only affects the email.

5. Open **Tools → WP Mail Logging** (or your mail catcher) and open the customer email for that order, subject *"Your … order has been received!"*. Direct bank transfer puts the order on hold, so this is the email you get, not the "Processing order" one.
6. The Shipping row should read `Shipping: Shipping TBD` in the label, with `Shipping TBD` as the value. Before this change the value read `Free!`.
7. Place a second order, this time choosing **Royal Mail 1st Class**.
8. Its Shipping row should read `Shipping: Royal Mail 1st Class` with `Free!` as the value. The method name must still appear in the label; only the value changes.
9. Repeat steps 3 and 4 with **Email improvements** turned off. Neither order should show `Free!`.

To check the plain text template, set **WooCommerce → Settings → Emails → Order on-hold → Email type** to **Plain text**, then repeat steps 3 to 6. The shipping line should behave the same way.

To check the filter, add this and repeat steps 3 to 6. The email should now read `Free!` for the $0 Flat Rate:

```php
add_filter( 'woocommerce_email_order_shipping_show_free_label', '__return_true' );
```

<!-- End testing instructions -->

### Testing that has already taken place:

Local wp-env, WordPress latest, PHP 8.1, PHPUnit 9.6.35.

- New integration tests in `tests/php/includes/emails/class-wc-email-order-details-shipping-test.php` render both templates and assert the shipping value cell. They cover Free Shipping, a $0 Flat Rate, a $0 Local Pickup, a paid Flat Rate, plain text, the feature flag being off, the row header keeping the method name, and the filter in both directions. `OK (15 tests, 31 assertions)`.
- Wider suite: `--filter WC_Email` gives `OK (163 tests, 365 assertions)`.
- One E2E case added to `tests/e2e/tests/email/order-emails.spec.ts` places an order over the REST API and reads the real sent email out of the mail log. Full `tests/email/` folder: `27 passed`.
- Both suites were mutation checked. Removing the method test makes 4 integration tests and 1 E2E test fail; removing the filter makes 4 integration tests fail.
- `lint:changes:branch` (PHP and JS) exits 0.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** This is a regression in 11.1.0, which is already released. If it should ride an 11.1.x point release instead, please reassign the milestone.

### Changelog entry

The changelog entry is already committed in this branch as `plugins/woocommerce/changelog/fix-68306-free-shipping-label-in-order-emails`, so neither box below is checked.

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Use of AI Tools

AI tooling was used to draft the change and its tests. All code, tests and testing instructions were reviewed and verified by me before submission.


