### PR TITLE
Add WIR franc (CHW) as a store currency

### DIFF
--- a/plugins/woocommerce/changelog/add-35684-chw-currency
+++ b/plugins/woocommerce/changelog/add-35684-chw-currency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the WIR franc (CHW) to the list of available store currencies.

--- a/plugins/woocommerce/client/blocks/packages/public-api/types/type-defs/currency.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/types/type-defs/currency.ts
@@ -76,6 +76,7 @@ export type CurrencyCode =
 	| 'CAD'
 	| 'CDF'
 	| 'CHF'
+	| 'CHW'
 	| 'CLP'
 	| 'CNY'
 	| 'COP'

--- a/plugins/woocommerce/i18n/currencies.php
+++ b/plugins/woocommerce/i18n/currencies.php
@@ -40,6 +40,7 @@ return array(
 	'CAD' => __( 'Canadian dollar', 'woocommerce' ),
 	'CDF' => __( 'Congolese franc', 'woocommerce' ),
 	'CHF' => __( 'Swiss franc', 'woocommerce' ),
+	'CHW' => __( 'WIR franc', 'woocommerce' ),
 	'CLP' => __( 'Chilean peso', 'woocommerce' ),
 	'CNY' => __( 'Chinese yuan', 'woocommerce' ),
 	'COP' => __( 'Colombian peso', 'woocommerce' ),

--- a/plugins/woocommerce/i18n/currency-info.php
+++ b/plugins/woocommerce/i18n/currency-info.php
@@ -263,6 +263,14 @@ return array(
 		'gsw_CH'  => $global_formats['rs_dot_apos_ltr'],
 		'rm_CH'   => $global_formats['rs_dot_apos_ltr'],
 	),
+	'CHW' => array(
+		'de_CH'   => $global_formats['ls_dot_apos_ltr'],
+		'fr_CH'   => $global_formats['rs_comma_space_ltr'],
+		'it_CH'   => $global_formats['ls_dot_apos_ltr'],
+		'default' => $global_formats['ls_dot_apos_ltr'],
+		'gsw_CH'  => $global_formats['rs_dot_apos_ltr'],
+		'rm_CH'   => $global_formats['rs_dot_apos_ltr'],
+	),
 	'CLP' => array(
 		'es_CL'   => $global_formats['lx_comma_dot_ltr'],
 		'default' => $global_formats['lx_comma_dot_ltr'],

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -563,6 +563,7 @@ function get_woocommerce_currency_symbols() {
 			'CAD' => '&#36;',
 			'CDF' => 'Fr',
 			'CHF' => '&#67;&#72;&#70;',
+			'CHW' => 'CHW',
 			'CLP' => '&#36;',
 			'CNY' => '&yen;',
 			'COP' => '&#36;',

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -74,6 +74,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 			'CAD' => 'Canadian dollar',
 			'CDF' => 'Congolese franc',
 			'CHF' => 'Swiss franc',
+			'CHW' => 'WIR franc',
 			'CLP' => 'Chilean peso',
 			'CNY' => 'Chinese yuan',
 			'COP' => 'Colombian peso',

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -230,6 +230,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		// Given specific currency.
 		$this->assertEquals( '&pound;', get_woocommerce_currency_symbol( 'GBP' ) );
 		$this->assertEquals( 'MOP&#36;', get_woocommerce_currency_symbol( 'MOP' ) );
+		$this->assertSame( 'CHW', get_woocommerce_currency_symbol( 'CHW' ) );
 		$this->assertSame( 'K', get_woocommerce_currency_symbol( 'ZMW' ), 'The Zambian kwacha should use its local display symbol.' );
 
 		// Each case.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds `CHW` (WIR franc) to WooCommerce’s built-in currencies. It is available in store settings and the `/wc/v3/data/currencies` API, uses Swiss number formatting and `CHW` as its display symbol, and is included in the exported Blocks `CurrencyCode` type.

`CHW` is an ISO 4217 currency code (numeric code 948). The Unicode Common Locale Data Repository (CLDR) provides the English name "WIR Franc" and identifies it as a non-tender currency for Switzerland ([en.xml](https://github.com/unicode-org/cldr/blob/main/common/main/en.xml), [supplementalData.xml](https://github.com/unicode-org/cldr/blob/main/common/supplemental/supplementalData.xml)). Because CLDR defines no separate symbol, WooCommerce uses `CHW` itself, consistent with `CHF`.

**Backward compatibility:** The runtime and API changes are additive. Existing currency values and filter signatures are unchanged, `/wc/v3/data/currencies` and the store-currency setting gain CHW, and the existing `CurrencyCode` export gains one literal. Existing filters can still override the CHW name or symbol. Downstream TypeScript code with an exhaustive `CurrencyCode` mapping may need to add CHW.

**Impact:** high. Any change under `woocommerce/i18n` is on the High-Impact list, so this needs an independent human review before merge.

**Out of scope:** `CHE` (WIR euro), the sibling code. Not requested in the issue.

Closes #35684.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="3456" height="1662" alt="2026-09-07-chw-currency-dropdown-before" src="https://github.com/user-attachments/assets/6ff91000-89e8-4ec3-9b84-5202bab855ca" /> | <img width="3456" height="1662" alt="2026-09-07-chw-currency-dropdown" src="https://github.com/user-attachments/assets/fd4da268-3c57-4ba3-810d-41e29782c91c" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

Preconditions: a store running this branch with at least one priced product and an enabled offline payment method, such as Check payments. Note the current store currency so you can restore it.

1. **Settings:** go to WooCommerce > Settings > General and open the Currency dropdown. `WIR franc (CHW) — CHW` is listed right after `Swiss franc (CHF) — CHF`. Select it and save.
2. **Storefront:** open the shop page. Prices render with `CHW` as the symbol. With the default "Left" currency position that is `CHW1,234.50`; placement follows your Currency position setting.
3. **Checkout:** add the product to the cart and proceed to checkout. Confirm the cart and checkout order summary display `CHW` for line items and totals. Complete the order with the offline payment method, then confirm the order-received page also displays the total in `CHW`.
4. **REST:** run the following with WP-CLI (prefix with `pnpm exec wp-env run cli` if you use wp-env):

   ```sh
   wp eval '$response = rest_do_request( new WP_REST_Request( "GET", "/wc/v3/data/currencies/CHW" ) ); echo wp_json_encode( $response->get_data() ) . PHP_EOL;' --user=1
   ```

   Expect `{"code":"CHW","name":"WIR franc","symbol":"CHW"}`.
5. Switch the currency back to the value from the preconditions and save.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- **Automated:** `WC_Tests_Core_Functions` passes (39 tests, 303 assertions). PHPCS and PHPStan clean, baseline untouched.
- **Manual (wp-env, PHP 8.1):** Tested successfully according to the instructions above.
- **Standards:** verified against CLDR `common/main/en.xml` and `supplementalData.xml` (region CH lists `CHW`, `tender="false"`, no symbol, 2 decimals).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code and Codex assisted with investigation, implementation, review, and validation. I reviewed the resulting diff and the CLDR source data.







