### PR TITLE
fix(email-editor): stop Media & Text floating so buttons don't bleed over it

### DIFF
--- a/packages/php/email-editor/changelog/fix-cm-520-media-text-float-button-bleed
+++ b/packages/php/email-editor/changelog/fix-cm-520-media-text-float-button-bleed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep Media & Text blocks in normal document flow so a button placed after one no longer paints its background across it. The wrapper table's align="left" rendered as a float in email clients, pulling the block out of flow so the following block failed to clear it. Alignment is preserved via the existing text-align CSS.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-media-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-media-text.php
@@ -101,10 +101,16 @@ class Media_Text extends Abstract_Block_Renderer {
 		);
 
 		// Apply class and style attributes to the wrapper table.
+		//
+		// Intentionally omit the `align` attribute. `align="left"` (or "right") on a table renders as
+		// `float: left` in email clients, taking the block out of normal flow — the block that follows
+		// then fails to clear it and overlaps it, so a following button paints its background across
+		// the media & text block above. Horizontal alignment is already carried by the `text-align`
+		// declaration in $block_styles['css'], so dropping the attribute preserves alignment while
+		// keeping the block in normal flow. Same fix as the gallery wrapper.
 		$table_attrs = array(
 			'class' => 'email-block-media-text ' . $original_wrapper_classname,
 			'style' => $block_styles['css'],
-			'align' => $rendering_context->get_default_text_align(),
 			'width' => '100%',
 		);
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Core_Renderers_Rtl_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Core_Renderers_Rtl_Test.php
@@ -110,8 +110,7 @@ class Core_Renderers_Rtl_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertNotFalse( $media_position );
 		$this->assertNotFalse( $text_position );
 		$this->assertLessThan( $text_position, $media_position );
-		$this->assertStringContainsString( 'text-align:right;', $rendered );
-		$this->assertStringContainsString( 'align="right"', $rendered );
+		$this->assertWrapperIsRtlAlignedWithoutFloat( $rendered, 'email-block-media-text' );
 	}
 
 	/**
@@ -202,8 +201,7 @@ class Core_Renderers_Rtl_Test extends \Email_Editor_Integration_Test_Case {
 			$this->rtl_context
 		);
 
-		$this->assertStringContainsString( 'text-align:right;', $rendered );
-		$this->assertStringContainsString( 'align="right"', $rendered );
+		$this->assertWrapperIsRtlAlignedWithoutFloat( $rendered, 'email-block-gallery' );
 	}
 
 	/**
@@ -223,6 +221,40 @@ class Core_Renderers_Rtl_Test extends \Email_Editor_Integration_Test_Case {
 
 		$this->assertStringContainsString( 'align="right"', $rendered );
 		$this->assertOuterSpacerAligned( $rendered, 'right' );
+	}
+
+	/**
+	 * Assert that a block's wrapper table carries its RTL alignment as a `text-align` declaration
+	 * rather than as an `align` attribute.
+	 *
+	 * `align="right"` on a table renders as `float: right` in email clients, taking the block out of
+	 * normal flow so the block that follows fails to clear it. Searching the whole render for the
+	 * substring `align="right"` does not pin this down: the Outlook-only spacer table emitted by
+	 * Abstract_Block_Renderer::add_spacer() carries one inside a conditional comment, so such an
+	 * assertion keeps passing after the wrapper's own attribute is gone. Inspect the wrapper tag.
+	 *
+	 * @param string $rendered Rendered HTML.
+	 * @param string $wrapper_class Class identifying the block's wrapper table.
+	 */
+	private function assertWrapperIsRtlAlignedWithoutFloat( string $rendered, string $wrapper_class ): void {
+		$processor = new \WP_HTML_Tag_Processor( $rendered );
+		$this->assertTrue(
+			$processor->next_tag(
+				array(
+					'tag_name'   => 'table',
+					'class_name' => $wrapper_class,
+				)
+			),
+			sprintf( 'Expected a wrapper table with the %s class.', $wrapper_class )
+		);
+
+		// No float-triggering align attribute ( get_attribute() is null when the attribute is absent ).
+		$this->assertNull( $processor->get_attribute( 'align' ) );
+
+		// RTL alignment is carried by the text-align declaration instead, keeping the block in flow.
+		$style = $processor->get_attribute( 'style' );
+		$this->assertIsString( $style );
+		$this->assertStringContainsString( 'text-align:right;', $style );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Media_Text_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Media_Text_Test.php
@@ -77,6 +77,38 @@ class Media_Text_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * The media & text wrapper table must not carry an `align="left"`/`align="right"` attribute: those
+	 * render as `float` in email clients, pulling the block out of normal flow so the block that follows
+	 * fails to clear it. A button placed after it then paints its background across the media & text
+	 * block above. Horizontal alignment must instead come from the `text-align` CSS declaration, which
+	 * keeps the block in normal flow.
+	 */
+	public function testItDoesNotFloatWrapperTableWithAlignAttribute(): void {
+		$rendered = $this->media_renderer->render( '', $this->parsed_media, $this->rendering_context );
+
+		// Locate the wrapper table by its class. Parsing the tag with WP_HTML_Tag_Processor is more
+		// robust than matching the raw HTML string, and matches the convention used elsewhere here.
+		$processor = new \WP_HTML_Tag_Processor( $rendered );
+		$this->assertTrue(
+			$processor->next_tag(
+				array(
+					'tag_name'   => 'table',
+					'class_name' => 'email-block-media-text',
+				)
+			),
+			'Expected a media & text wrapper table with the email-block-media-text class.'
+		);
+
+		// No float-triggering align attribute on the wrapper table ( get_attribute() is null when absent ).
+		$this->assertNull( $processor->get_attribute( 'align' ) );
+
+		// Alignment is preserved via the text-align CSS declaration instead, keeping the block in normal flow.
+		$style = $processor->get_attribute( 'style' );
+		$this->assertIsString( $style );
+		$this->assertStringContainsString( 'text-align', $style );
+	}
+
+	/**
 	 * Test it handles media positioning
 	 */
 	public function testItHandlesMediaPositioning(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

The Media & Text renderer emitted `align="left"` on its wrapper `<table>` (from the default text align). Email clients render `align="left"`/`align="right"` on a table as `float: left`, which takes the block out of normal document flow. The block that follows then fails to clear it and overlaps it — so a Buttons block placed after a Media & Text block paints its background across the media and text above it.

This is the same defect, and the same one-line fix, that #66833 applied to the gallery wrapper. Media & Text was missed at the time.

The `align` attribute is dropped. Horizontal alignment is already carried by the `text-align` declaration in the wrapper's inline styles (`$block_styles['css']`, set a few lines above), so alignment is preserved while the block stays in normal flow.

I swept every other block renderer for the same pattern; the rest are fine:

- `class-audio.php` sets `float: none` in the same table's style alongside its `align`.
- `class-embed.php` and the `add_spacer` / `email-root-padding` wrappers (`class-abstract-block-renderer.php`, `class-content-renderer.php`) emit their `align`-carrying tables inside `<!--[if mso | IE]>` conditional comments, so non-Outlook clients never see them.
- `class-column.php`, `class-fallback.php` and `class-button.php` put `align` on `<td>` elements, where it is ordinary horizontal text alignment and does not float.
- `class-columns.php`, `class-cover.php` and `class-social-links.php` use `align="center"`, which does not float.

A second commit fixes the RTL tests for both this block and the gallery. `Core_Renderers_Rtl_Test` asserted alignment with a bare `assertStringContainsString( 'align="right"', $rendered )` over the whole render, which does not pin the wrapper: the Outlook-only spacer table from `Abstract_Block_Renderer::add_spacer()` carries an `align="right"` inside an `<!--[if mso | IE]-->` conditional comment, so the assertion keeps passing once the wrapper's own attribute is gone. The gallery test has been passing for the wrong reason since #66833, and the media-text test would have started doing the same here — both silently losing the RTL coverage their names claim. Both now assert against the wrapper tag itself via `WP_HTML_Tag_Processor`: no `align` attribute, and `text-align:right` in its inline style.

**Backward compatibility:** no public or externally exposed signature, hook, or script/style handle changes. The only change is one attribute in the rendered email HTML of the `core/media-text` block. Rendering is not multisite- or install-layout-sensitive, and no global state is newly relied on.

Fixes CM-520.

(For Bug Fixes) Bug introduced in PR # — not a regression; the attribute has been present since the block renderer was added.

### Screenshots or screen recordings:

The **iOS Gmail app**, from a WordPress.com test send with this patch applied, of a post containing a Media & Text block followed by a Buttons block. Before, the button's background is painted across the whole Media & Text block above it; after, the block renders normally and the button sits below it.

| Before | After |
| ------ | ----- |
| <img width="563" height="1218" alt="IMG_0868" src="https://github.com/user-attachments/assets/c5cf933e-fc03-4e31-80ad-897e0d90bc16" /> | <img width="563" height="1218" alt="IMG_0870" src="https://github.com/user-attachments/assets/531f4457-b876-4bc7-bbd1-2ce8f33eebe1" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In the email editor (or any post that is sent as an email through the email editor), build content in this order: a paragraph, a **Media & Text** block with an image and some text, then a **Buttons** block containing one button. Set the button's background color to something clearly visible, and set the Buttons block's justification to Center.
2. Send the email to an address you can open in the **Gmail mobile app** (iOS or Android), or otherwise view the rendered email HTML at a viewport narrower than 660px.
3. **Before this change:** the button's background color is painted across the whole Media & Text block above it — the image and the text sit on top of the button's background.
4. **After this change:** the Media & Text block renders on the normal background, and the button and its background sit below it.
5. Confirm the Media & Text block's own horizontal alignment is unchanged, and check an RTL email as well (the same attribute previously emitted `align="right"` there).
6. Confirm no vertical spacing regression between the Media & Text block and the block that follows it.

<!-- End testing instructions -->

### Testing that has already taken place:

- **Verified in the real client the bug was reported against:** a sandboxed WordPress.com test send, opened in the iOS Gmail app, shows the bleed before the patch and clean rendering after (screenshots above).
- Reproduced and verified locally end-to-end: rendered the block markup above through the real `Renderer` via a PHPUnit integration test, dumped the resulting email HTML, and screenshotted it in WebKit at 390px. The overlap is present before the change and gone after it, matching what the real Gmail send showed. The same experiment against Chromium confirms the float overlap reproduces in both engines.
- Confirmed the identical symptom reproduces for galleries by temporarily reinstating the `align` attribute that #66833 removed — establishing this as one bug class with two instances rather than two unrelated bugs.
- Added a regression test (`Media_Text_Test::testItDoesNotFloatWrapperTableWithAlignAttribute`) mirroring the gallery equivalent added in #66833. Verified it **fails** with the attribute restored (`Failed asserting that 'left' is null.`) and passes with the fix.
- Confirmed RTL alignment is genuinely preserved by dumping the RTL render: the wrapper carries `text-align:right;` and no `align`, and the only remaining `align="right"` sits inside the Outlook conditional comment.
- Verified the two rewritten RTL assertions **fail** (`Failed asserting that 'right' is null.`) when the `align` attribute is reinstated on either renderer.
- Full `packages/php/email-editor` integration suite: 544 tests, 1951 assertions, 0 failures (4 pre-existing skips unrelated to this change).
- `composer run-script phpcs` over the whole package: clean, no errors or warnings.
- PHPStan (level 9) on the modified file: no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`: clean.

Environment: wp-env, PHP 8.1, PHPUnit 9.6.34.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entry was added manually: `packages/php/email-editor/changelog/fix-cm-520-media-text-float-button-bleed`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Keep Media & Text blocks in normal document flow so a button placed after one no longer paints its background across it.

</details>

### Use of AI Tools

Authored with Claude Code (Claude Opus 5). The AI performed the codebase investigation, the reproduction (building the render harness and the WebKit comparison), wrote the one-line fix, the code comment and the regression test, and drafted this description. I reviewed the diff, the reproduction evidence and the test, and I take responsibility for the contents of this pull request.


