### PR TITLE
Add unsold products filter and last sold date to Products analytics

### DIFF
--- a/plugins/woocommerce/changelog/fix-44066-unsold-products-analytics
+++ b/plugins/woocommerce/changelog/fix-44066-unsold-products-analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an "Unsold products" filter to Analytics > Products that lists products with no sales in the selected period, a "Last sold" column showing when each product last sold, and lifetime sales in the product details. Also available as an unsold parameter on the products report REST endpoint.

--- a/plugins/woocommerce/client/admin/client/analytics/report/products/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/products/config.js
@@ -65,6 +65,10 @@ const filterConfig = {
 	filters: [
 		{ label: __( 'All products', 'woocommerce' ), value: 'all' },
 		{
+			label: __( 'Unsold products', 'woocommerce' ),
+			value: 'unsold',
+		},
+		{
 			label: __( 'Single product', 'woocommerce' ),
 			value: 'select_product',
 			chartMode: 'item-comparison',

--- a/plugins/woocommerce/client/admin/client/analytics/report/products/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/products/index.js
@@ -60,6 +60,10 @@ class ProductsReport extends Component {
 			return <AnalyticsError />;
 		}
 
+		// Every metric an unsold product reports is zero, so the summary and
+		// chart would only show flat lines.
+		const isUnsoldView = query.filter === 'unsold';
+
 		const chartQuery = {
 			...query,
 		};
@@ -78,30 +82,37 @@ class ProductsReport extends Component {
 					advancedFilters={ advancedFilters }
 					report="products"
 				/>
-				<ReportSummary
-					mode={ mode }
-					charts={ charts }
-					endpoint="products"
-					query={ chartQuery }
-					selectedChart={ getSelectedChart( query.chart, charts ) }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-				/>
-				<ReportChart
-					charts={ charts }
-					mode={ mode }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-					endpoint="products"
-					isRequesting={ isRequesting }
-					itemsLabel={ itemsLabel }
-					path={ path }
-					query={ chartQuery }
-					selectedChart={ getSelectedChart(
-						chartQuery.chart,
-						charts
-					) }
-				/>
+				{ ! isUnsoldView && (
+					<ReportSummary
+						mode={ mode }
+						charts={ charts }
+						endpoint="products"
+						query={ chartQuery }
+						selectedChart={ getSelectedChart(
+							query.chart,
+							charts
+						) }
+						filters={ filters }
+						advancedFilters={ advancedFilters }
+					/>
+				) }
+				{ ! isUnsoldView && (
+					<ReportChart
+						charts={ charts }
+						mode={ mode }
+						filters={ filters }
+						advancedFilters={ advancedFilters }
+						endpoint="products"
+						isRequesting={ isRequesting }
+						itemsLabel={ itemsLabel }
+						path={ path }
+						query={ chartQuery }
+						selectedChart={ getSelectedChart(
+							chartQuery.chart,
+							charts
+						) }
+					/>
+				) }
 				{ isSingleProductVariable ? (
 					<VariationsReportTable
 						baseSearchQuery={ { filter: 'single_product' } }

--- a/plugins/woocommerce/client/admin/client/analytics/report/products/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/products/table.js
@@ -8,8 +8,9 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect } from '@wordpress/data';
 import { map } from 'lodash';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { Link, Tag } from '@woocommerce/components';
+import { Link, Tag, Date } from '@woocommerce/components';
 import { formatValue } from '@woocommerce/number';
+import { defaultTableDateFormat } from '@woocommerce/date';
 import { getAdminLink } from '@woocommerce/settings';
 import { itemsStore } from '@woocommerce/data';
 import { CurrencyContext } from '@woocommerce/currency';
@@ -74,6 +75,16 @@ class ProductsReportTable extends Component {
 				isNumeric: true,
 			},
 			{
+				label: __( 'Last sold', 'woocommerce' ),
+				key: 'last_sold',
+				isSortable: true,
+			},
+			{
+				label: __( 'Lifetime sales', 'woocommerce' ),
+				key: 'total_sales',
+				isNumeric: true,
+			},
+			{
 				label: __( 'Category', 'woocommerce' ),
 				key: 'product_cat',
 			},
@@ -107,6 +118,10 @@ class ProductsReportTable extends Component {
 			getCurrencyConfig,
 		} = this.context;
 		const currency = getCurrencyConfig();
+		const dateFormat = getAdminSetting(
+			'dateFormat',
+			defaultTableDateFormat
+		);
 
 		return map( data, ( row ) => {
 			const {
@@ -114,6 +129,7 @@ class ProductsReportTable extends Component {
 				items_sold: itemsSold,
 				net_revenue: netRevenue,
 				orders_count: ordersCount,
+				last_sold: lastSold,
 			} = row;
 			const extendedInfo = row.extended_info || {};
 			const {
@@ -123,6 +139,7 @@ class ProductsReportTable extends Component {
 				sku,
 				stock_status: extendedInfoStockStatus,
 				stock_quantity: stockQuantity,
+				total_sales: totalSales,
 				variations = [],
 			} = extendedInfo;
 
@@ -202,6 +219,18 @@ class ProductsReportTable extends Component {
 						</Link>
 					),
 					value: ordersCount,
+				},
+				{
+					display: lastSold ? (
+						<Date date={ lastSold } visibleFormat={ dateFormat } />
+					) : (
+						''
+					),
+					value: lastSold || '',
+				},
+				{
+					display: formatValue( currency, 'number', totalSales || 0 ),
+					value: totalSales || 0,
 				},
 				{
 					display: (
@@ -325,6 +354,10 @@ class ProductsReportTable extends Component {
 			query,
 		} = this.props;
 
+		// Every metric an unsold product reports is zero, so the table sorts by
+		// title unless the merchant picked another column.
+		const isUnsoldView = query.filter === 'unsold';
+
 		const labels = {
 			helpText: __(
 				'Check at least two products below to compare',
@@ -354,10 +387,13 @@ class ProductsReportTable extends Component {
 				limitProperties={ limitProperties }
 				baseSearchQuery={ baseSearchQuery }
 				tableQuery={ {
-					orderby: query.orderby || 'items_sold',
+					orderby:
+						query.orderby ||
+						( isUnsoldView ? 'product_name' : 'items_sold' ),
 					order: query.order || 'desc',
 					extended_info: true,
 					segmentby: query.segmentby,
+					...( isUnsoldView ? { unsold: true } : {} ),
 				} }
 				title={ __( 'Products', 'woocommerce' ) }
 				columnPrefsKey="products_report_columns"

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -41122,12 +41122,6 @@ parameters:
 			path: src/Admin/API/Reports/DataStore.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\DataStore\:\:cast_numbers\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\Reports\\WP_Error\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/DataStore.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\DataStore\:\:create_interval_subtotals\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -794,7 +794,7 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 	 * Casts strings returned from the database to appropriate data types for output.
 	 *
 	 * @param array $array Associative array of values extracted from the database.
-	 * @return array|WP_Error
+	 * @return array
 	 */
 	protected function cast_numbers( $array ) {
 		$retyped_array = array();

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -157,6 +157,12 @@ class Controller extends GenericController implements ExportableInterface {
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Number of orders product appeared in.', 'woocommerce' ),
 				),
+				'last_sold'     => array(
+					'type'        => array( 'string', 'null' ),
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'Date the product was last sold in the requested period, or null when it sold nothing.', 'woocommerce' ),
+				),
 				'extended_info' => array(
 					'name'             => array(
 						'type'        => 'string',
@@ -218,6 +224,12 @@ class Controller extends GenericController implements ExportableInterface {
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Product SKU.', 'woocommerce' ),
 					),
+					'total_sales'      => array(
+						'type'        => 'integer',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Lifetime quantity of the product sold, across all dates.', 'woocommerce' ),
+					),
 				),
 			),
 		);
@@ -241,6 +253,7 @@ class Controller extends GenericController implements ExportableInterface {
 				'product_name',
 				'variations',
 				'sku',
+				'last_sold',
 			)
 		);
 		$params['categories']      = array(
@@ -275,6 +288,13 @@ class Controller extends GenericController implements ExportableInterface {
 		$params['search']        = ProductSearchQuery::get_collection_param();
 		$params['extended_info'] = array(
 			'description'       => __( 'Add additional piece of info about each product to the report.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'sanitize_callback' => 'wc_string_to_bool',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['unsold']        = array(
+			'description'       => __( 'Limit result to products with no sales in the requested period.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
@@ -326,6 +346,8 @@ class Controller extends GenericController implements ExportableInterface {
 			'items_sold'   => __( 'Items sold', 'woocommerce' ),
 			'net_revenue'  => __( 'N. Revenue', 'woocommerce' ),
 			'orders_count' => __( 'Orders', 'woocommerce' ),
+			'last_sold'    => __( 'Last sold', 'woocommerce' ),
+			'total_sales'  => __( 'Lifetime sales', 'woocommerce' ),
 			'product_cat'  => __( 'Category', 'woocommerce' ),
 			'variations'   => __( 'Variations', 'woocommerce' ),
 		);
@@ -360,6 +382,8 @@ class Controller extends GenericController implements ExportableInterface {
 			'items_sold'   => $item['items_sold'],
 			'net_revenue'  => $item['net_revenue'],
 			'orders_count' => $item['orders_count'],
+			'last_sold'    => isset( $item['last_sold'] ) ? $item['last_sold'] : '',
+			'total_sales'  => isset( $item['extended_info']['total_sales'] ) ? $item['extended_info']['total_sales'] : 0,
 			'product_cat'  => $this->get_categories( $item['extended_info']['category_ids'] ),
 			'variations'   => isset( $item['extended_info']['variations'] ) ? count( $item['extended_info']['variations'] ) : 0,
 		);

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
@@ -53,6 +53,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		'items_sold'       => 'intval',
 		'net_revenue'      => 'floatval',
 		'orders_count'     => 'intval',
+		'last_sold'        => 'strval',
 		// Extended attributes.
 		'name'             => 'strval',
 		'price'            => 'floatval',
@@ -64,6 +65,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		'category_ids'     => 'array_values',
 		'variations'       => 'array_values',
 		'sku'              => 'strval',
+		'total_sales'      => 'intval',
 	);
 
 	/**
@@ -83,7 +85,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		'category_ids',
 		'variations',
 		'sku',
+		'total_sales',
 	);
+
+	/**
+	 * Whether the query currently being served carries an `unsold` argument.
+	 *
+	 * @var bool
+	 */
+	private $is_unsold = false;
 
 	/**
 	 * Data store context used to pass to filters.
@@ -120,6 +130,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'items_sold'   => 'SUM(product_qty) as items_sold',
 			'net_revenue'  => 'SUM(product_net_revenue) AS net_revenue',
 			'orders_count' => "COUNT( DISTINCT ( CASE WHEN product_gross_revenue >= 0 THEN {$table_name}.order_id END ) ) as orders_count",
+			'last_sold'    => "MAX(CASE WHEN {$table_name}.product_qty > 0 THEN {$table_name}.date_created END) AS last_sold",
 		);
 	}
 
@@ -282,6 +293,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function get_cache_key( $params ) {
 		$this->is_search = ! empty( $params['search'] );
+		$this->is_unsold = ! empty( $params['unsold'] );
 
 		return parent::get_cache_key( $params );
 	}
@@ -302,7 +314,18 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		// A search is resolved against product titles and SKUs while the report runs, and nothing
 		// invalidates the report cache when one is renamed, so a cached response would keep
 		// answering with the old matches for up to a week.
-		return $this->is_search ? false : $use_cache;
+		if ( $this->is_search ) {
+			return false;
+		}
+
+		// The unsold list depends on which products exist, and nothing invalidates the report
+		// cache when a product is created or deleted, so a cached response would keep leaving
+		// new products out for up to a week.
+		if ( $this->is_unsold ) {
+			return false;
+		}
+
+		return $use_cache;
 	}
 
 	/**
@@ -429,6 +452,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$defaults['product_includes']  = array();
 		$defaults['search']            = array();
 		$defaults['extended_info']     = false;
+		$defaults['unsold']            = false;
 
 		return $defaults;
 	}
@@ -441,7 +465,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @see get_data
 	 * @param array $query_args Query parameters.
-	 * @return stdClass|WP_Error Data object `{ totals: *, intervals: array, total: int, pages: int, page_no: int }`, or error.
+	 * @return \stdClass|\WP_Error Data object `{ totals: *, intervals: array, total: int, pages: int, page_no: int }`, or error.
 	 */
 	public function get_noncached_data( $query_args ) {
 		global $wpdb;
@@ -456,6 +480,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'pages'   => 0,
 			'page_no' => 0,
 		);
+
+		if ( ! empty( $query_args['unsold'] ) ) {
+			return $this->get_unsold_data( $query_args, $data );
+		}
 
 		$selections        = $this->selected_columns( $query_args );
 		$included_products = $this->get_included_products_array( $query_args );
@@ -542,7 +570,17 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$product_data = array_map( array( $this, 'cast_numbers' ), $product_data );
-		$data         = (object) array(
+
+		// cast_numbers stringifies the null a padded row carries for its columns, but a product
+		// with no sales in the period has no last sale to report, so the field stays null as the
+		// schema declares it.
+		foreach ( $product_data as $key => $row ) {
+			if ( isset( $row['last_sold'] ) && '' === $row['last_sold'] ) {
+				$product_data[ $key ]['last_sold'] = null;
+			}
+		}
+
+		$data = (object) array(
 			'data'    => $product_data,
 			'total'   => $total_results,
 			'pages'   => $total_pages,
@@ -550,6 +588,146 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		);
 
 		return $data;
+	}
+
+	/**
+	 * Returns the report rows for products with no sales in the requested period.
+	 *
+	 * The report table is grouped by the sales lookup, so products that sold nothing in the period
+	 * are absent from it. This builds the opposite set: every published product LEFT JOINed to the
+	 * period's per-product sales, keeping only the products the join misses. All the metrics come
+	 * back as zero and `last_sold` as null, since the products have nothing to report for the period.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param array     $query_args Query parameters.
+	 * @param \stdClass $data       Empty report data object to fill in.
+	 * @return \stdClass Data object `{ data: array, total: int, pages: int, page_no: int }`.
+	 */
+	private function get_unsold_data( $query_args, $data ) {
+		global $wpdb;
+
+		$table_name = self::get_db_table_name();
+		$params     = $this->get_limit_params( $query_args );
+
+		// Products that sold in the period, aggregated per product. A product missing from this
+		// set is an unsold one. The order status and variation filters go in here: they decide
+		// whether a sale counts, not which products exist.
+		$sold_subquery = new SqlQuery( $this->context . '_subquery' );
+		$sold_subquery->add_sql_clause( 'select', 'product_id' );
+		$sold_subquery->add_sql_clause( 'from', $table_name );
+
+		foreach ( array(
+			'after'  => '>=',
+			'before' => '<=',
+		) as $bound => $comparator ) {
+			if ( empty( $query_args[ $bound ] ) || ! $query_args[ $bound ] instanceof \DateTimeInterface ) {
+				continue;
+			}
+			$datetime = $query_args[ $bound ];
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- matches add_time_period_sql_params; the value comes from a formatted datetime object.
+			$datetime_str = $datetime instanceof \WC_DateTime
+				? $datetime->date( TimeInterval::$sql_datetime_format )
+				: $datetime->format( TimeInterval::$sql_datetime_format );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is a table name and $datetime_str a formatted date.
+			$sold_subquery->add_sql_clause( 'where_time', "AND {$table_name}.date_created {$comparator} '{$datetime_str}'" );
+		}
+
+		$included_variations = $this->get_included_variations( $query_args );
+		if ( $included_variations ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is a table name, $included_variations is prepared.
+			$sold_subquery->add_sql_clause( 'where', "AND {$table_name}.variation_id IN ({$included_variations})" );
+		}
+
+		$order_status_filter = $this->get_status_subquery( $query_args );
+		if ( $order_status_filter ) {
+			$sold_subquery->add_sql_clause( 'join', "JOIN {$wpdb->prefix}wc_order_stats ON {$table_name}.order_id = {$wpdb->prefix}wc_order_stats.order_id" );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_status_filter is built from escaped status slugs.
+			$sold_subquery->add_sql_clause( 'where', "AND ( {$order_status_filter} )" );
+		}
+
+		$sold_subquery->add_sql_clause( 'group_by', 'product_id' );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- built from prepared fragments above.
+		$sold_statement = $sold_subquery->get_query_statement();
+
+		$this->clear_sql_clause( 'select' );
+		$this->add_sql_clause( 'select', 'posts.ID AS product_id, 0 AS items_sold, 0 AS net_revenue, 0 AS orders_count, NULL AS last_sold' );
+		$this->add_sql_clause( 'from', "{$wpdb->posts} AS posts" );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $wpdb->posts is a table name, $sold_statement is built from prepared fragments.
+		$this->add_sql_clause( 'left_join', "LEFT JOIN ( {$sold_statement} ) AS sold ON sold.product_id = posts.ID" );
+		$this->add_sql_clause( 'where', "AND posts.post_type = 'product'" );
+		$this->add_sql_clause( 'where', "AND posts.post_status = 'publish'" );
+		$this->add_sql_clause( 'where', 'AND sold.product_id IS NULL' );
+
+		$included_products = $this->get_included_products_array( $query_args );
+		$search_subquery   = $this->get_search_subquery( $query_args, $included_products );
+		$product_id_filter = ProductSearchQuery::get_id_condition( 'posts.ID', $search_subquery, $included_products );
+		if ( $product_id_filter ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $product_id_filter is built from prepared fragments.
+			$this->add_sql_clause( 'where', "AND {$product_id_filter}" );
+		}
+
+		// A zero metric cannot be sorted on, so only the product attributes stay sortable, and
+		// anything else falls back to the title.
+		$this->clear_sql_clause( 'order_by' );
+		switch ( $query_args['orderby'] ?? '' ) {
+			case 'sku':
+				$this->add_from_sql_params( array( 'orderby' => 'sku' ), 'outer', 'posts.ID' );
+				$this->add_sql_clause( 'order_by', 'meta_value' );
+				break;
+			case 'variations':
+				$this->add_from_sql_params( array( 'orderby' => 'variations' ), 'outer', 'posts.ID' );
+				$this->add_sql_clause( 'order_by', 'variations' );
+				break;
+			case 'product_id':
+				$this->add_sql_clause( 'order_by', 'posts.ID' );
+				break;
+			default:
+				$this->add_sql_clause( 'order_by', 'posts.post_title' );
+		}
+		$this->add_orderby_order_clause( $query_args, $this );
+		// Without a tiebreak the database is free to resolve equal titles differently per page,
+		// so a product can come back on two of them while another is never reached.
+		$order_by = $this->get_sql_clause( 'order_by' );
+		$this->clear_sql_clause( 'order_by' );
+		$this->add_sql_clause( 'order_by', "{$order_by}, posts.ID" );
+
+		$count_query = "SELECT COUNT(*) FROM (
+				{$this->get_query_statement()}
+			) AS tt";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- built from prepared fragments.
+		$total_results = (int) $wpdb->get_var( $count_query );
+		$total_pages   = (int) ceil( $total_results / $params['per_page'] );
+
+		if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
+			return $data;
+		}
+
+		$this->get_limit_sql_params( $query_args );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- built from prepared fragments.
+		$product_data = $wpdb->get_results( $this->get_query_statement(), ARRAY_A );
+
+		if ( null === $product_data ) {
+			return $data;
+		}
+
+		$product_data = array_map( array( $this, 'cast_numbers' ), $product_data );
+
+		// cast_numbers stringifies the null the SQL returns, but an unsold product has no
+		// last sale to report, so the field stays null as the schema declares it.
+		foreach ( $product_data as $key => $row ) {
+			if ( isset( $row['last_sold'] ) && '' === $row['last_sold'] ) {
+				$product_data[ $key ]['last_sold'] = null;
+			}
+		}
+
+		return (object) array(
+			'data'    => $product_data,
+			'total'   => $total_results,
+			'pages'   => $total_pages,
+			'page_no' => (int) $query_args['page'],
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-products.php
@@ -550,11 +550,12 @@ class WC_Admin_Tests_API_Reports_Products extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 5, count( $properties ) );
+		$this->assertEquals( 6, count( $properties ) );
 		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'items_sold', $properties );
 		$this->assertArrayHasKey( 'net_revenue', $properties );
 		$this->assertArrayHasKey( 'orders_count', $properties );
+		$this->assertArrayHasKey( 'last_sold', $properties );
 		$this->assertArrayHasKey( 'extended_info', $properties );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Products/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Products/DataStoreTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Admin\API\Reports\Products;
 use Automattic\WooCommerce\Admin\API\Reports\Cache;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
+use Automattic\WooCommerce\Enums\OrderStatus;
 use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
@@ -85,9 +86,73 @@ class DataStoreTest extends WC_Unit_Test_Case {
 		$data_store = new ProductsDataStore();
 		return $data_store->get_data(
 			array(
-				'after'    => gmdate( 'Y-m-d', strtotime( '-1 day' ) ) . 'T00:00:00',
-				'before'   => gmdate( 'Y-m-d', strtotime( '+1 day' ) ) . 'T23:59:59',
-				'products' => array( $product_id ),
+				'after'         => gmdate( 'Y-m-d', strtotime( '-1 day' ) ) . 'T00:00:00',
+				'before'        => gmdate( 'Y-m-d', strtotime( '+1 day' ) ) . 'T23:59:59',
+				'products'      => array( $product_id ),
+				'extended_info' => true,
+			)
+		);
+	}
+
+	/**
+	 * Create a simple product.
+	 *
+	 * @param string $name Product name.
+	 * @return WC_Product_Simple
+	 */
+	private function create_product( $name ) {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( $name );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * Create a completed order holding the given products, and sync it into the report tables.
+	 *
+	 * @param WC_Product $product    Product to sell.
+	 * @param int        $quantity   Optional. Quantity of the product in the order.
+	 * @param string     $created_on Optional. Creation date of the order, in a date() format.
+	 * @return WC_Order
+	 */
+	private function create_synced_completed_order( $product, $quantity = 2, $created_on = 'now' ) {
+		$order = wc_create_order();
+		$order->add_product( $product, $quantity );
+		$order->calculate_totals();
+		$order->set_date_created( strtotime( $created_on ) );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		OrdersStatsDataStore::sync_order( $order->get_id() );
+		ProductsDataStore::sync_order_products( $order->get_id() );
+
+		return $order;
+	}
+
+	/**
+	 * Query the products report for the unsold products of a period.
+	 *
+	 * @param string $after  Period start, in a date() format.
+	 * @param string $before Period end, in a date() format.
+	 * @param array  $extra  Optional. Extra query arguments.
+	 * @return object Report data.
+	 */
+	private function get_unsold_report_data( $after, $before, array $extra = array() ) {
+		Cache::invalidate();
+		$data_store = new ProductsDataStore();
+
+		return $data_store->get_data(
+			array_merge(
+				array(
+					'after'    => gmdate( 'Y-m-d', strtotime( $after ) ) . 'T00:00:00',
+					'before'   => gmdate( 'Y-m-d', strtotime( $before ) ) . 'T23:59:59',
+					'unsold'   => true,
+					'orderby'  => 'product_name',
+					'order'    => 'asc',
+					'per_page' => 100,
+				),
+				$extra
 			)
 		);
 	}
@@ -118,5 +183,171 @@ class DataStoreTest extends WC_Unit_Test_Case {
 		$items_sold = array_sum( array_map( 'absint', array_column( $data->data, 'items_sold' ) ) );
 
 		$this->assertSame( 2, $items_sold, 'Orders in a non-excluded custom status should be counted in the products report' );
+	}
+
+	/**
+	 * @testdox Products report with the unsold filter should return products with no sales in the period.
+	 */
+	public function test_unsold_filter_returns_products_without_sales_in_the_period(): void {
+		$sold   = $this->create_product( 'Alpha Widget' );
+		$unsold = $this->create_product( 'Beta Widget' );
+
+		$this->create_synced_completed_order( $sold );
+
+		$data  = $this->get_unsold_report_data( '-1 day', '+1 day' );
+		$by_id = array_column( $data->data, null, 'product_id' );
+
+		$this->assertSame( 1, $data->total, 'Only the product without sales should be reported' );
+		$this->assertArrayHasKey( $unsold->get_id(), $by_id, 'The product without sales should be reported' );
+		$this->assertArrayNotHasKey( $sold->get_id(), $by_id, 'The product with sales should be left out' );
+
+		$row = $by_id[ $unsold->get_id() ];
+
+		$this->assertSame( 0, $row['items_sold'], 'An unsold product should report zero items sold' );
+		$this->assertSame( 0.0, $row['net_revenue'], 'An unsold product should report zero net revenue' );
+		$this->assertSame( 0, $row['orders_count'], 'An unsold product should report zero orders' );
+		$this->assertNull( $row['last_sold'], 'An unsold product should report no last sold date' );
+	}
+
+	/**
+	 * @testdox Products report with the unsold filter should leave out a product whose sale falls outside the period.
+	 */
+	public function test_unsold_filter_ignores_sales_outside_the_period(): void {
+		$product = $this->create_product( 'Alpha Widget' );
+
+		$this->create_synced_completed_order( $product, 2, '-10 days' );
+
+		$data = $this->get_unsold_report_data( '-1 day', '+1 day' );
+
+		$this->assertSame( 1, $data->total, 'A product sold outside the period should be reported as unsold' );
+		$this->assertSame( $product->get_id(), (int) $data->data[0]['product_id'] );
+		$this->assertNull( $data->data[0]['last_sold'], 'A product sold outside the period should report no last sold date for the period' );
+	}
+
+	/**
+	 * @testdox Products report should return the last sold date and lifetime sales of a product with sales.
+	 *
+	 * The first order falls outside the report period, so its units count toward lifetime sales
+	 * only.
+	 */
+	public function test_last_sold_and_lifetime_sales_are_reported_for_sold_products(): void {
+		$product = $this->create_product( 'Alpha Widget' );
+
+		$this->create_synced_completed_order( $product, 3, '-10 days' );
+		$this->create_synced_completed_order( $product, 5, '-1 day' );
+
+		$data = $this->get_product_report_data( $product->get_id() );
+		$row  = $data->data[0];
+
+		$this->assertSame( 5, $row['items_sold'], 'Only the order inside the period should be counted' );
+		$this->assertSame(
+			gmdate( 'Y-m-d', strtotime( '-1 day' ) ),
+			gmdate( 'Y-m-d', strtotime( $row['last_sold'] ) ),
+			'The last sold date should be the date of the latest order in the period'
+		);
+		$this->assertSame(
+			8,
+			$row['extended_info']['total_sales'],
+			'Lifetime sales should count every unit ever sold, not just the ones in the period'
+		);
+	}
+
+	/**
+	 * @testdox Products report should not report a refund as the last sold date.
+	 *
+	 * The refund lands after the order, on the refund's own date, so a bare MAX over the
+	 * period's rows would report the refund as the last sale.
+	 */
+	public function test_last_sold_ignores_refund_rows(): void {
+		$product = $this->create_product( 'Alpha Widget' );
+
+		$order      = $this->create_synced_completed_order( $product, 2, '-3 days' );
+		$order_item = reset( $order->get_items() );
+
+		$refund = wc_create_refund(
+			array(
+				'amount'     => 10,
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$order_item->get_id() => array(
+						'qty'          => 1,
+						'refund_total' => 10,
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'Refund creation should succeed' );
+
+		OrdersStatsDataStore::sync_order( $refund->get_id() );
+		ProductsDataStore::sync_order_products( $refund->get_id() );
+
+		Cache::invalidate();
+		$data_store = new ProductsDataStore();
+		$data       = $data_store->get_data(
+			array(
+				// Covers both the order and the refund.
+				'after'  => gmdate( 'Y-m-d', strtotime( '-4 days' ) ) . 'T00:00:00',
+				'before' => gmdate( 'Y-m-d', strtotime( '+1 day' ) ) . 'T23:59:59',
+			)
+		);
+
+		$this->assertSame(
+			gmdate( 'Y-m-d', strtotime( '-3 days' ) ),
+			gmdate( 'Y-m-d', strtotime( $data->data[0]['last_sold'] ) ),
+			'The refund row should not count as the last sale'
+		);
+	}
+
+	/**
+	 * @testdox Products report with the unsold filter should leave out a product sold in an excluded order status.
+	 */
+	public function test_unsold_filter_respects_excluded_order_statuses(): void {
+		$product = $this->create_product( 'Alpha Widget' );
+
+		$order = wc_create_order();
+		$order->add_product( $product, 2 );
+		$order->calculate_totals();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		OrdersStatsDataStore::sync_order( $order->get_id() );
+		ProductsDataStore::sync_order_products( $order->get_id() );
+
+		$data  = $this->get_unsold_report_data( '-1 day', '+1 day' );
+		$by_id = array_column( $data->data, null, 'product_id' );
+
+		$this->assertArrayHasKey( $product->get_id(), $by_id, 'A product whose only orders were cancelled should still be reported as unsold' );
+	}
+
+	/**
+	 * @testdox Products report with the unsold filter should page through the products without sales.
+	 */
+	public function test_unsold_filter_pagination(): void {
+		// The report orders by title, so the expected page contents follow the names, not the
+		// order the products were created in.
+		$unsold_by_name = array(
+			'Alpha Widget' => null,
+			'Beta Widget'  => null,
+			'Delta Widget' => null,
+			'Gamma Widget' => null,
+		);
+		foreach ( $unsold_by_name as $name => $unused ) {
+			$unsold_by_name[ $name ] = $this->create_product( $name )->get_id();
+		}
+
+		$data = $this->get_unsold_report_data(
+			'-1 day',
+			'+1 day',
+			array(
+				'per_page' => 2,
+				'page'     => 2,
+			)
+		);
+
+		$this->assertSame( 4, $data->total, 'All products without sales should be counted' );
+		$this->assertSame( 2, $data->pages );
+		$this->assertSame( 2, count( $data->data ) );
+		$this->assertSame( array_slice( array_values( $unsold_by_name ), 2 ), array_map( 'absint', array_column( $data->data, 'product_id' ) ), 'The second page should hold the remaining products in title order' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #44066.

Store owners want to know which of their products are not selling, but the Products report is built from the sales lookup table and grouped by it, so a product with no sales in the period never appears as a row. This PR adds an "Unsold products" option to the report's Show filter that lists published products with no sales in the selected period, so they can be spotted alongside the sold ones instead of by cross-checking the product list against the report.

Alongside the filter it adds:

- A sortable "Last sold" column showing the date of the product's last sale within the selected period (`MAX` over rows with positive quantity, so a refund row never shows up as the last sale). Blank for products that sold nothing in the period.
- Lifetime sales (`total_sales`, the existing product meta) under extended info, as a "Lifetime sales" column, so an unsold product's all-time numbers are visible in the same view.
- A new boolean `unsold` param on the `wc-analytics/reports/products` endpoint, with `last_sold` (string or null) on each row and `total_sales` under `extended_info`. Both the browser CSV download and the scheduled email export pick up the new columns.
- The summary and chart sections are hidden while the unsold filter is active, because every metric an unsold product reports is zero.

The change is additive and backward compatible: a new optional REST param, two new response fields, no changed signatures, and no hooks touched. Report cache keys already hash query params, and unsold queries bypass the report cache (like search does) because product creation and deletion do not invalidate it.

Repro of the gap this fills, on trunk: open Analytics > Products, pick any period, and note that a product with no sales in that period is absent from the table no matter which filter or search you use. There is no way to list unsold products today.

(Not a bug fix, so no introducing PR to reference.)

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| The Show filter has no way to list products without sales, and unsold products are absent from the table | New "Unsold products" filter option lists them, with a "Last sold" column on the default view and a "Lifetime sales" column available |

(Screenshots to be added after the draft is posted; see testing steps 3 and 5 for what to expect.)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open WooCommerce > Analytics > Products and confirm the default view now shows a "Last sold" column with dates for products that sold in the selected period.
2. Pick a date period in the date picker, then choose "Unsold products" in the Show filter.
3. Confirm the table lists only products with no sales in that period: items sold, net sales, and orders read 0, "Last sold" is blank, and the summary and chart are hidden.
4. Sort the table by title and by SKU and page through the results; the list should stay stable.
5. Turn on the "Lifetime sales" column through the columns menu and confirm it shows each product's all-time sold quantity, including for unsold products.
6. Create a new product while the unsold filter is active and reload; it should appear without waiting for the analytics cache to expire.
7. Click Download on the table and confirm the CSV includes "Last sold" and "Lifetime sales" columns.
8. Optional, REST: `GET /wc-analytics/reports/products?unsold=true&per_page=5` returns the same list with `last_sold: null` on each row.

<!-- End testing instructions -->

### Testing that has already taken place:

Ran in wp-env (WordPress trunk checkout, WooCommerce 11.2.0-dev, PHP 8.1, custom orders tables disabled):

- New data store tests in `tests/php/src/Admin/API/Reports/Products/DataStoreTest.php` (8 tests): unsold filtering, a sale outside the period not counting, zero metrics and null `last_sold`, lifetime sales across a period boundary, excluded order statuses respected, pagination in title order, and a refund row not counting as the last sale. All pass.
- Existing `WC_Admin_Tests_API_Reports_Products` REST tests (26 tests) pass, with the schema count updated for the new field.
- The full `DataStoreTest` filter group passes (349 tests, 3 pre-existing skips unrelated to this change).
- `lint:php:changes`, `lint:changes:branch` (PHP and JS), and PHPStan are clean; one stale baseline entry (`cast_numbers` invalid return type) was removed so the baseline shrank.
- Manually exercised the endpoint with `unsold=true` against a wp-env store with a mix of sold and unsold products.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually as `plugins/woocommerce/changelog/fix-44066-unsold-products-analytics` in this branch (Significance: minor, Type: add), since the automated job can fail for PRs opened from forks.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
