### PR TITLE
Reactivate todo tracking on pull requests

### DIFF
--- a/.github/todo-matcher-probe.txt
+++ b/.github/todo-matcher-probe.txt
@@ -1,0 +1,16 @@
+Temporary probe for the todo tracking workflow. Delete before merge.
+
+Isolating one variable: whether a URL on the same line as the todo keyword
+stops the matcher seeing it. All four below are invented, not real work.
+
+// TODO: Alpha has no link at all.
+
+// TODO: Beta has an inline link https://github.com/woocommerce/woocommerce/pull/12345 mid sentence.
+
+/**
+ * TODO: Gamma keeps its link on a continuation line.
+ *
+ * See https://github.com/woocommerce/woocommerce/pull/12345
+ */
+
+// TODO: Delta has a bare domain github.com/woocommerce/woocommerce/pull/12345 with no scheme.

--- a/.github/workflows/pr-todo-tracking.yml
+++ b/.github/workflows/pr-todo-tracking.yml
@@ -28,9 +28,13 @@ jobs:
             # The issues arrive unlabelled, which is fine: they sync into Linear and get
             # triaged there like any other report.
             #
-            # The action also renames those issues on the issues edited event. That trigger
-            # is left out on purpose, since it would start a runner on every issue edit in
-            # the repo, and the Linear sync generates plenty of those.
+            # The issues edited trigger is left out on purpose. It only renames the bot's
+            # own issues, and subscribing would start a runner on every issue edit here.
+            #
+            # This action targets an old Node runtime, so every run logs a deprecation
+            # warning and GitHub executes it on Node 24 instead. That is expected and not a
+            # failure. There is nothing newer to move to, since upstream trunk still
+            # declares node12; fixing it means a pull request against woocommerce/automations.
             - uses: woocommerce/automations@dde49354e6307929d4f2daa9afcba97d1f4d09b2 # v1.5.0
               with:
                   github_token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/pr-todo-tracking.yml
+++ b/.github/workflows/pr-todo-tracking.yml
@@ -1,0 +1,37 @@
+name: 'Track Todos'
+on:
+    pull_request:
+        types: [opened, synchronize, closed]
+    push:
+        branches: [trunk]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+    track_todos:
+        name: Track todos
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: write
+        steps:
+            # Comments on a pull request with the todos its diff adds, then opens an issue
+            # for each one on merge. The action reads the diff through the API and never
+            # checks out the branch, so no pull request code runs here.
+            #
+            # The issues arrive unlabelled, which is fine: they sync into Linear and get
+            # triaged there like any other report.
+            #
+            # The action also renames those issues on the issues edited event. That trigger
+            # is left out on purpose, since it would start a runner on every issue edit in
+            # the repo, and the Linear sync generates plenty of those.
+            - uses: woocommerce/automations@dde49354e6307929d4f2daa9afcba97d1f4d09b2 # v1.5.0
+              with:
+                  github_token: '${{ secrets.GITHUB_TOKEN }}'
+                  automations: todos


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`woocommerce-blocks` ran `woocommerce/automations` with the `todos` automation until it folded into the monorepo, and we never picked it back up. This restores it.

**On a pull request** it comments with the todos the diff adds, `cc @author`, so they get seen during review.

**On merge** it opens an issue for each todo that has no matching issue yet. Those issues arrive unlabelled and unassigned — **they sync into Linear and land in Triage, where they get labelled and prioritised like any other report.** Volume is small: 17 todos were added to trunk in the last 90 days, so roughly one a week.

One behaviour to be aware of: if a bot issue is closed as won't do, a later PR touching that same line reopens it, and the sync carries that back to Linear.

Pinned to the v1.5.0 commit rather than the mutable `v1` tag, matching the rest of our workflows.

**The second commit is a probe and should not merge.** It only exists to exercise the matcher on this PR.

### How to test the changes in this Pull Request:

1. Open this PR and wait for the **Track Todos** check.
2. Confirm the action comments with the todos it found in `.github/todo-matcher-probe.txt`, cc'ing the author.
3. Issue creation only fires on merge, so it can't be exercised from a draft.

Only runs on branches in this repo — the action skips fork PRs, so community PRs get no todo comments.

### Testing that has already taken place:

Several runs on this PR, all green, comments posted as expected.

One limitation found while testing, worth knowing before this merges: the matcher misses any todo with a `https://` URL on the same line as the keyword, because the pattern treats the `//` as a comment delimiter. That affects 27 of the 224 todo lines already in the tree, but none of the 17 added in the last 90 days, so it barely touches what this workflow actually sees. Moving the link to a continuation line makes it match. Reporting it upstream separately.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Repository tooling only, no plugin code changes, consistent with other workflow-only PRs.

</details>

### Use of AI Tools

Written with Claude Code. It traced the action's source, drafted the workflow, and wrote this description. I reviewed the workflow and the pinned SHA before pushing.
