### PR TITLE
Fix stock notifications "log in" link on product page pointing to /my-account/my-account/

### DIFF
--- a/plugins/woocommerce/changelog/68450-fix-68449-stock-notifications-login-link-url
+++ b/plugins/woocommerce/changelog/68450-fix-68449-stock-notifications-login-link-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix stock notifications "log in" link on product page pointing to /my-account/my-account/.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
@@ -152,7 +152,7 @@ class ProductPageIntegration {
 		}
 
 		$text = __( 'Please {login_link} to sign up for stock notifications.', 'woocommerce' );
-		$text = str_replace( '{login_link}', '<a href="' . wc_get_account_endpoint_url( 'my-account' ) . '">' . _x( 'log in', 'back in stock form', 'woocommerce' ) . '</a>', $text );
+		$text = str_replace( '{login_link}', '<a href="' . wc_get_page_permalink( 'myaccount' ) . '">' . _x( 'log in', 'back in stock form', 'woocommerce' ) . '</a>', $text );
 		wc_print_notice( $text, 'notice' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/ProductPageIntegrationTests.php
@@ -1,0 +1,82 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Frontend;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Frontend\ProductPageIntegration;
+use Automattic\WooCommerce\Internal\StockNotifications\Frontend\SignupService;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EligibilityService;
+use WC_Helper_Product;
+
+/**
+ * Tests for ProductPageIntegration class.
+ */
+class ProductPageIntegrationTests extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ProductPageIntegration
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		wc_clear_notices();
+
+		$eligibility_service = $this->createMock( EligibilityService::class );
+		$signup_service      = $this->createMock( SignupService::class );
+
+		$this->sut = new ProductPageIntegration();
+		$this->sut->init( $eligibility_service, $signup_service );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wc_clear_notices();
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox display_account_required prints notice linking to the My Account page permalink without redundant path segments.
+	 */
+	public function test_display_account_required_login_link_points_to_my_account_page(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		ob_start();
+		$this->sut->display_account_required( $product );
+		$output = ob_get_clean();
+
+		$my_account_url = wc_get_page_permalink( 'myaccount' );
+
+		$this->assertStringContainsString( 'href="' . $my_account_url . '"', $output );
+		$this->assertStringNotContainsString( '/my-account/my-account/', $output );
+	}
+
+	/**
+	 * @testdox display_account_required respects custom filter override.
+	 */
+	public function test_display_account_required_respects_filter(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$custom_message = '<div class="custom-account-required">Custom Message</div>';
+		add_filter(
+			'woocommerce_customer_stock_notifications_account_required_message_html',
+			static function () use ( $custom_message ) {
+				return $custom_message;
+			}
+		);
+
+		ob_start();
+		$this->sut->display_account_required( $product );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $custom_message, $output );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

Closes #68449.
(For Bug Fixes) Bug introduced in PR #59947.

When a guest views an out-of-stock product with Back in Stock Notifications enabled and "account required" configured, the notice displayed is:
> "Please log in to sign up for stock notifications."

Previously, `ProductPageIntegration::display_account_required()` called `wc_get_account_endpoint_url( 'my-account' )`. Because `wc_get_account_endpoint_url()` appends non-`'dashboard'` endpoints as slugs under the My Account permalink via `wc_get_endpoint_url()`, the link resolved to `/my-account/my-account/` (or `?page_id=X&my-account`).

This PR updates `ProductPageIntegration::display_account_required()` to call `wc_get_page_permalink( 'myaccount' )` directly, matching the pattern used in templates and other core services. It also adds unit tests in `ProductPageIntegrationTests.php` to verify the link points to the My Account permalink and respects the custom HTML filter.

### How to test the changes in this Pull Request:

1. Enable Back in Stock Notifications (**WooCommerce → Settings → Advanced → Features**).
2. Under stock notification settings, ensure account registration/login is required for signups.
3. In an incognito window or while logged out as a guest, view an out-of-stock product.
4. Observe the notice: *"Please log in to sign up for stock notifications."*
5. Inspect or click the **log in** link.
6. Verify the link points directly to the My Account page URL (e.g. `/my-account/`), not `/my-account/my-account/`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix stock notifications "log in" link on product page pointing to /my-account/my-account/.

</details>
