### PR TITLE
Support array values for structured data types

### DIFF
--- a/plugins/woocommerce/changelog/30964-support-array-structured-data-types
+++ b/plugins/woocommerce/changelog/30964-support-array-structured-data-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow structured data filters to return multiple schema types without causing a fatal error or dropping valid product markup.

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -53,7 +53,8 @@ class WC_Structured_Data {
 	 * @since 3.0.0
 	 * @since 11.2.0 Added support for multiple schema types in `@type`.
 	 *
-	 * @param  array $data  Structured data. The `@type` value accepts a string or an array of strings; any invalid array member rejects the node.
+	 * @param  array $data  Structured data. The `@type` value accepts a string or an array of strings.
+	 *                      Every type must contain 1 to 20 ASCII letters; any invalid array member rejects the node.
 	 * @param  bool  $reset Unset data (default: false).
 	 * @return bool
 	 */

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -50,7 +50,10 @@ class WC_Structured_Data {
 	/**
 	 * Sets data.
 	 *
-	 * @param  array $data  Structured data.
+	 * @since 3.0.0
+	 * @since 11.2.0 Added support for multiple schema types in `@type`.
+	 *
+	 * @param  array $data  Structured data. The `@type` value accepts a string or an array of strings; any invalid array member rejects the node.
 	 * @param  bool  $reset Unset data (default: false).
 	 * @return bool
 	 */
@@ -65,6 +68,8 @@ class WC_Structured_Data {
 					return false;
 				}
 			}
+
+			$data['@type'] = array_values( $data['@type'] );
 		} elseif ( ! isset( $data['@type'] ) || ! preg_match( '|^[a-zA-Z]{1,20}$|', $data['@type'] ) ) {
 			return false;
 		}
@@ -108,7 +113,7 @@ class WC_Structured_Data {
 		foreach ( $this->get_data() as $value ) {
 			if ( is_array( $value['@type'] ) ) {
 				$value_types    = array_map( 'strtolower', $value['@type'] );
-				$matching_types = array_intersect( $value_types, $types );
+				$matching_types = array_intersect( $types, $value_types );
 				$type           = $matching_types ? reset( $matching_types ) : reset( $value_types );
 
 				$data[ $type ][] = $value;

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -55,7 +55,17 @@ class WC_Structured_Data {
 	 * @return bool
 	 */
 	public function set_data( $data, $reset = false ) {
-		if ( ! isset( $data['@type'] ) || ! preg_match( '|^[a-zA-Z]{1,20}$|', $data['@type'] ) ) {
+		if ( isset( $data['@type'] ) && is_array( $data['@type'] ) ) {
+			if ( empty( $data['@type'] ) ) {
+				return false;
+			}
+
+			foreach ( $data['@type'] as $type ) {
+				if ( ! is_string( $type ) || ! preg_match( '|^[a-zA-Z]{1,20}$|', $type ) ) {
+					return false;
+				}
+			}
+		} elseif ( ! isset( $data['@type'] ) || ! preg_match( '|^[a-zA-Z]{1,20}$|', $data['@type'] ) ) {
 			return false;
 		}
 
@@ -96,7 +106,15 @@ class WC_Structured_Data {
 
 		// Put together the values of same type of structured data.
 		foreach ( $this->get_data() as $value ) {
-			$data[ strtolower( $value['@type'] ) ][] = $value;
+			if ( is_array( $value['@type'] ) ) {
+				$value_types    = array_map( 'strtolower', $value['@type'] );
+				$matching_types = array_intersect( $value_types, $types );
+				$type           = $matching_types ? reset( $matching_types ) : reset( $value_types );
+
+				$data[ $type ][] = $value;
+			} else {
+				$data[ strtolower( $value['@type'] ) ][] = $value;
+			}
 		}
 
 		// Wrap the multiple values of each type inside a graph... Then add context to each type.

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -21,6 +21,27 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_structured_data() preserves scalar @type grouping.
+	 */
+	public function test_get_structured_data_preserves_scalar_type_grouping(): void {
+		$markup = array(
+			'@type' => 'Product',
+			'name'  => 'Test product',
+		);
+		$this->structured_data->set_data( $markup );
+
+		$this->assertSame(
+			array(
+				'@context' => 'https://schema.org/',
+				'@type'    => 'Product',
+				'name'     => 'Test product',
+			),
+			$this->structured_data->get_structured_data( array( 'product' ) ),
+			'Scalar structured data should retain its existing grouping and output.'
+		);
+	}
+
+	/**
 	 * Test is_valid_gtin function
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -99,7 +99,7 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 	 * @testdox set_data() rejects an invalid array @type.
 	 *
 	 * @testWith [[]]
-	 *           [["Product", 123]]
+	 *           [["Product", ["Review"]]]
 	 *           [["Product", "Invalid-Type"]]
 	 *           [["Product", "ABCDEFGHIJKLMNOPQRSTU"]]
 	 *

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -42,6 +42,70 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox set_data() accepts a valid array @type without changing it.
+	 */
+	public function test_set_data_accepts_valid_array_type(): void {
+		$markup = array(
+			'@type' => array( 'Car', 'Product' ),
+			'name'  => 'Test product',
+		);
+
+		$this->assertTrue(
+			$this->structured_data->set_data( $markup ),
+			'A valid array @type should be accepted.'
+		);
+		$this->assertSame(
+			array( $markup ),
+			$this->structured_data->get_data(),
+			'A valid array @type should be stored verbatim.'
+		);
+	}
+
+	/**
+	 * @testdox set_data() rejects an invalid array @type.
+	 *
+	 * @testWith [[]]
+	 *           [["Product", 123]]
+	 *           [["Product", "Invalid-Type"]]
+	 *
+	 * @param array $types Structured data types.
+	 */
+	public function test_set_data_rejects_invalid_array_type( array $types ): void {
+		$this->assertFalse(
+			$this->structured_data->set_data( array( '@type' => $types ) ),
+			'Empty arrays, non-string members, and pattern-invalid members should be rejected.'
+		);
+	}
+
+	/**
+	 * @testdox get_structured_data() emits array @type values for matching or unfiltered requests.
+	 *
+	 * @testWith [["Car", "Product"], ["product"]]
+	 *           [["Thing", "CustomType"], ["customtype"]]
+	 *           [["Car", "Product"], []]
+	 *
+	 * @param string[] $schema_types    Schema types stored in the markup.
+	 * @param string[] $requested_types Lower-case output types requested by the caller.
+	 */
+	public function test_get_structured_data_outputs_array_type( array $schema_types, array $requested_types ): void {
+		$markup = array(
+			'@type' => $schema_types,
+			'name'  => 'Test product',
+		);
+		$this->structured_data->set_data( $markup );
+
+		$this->assertSame(
+			array(
+				'@context' => 'https://schema.org/',
+				'@type'    => $schema_types,
+				'name'     => 'Test product',
+			),
+			$this->structured_data->get_structured_data( $requested_types ),
+			'Array @type markup should survive grouping and page-type filtering.'
+		);
+	}
+
+	/**
 	 * Test is_valid_gtin function
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -43,10 +43,16 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 
 	/**
 	 * @testdox set_data() accepts a valid list of @type values.
+	 *
+	 * @testWith [["Car", "Product"]]
+	 *           [["A"]]
+	 *           [["ABCDEFGHIJKLMNOPQRST"]]
+	 *
+	 * @param array $types Structured data types.
 	 */
-	public function test_set_data_accepts_valid_array_type(): void {
+	public function test_set_data_accepts_valid_array_type( array $types ): void {
 		$markup = array(
-			'@type' => array( 'Car', 'Product' ),
+			'@type' => $types,
 			'name'  => 'Test product',
 		);
 
@@ -95,6 +101,7 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 	 * @testWith [[]]
 	 *           [["Product", 123]]
 	 *           [["Product", "Invalid-Type"]]
+	 *           [["Product", "ABCDEFGHIJKLMNOPQRSTU"]]
 	 *
 	 * @param array $types Structured data types.
 	 */

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -177,6 +177,43 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox woocommerce_structured_data_context receives the string grouping key and complete @type array.
+	 */
+	public function test_structured_data_context_receives_array_type_and_string_grouping_key(): void {
+		$markup           = array(
+			'@type' => array( 'Review', 'Product' ),
+			'name'  => 'Multi-type product',
+		);
+		$filter_arguments = array();
+
+		add_filter(
+			'woocommerce_structured_data_context',
+			static function ( $context, $data, $type, $value ) use ( &$filter_arguments ) {
+				$filter_arguments = array(
+					'type'  => $type,
+					'value' => $value,
+				);
+
+				return $context;
+			},
+			10,
+			4
+		);
+
+		$this->structured_data->set_data( $markup );
+		$this->structured_data->get_structured_data( array( 'product', 'review' ) );
+
+		$this->assertSame(
+			array(
+				'type'  => 'product',
+				'value' => array( $markup ),
+			),
+			$filter_arguments,
+			'The context filter should receive the selected string grouping key and the unmodified multi-type node.'
+		);
+	}
+
+	/**
 	 * @testdox get_structured_data() excludes multi-type nodes without a requested type.
 	 */
 	public function test_get_structured_data_excludes_array_type_without_requested_match(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -42,7 +42,7 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox set_data() accepts a valid array @type without changing it.
+	 * @testdox set_data() accepts a valid list of @type values.
 	 */
 	public function test_set_data_accepts_valid_array_type(): void {
 		$markup = array(
@@ -57,7 +57,35 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 		$this->assertSame(
 			array( $markup ),
 			$this->structured_data->get_data(),
-			'A valid array @type should be stored verbatim.'
+			'A valid list of @type values should retain its values and order.'
+		);
+	}
+
+	/**
+	 * @testdox set_data() normalizes a non-list @type array before storage.
+	 */
+	public function test_set_data_normalizes_non_list_array_type(): void {
+		$markup = array(
+			'@type' => array(
+				0 => 'Product',
+				2 => 'Book',
+			),
+			'name'  => 'Test product',
+		);
+
+		$this->assertTrue(
+			$this->structured_data->set_data( $markup ),
+			'A valid non-list @type array should be accepted.'
+		);
+		$this->assertSame(
+			array(
+				array(
+					'@type' => array( 'Product', 'Book' ),
+					'name'  => 'Test product',
+				),
+			),
+			$this->structured_data->get_data(),
+			'A non-list @type array should be reindexed so it encodes as a JSON list.'
 		);
 	}
 
@@ -102,6 +130,60 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 			),
 			$this->structured_data->get_structured_data( $requested_types ),
 			'Array @type markup should survive grouping and page-type filtering.'
+		);
+	}
+
+	/**
+	 * @testdox get_structured_data() groups multi-type nodes by requested type priority.
+	 */
+	public function test_get_structured_data_groups_array_type_by_requested_priority(): void {
+		$this->structured_data->set_data(
+			array(
+				'@type' => 'Product',
+				'name'  => 'Scalar product',
+			)
+		);
+		$this->structured_data->set_data(
+			array(
+				'@type' => array( 'Review', 'Product' ),
+				'name'  => 'Multi-type product',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'@context' => 'https://schema.org/',
+				'@graph'   => array(
+					array(
+						'@type' => 'Product',
+						'name'  => 'Scalar product',
+					),
+					array(
+						'@type' => array( 'Review', 'Product' ),
+						'name'  => 'Multi-type product',
+					),
+				),
+			),
+			$this->structured_data->get_structured_data( array( 'product', 'review' ) ),
+			'Multi-type nodes should join the group selected by the requested type order.'
+		);
+	}
+
+	/**
+	 * @testdox get_structured_data() excludes multi-type nodes without a requested type.
+	 */
+	public function test_get_structured_data_excludes_array_type_without_requested_match(): void {
+		$this->structured_data->set_data(
+			array(
+				'@type' => array( 'Thing', 'CreativeWork' ),
+				'name'  => 'Unrequested node',
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			$this->structured_data->get_structured_data( array( 'product' ) ),
+			'Multi-type nodes without a requested type should be excluded.'
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Schema.org permits nodes to use multiple `@type` values, but `WC_Structured_Data` passed array values to string-only PHP functions, preventing valid product markup from being emitted. This change validates every array member with the existing type-name rules, normalizes accepted arrays to list-shaped values, and groups them under the first type requested by the current output context. Backward compatibility is preserved for scalar values; invalid arrays are rejected as a unit, and arrays without a requested match are filtered out like scalar types.

This touches a public method plus values supplied through public filters, so the PR is labeled `impact: high`. Extensions inspecting nodes through `woocommerce_structured_data_context` can now receive an array-valued `@type` when another extension enables multiple types, so callbacks need to handle both `string` and `array` values. The separate filter grouping key remains a string, selected by the first matching requested type.

Closes #30964.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Structured_Data_Test` and confirm all 28 tests pass.
2. In a local test store, create and publish a simple product.
3. Add this temporary filter through a code snippet or the active theme:

   ```php
   add_filter(
       'woocommerce_structured_data_product',
       function ( $markup ) {
           $markup['@type'] = array(
               0 => 'Book',
               2 => 'Product',
           );
           return $markup;
       }
   );
   ```

4. Open the product page and inspect its source for the `application/ld+json` script.
5. Confirm the product node remains present, emits `"@type":["Book","Product"]`, and causes no PHP warning or fatal error.
6. Remove the temporary filter, reload the product page, and confirm the scalar `"@type":"Product"` output remains unchanged.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Automated tests.
- A local single-site browser smoke test with Twenty Twenty-Four confirmed the Shop returned HTTP 200, emitted parseable scalar `BreadcrumbList` JSON-LD, and logged no console errors.
- Multisite was not tested; this change does not read or write site-specific state.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex assisted with issue analysis, implementation, tests, verification, and drafting this Pull Request.
