### PR TITLE
Align E2E PHP coverage across routine and nightly checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,8 @@ jobs:
           name: '${{ matrix.report.resultsBlobName }}__${{ strategy.job-index }}'
           path: ${{ env.ARTIFACTS_PATH }}
           retention-days: 7
+          # A failed report merge can leave the previous attempt's artifact behind.
+          overwrite: true
 
   evaluate-project-jobs:
     # In order to add a required status check we need a consistent job that we can grab onto.
@@ -519,7 +521,10 @@ jobs:
     runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs: ['project-jobs', 'woocommerce-plugin-build-artifact', 'project-lint-jobs', 'project-test-jobs', 'evaluate-project-jobs']
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' }}
+    # Match the three-attempt limit in retry-nightly-tests.yml before alerting on nightly failures.
+    if: >-
+      ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' &&
+          ( inputs.trigger != 'nightly-checks' || github.event_name != 'schedule' || github.run_attempt >= 3 ) }}
     env:
       NON_SUCCESSFUL_JOBS: ${{ needs.evaluate-project-jobs.outputs.non_successful_jobs }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,7 @@ jobs:
     timeout-minutes: 5
     needs: ['project-jobs', 'woocommerce-plugin-build-artifact', 'project-lint-jobs', 'project-test-jobs', 'evaluate-project-jobs']
     # Match the three-attempt limit in retry-nightly-tests.yml before alerting on nightly failures.
+    # Other workflows share this job and should still report failures immediately.
     if: >-
       ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' &&
           (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,10 @@ jobs:
     # Match the three-attempt limit in retry-nightly-tests.yml before alerting on nightly failures.
     if: >-
       ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' &&
-          ( inputs.trigger != 'nightly-checks' || github.event_name != 'schedule' || github.run_attempt >= 3 ) }}
+          (
+            ( inputs.trigger == 'nightly-checks' && github.event_name == 'schedule' && github.run_attempt >= 3 ) ||
+            ( inputs.trigger != 'nightly-checks' || github.event_name != 'schedule' )
+          ) }}
     env:
       NON_SUCCESSFUL_JOBS: ${{ needs.evaluate-project-jobs.outputs.non_successful_jobs }}
     steps:

--- a/.github/workflows/retry-nightly-tests.yml
+++ b/.github/workflows/retry-nightly-tests.yml
@@ -1,0 +1,52 @@
+name: 'Retry nightly tests'
+
+on:
+    workflow_run:
+        workflows: ['Release checks run']
+        types: [completed]
+        branches: [trunk]
+
+permissions:
+    actions: write
+
+concurrency:
+    group: retry-nightly-tests-${{ github.event.workflow_run.id }}
+    cancel-in-progress: false
+
+jobs:
+    retry:
+        if: >-
+            ${{ github.repository == 'woocommerce/woocommerce' &&
+                github.event.workflow_run.event == 'schedule' &&
+                contains( fromJSON('["failure", "timed_out"]'), github.event.workflow_run.conclusion ) }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: 'Re-run failed jobs, up to three total attempts'
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: |
+                      const maxAttempts = 3;
+                      const completedRun = context.payload.workflow_run;
+                      const params = { ...context.repo, run_id: completedRun.id };
+                      const { data: run } = await github.rest.actions.getWorkflowRun( params );
+
+                      // A manual rerun or a delayed event may have advanced the run already.
+                      if (
+                          run.status !== 'completed' ||
+                          run.run_attempt !== completedRun.run_attempt ||
+                          run.event !== 'schedule' ||
+                          run.path !== '.github/workflows/tests-on-release.yml' ||
+                          ! [ 'failure', 'timed_out' ].includes( run.conclusion )
+                      ) {
+                          core.info( 'The nightly run is no longer eligible for a retry.' );
+                          return;
+                      }
+
+                      if ( run.run_attempt >= maxAttempts ) {
+                          core.info( `Stopping after ${ run.run_attempt } attempts: ${ run.html_url }` );
+                          return;
+                      }
+
+                      await github.rest.actions.reRunWorkflowFailedJobs( params );
+                      core.info( `Requested attempt ${ run.run_attempt + 1 }/${ maxAttempts }: ${ run.html_url }` );

--- a/plugins/woocommerce/changelog/dev-align-e2e-php-coverage
+++ b/plugins/woocommerce/changelog/dev-align-e2e-php-coverage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Align E2E PHP coverage across routine and nightly CI checks.
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -245,7 +245,7 @@
 					]
 				},
 				{
-					"name": "Core e2e tests - parallel",
+					"name": "Core e2e tests - parallel - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:core-parallel",
@@ -268,11 +268,15 @@
 						"uninstall.php"
 					],
 					"testEnv": {
-						"start": "env:e2e --debug"
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "8.3"
+						}
 					},
 					"events": [
 						"pull_request",
 						"push",
+						"nightly-checks",
 						"release-checks",
 						"core-e2e"
 					],
@@ -283,7 +287,32 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - serial",
+					"name": "Core e2e tests - parallel - PHP 7.4",
+					"testType": "e2e",
+					"usesSharedPluginBuild": true,
+					"command": "test:e2e:core-parallel",
+					"shardingArguments": [
+						"--shard=1/2",
+						"--shard=2/2"
+					],
+					"changes": [],
+					"testEnv": {
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "7.4"
+						}
+					},
+					"events": [
+						"nightly-checks"
+					],
+					"report": {
+						"resultsBlobName": "core-e2e-report-php-7.4",
+						"resultsPath": "tests/e2e/test-results",
+						"allure": true
+					}
+				},
+				{
+					"name": "Core e2e tests - serial - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:core-serial",
@@ -306,11 +335,15 @@
 						"uninstall.php"
 					],
 					"testEnv": {
-						"start": "env:e2e --debug"
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "8.3"
+						}
 					},
 					"events": [
 						"pull_request",
 						"push",
+						"nightly-checks",
 						"release-checks",
 						"core-e2e"
 					],
@@ -321,7 +354,32 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - Gutenberg stable",
+					"name": "Core e2e tests - serial - PHP 7.4",
+					"testType": "e2e",
+					"usesSharedPluginBuild": true,
+					"command": "test:e2e:core-serial",
+					"shardingArguments": [
+						"--shard=1/2",
+						"--shard=2/2"
+					],
+					"changes": [],
+					"testEnv": {
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "7.4"
+						}
+					},
+					"events": [
+						"nightly-checks"
+					],
+					"report": {
+						"resultsBlobName": "core-e2e-report-php-7.4",
+						"resultsPath": "tests/e2e/test-results",
+						"allure": true
+					}
+				},
+				{
+					"name": "Core e2e tests - Gutenberg stable - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:gb-stable",
@@ -339,7 +397,10 @@
 						"core-e2e-gutenberg"
 					],
 					"testEnv": {
-						"start": "env:e2e --debug"
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "8.3"
+						}
 					},
 					"report": {
 						"resultsBlobName": "gutenberg-stable-e2e-report",
@@ -348,7 +409,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - Gutenberg nightly",
+					"name": "Core e2e tests - Gutenberg nightly - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:gb-nightly",
@@ -365,7 +426,10 @@
 						"core-e2e-gutenberg"
 					],
 					"testEnv": {
-						"start": "env:e2e --debug"
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "8.3"
+						}
 					},
 					"report": {
 						"resultsBlobName": "gutenberg-nightly-e2e-report",
@@ -374,7 +438,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - (HPOS:off)",
+					"name": "Core e2e tests - (HPOS:off) - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:hpos-off",
@@ -392,7 +456,10 @@
 						"core-e2e-hpos-disabled"
 					],
 					"testEnv": {
-						"start": "env:e2e --debug"
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "8.3"
+						}
 					},
 					"report": {
 						"resultsBlobName": "core-e2e-reports-hpos-disabled",
@@ -422,9 +489,7 @@
 						}
 					},
 					"events": [
-						"pull_request",
 						"nightly-checks",
-						"release-checks",
 						"core-e2e-php-8.5"
 					],
 					"report": {
@@ -455,9 +520,7 @@
 						}
 					},
 					"events": [
-						"pull_request",
 						"nightly-checks",
-						"release-checks",
 						"core-e2e-php-8.5"
 					],
 					"report": {
@@ -467,7 +530,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - WP L-1 - serial",
+					"name": "Core e2e tests - WP L-1 - serial - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:core-serial",
@@ -484,7 +547,8 @@
 					"testEnv": {
 						"start": "env:e2e --debug",
 						"config": {
-							"wpVersion": "latest-1"
+							"wpVersion": "latest-1",
+							"phpVersion": "8.3"
 						}
 					},
 					"events": [
@@ -500,7 +564,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - WP L-1 - parallel",
+					"name": "Core e2e tests - WP L-1 - parallel - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:core-parallel",
@@ -517,7 +581,8 @@
 					"testEnv": {
 						"start": "env:e2e --debug",
 						"config": {
-							"wpVersion": "latest-1"
+							"wpVersion": "latest-1",
+							"phpVersion": "8.3"
 						}
 					},
 					"events": [
@@ -533,7 +598,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - WP pre-release - serial",
+					"name": "Core e2e tests - WP pre-release - serial - PHP 8.3",
 					"optional": true,
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
@@ -551,7 +616,8 @@
 					"testEnv": {
 						"start": "env:e2e --debug",
 						"config": {
-							"wpVersion": "prerelease"
+							"wpVersion": "prerelease",
+							"phpVersion": "8.3"
 						}
 					},
 					"events": [
@@ -567,7 +633,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - WP pre-release - parallel",
+					"name": "Core e2e tests - WP pre-release - parallel - PHP 8.3",
 					"optional": true,
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
@@ -585,7 +651,8 @@
 					"testEnv": {
 						"start": "env:e2e --debug",
 						"config": {
-							"wpVersion": "prerelease"
+							"wpVersion": "prerelease",
+							"phpVersion": "8.3"
 						}
 					},
 					"events": [
@@ -854,7 +921,7 @@
 					}
 				},
 				{
-					"name": "Blocks e2e tests",
+					"name": "Blocks e2e tests - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:blocks",
@@ -895,12 +962,13 @@
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {
-							"phpVersion": "7.4"
+							"phpVersion": "8.3"
 						}
 					},
 					"events": [
 						"pull_request",
 						"push",
+						"nightly-checks",
 						"release-checks",
 						"blocks-e2e"
 					],
@@ -911,7 +979,79 @@
 					}
 				},
 				{
-					"name": "Blocks e2e tests - unified editor assets",
+					"name": "Blocks e2e tests - PHP 7.4",
+					"testType": "e2e",
+					"usesSharedPluginBuild": true,
+					"command": "test:e2e:blocks",
+					"shardingArguments": [
+						"--shard=1/10",
+						"--shard=2/10",
+						"--shard=3/10",
+						"--shard=4/10",
+						"--shard=5/10",
+						"--shard=6/10",
+						"--shard=7/10",
+						"--shard=8/10",
+						"--shard=9/10",
+						"--shard=10/10"
+					],
+					"changes": [],
+					"onlyForDependencies": [
+						"@woocommerce/block-library"
+					],
+					"testEnv": {
+						"start": "env:start:blocks",
+						"config": {
+							"phpVersion": "7.4"
+						}
+					},
+					"events": [
+						"nightly-checks"
+					],
+					"report": {
+						"resultsBlobName": "blocks-e2e-report-php-7.4",
+						"resultsPath": "tests/e2e/test-results",
+						"allure": true
+					}
+				},
+				{
+					"name": "Blocks e2e tests - PHP 8.5",
+					"testType": "e2e",
+					"usesSharedPluginBuild": true,
+					"command": "test:e2e:blocks",
+					"shardingArguments": [
+						"--shard=1/10",
+						"--shard=2/10",
+						"--shard=3/10",
+						"--shard=4/10",
+						"--shard=5/10",
+						"--shard=6/10",
+						"--shard=7/10",
+						"--shard=8/10",
+						"--shard=9/10",
+						"--shard=10/10"
+					],
+					"changes": [],
+					"onlyForDependencies": [
+						"@woocommerce/block-library"
+					],
+					"testEnv": {
+						"start": "env:start:blocks",
+						"config": {
+							"phpVersion": "8.5"
+						}
+					},
+					"events": [
+						"nightly-checks"
+					],
+					"report": {
+						"resultsBlobName": "blocks-e2e-report-php-8.5",
+						"resultsPath": "tests/e2e/test-results",
+						"allure": true
+					}
+				},
+				{
+					"name": "Blocks e2e tests - unified editor assets - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:blocks:unified-editor-assets",
@@ -950,7 +1090,7 @@
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {
-							"phpVersion": "7.4"
+							"phpVersion": "8.3"
 						}
 					},
 					"events": [
@@ -963,7 +1103,7 @@
 					}
 				},
 				{
-					"name": "Blocks e2e tests - WP pre-release",
+					"name": "Blocks e2e tests - WP pre-release - PHP 8.3",
 					"optional": true,
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
@@ -998,7 +1138,7 @@
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {
-							"phpVersion": "7.4",
+							"phpVersion": "8.3",
 							"wpVersion": "prerelease"
 						}
 					},
@@ -1015,7 +1155,7 @@
 					}
 				},
 				{
-					"name": "Blocks e2e tests - WP latest-1",
+					"name": "Blocks e2e tests - WP latest-1 - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:blocks",
@@ -1049,7 +1189,7 @@
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {
-							"phpVersion": "7.4",
+							"phpVersion": "8.3",
 							"wpVersion": "latest-1"
 						}
 					},
@@ -1096,7 +1236,7 @@
 					}
 				},
 				{
-					"name": "Core e2e tests - PayPal Standard",
+					"name": "Core e2e tests - PayPal Standard - PHP 8.3",
 					"testType": "e2e",
 					"usesSharedPluginBuild": true,
 					"command": "test:e2e:paypal-standard",
@@ -1113,7 +1253,10 @@
 						"core-e2e"
 					],
 					"testEnv": {
-						"start": "env:e2e --debug"
+						"start": "env:e2e --debug",
+						"config": {
+							"phpVersion": "8.3"
+						}
 					},
 					"report": {
 						"resultsBlobName": "core-e2e-report",

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -73,6 +73,14 @@ run `pnpm playwright test --help`
 The e2e test environment configuration can be found in the `.wp-env.e2e.json` file in the `plugins/woocommerce`
 folder (the `.wp-env.json` file configures the separate dev environment, and `.wp-env.test.json` the lean PHP-unit environment).
 
+### PHP coverage in CI
+
+PR, push, release, and pre-release E2E checks use PHP 8.3. Scheduled nightly checks run the standard Core and Blocks suites, including all their shards, on PHP 7.4, 8.3, and 8.5 (the latest supported release). Additional WordPress, Gutenberg, HPOS, and unified editor assets variants run on PHP 8.3. PHP unit, API, and performance jobs keep their existing configurations.
+
+The policy lives in `config.ci.tests` in `plugins/woocommerce/package.json`, using each job's `events` and `testEnv.config.phpVersion`. PHP 7.4 and 8.5 have separate nightly entries and report names; the existing report names represent PHP 8.3. When updating the policy, keep the routine version aligned with store usage and update the latest nightly version as WooCommerce adopts a newer PHP release.
+
+Custom on-demand triggers run their selected jobs with the configured PHP version; `core-e2e-php-8.5` remains available for PHP 8.5. Tests against existing hosted sites also keep the host's PHP version. Local E2E environments continue to use `.wp-env.e2e.json`; set `WP_ENV_PHP_VERSION=8.3` when starting the environment to reproduce routine CI coverage.
+
 For more information on how to configure the test environment for `wp-env`, please check out
 the official [documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/env).
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Routine E2E checks currently split PHP coverage between Core and Blocks. Following the [PHP coverage discussion](https://wooengineering.wordpress.com/2026/09/07/aligning-php-version-coverage-across-woocommerce-e2e-tests/), use PHP 8.3 for PRs, trunk pushes, releases, and pre-release checks, and cover PHP 7.4, 8.3, and 8.5 in the standard Core and Blocks nightly suites through the existing `config.ci.tests` entries in `plugins/woocommerce/package.json`.

| E2E checks | PHP versions |
| --- | --- |
| PR, push, release, pre-release | 8.3 |
| Nightly standard Core and Blocks suites, including all shards | 7.4, 8.3, 8.5 |
| Nightly additional WordPress/Gutenberg/HPOS/unified editor assets variants | 8.3 |

PHP 8.3 is the proposed representative store version; PHP 7.4 covers the WooCommerce minimum, and PHP 8.5 is the latest supported release. Nightly variants have distinct report names for each PHP version. The existing `core-e2e-php-8.5` on-demand trigger remains available. PHP unit, API, performance, local environment defaults, and externally hosted test environments retain their existing configurations.

**Stacked on #68451; merge that PR first.** Its retry workflow allows three total attempts before reporting scheduled nightly failures to Slack. Since the parent branch is on a fork, this PR targets `trunk` and currently includes the parent commits. Review only this follow-up using [the comparison against the parent branch](https://github.com/gigitux/woocommerce/compare/dev/retry-nightly-failed-jobs...dev/align-e2e-php-coverage).

The expanded nightly configuration has up to 83 E2E jobs (55 on PHP 8.3 and 14 each on PHP 7.4 and 8.5), compared with 45 previously. WordPress pre-release jobs are omitted when no pre-release is available. This is CI configuration and documentation only, with no merchant-facing behavior change.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; CI configuration only.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and install the repository dependencies with `pnpm install --frozen-lockfile`.
2. From the repository root, generate the routine matrices without executing tests:

   ```sh
   pnpm utils ci-jobs --event pull_request --list
   pnpm utils ci-jobs --event push --list
   pnpm utils ci-jobs --event release-checks --list
   ```

   Confirm all WooCommerce E2E job names contain PHP 8.3. The reusable CI workflow maps its `pre-release` trigger to `release-checks`, so the third command covers that selection too. Omitting a base ref deliberately considers all projects changed; an actual PR can select fewer jobs based on its changed files.
3. Generate the nightly matrix:

   ```sh
   pnpm utils ci-jobs --event nightly-checks --list
   ```

   Confirm the standard Core serial/parallel and Blocks suites have the same shards on PHP 7.4, 8.3, and 8.5. Additional WordPress, Gutenberg, HPOS, and unified editor assets variants should appear only on PHP 8.3. Confirm report names separate PHP versions. WordPress pre-release variants only appear when the WordPress API supplies a pre-release.
4. Inspect `config.ci.tests` in `plugins/woocommerce/package.json`: routine entries specify `testEnv.config.phpVersion: "8.3"`; additional PHP 7.4/8.5 entries select `nightly-checks`. Existing Core PHP 8.5 entries also retain their dedicated on-demand trigger. The generator maps these values to `WP_ENV_PHP_VERSION` for environment startup.
5. For runtime validation, inspect this PR's E2E jobs for PHP 8.3 environment startup and test results. After #68451 and this PR merge, inspect the scheduled nightly run for all three PHP versions and separate Allure reports. Reproduce the retry behavior using the fork smoke-test steps in #68451; the matrix-generation commands above do not trigger retries or send Slack messages.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Validated the existing `pnpm utils ci-jobs` command for all four events, capturing its actual GitHub Actions outputs and asserting the PHP environment values, matching nightly shards, unique job names, and report registration. With no WordPress pre-release currently available, the generated E2E counts were:

| Event | PHP 8.3 | PHP 7.4 | PHP 8.5 | Total test jobs, including other test types |
| --- | --- | --- | --- | --- |
| pull_request | 31 | 0 | 0 | 71 |
| push | 15 | 0 | 0 | 55 |
| release-checks | 32 | 0 | 0 | 34 |
| nightly-checks | 41 | 14 | 14 | 71 |

Also compared non-E2E definitions against the parent branch (unchanged), checked the full configured nightly coverage including optional pre-release entries, and passed Prettier, Markdown lint, and `git diff --check`. Validation used Node 24.15 and pnpm 10.33 on macOS. Full E2E suites and PHP environment startup have not been executed for this change; no store or hosting environment was used for the configuration checks.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/dev-align-e2e-php-coverage`. Internal CI configuration and documentation; no merchant-facing changelog message.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex authored the configuration, documentation, changelog, and PR description, and performed the automated configuration checks described above.
