### PR TITLE
Scope notice dismissals per site on multisite (follow-up to #68412)

### DIFF
--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -109,7 +109,7 @@ class WC_Helper_Admin {
 				$settings['wccomHelper']['maybe_deleted_connection']     = WC_Woo_Helper_Connection::get_deleted_connection_notice();
 
 				// The "Connected to <email>" banner on My Subscriptions stays hidden once dismissed.
-				$settings['wccomHelper']['show_connected_account_notice'] = PluginsHelper::should_show_notice( PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, false );
+				$settings['wccomHelper']['show_connected_account_notice'] = PluginsHelper::should_show_notice( PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, false, true );
 
 				// Read last: the notices above already trigger a subscriptions fetch,
 				// so by this point any failure from it has been recorded.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -109,7 +109,7 @@ class WC_Helper_Admin {
 				$settings['wccomHelper']['maybe_deleted_connection']     = WC_Woo_Helper_Connection::get_deleted_connection_notice();
 
 				// The "Connected to <email>" banner on My Subscriptions stays hidden once dismissed.
-				$settings['wccomHelper']['show_connected_account_notice'] = PluginsHelper::should_show_notice( PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, false, true );
+				$settings['wccomHelper']['show_connected_account_notice'] = PluginsHelper::should_show_notice( PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, false );
 
 				// Read last: the notices above already trigger a subscriptions fetch,
 				// so by this point any failure from it has been recorded.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1079,8 +1079,8 @@ class WC_Helper {
 		do_action( 'woocommerce_helper_connect_start' );
 
 		// Ignore all previously dismissed connected notices.
-		delete_metadata( 'user', 0, \Automattic\WooCommerce\Admin\PluginsHelper::DISMISS_CONNECT_NOTICE, '', true );
-		\Automattic\WooCommerce\Admin\PluginsHelper::delete_connected_account_notice_dismissal();
+		\Automattic\WooCommerce\Admin\PluginsHelper::delete_notice_dismissal( \Automattic\WooCommerce\Admin\PluginsHelper::DISMISS_CONNECT_NOTICE );
+		\Automattic\WooCommerce\Admin\PluginsHelper::delete_notice_dismissal( \Automattic\WooCommerce\Admin\PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE );
 
 		$connect_url = add_query_arg(
 			array(

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1080,7 +1080,7 @@ class WC_Helper {
 
 		// Ignore all previously dismissed connected notices.
 		delete_metadata( 'user', 0, \Automattic\WooCommerce\Admin\PluginsHelper::DISMISS_CONNECT_NOTICE, '', true );
-		delete_metadata( 'user', 0, \Automattic\WooCommerce\Admin\PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, '', true );
+		\Automattic\WooCommerce\Admin\PluginsHelper::delete_connected_account_notice_dismissal();
 
 		$connect_url = add_query_arg(
 			array(

--- a/plugins/woocommerce/src/Admin/API/Notice.php
+++ b/plugins/woocommerce/src/Admin/API/Notice.php
@@ -66,19 +66,19 @@ class Notice extends \WC_REST_Data_Controller {
 		$dismissed = false;
 		switch ( $notice_id ) {
 			case 'woo-subscription-expired-notice':
-				update_user_meta( get_current_user_id(), PluginsHelper::DISMISS_EXPIRED_SUBS_NOTICE, time() );
+				Users::update_site_user_meta( get_current_user_id(), PluginsHelper::DISMISS_EXPIRED_SUBS_NOTICE, time() );
 				$dismissed = true;
 				break;
 			case 'woo-subscription-expiring-notice':
-				update_user_meta( get_current_user_id(), PluginsHelper::DISMISS_EXPIRING_SUBS_NOTICE, time() );
+				Users::update_site_user_meta( get_current_user_id(), PluginsHelper::DISMISS_EXPIRING_SUBS_NOTICE, time() );
 				$dismissed = true;
 				break;
 			case 'woo-disconnect-notice':
-				update_user_meta( get_current_user_id(), PluginsHelper::DISMISS_DISCONNECT_NOTICE, time() );
+				Users::update_site_user_meta( get_current_user_id(), PluginsHelper::DISMISS_DISCONNECT_NOTICE, time() );
 				$dismissed = true;
 				break;
 			case 'woo-connect-notice':
-				update_user_meta( get_current_user_id(), PluginsHelper::DISMISS_CONNECT_NOTICE, time() );
+				Users::update_site_user_meta( get_current_user_id(), PluginsHelper::DISMISS_CONNECT_NOTICE, time() );
 				$dismissed = true;
 				break;
 			case 'woo-connected-account-notice':

--- a/plugins/woocommerce/src/Admin/API/Notice.php
+++ b/plugins/woocommerce/src/Admin/API/Notice.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -81,7 +82,8 @@ class Notice extends \WC_REST_Data_Controller {
 				$dismissed = true;
 				break;
 			case 'woo-connected-account-notice':
-				update_user_meta( get_current_user_id(), PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, time() );
+				// Store site-scoped so a dismissal on one multisite site doesn't hide the banner on another.
+				Users::update_site_user_meta( get_current_user_id(), PluginsHelper::DISMISS_CONNECTED_ACCOUNT_NOTICE, time() );
 				$dismissed = true;
 				break;
 		}

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -1387,19 +1387,19 @@ class PluginsHelper {
 	/**
 	 * Determine whether a specific notice should be shown to the current user.
 	 *
+	 * Dismissals are stored site-scoped, so dismissing a notice on one multisite site
+	 * doesn't hide it on the others.
+	 *
 	 * @param string $dismiss_notice_meta User meta that includes the timestamp when a store notice was dismissed.
 	 * @param bool   $show_after_one_month Show the notices dismissed earlier than one month.
-	 * @param bool   $site_scoped Whether the dismissal is stored per site (multisite) rather than network-wide.
 	 * @return bool True if the notice should be shown, false otherwise.
 	 */
-	public static function should_show_notice( $dismiss_notice_meta, $show_after_one_month = true, $site_scoped = false ) {
+	public static function should_show_notice( $dismiss_notice_meta, $show_after_one_month = true ) {
 		// Get the current user ID.
 		$user_id = get_current_user_id();
 
 		// Get the timestamp when the notice was dismissed.
-		$dismissed_timestamp = $site_scoped
-			? Users::get_site_user_meta( $user_id, $dismiss_notice_meta )
-			: get_user_meta( $user_id, $dismiss_notice_meta, true );
+		$dismissed_timestamp = Users::get_site_user_meta( $user_id, $dismiss_notice_meta );
 
 		if ( ! $show_after_one_month ) {
 			return empty( $dismissed_timestamp );
@@ -1412,24 +1412,21 @@ class PluginsHelper {
 
 		// If the notice was dismissed more than a month ago, delete the meta value and show the notice.
 		if ( ! empty( $dismissed_timestamp ) ) {
-			$site_scoped
-				? Users::delete_site_user_meta( $user_id, $dismiss_notice_meta )
-				: delete_user_meta( $user_id, $dismiss_notice_meta );
+			Users::delete_site_user_meta( $user_id, $dismiss_notice_meta );
 		}
 
 		return true;
 	}
 
 	/**
-	 * Delete the connected account notice dismissal for all users on the current site.
+	 * Delete a notice dismissal for all users on the current site.
 	 *
-	 * The dismissal is stored site-scoped (see should_show_notice), so starting a new
-	 * WooCommerce.com connection only resets it for the site being connected.
+	 * Pairs with should_show_notice(), which stores dismissals site-scoped.
+	 *
+	 * @param string $dismiss_notice_meta User meta key of the dismissal.
 	 */
-	public static function delete_connected_account_notice_dismissal(): void {
-		global $wpdb;
-		$key = self::DISMISS_CONNECTED_ACCOUNT_NOTICE . '_' . rtrim( $wpdb->get_blog_prefix(), '_' );
-		delete_metadata( 'user', 0, $key, '', true );
+	public static function delete_notice_dismissal( string $dismiss_notice_meta ): void {
+		Users::delete_site_user_meta_for_all_users( $dismiss_notice_meta );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -14,6 +14,7 @@ use Automatic_Upgrader_Skin;
 use Automattic\WooCommerce\Admin\PluginsInstallLoggers\AsyncPluginsInstallLogger;
 use Automattic\WooCommerce\Admin\PluginsInstallLoggers\PluginsInstallLogger;
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use Automattic\WooCommerce\Utilities\PluginUtil;
 use Plugin_Upgrader;
 use WC_Helper;
@@ -1388,14 +1389,17 @@ class PluginsHelper {
 	 *
 	 * @param string $dismiss_notice_meta User meta that includes the timestamp when a store notice was dismissed.
 	 * @param bool   $show_after_one_month Show the notices dismissed earlier than one month.
+	 * @param bool   $site_scoped Whether the dismissal is stored per site (multisite) rather than network-wide.
 	 * @return bool True if the notice should be shown, false otherwise.
 	 */
-	public static function should_show_notice( $dismiss_notice_meta, $show_after_one_month = true ) {
+	public static function should_show_notice( $dismiss_notice_meta, $show_after_one_month = true, $site_scoped = false ) {
 		// Get the current user ID.
 		$user_id = get_current_user_id();
 
 		// Get the timestamp when the notice was dismissed.
-		$dismissed_timestamp = get_user_meta( $user_id, $dismiss_notice_meta, true );
+		$dismissed_timestamp = $site_scoped
+			? Users::get_site_user_meta( $user_id, $dismiss_notice_meta )
+			: get_user_meta( $user_id, $dismiss_notice_meta, true );
 
 		if ( ! $show_after_one_month ) {
 			return empty( $dismissed_timestamp );
@@ -1408,10 +1412,24 @@ class PluginsHelper {
 
 		// If the notice was dismissed more than a month ago, delete the meta value and show the notice.
 		if ( ! empty( $dismissed_timestamp ) ) {
-			delete_user_meta( $user_id, $dismiss_notice_meta );
+			$site_scoped
+				? Users::delete_site_user_meta( $user_id, $dismiss_notice_meta )
+				: delete_user_meta( $user_id, $dismiss_notice_meta );
 		}
 
 		return true;
+	}
+
+	/**
+	 * Delete the connected account notice dismissal for all users on the current site.
+	 *
+	 * The dismissal is stored site-scoped (see should_show_notice), so starting a new
+	 * WooCommerce.com connection only resets it for the site being connected.
+	 */
+	public static function delete_connected_account_notice_dismissal(): void {
+		global $wpdb;
+		$key = self::DISMISS_CONNECTED_ACCOUNT_NOTICE . '_' . rtrim( $wpdb->get_blog_prefix(), '_' );
+		delete_metadata( 'user', 0, $key, '', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/Users.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Users.php
@@ -212,4 +212,20 @@ class Users {
 		$site_specific_key = $meta_key . '_' . rtrim( $wpdb->get_blog_prefix(), '_' );
 		return delete_user_meta( $user_id, $site_specific_key, $meta_value );
 	}
+
+	/**
+	 * Site-specific means of deleting user meta for all users on the current site.
+	 *
+	 * Pairs with update_site_user_meta(): deletes the site-prefixed meta key for every user,
+	 * regardless of the stored value.
+	 *
+	 * @param string $meta_key Metadata key.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public static function delete_site_user_meta_for_all_users( string $meta_key ): bool {
+		global $wpdb;
+		$site_specific_key = $meta_key . '_' . rtrim( $wpdb->get_blog_prefix(), '_' );
+		return delete_metadata( 'user', 0, $site_specific_key, '', true );
+	}
 }


### PR DESCRIPTION
Stacked draft on #68412 so the diff renders cleanly. Addresses the CodeRabbit multisite finding: user meta written with `update_user_meta()` is network-wide on multisite, so a dismissal hid the banner/notice on every site in the network.

Extends the fix to all five notice keys on the `/wc-admin/notice/dismiss` endpoint (subscription expired/expiring, disconnect, connect, connected account):

- `PluginsHelper::should_show_notice()` reads and clears dismissals via the site-scoped `Users` helpers.
- `Notice::dissmiss_notice()` writes them the same way.
- Reconnect reset deletes the current site's prefixed key via `PluginsHelper::delete_notice_dismissal()`.

Behavior change on multisite: dismissals become per site; existing network-wide rows are orphaned, so users see each notice once more. Single-site installs only see the meta key gain a blog-prefix suffix.

phpcs and PHPStan clean on the touched files. No multisite test yet — to be added before this lands. Intended to be folded into #68412 or merged as a follow-up; do not merge this draft directly.