### PR TITLE
Expose stock notifications settings through the REST settings API

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-7691-stock-notifications-rest-settings
+++ b/plugins/woocommerce/changelog/fix-wooplug-7691-stock-notifications-rest-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Expose the Customer Stock Notifications settings through the REST settings API by registering them outside the admin context.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/AdminManager.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/AdminManager.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\StockNotifications\Admin;
 
 use Automattic\WooCommerce\Internal\StockNotifications\Admin\MenusController;
-use Automattic\WooCommerce\Internal\StockNotifications\Admin\SettingsController;
 use Automattic\Jetpack\Constants;
 
 /**
@@ -27,7 +26,6 @@ class AdminManager {
 
 		$container = wc_get_container();
 		$container->get( MenusController::class );
-		$container->get( SettingsController::class );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/SettingsController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/SettingsController.php
@@ -26,6 +26,12 @@ class SettingsController {
 		// Add the My Account endpoint setting to the Advanced tab.
 		add_filter( 'woocommerce_get_settings_advanced', array( $this, 'add_my_account_endpoint_setting' ), 100, 2 );
 
+		// The product edit hooks stay admin-only: process_product_object() reads $_POST and
+		// checks an admin nonce, so it must not run for cron or CLI code that fires the hook.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		// Display admin notices about incompatible settings combinations.
 		add_action( 'admin_notices', array( $this, 'output_admin_notices' ) );
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/StockNotifications.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/StockNotifications.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Privacy\PrivacyEraser;
 use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailManager;
 use Automattic\WooCommerce\Internal\StockNotifications\AsyncTasks\NotificationsProcessor;
 use Automattic\WooCommerce\Internal\StockNotifications\Admin\AdminManager;
+use Automattic\WooCommerce\Internal\StockNotifications\Admin\SettingsController;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\ProductPageIntegration;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\FormHandlerService;
@@ -123,6 +124,10 @@ class StockNotifications implements RegisterHooksInterface {
 		$container->get( FormHandlerService::class );
 		$container->get( NotificationManagementService::class );
 		$container->get( MyAccountEndpoint::class );
+
+		// The settings filters must attach outside admin too, or the REST settings
+		// API (`is_admin()` is false there) never sees the feature's settings.
+		$container->get( SettingsController::class );
 
 		if ( is_admin() ) {
 			$container->get( AdminManager::class );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -3,7 +3,7 @@
 declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Admin;
 
-use Automattic\WooCommerce\Internal\StockNotifications\Admin\SettingsController as StockNotificationsSettings;
+use Automattic\WooCommerce\Internal\StockNotifications\Admin\SettingsController;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
 use WC_Settings_Advanced;
 use WC_Settings_Products;
@@ -16,7 +16,7 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 	/**
 	 * The controller whose hooks the tests exercise.
 	 *
-	 * @var StockNotificationsSettings
+	 * @var SettingsController
 	 */
 	private $controller;
 
@@ -25,9 +25,8 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		// Only AdminManager resolves the controller, and only in admin context. Built directly
-		// rather than through the container, whose cached instance loses its hooks after the first test.
-		$this->controller = new StockNotificationsSettings();
+		// Built directly rather than through the container, whose cached instance loses its hooks after the first test.
+		$this->controller = new SettingsController();
 	}
 
 	/**
@@ -72,6 +71,57 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected, $setting_ids_and_types );
+	}
+
+	/**
+	 * @testdox Outside admin, only the settings filters are attached.
+	 */
+	public function test_only_settings_filters_are_attached_outside_admin(): void {
+		$this->assertFalse( is_admin() );
+
+		$sut = new SettingsController();
+
+		$this->assertSame( 100, has_filter( 'woocommerce_get_sections_products', array( $sut, 'add_customer_stock_notifications_section' ) ) );
+		$this->assertSame( 100, has_filter( 'woocommerce_get_settings_products', array( $sut, 'add_customer_stock_notifications_settings' ) ) );
+		$this->assertSame( 100, has_filter( 'woocommerce_get_settings_advanced', array( $sut, 'add_my_account_endpoint_setting' ) ) );
+		$this->assertFalse( has_action( 'admin_notices', array( $sut, 'output_admin_notices' ) ) );
+		$this->assertFalse( has_action( 'woocommerce_product_options_stock_status', array( $sut, 'add_disable_stock_notifications_checkbox' ) ) );
+		$this->assertFalse( has_action( 'woocommerce_admin_process_product_object', array( $sut, 'process_product_object' ) ) );
+
+		$this->remove_hooks( $sut );
+	}
+
+	/**
+	 * @testdox In admin, the product edit and notice hooks are attached as well.
+	 */
+	public function test_admin_hooks_are_attached_in_admin(): void {
+		set_current_screen( 'edit-post' );
+		$this->assertTrue( is_admin() );
+
+		$sut = new SettingsController();
+
+		$this->assertSame( 100, has_filter( 'woocommerce_get_sections_products', array( $sut, 'add_customer_stock_notifications_section' ) ) );
+		$this->assertSame( 100, has_filter( 'woocommerce_get_settings_products', array( $sut, 'add_customer_stock_notifications_settings' ) ) );
+		$this->assertSame( 100, has_filter( 'woocommerce_get_settings_advanced', array( $sut, 'add_my_account_endpoint_setting' ) ) );
+		$this->assertSame( 10, has_action( 'admin_notices', array( $sut, 'output_admin_notices' ) ) );
+		$this->assertSame( 20, has_action( 'woocommerce_product_options_stock_status', array( $sut, 'add_disable_stock_notifications_checkbox' ) ) );
+		$this->assertSame( 10, has_action( 'woocommerce_admin_process_product_object', array( $sut, 'process_product_object' ) ) );
+
+		$this->remove_hooks( $sut );
+	}
+
+	/**
+	 * Detach every hook a test instance attached, so it does not leak into other tests.
+	 *
+	 * @param SettingsController $sut The instance under test.
+	 */
+	private function remove_hooks( SettingsController $sut ): void {
+		remove_filter( 'woocommerce_get_sections_products', array( $sut, 'add_customer_stock_notifications_section' ), 100 );
+		remove_filter( 'woocommerce_get_settings_products', array( $sut, 'add_customer_stock_notifications_settings' ), 100 );
+		remove_filter( 'woocommerce_get_settings_advanced', array( $sut, 'add_my_account_endpoint_setting' ), 100 );
+		remove_action( 'admin_notices', array( $sut, 'output_admin_notices' ) );
+		remove_action( 'woocommerce_product_options_stock_status', array( $sut, 'add_disable_stock_notifications_checkbox' ), 20 );
+		remove_action( 'woocommerce_admin_process_product_object', array( $sut, 'process_product_object' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -87,8 +87,6 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 		$this->assertFalse( has_action( 'admin_notices', array( $sut, 'output_admin_notices' ) ) );
 		$this->assertFalse( has_action( 'woocommerce_product_options_stock_status', array( $sut, 'add_disable_stock_notifications_checkbox' ) ) );
 		$this->assertFalse( has_action( 'woocommerce_admin_process_product_object', array( $sut, 'process_product_object' ) ) );
-
-		$this->remove_hooks( $sut );
 	}
 
 	/**
@@ -106,22 +104,6 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 		$this->assertSame( 10, has_action( 'admin_notices', array( $sut, 'output_admin_notices' ) ) );
 		$this->assertSame( 20, has_action( 'woocommerce_product_options_stock_status', array( $sut, 'add_disable_stock_notifications_checkbox' ) ) );
 		$this->assertSame( 10, has_action( 'woocommerce_admin_process_product_object', array( $sut, 'process_product_object' ) ) );
-
-		$this->remove_hooks( $sut );
-	}
-
-	/**
-	 * Detach every hook a test instance attached, so it does not leak into other tests.
-	 *
-	 * @param SettingsController $sut The instance under test.
-	 */
-	private function remove_hooks( SettingsController $sut ): void {
-		remove_filter( 'woocommerce_get_sections_products', array( $sut, 'add_customer_stock_notifications_section' ), 100 );
-		remove_filter( 'woocommerce_get_settings_products', array( $sut, 'add_customer_stock_notifications_settings' ), 100 );
-		remove_filter( 'woocommerce_get_settings_advanced', array( $sut, 'add_my_account_endpoint_setting' ), 100 );
-		remove_action( 'admin_notices', array( $sut, 'output_admin_notices' ) );
-		remove_action( 'woocommerce_product_options_stock_status', array( $sut, 'add_disable_stock_notifications_checkbox' ), 20 );
-		remove_action( 'woocommerce_admin_process_product_object', array( $sut, 'process_product_object' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsTests.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\Tests\Internal\StockNotifications;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\StockNotifications\DataRetentionController;
 use Automattic\WooCommerce\Internal\StockNotifications\StockNotifications;
+use WC_Admin_Settings;
+use WC_Settings_Products;
 
 /**
  * StockNotifications controller tests.
@@ -83,6 +85,31 @@ class StockNotificationsTests extends \WC_Unit_Test_Case {
 				'Toggling the feature should queue a rewrite rules flush.'
 			);
 		}
+	}
+
+	/**
+	 * @testdox The settings are registered outside admin, so the REST settings API can see them.
+	 */
+	public function test_settings_are_registered_outside_admin(): void {
+		$this->assertFalse( is_admin(), 'This test must run outside the admin context, as REST requests do.' );
+
+		$products_page = null;
+		foreach ( WC_Admin_Settings::get_settings_pages() as $page ) {
+			if ( $page instanceof WC_Settings_Products ) {
+				$products_page = $page;
+				break;
+			}
+		}
+		$this->assertNotNull( $products_page, 'The Products settings page should be registered.' );
+
+		$this->assertArrayHasKey( 'customer_stock_notifications', $products_page->get_sections() );
+
+		$setting_ids = array_column( $products_page->get_settings_for_section( 'customer_stock_notifications' ), 'id' );
+		$this->assertContains( 'woocommerce_customer_stock_notifications_allow_signups', $setting_ids );
+		$this->assertContains( 'woocommerce_customer_stock_notifications_require_double_opt_in', $setting_ids );
+		$this->assertContains( 'woocommerce_customer_stock_notifications_require_account', $setting_ids );
+		$this->assertContains( 'woocommerce_customer_stock_notifications_create_account_on_signup', $setting_ids );
+		$this->assertContains( 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold', $setting_ids );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsTests.php
@@ -92,6 +92,7 @@ class StockNotificationsTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_settings_are_registered_outside_admin(): void {
 		$this->assertFalse( is_admin(), 'This test must run outside the admin context, as REST requests do.' );
+		$this->init_stock_notifications_services();
 
 		$products_page = null;
 		foreach ( WC_Admin_Settings::get_settings_pages() as $page ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Customer Stock Notifications settings section (Products › Customer stock notifications) was registered by `SettingsController`, which was only resolved from `AdminManager` behind `is_admin()`. REST requests run with `is_admin()` false, so the `woocommerce_get_sections_products` / `woocommerce_get_settings_products` filters never attached there and `GET /wp-json/wc/v3/settings/products` omitted the feature's settings (and `PUT` on them returned `rest_setting_setting_invalid`).

This PR:

- Resolves `SettingsController` directly from `StockNotifications::maybe_init_services()`, outside the `is_admin()` guard, so the settings filters attach in every context (still behind the feature flag check). `AdminManager` no longer resolves it.
- Keeps the product edit hooks (`admin_notices`, `woocommerce_product_options_stock_status`, `woocommerce_admin_process_product_object`) admin-only via an `is_admin()` guard inside the `SettingsController` constructor. `process_product_object()` reads `$_POST` and calls `check_admin_referer()`, so it must not run for cron or CLI code that fires `woocommerce_admin_process_product_object`.
- Adds tests: the section and settings are visible through `WC_Admin_Settings::get_settings_pages()` when `is_admin()` is false, and only the settings filters attach outside admin while all hooks attach in admin.

The `woocommerce_myaccount_stock_notifications_endpoint` option from #68291 registers through the same class, so it is now exposed via `GET /wp-json/wc/v3/settings/advanced` as well.

**Backward compatibility:** no public signatures or hooks change. The settings filters now also run in non-admin contexts, which is the intended behaviour and matches every other core settings section. The three admin hooks attach in exactly the same contexts as before.

Linear: [WOOPLUG-7691](https://linear.app/a8c/issue/WOOPLUG-7691/bis-stock-notifications-settings-are-not-exposed-through-the-rest)

Bug introduced in PR #59947.

### How to test the changes in this Pull Request:

1. Enable the Customer Stock Notifications feature under WooCommerce › Settings › Advanced › Features.
2. Using an application password, request `GET /wp-json/wc/v3/settings/products`.
3. Confirm the response includes `woocommerce_customer_stock_notifications_allow_signups`, `woocommerce_customer_stock_notifications_require_double_opt_in`, `woocommerce_customer_stock_notifications_require_account`, `woocommerce_customer_stock_notifications_create_account_on_signup`, and `woocommerce_customer_stock_notifications_unverified_deletions_days_threshold`. On trunk these are missing.
4. Request `PUT /wp-json/wc/v3/settings/products/woocommerce_customer_stock_notifications_allow_signups` with body `{"value":"no"}` and confirm it returns 200 with the updated value. On trunk this returns 404 `rest_setting_setting_invalid`.
5. In wp-admin, open WooCommerce › Settings › Products › Customer stock notifications and confirm the section still renders and saves.
6. Edit a simple product, toggle the "Customer stock notifications" checkbox under Inventory, and confirm it saves.
7. Request `GET /wp-json/wc/v3/settings/advanced` and confirm `woocommerce_myaccount_stock_notifications_endpoint` is present. On trunk it is missing.
8. Disable the feature and confirm the settings disappear from both REST responses again.

### Testing that has already taken place:

- `SettingsControllerTests` and `StockNotificationsTests` pass locally (9 tests, 37 assertions) in wp-env with PHP 8.1.
- phpcs (`lint:php:changes`) and PHPStan clean on the changed files.
- Verified in-tree that the only firer of `woocommerce_admin_process_product_object` is `WC_Meta_Box_Product_Data::save`, which already runs behind the `woocommerce_meta_nonce` check.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually (`plugins/woocommerce/changelog/fix-wooplug-7691-stock-notifications-rest-settings`).

### Use of AI Tools

Implemented with Claude Code; all changes reviewed and tested by the author.

