### PR TITLE
Fix leaked dialog listener in the brands E2E test

### DIFF
--- a/plugins/woocommerce/tests/e2e/tests/brands/create-product-brand.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/brands/create-product-brand.spec.ts
@@ -144,6 +144,11 @@ test( 'Merchant can add brands', async ( { page } ) => {
 			.first()
 			.click();
 
+		// The delete confirm is bound by a footer script on DOM ready. Clicking
+		// "Delete" before the page has loaded follows the link with no dialog and
+		// leaves the listener below to fire on the next delete.
+		await page.waitForURL( /term\.php/ );
+
 		// After clicking the "Delete" button, there will be a confirmation dialog.
 		page.once( 'dialog', ( dialog ) => {
 			// Click "OK" to confirm the deletion.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`Merchant can add brands` fails now and then with `dialog.accept: Cannot accept dialog which is already handled!`. The test reports dashboard shows 7 hits since 2026-07-08, all on PR and release-check runs, for example [this run](https://github.com/woocommerce/woocommerce/actions/runs/33753782095/job/100644229189).

The trace of that run shows the cause. `deleteBrand()` clicks the brand row, then clicks Delete on the term edit page. WordPress binds the delete confirm from a footer script on DOM ready. On a slow runner the Delete link is clickable before that happens, so the click follows the link with no confirm and the brand is deleted anyway. The `page.once( 'dialog' )` listener registered for that delete stays behind. The next delete does raise a confirm, both listeners call `accept()`, and the second one throws.

The fix waits for the term edit page to finish loading before clicking Delete, so the confirm always fires and each listener is consumed by its own dialog.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #50165.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the spec in the `core-parallel` project: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:core-parallel tests/brands/create-product-brand.spec.ts`. It should pass.
2. To see the mechanism, open the trace of the [failing run](https://github.com/woocommerce/woocommerce/actions/runs/33753782095/job/100644229189) (artifact `core-e2e-report-attempt-1`): the first Delete click navigates with no `dialog` event, and the second Delete click produces one dialog with two `Dialog.accept` calls, the second of which fails.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Analyzed the Playwright trace of the failing run (see step 2 above).
- Reproduced locally against a wp-env site (WC 11.2.0-dev, WP 7.1) with a standalone Playwright 1.61 script that mirrors `deleteBrand()` and records, right before the Delete click, whether the confirm handler is bound. Without the wait: handler unbound in 36 of 36 deletes, no dialog in 30, and the "already handled" error whenever a later dialog fired. With the wait: handler bound and dialog fired in 18 of 18 deletes, no listener leaked. Same result at 1x and 8x CPU throttling.
- Checked the history of this spec on the test reports dashboard: every recorded failure since 2026-07-08 is this error, none on trunk pushes (0 of 204 reports), all on PR and release-check runs.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

E2E test-only change; nothing ships to merchants.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The trace analysis, CI history lookup, local repro script and this patch were drafted with Claude Code and reviewed by the author.
