### PR TITLE
Create strip_whitespace and strip_whitespace_and_password_form_ids utils for SingleProductTemplateTests to avoid repeating the same logic in every test

### DIFF
--- a/plugins/woocommerce/changelog/update-SingleProductTemplateTests-utils
+++ b/plugins/woocommerce/changelog/update-SingleProductTemplateTests-utils
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Create strip_whitespace and strip_whitespace_and_password_form_ids utils for SingleProductTemplateTests to avoid repeating the same logic in every test
+
+

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateCompatibilityTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateCompatibilityTests.php
@@ -38,10 +38,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -73,10 +73,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -156,10 +156,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -191,10 +191,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -226,10 +226,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -293,10 +293,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -322,10 +322,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 
@@ -352,10 +352,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -393,10 +393,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -430,10 +430,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -468,10 +468,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 
 	/**
@@ -504,9 +504,9 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $result );
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
-
-		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -211,8 +211,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			TemplateContentUtils::strip_whitespace( $result ),
-			TemplateContentUtils::strip_whitespace( $expected_single_product_template )
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace( $result )
 		);
 	}
 
@@ -246,8 +246,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result ),
-			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template )
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result )
 		);
 	}
 
@@ -358,8 +358,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result ),
-			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template )
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result )
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -13,10 +13,7 @@ use WP_UnitTestCase;
 class SingleProductTemplateTests extends WP_UnitTestCase {
 
 	/**
-	 * Test that the Product Catalog template content isn't updated mistakenly.
-	 * In other words, make sure the Single Product template logic doesn't leak
-	 * into other templates.
-	 *
+	 * @testdox Should not update Product Catalog template content so Single Product template logic does not leak into other templates.
 	 */
 	public function test_dont_update_single_product_content_for_other_templates() {
 		$single_product_template                  = new SingleProductTemplate();
@@ -44,9 +41,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Single Product template content isn't updated if it
-	 * contains the Legacy Template block.
-	 *
+	 * @testdox Should not update Single Product template content when it contains the Legacy Template block.
 	 */
 	public function test_dont_update_single_product_content_with_legacy_template() {
 		$single_product_template                 = new SingleProductTemplate();
@@ -74,9 +69,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Single Product template content is updated if it doesn't
-	 * contain the Legacy Template block.
-	 *
+	 * @testdox Should update Single Product template content when it does not contain the Legacy Template block.
 	 */
 	public function test_update_single_product_content_with_legacy_template() {
 		$single_product_template                  = new SingleProductTemplate();
@@ -112,9 +105,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Single Product template content isn't updated if it
-	 * contains a pattern with the Legacy Template block.
-	 *
+	 * @testdox Should not update Single Product template content when a pattern contains the Legacy Template block.
 	 */
 	public function test_dont_update_single_product_content_with_legacy_template_inside_a_pattern() {
 		register_block_pattern(
@@ -150,9 +141,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Single Product template content is updated if it doesn't
-	 * contain the Legacy Template block.
-	 *
+	 * @testdox Should update Single Product template content when a pattern does not contain the Legacy Template block.
 	 */
 	public function test_update_single_product_content_with_legacy_template_inside_a_pattern() {
 		register_block_pattern(
@@ -196,8 +185,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the password form isn't added to the Single Product Template.
-	 *
+	 * @testdox Should not add the password form when the template has no Single Product blocks.
 	 */
 	public function test_no_remove_block_when_no_single_product_is_in_the_template() {
 		$default_single_product_template = '
@@ -229,7 +217,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the password form is added to the Single Product Template.
+	 * @testdox Should add the password form to the Single Product template.
 	 */
 	public function test_replace_single_product_blocks_with_input_form() {
 		$default_single_product_template = '
@@ -264,7 +252,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the password form is added to the Single Product Template with the default template.
+	 * @testdox Should add the password form to the default Single Product template.
 	 */
 	public function test_replace_default_template_single_product_blocks_with_input_form() {
 		$default_single_product_template = '

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -106,8 +106,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			self::strip_whitespace( $expected_single_product_template_content ),
-			self::strip_whitespace( $result[0]->content )
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template_content ),
+			TemplateContentUtils::strip_whitespace( $result[0]->content )
 		);
 	}
 
@@ -190,8 +190,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			self::strip_whitespace( $expected_single_product_template_content ),
-			self::strip_whitespace( $result[0]->content )
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template_content ),
+			TemplateContentUtils::strip_whitespace( $result[0]->content )
 		);
 	}
 
@@ -223,8 +223,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			self::strip_whitespace( $result ),
-			self::strip_whitespace( $expected_single_product_template )
+			TemplateContentUtils::strip_whitespace( $result ),
+			TemplateContentUtils::strip_whitespace( $expected_single_product_template )
 		);
 	}
 
@@ -258,8 +258,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			self::strip_whitespace_and_password_form_ids( $result ),
-			self::strip_whitespace_and_password_form_ids( $expected_single_product_template )
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result ),
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template )
 		);
 	}
 
@@ -370,32 +370,8 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			self::strip_whitespace_and_password_form_ids( $result ),
-			self::strip_whitespace_and_password_form_ids( $expected_single_product_template )
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result ),
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template )
 		);
-	}
-
-	/**
-	 * Remove whitespace so template HTML can be compared without formatting differences.
-	 *
-	 * @param string $content Template HTML.
-	 * @return string
-	 */
-	private static function strip_whitespace( string $content ): string {
-		return preg_replace( '/\s+/', '', $content );
-	}
-
-	/**
-	 * Remove whitespace and dynamic password form IDs so HTML can be compared.
-	 *
-	 * WordPress generates unique IDs like pwbox-123 on each call to get_the_password_form().
-	 *
-	 * @param string $content Template HTML.
-	 * @return string
-	 */
-	private static function strip_whitespace_and_password_form_ids( string $content ): string {
-		$without_whitespace = self::strip_whitespace( $content );
-
-		return preg_replace( '/pwbox-\d+/', '', $without_whitespace );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -382,9 +382,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	 * @return string
 	 */
 	private static function strip_whitespace( string $content ): string {
-		$stripped = preg_replace( '/\s+/', '', $content );
-
-		return is_string( $stripped ) ? $stripped : '';
+		return preg_replace( '/\s+/', '', $content );
 	}
 
 	/**
@@ -397,8 +395,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	 */
 	private static function strip_whitespace_and_password_form_ids( string $content ): string {
 		$without_whitespace = self::strip_whitespace( $content );
-		$stripped           = preg_replace( '/pwbox-\d+/', '', $without_whitespace );
 
-		return is_string( $stripped ) ? $stripped : $without_whitespace;
+		return preg_replace( '/pwbox-\d+/', '', $without_whitespace );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\Templates;
 
@@ -104,16 +105,9 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			),
 		);
 
-		$expected_single_product_template_without_whitespace = preg_replace(
-			'/\s+/',
-			'',
-			$expected_single_product_template_content
-		);
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result[0]->content );
-
 		$this->assertEquals(
-			$expected_single_product_template_without_whitespace,
-			$result_without_whitespace
+			self::strip_whitespace( $expected_single_product_template_content ),
+			self::strip_whitespace( $result[0]->content )
 		);
 	}
 
@@ -195,16 +189,9 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			),
 		);
 
-		$expected_single_product_template_without_whitespace = preg_replace(
-			'/\s+/',
-			'',
-			$expected_single_product_template_content
-		);
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result[0]->content );
-
 		$this->assertEquals(
-			$expected_single_product_template_without_whitespace,
-			$result_without_whitespace
+			self::strip_whitespace( $expected_single_product_template_content ),
+			self::strip_whitespace( $result[0]->content )
 		);
 	}
 
@@ -235,16 +222,9 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			$default_single_product_template
 		);
 
-		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
-		$expected_single_product_template_without_whitespace = preg_replace(
-			'/\s+/',
-			'',
-			$expected_single_product_template
-		);
-
 		$this->assertEquals(
-			$result_without_whitespace,
-			$expected_single_product_template_without_whitespace
+			self::strip_whitespace( $result ),
+			self::strip_whitespace( $expected_single_product_template )
 		);
 	}
 
@@ -277,28 +257,9 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			$default_single_product_template
 		);
 
-		$result_without_whitespace                          = preg_replace( '/\s+/', '', $result );
-		$result_without_whitespace_without_custom_pwbox_ids = preg_replace(
-			'/pwbox-\d+/',
-			'',
-			$result_without_whitespace
-		);
-
-		$expected_single_product_template_without_whitespace = preg_replace(
-			'/\s+/',
-			'',
-			$expected_single_product_template
-		);
-
-		$expected_single_product_template_without_whitespace_without_custom_pwbox_ids = preg_replace(
-			'/pwbox-\d+/',
-			'',
-			$expected_single_product_template_without_whitespace
-		);
-
 		$this->assertEquals(
-			$result_without_whitespace_without_custom_pwbox_ids,
-			$expected_single_product_template_without_whitespace_without_custom_pwbox_ids
+			self::strip_whitespace_and_password_form_ids( $result ),
+			self::strip_whitespace_and_password_form_ids( $expected_single_product_template )
 		);
 	}
 
@@ -408,28 +369,36 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			$default_single_product_template
 		);
 
-		$result_without_whitespace                          = preg_replace( '/\s+/', '', $result );
-		$result_without_whitespace_without_custom_pwbox_ids = preg_replace(
-			'/pwbox-\d+/',
-			'',
-			$result_without_whitespace
-		);
-
-		$expected_single_product_template_without_whitespace = preg_replace(
-			'/\s+/',
-			'',
-			$expected_single_product_template
-		);
-
-		$expected_single_product_template_without_whitespace_without_custom_pwbox_ids = preg_replace(
-			'/pwbox-\d+/',
-			'',
-			$expected_single_product_template_without_whitespace
-		);
-
 		$this->assertEquals(
-			$result_without_whitespace_without_custom_pwbox_ids,
-			$expected_single_product_template_without_whitespace_without_custom_pwbox_ids
+			self::strip_whitespace_and_password_form_ids( $result ),
+			self::strip_whitespace_and_password_form_ids( $expected_single_product_template )
 		);
+	}
+
+	/**
+	 * Remove whitespace so template HTML can be compared without formatting differences.
+	 *
+	 * @param string $content Template HTML.
+	 * @return string
+	 */
+	private static function strip_whitespace( string $content ): string {
+		$stripped = preg_replace( '/\s+/', '', $content );
+
+		return is_string( $stripped ) ? $stripped : '';
+	}
+
+	/**
+	 * Remove whitespace and dynamic password form IDs so HTML can be compared.
+	 *
+	 * WordPress generates unique IDs like pwbox-123 on each call to get_the_password_form().
+	 *
+	 * @param string $content Template HTML.
+	 * @return string
+	 */
+	private static function strip_whitespace_and_password_form_ids( string $content ): string {
+		$without_whitespace = self::strip_whitespace( $content );
+		$stripped           = preg_replace( '/pwbox-\d+/', '', $without_whitespace );
+
+		return is_string( $stripped ) ? $stripped : $without_whitespace;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/TemplateContentUtils.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/TemplateContentUtils.php
@@ -1,0 +1,32 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Templates;
+
+/**
+ * Helpers for comparing template HTML in tests.
+ */
+class TemplateContentUtils {
+
+	/**
+	 * Remove whitespace so template HTML can be compared without formatting differences.
+	 *
+	 * @param string $content Template HTML.
+	 * @return string
+	 */
+	public static function strip_whitespace( string $content ): string {
+		return preg_replace( '/\s+/', '', $content );
+	}
+
+	/**
+	 * Remove whitespace and dynamic password form IDs so HTML can be compared.
+	 *
+	 * WordPress generates unique IDs like pwbox-123 on each call to get_the_password_form().
+	 *
+	 * @param string $content Template HTML.
+	 * @return string
+	 */
+	public static function strip_whitespace_and_password_form_ids( string $content ): string {
+		return preg_replace( '/pwbox-\d+/', '', self::strip_whitespace( $content ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As in https://github.com/woocommerce/woocommerce/pull/68479 I'm introducing more tests to SingleProductTemplateTests, I thought it would make sense to introduce this two utils that help reduce the LOC of the file. I split it from the other PRs to keep the diff small in each one so it's easier to review.

### How to test the changes in this Pull Request:

1. Make sure CI pass.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
