### PR TITLE
Fix Taxes report counting placeholder tax entries as taxable amount

### DIFF
--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -702,6 +702,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			// only mis-split the base between multiple compound rates, not the total.
 			$compound_running_tax = 0.0;
 			foreach ( $taxes['total'] as $rate_id => $tax ) {
+				// Admin saves without recalculating store '' for rates that never applied
+				// to the item. Numeric zero still counts (zero-rated sales).
+				if ( ! is_numeric( $tax ) ) {
+					continue;
+				}
+
 				$base = (float) $item->get_total();
 				if ( in_array( (int) $rate_id, $compound_rate_ids, true ) ) {
 					$base                 += $non_compound_tax + $compound_running_tax;

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -690,7 +690,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$non_compound_tax = 0.0;
 			foreach ( $taxes['total'] as $rate_id => $tax ) {
-				if ( ! in_array( (int) $rate_id, $compound_rate_ids, true ) ) {
+				if ( is_numeric( $tax ) && ! in_array( (int) $rate_id, $compound_rate_ids, true ) ) {
 					$non_compound_tax += (float) $tax;
 				}
 			}

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Taxes/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Taxes/DataStoreTest.php
@@ -558,6 +558,45 @@ class DataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox An admin order save that leaves empty tax placeholders on items records no base for that rate.
+	 */
+	public function test_sync_order_taxes_ignores_placeholder_tax_entries(): void {
+		global $wpdb;
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$rate_id       = $this->insert_tax_rate();
+		$other_rate_id = $this->insert_tax_rate( '7', 2 );
+		$order         = $this->create_taxed_de_order();
+
+		// An admin save without recalculating stores '' for rates that never applied to the
+		// item. Blank the second rate on the fee and shipping only, so its base must come
+		// from the product line alone.
+		foreach ( $order->get_items( array( OrderItemType::FEE, OrderItemType::SHIPPING ) ) as $item ) {
+			$taxes                            = $item->get_taxes();
+			$taxes['total'][ $other_rate_id ] = '';
+			if ( isset( $taxes['subtotal'] ) ) {
+				$taxes['subtotal'][ $other_rate_id ] = '';
+			}
+			$item->set_taxes( $taxes );
+			$item->save();
+		}
+		$order->update_taxes();
+		$order->save();
+
+		DataStore::sync_order_taxes( $order->get_id() );
+
+		$amounts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT tax_rate_id, taxable_amount FROM {$wpdb->prefix}wc_order_tax_lookup WHERE order_id = %d",
+				$order->get_id()
+			),
+			OBJECT_K
+		);
+		$this->assertSame( 200.0, (float) $amounts[ $other_rate_id ]->taxable_amount, 'Placeholder entries must not add the fee and shipping totals to the rate.' );
+		$this->assertSame( 215.0, (float) $amounts[ $rate_id ]->taxable_amount, 'The rate without placeholders must keep its full base.' );
+	}
+
+	/**
 	 * @testdox Syncing an order records the base of a compound tax rate including the taxes it compounds over.
 	 */
 	public function test_sync_order_taxes_records_taxable_amount_for_compound_rate(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Saving an order in the admin without recalculating stores '' tax placeholders on items for every order tax rate that never applied to them, and `get_taxable_amounts_by_rate()` counted each placeholder as if the rate had taxed the item, inflating that rate's Taxable amount in the Analytics Taxes report. Skip non-numeric tax values so only rates that actually applied contribute an item's base. Numeric zero still counts, so zero-rated sales keep recording their base.

Closes WOOAIRR-263.

Bug introduced in PR #68233.

### How to test the changes in this Pull Request:

1. Enable taxes and create two standard rates: 19% (products and shipping) and 7% with only "Shipping" checked.
2. Place and complete an order containing one product plus flat-rate shipping, then let the analytics import run (Tools > Scheduled Actions, run the pending `wc-admin` actions).
3. Edit the order in wp-admin, change the product quantity, and click Save (not Recalculate), then run the pending import actions again.
4. Open Analytics > Taxes: the 7% rate's Taxable amount must equal the shipping total only. Without this fix it also includes the product total.

### Testing that has already taken place:

- New regression test drives the real producer chain (`set_taxes()` with '' placeholders, then `WC_Abstract_Order::update_taxes()`) and fails on trunk without the fix.
- Full Taxes report suites pass (`DataStoreTest`, legacy `WC_Admin_Tests_API_Reports_Taxes`, `OrderTaxLookupMigratorTest`), plus PHPStan and phpcs-changed on the diff.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Fixes the unreleased taxable amount column added in #68233 (11.2.0). That PR's changelog entry already covers the feature.

</details>

### Use of AI Tools

Authored with Claude Code. The fix and regression test were human-directed, independently AI-reviewed, and validated against the full Taxes report test suites.
