### PR TITLE
Include the date range in emailed Analytics report exports

### DIFF
--- a/plugins/woocommerce/changelog/49059-include-dates-in-emailed-analytics-exports
+++ b/plugins/woocommerce/changelog/49059-include-dates-in-emailed-analytics-exports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Include the report's date range in emailed Analytics exports, in the email and in the downloaded file's name.

--- a/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
@@ -19,6 +19,21 @@ do_action( 'woocommerce_email_header', $email_heading, $email );
 		echo esc_html( sprintf( __( 'Download your %s Report', 'woocommerce' ), $report_name ) );
 	?>
 </a>
+<?php
+/**
+ * Date range the report covers, passed in by ReportCSVEmail. Empty for reports without one.
+ *
+ * @var string $date_range
+ */
+if ( ! empty( $date_range ) ) :
+	?>
+<p>
+	<?php
+		/* translators: %s: the date range the report covers, e.g. "June 1, 2025 - June 30, 2025" */
+		echo esc_html( sprintf( __( 'Date range: %s', 'woocommerce' ), $date_range ) );
+	?>
+</p>
+<?php endif; ?>
 <p>
 	<?php
 		/**

--- a/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
@@ -17,6 +17,18 @@ echo wp_kses_post( sprintf( __( 'Download your %1$s Report: %2$s', 'woocommerce'
 echo "\n\n";
 
 /**
+ * Date range the report covers, passed in by ReportCSVEmail. Empty for reports without one.
+ *
+ * @var string $date_range
+ */
+if ( ! empty( $date_range ) ) {
+	/* translators: %s: the date range the report covers, e.g. "June 1, 2025 - June 30, 2025" */
+	echo esc_html( sprintf( __( 'Date range: %s', 'woocommerce' ), $date_range ) );
+
+	echo "\n\n";
+}
+
+/**
  * Length of time the download link stays valid, passed in by ReportCSVEmail.
  *
  * @var string $retention

--- a/plugins/woocommerce/src/Admin/API/Reports/Export/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Export/Controller.php
@@ -255,12 +255,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 
 		// @todo - add thing in the links below instead?
 		if ( 100 === $percentage ) {
-			$query_args = array(
-				'action'   => ReportExporter::DOWNLOAD_EXPORT_ACTION,
-				'filename' => "wc-{$report_type}-report-export-{$export_id}",
-			);
-
-			$result['download_url'] = add_query_arg( $query_args, admin_url() );
+			$result['download_url'] = ReportExporter::get_download_url( $report_type, $export_id );
 		}
 
 		// Wrap the data in a response object.

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -53,6 +53,8 @@ class ReportCSVEmail extends \WC_Email {
 	 * Constructor.
 	 */
 	public function __construct() {
+		$this->placeholders['{report_date_range}'] = '';
+
 		$this->id             = 'admin_report_export_download';
 		$this->template_base  = WC()->plugin_path() . '/includes/react-admin/emails/';
 		$this->template_html  = 'html-admin-report-export-download.php';
@@ -188,21 +190,31 @@ class ReportCSVEmail extends \WC_Email {
 	}
 
 	/**
+	 * Set the date range the report covers, so the email can say which period it is for.
+	 *
+	 * Call before trigger(). Reports that are not limited to a period, such as Stock, leave it unset.
+	 *
+	 * @since 11.2.0
+	 * @param string $date_range The date range the report covers, formatted for display.
+	 * @return void
+	 */
+	public function set_report_date_range( $date_range ) {
+		$this->report_date_range = is_string( $date_range ) ? $date_range : '';
+
+		$this->placeholders['{report_date_range}'] = $this->report_date_range;
+	}
+
+	/**
 	 * Trigger the sending of this email.
 	 *
 	 * @param int    $user_id User ID to email.
 	 * @param string $report_type The type of report export being emailed.
 	 * @param string $download_url The URL for downloading the report.
-	 * @param string $date_range Optional. The date range the report covers, formatted for display.
-	 *                           Empty for reports that are not limited to a period, such as Stock.
 	 */
-	public function trigger( $user_id, $report_type, $download_url, $date_range = '' ) {
-		$user                    = new \WP_User( $user_id );
-		$this->recipient         = $user->user_email;
-		$this->download_url      = $download_url;
-		$this->report_date_range = is_string( $date_range ) ? $date_range : '';
-
-		$this->placeholders['{report_date_range}'] = $this->report_date_range;
+	public function trigger( $user_id, $report_type, $download_url ) {
+		$user               = new \WP_User( $user_id );
+		$this->recipient    = $user->user_email;
+		$this->download_url = $download_url;
 
 		if ( isset( $this->report_labels[ $report_type ] ) ) {
 			$this->report_type                   = $this->report_labels[ $report_type ];

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -43,6 +43,13 @@ class ReportCSVEmail extends \WC_Email {
 	protected $download_url;
 
 	/**
+	 * Date range the report covers, formatted for display. Empty when the report has no range.
+	 *
+	 * @var string
+	 */
+	protected $report_date_range = '';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -111,9 +118,16 @@ class ReportCSVEmail extends \WC_Email {
 	/**
 	 * Get email subject.
 	 *
+	 * Says which period the report covers when it has one, so a merchant running the same report
+	 * over several date ranges can tell the emails apart without opening them.
+	 *
 	 * @return string
 	 */
 	public function get_default_subject() {
+		if ( '' !== $this->report_date_range ) {
+			return __( '[{site_title}]: Your {report_name} Report for {report_date_range} is ready', 'woocommerce' );
+		}
+
 		return __( '[{site_title}]: Your {report_name} Report download is ready', 'woocommerce' );
 	}
 
@@ -127,6 +141,7 @@ class ReportCSVEmail extends \WC_Email {
 			$this->template_html,
 			array(
 				'report_name'   => $this->report_type,
+				'date_range'    => $this->report_date_range,
 				'download_url'  => $this->download_url,
 				'email_heading' => $this->get_heading(),
 				'sent_to_admin' => true,
@@ -149,6 +164,7 @@ class ReportCSVEmail extends \WC_Email {
 			$this->template_plain,
 			array(
 				'report_name'   => $this->report_type,
+				'date_range'    => $this->report_date_range,
 				'download_url'  => $this->download_url,
 				'email_heading' => $this->get_heading(),
 				'sent_to_admin' => true,
@@ -177,11 +193,16 @@ class ReportCSVEmail extends \WC_Email {
 	 * @param int    $user_id User ID to email.
 	 * @param string $report_type The type of report export being emailed.
 	 * @param string $download_url The URL for downloading the report.
+	 * @param string $date_range Optional. The date range the report covers, formatted for display.
+	 *                           Empty for reports that are not limited to a period, such as Stock.
 	 */
-	public function trigger( $user_id, $report_type, $download_url ) {
-		$user               = new \WP_User( $user_id );
-		$this->recipient    = $user->user_email;
-		$this->download_url = $download_url;
+	public function trigger( $user_id, $report_type, $download_url, $date_range = '' ) {
+		$user                    = new \WP_User( $user_id );
+		$this->recipient         = $user->user_email;
+		$this->download_url      = $download_url;
+		$this->report_date_range = is_string( $date_range ) ? $date_range : '';
+
+		$this->placeholders['{report_date_range}'] = $this->report_date_range;
 
 		if ( isset( $this->report_labels[ $report_type ] ) ) {
 			$this->report_type                   = $this->report_labels[ $report_type ];

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -44,6 +44,13 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	protected $controller;
 
 	/**
+	 * Detail appended to the name the export is downloaded as.
+	 *
+	 * @var string
+	 */
+	protected $download_suffix = '';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $type Report type. E.g. 'customers'.
@@ -110,10 +117,43 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	/**
 	 * Get file path to export to.
 	 *
+	 * Always the stored name, never the name the export is downloaded as.
+	 *
 	 * @return string
 	 */
 	protected function get_file_path() {
-		return self::get_reports_directory() . $this->get_filename();
+		return self::get_reports_directory() . parent::get_filename();
+	}
+
+	/**
+	 * Get the name the export is downloaded as.
+	 *
+	 * The stored file keeps its own name, which only has to identify the export. See get_file_path().
+	 *
+	 * @return string
+	 */
+	public function get_filename() {
+		$filename = parent::get_filename();
+
+		if ( '' === $this->download_suffix ) {
+			return $filename;
+		}
+
+		return sanitize_file_name( preg_replace( '/\.csv$/', '', $filename ) . '-' . $this->download_suffix . '.csv' );
+	}
+
+	/**
+	 * Add detail to the name the export is downloaded as, leaving the stored file's name alone.
+	 *
+	 * Lets a download say what the report covers, such as the date range, when the stored name
+	 * only identifies the export.
+	 *
+	 * @since 11.2.0
+	 * @param string $suffix Detail to append to the download's name, e.g. a date range.
+	 * @return void
+	 */
+	public function set_download_suffix( $suffix ) {
+		$this->download_suffix = sanitize_file_name( $suffix );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -117,29 +117,45 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	/**
 	 * Get file path to export to.
 	 *
-	 * Always the stored name, never the name the export is downloaded as.
-	 *
 	 * @return string
 	 */
 	protected function get_file_path() {
-		return self::get_reports_directory() . parent::get_filename();
+		return self::get_reports_directory() . $this->get_filename();
 	}
 
 	/**
 	 * Get the name the export is downloaded as.
 	 *
-	 * The stored file keeps its own name, which only has to identify the export. See get_file_path().
+	 * The stored file keeps get_filename(), which only has to identify the export.
 	 *
+	 * @since 11.2.0
 	 * @return string
 	 */
-	public function get_filename() {
-		$filename = parent::get_filename();
+	public function get_download_filename() {
+		$filename = $this->get_filename();
 
 		if ( '' === $this->download_suffix ) {
 			return $filename;
 		}
 
 		return sanitize_file_name( preg_replace( '/\.csv$/', '', $filename ) . '-' . $this->download_suffix . '.csv' );
+	}
+
+	/**
+	 * Set the export headers.
+	 *
+	 * Re-sends the parent's Content-Disposition so the download is named after what the report
+	 * covers, leaving the stored file's name alone.
+	 *
+	 * @since 11.2.0
+	 * @return void
+	 */
+	public function send_headers() {
+		parent::send_headers();
+
+		if ( '' !== $this->download_suffix ) {
+			header( 'Content-Disposition: attachment; filename=' . $this->get_download_filename() );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -138,7 +138,8 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 			return $filename;
 		}
 
-		return sanitize_file_name( preg_replace( '/\.csv$/', '', $filename ) . '-' . $this->download_suffix . '.csv' );
+		// Stripped and restored the way set_filename() does it, so the name keeps a single .csv.
+		return sanitize_file_name( str_replace( '.csv', '', $filename ) . '-' . $this->download_suffix . '.csv' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -303,36 +303,51 @@ class ReportExporter {
 	}
 
 	/**
-	 * Serve the export file.
+	 * Build the exporter a download request is asking for.
+	 *
+	 * A read-only download of a report the requesting user is already allowed to view, gated on
+	 * the view_woocommerce_reports capability, so a nonce would only prevent nuisance CSRF. The
+	 * action is compared verbatim against a fixed name, and set_filename() applies
+	 * sanitize_file_name(), which keeps the path inside the reports directory. A nonce is not an
+	 * option here either: nonces last 24 hours, and this link is emailed and kept for a week.
+	 *
+	 * @param array $request Unslashed request parameters, expected to be `$_GET`.
+	 * @return ReportCSVExporter|null The exporter for the requested export, or null when the request asks for no export.
 	 */
-	public static function download_export_file() {
-		/*
-		 * A read-only download of a report the requesting user is already allowed to view, gated on
-		 * the view_woocommerce_reports capability, so a nonce would only prevent nuisance CSRF. The
-		 * action is compared verbatim against a fixed name, and set_filename() applies
-		 * sanitize_file_name(), which keeps the path inside the reports directory. A nonce is not an
-		 * option here either: nonces last 24 hours, and this link is emailed and kept for a week.
-		 */
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	private static function get_requested_export( $request ) {
 		if (
-			! isset( $_GET['action'] ) ||
-			self::DOWNLOAD_EXPORT_ACTION !== wp_unslash( $_GET['action'] ) ||
-			empty( $_GET['filename'] ) ||
-			! is_string( $_GET['filename'] ) ||
+			! is_array( $request ) ||
+			! isset( $request['action'] ) ||
+			self::DOWNLOAD_EXPORT_ACTION !== $request['action'] ||
+			empty( $request['filename'] ) ||
+			! is_string( $request['filename'] ) ||
 			! current_user_can( 'view_woocommerce_reports' )
 		) {
-			return;
+			return null;
 		}
 
 		$exporter = new ReportCSVExporter();
-		$exporter->set_filename( wp_unslash( $_GET['filename'] ) );
+		$exporter->set_filename( $request['filename'] );
 
 		// The stored name only identifies the export, so the emailed link carries the report's date
 		// range to name the download after the period it covers. It never reaches the file path.
-		if ( ! empty( $_GET['date_range'] ) && is_string( $_GET['date_range'] ) ) {
-			$exporter->set_download_suffix( wp_unslash( $_GET['date_range'] ) );
+		if ( ! empty( $request['date_range'] ) && is_string( $request['date_range'] ) ) {
+			$exporter->set_download_suffix( $request['date_range'] );
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		return $exporter;
+	}
+
+	/**
+	 * Serve the export file.
+	 */
+	public static function download_export_file() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read in get_requested_export(), which documents why there is no nonce and validates every value it reads.
+		$exporter = self::get_requested_export( wp_unslash( $_GET ) );
+
+		if ( ! $exporter ) {
+			return;
+		}
 
 		// Say so rather than serving an empty CSV: the exporter creates a blank file for a path
 		// that no longer exists, which reads as a report with no results.

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -168,7 +168,7 @@ class ReportExporter {
 		$report_args['page'] = $page_number;
 
 		$exporter = new ReportCSVExporter( $report_type, $report_args );
-		$exporter->set_filename( "wc-{$report_type}-report-export-{$export_id}" );
+		$exporter->set_filename( self::get_export_filename( $report_type, $export_id ) );
 		$exporter->generate_file();
 
 		self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
@@ -218,6 +218,41 @@ class ReportExporter {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get the name a report export is stored under.
+	 *
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @return string
+	 */
+	private static function get_export_filename( $report_type, $export_id ) {
+		return "wc-{$report_type}-report-export-{$export_id}";
+	}
+
+	/**
+	 * Get the URL a finished report export is downloaded from.
+	 *
+	 * @since 11.2.0
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @param array  $report_args Optional. Report parameters the export was queued with. When they name
+	 *                            a date range, the link carries it so the download is named after it.
+	 * @return string
+	 */
+	public static function get_download_url( $report_type, $export_id, $report_args = array() ) {
+		$query_args = array(
+			'action'   => self::DOWNLOAD_EXPORT_ACTION,
+			'filename' => self::get_export_filename( $report_type, $export_id ),
+		);
+
+		$date_range = self::get_export_date_range( $report_args );
+		if ( $date_range ) {
+			$query_args['date_range'] = $date_range['after'] . '-to-' . $date_range['before'];
+		}
+
+		return add_query_arg( $query_args, admin_url() );
 	}
 
 	/**
@@ -384,17 +419,7 @@ class ReportExporter {
 		$percent_complete = self::get_export_percentage_complete( $report_type, $export_id );
 
 		if ( 100 === $percent_complete ) {
-			$query_args = array(
-				'action'   => self::DOWNLOAD_EXPORT_ACTION,
-				'filename' => "wc-{$report_type}-report-export-{$export_id}",
-			);
-
-			$date_range = self::get_export_date_range( $report_args );
-			if ( $date_range ) {
-				$query_args['date_range'] = $date_range['after'] . '-to-' . $date_range['before'];
-			}
-
-			$download_url = add_query_arg( $query_args, admin_url() );
+			$download_url = self::get_download_url( $report_type, $export_id, $report_args );
 
 			\WC_Emails::instance();
 			$email = new ReportCSVEmail();

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -316,7 +316,7 @@ class ReportExporter {
 		}
 
 		/* translators: 1: first day of the period a report covers, 2: last day of that period. */
-		return sprintf( __( '%1$s - %2$s', 'woocommerce' ), $after, $before );
+		return sprintf( _x( '%1$s - %2$s', 'Report date range: from-to', 'woocommerce' ), $after, $before );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -291,15 +291,15 @@ class ReportExporter {
 	 * @return string The date in the store's date format, or an empty string when it cannot be read.
 	 */
 	private static function format_date_range_bound( $date ) {
-		// Read and formatted in UTC so the date reads back exactly as the merchant picked it.
-		$utc    = new \DateTimeZone( 'UTC' );
-		$parsed = \DateTimeImmutable::createFromFormat( 'Y-m-d|', $date, $utc );
+		// Read in the store's own timezone, so the date reads back as the merchant picked it and a
+		// date format that names the timezone names theirs rather than UTC. Midday is a safe anchor.
+		$parsed = \DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $date . ' 12:00:00', wp_timezone() );
 
 		if ( false === $parsed ) {
 			return '';
 		}
 
-		return (string) wp_date( get_option( 'date_format' ), $parsed->getTimestamp(), $utc );
+		return (string) wp_date( wc_date_format(), $parsed->getTimestamp() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -287,7 +287,6 @@ class ReportExporter {
 	/**
 	 * Format one end of a report's date range for display.
 	 *
-	 * @since 11.2.0
 	 * @param string $date Date as `Y-m-d`.
 	 * @return string The date in the store's date format, or an empty string when it cannot be read.
 	 */

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Admin\Schedulers\SchedulerTraits;
+use Automattic\WooCommerce\Utilities\TimeUtil;
 
 /**
  * ReportExporter Class.
@@ -238,10 +239,12 @@ class ReportExporter {
 		foreach ( array( 'after', 'before' ) as $bound ) {
 			// Report args arrive from a REST request, so they hold whatever the caller sent. Take the
 			// date as written rather than converting it: the report reads these as store local time.
+			// The shape alone is not enough, since a date like 2025-06-31 would roll over to July 1.
 			if (
 				empty( $report_args[ $bound ] ) ||
 				! is_string( $report_args[ $bound ] ) ||
-				! preg_match( '/^(\d{4}-\d{2}-\d{2})/', $report_args[ $bound ], $matches )
+				! preg_match( '/^(\d{4}-\d{2}-\d{2})/', $report_args[ $bound ], $matches ) ||
+				! TimeUtil::is_valid_date( $matches[1], 'Y-m-d' )
 			) {
 				return array();
 			}

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -423,7 +423,8 @@ class ReportExporter {
 
 			\WC_Emails::instance();
 			$email = new ReportCSVEmail();
-			$email->trigger( $user_id, $report_type, $download_url, self::get_export_date_range_label( $report_args ) );
+			$email->set_report_date_range( self::get_export_date_range_label( $report_args ) );
+			$email->trigger( $user_id, $report_type, $download_url );
 		}
 	}
 }

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -146,7 +146,7 @@ class ReportExporter {
 			self::queue_batches( 1, $num_batches, 'export_report', $report_batch_args );
 
 			if ( $send_email ) {
-				$email_action_args = array( get_current_user_id(), $export_id, $report_type );
+				$email_action_args = array( get_current_user_id(), $export_id, $report_type, $report_args );
 				self::schedule_action( 'email_report_download_link', $email_action_args );
 			}
 		}
@@ -220,6 +220,87 @@ class ReportExporter {
 	}
 
 	/**
+	 * Get the date range a report export covers.
+	 *
+	 * Reports are not all limited to a period. Stock, for one, has no date range at all.
+	 *
+	 * @since 11.2.0
+	 * @param array $report_args Report parameters, passed to data query.
+	 * @return string[] The range's `after` and `before` dates as `Y-m-d`, or an empty array when the report has no range.
+	 */
+	public static function get_export_date_range( $report_args ) {
+		if ( ! is_array( $report_args ) ) {
+			return array();
+		}
+
+		$date_range = array();
+
+		foreach ( array( 'after', 'before' ) as $bound ) {
+			// Report args arrive from a REST request, so they hold whatever the caller sent. Take the
+			// date as written rather than converting it: the report reads these as store local time.
+			if (
+				empty( $report_args[ $bound ] ) ||
+				! is_string( $report_args[ $bound ] ) ||
+				! preg_match( '/^(\d{4}-\d{2}-\d{2})/', $report_args[ $bound ], $matches )
+			) {
+				return array();
+			}
+
+			$date_range[ $bound ] = $matches[1];
+		}
+
+		return $date_range;
+	}
+
+	/**
+	 * Get the date range a report export covers, formatted for display.
+	 *
+	 * @since 11.2.0
+	 * @param array $report_args Report parameters, passed to data query.
+	 * @return string Date range in the site's date format, or an empty string when the report has no range.
+	 */
+	public static function get_export_date_range_label( $report_args ) {
+		$date_range = self::get_export_date_range( $report_args );
+
+		if ( ! $date_range ) {
+			return '';
+		}
+
+		$after  = self::format_date_range_bound( $date_range['after'] );
+		$before = self::format_date_range_bound( $date_range['before'] );
+
+		if ( '' === $after || '' === $before ) {
+			return '';
+		}
+
+		if ( $after === $before ) {
+			return $after;
+		}
+
+		/* translators: 1: first day of the period a report covers, 2: last day of that period. */
+		return sprintf( __( '%1$s - %2$s', 'woocommerce' ), $after, $before );
+	}
+
+	/**
+	 * Format one end of a report's date range for display.
+	 *
+	 * @since 11.2.0
+	 * @param string $date Date as `Y-m-d`.
+	 * @return string The date in the store's date format, or an empty string when it cannot be read.
+	 */
+	private static function format_date_range_bound( $date ) {
+		// Read and formatted in UTC so the date reads back exactly as the merchant picked it.
+		$utc    = new \DateTimeZone( 'UTC' );
+		$parsed = \DateTimeImmutable::createFromFormat( 'Y-m-d|', $date, $utc );
+
+		if ( false === $parsed ) {
+			return '';
+		}
+
+		return (string) wp_date( get_option( 'date_format' ), $parsed->getTimestamp(), $utc );
+	}
+
+	/**
 	 * Serve the export file.
 	 */
 	public static function download_export_file() {
@@ -243,6 +324,12 @@ class ReportExporter {
 
 		$exporter = new ReportCSVExporter();
 		$exporter->set_filename( wp_unslash( $_GET['filename'] ) );
+
+		// The stored name only identifies the export, so the emailed link carries the report's date
+		// range to name the download after the period it covers. It never reaches the file path.
+		if ( ! empty( $_GET['date_range'] ) && is_string( $_GET['date_range'] ) ) {
+			$exporter->set_download_suffix( wp_unslash( $_GET['date_range'] ) );
+		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// Say so rather than serving an empty CSV: the exporter creates a blank file for a path
@@ -272,21 +359,29 @@ class ReportExporter {
 	 * @param int    $user_id User ID that requested the email.
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param array  $report_args Optional. Report parameters the export was queued with. Exports queued
+	 *                            before WooCommerce 11.2.0 run without them.
 	 * @return void
 	 */
-	public static function email_report_download_link( $user_id, $export_id, $report_type ) {
+	public static function email_report_download_link( $user_id, $export_id, $report_type, $report_args = array() ) {
 		$percent_complete = self::get_export_percentage_complete( $report_type, $export_id );
 
 		if ( 100 === $percent_complete ) {
-			$query_args   = array(
+			$query_args = array(
 				'action'   => self::DOWNLOAD_EXPORT_ACTION,
 				'filename' => "wc-{$report_type}-report-export-{$export_id}",
 			);
+
+			$date_range = self::get_export_date_range( $report_args );
+			if ( $date_range ) {
+				$query_args['date_range'] = $date_range['after'] . '-to-' . $date_range['before'];
+			}
+
 			$download_url = add_query_arg( $query_args, admin_url() );
 
 			\WC_Emails::instance();
 			$email = new ReportCSVEmail();
-			$email->trigger( $user_id, $report_type, $download_url );
+			$email->trigger( $user_id, $report_type, $download_url, self::get_export_date_range_label( $report_args ) );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
@@ -26,11 +26,11 @@ class ReportCSVEmailTest extends WC_Unit_Test_Case {
 	 */
 	private function create_email( string $date_range = '' ): ReportCSVEmail {
 		$email = new ReportCSVEmail();
+		$email->set_report_date_range( $date_range );
 
 		foreach ( array(
-			'report_type'       => 'Orders',
-			'download_url'      => 'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
-			'report_date_range' => $date_range,
+			'report_type'  => 'Orders',
+			'download_url' => 'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
 		) as $name => $value ) {
 			$property = new \ReflectionProperty( ReportCSVEmail::class, $name );
 			$property->setAccessible( true );
@@ -129,6 +129,19 @@ class ReportCSVEmailTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox trigger() keeps the parameters it shipped with, so a subclass overriding it still loads.
+	 */
+	public function test_trigger_keeps_its_original_parameters(): void {
+		$parameters = ( new \ReflectionMethod( ReportCSVEmail::class, 'trigger' ) )->getParameters();
+
+		$this->assertCount(
+			3,
+			$parameters,
+			'trigger() is public and overridable. Adding a parameter, even an optional one, fatals every subclass that overrides the original three. Pass anything new through a setter instead.'
+		);
+	}
+
+	/**
 	 * Send the email to a user and return the subject it went out with.
 	 *
 	 * @param string $date_range Optional. Date range the report covers, formatted for display.
@@ -137,12 +150,13 @@ class ReportCSVEmailTest extends WC_Unit_Test_Case {
 	private function trigger_and_get_subject( string $date_range = '' ): string {
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$mailer  = tests_retrieve_phpmailer_instance();
+		$email   = new ReportCSVEmail();
 
-		( new ReportCSVEmail() )->trigger(
+		$email->set_report_date_range( $date_range );
+		$email->trigger(
 			$user_id,
 			'orders',
-			'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
-			$date_range
+			'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export'
 		);
 
 		$sent = end( $mailer->mock_sent );

--- a/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
@@ -21,14 +21,16 @@ class ReportCSVEmailTest extends WC_Unit_Test_Case {
 	/**
 	 * Build an email addressed at a generated export.
 	 *
+	 * @param string $date_range Optional. Date range the report covers, formatted for display.
 	 * @return ReportCSVEmail
 	 */
-	private function create_email(): ReportCSVEmail {
+	private function create_email( string $date_range = '' ): ReportCSVEmail {
 		$email = new ReportCSVEmail();
 
 		foreach ( array(
-			'report_type'  => 'Orders',
-			'download_url' => 'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
+			'report_type'       => 'Orders',
+			'download_url'      => 'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
+			'report_date_range' => $date_range,
 		) as $name => $value ) {
 			$property = new \ReflectionProperty( ReportCSVEmail::class, $name );
 			$property->setAccessible( true );
@@ -62,5 +64,89 @@ class ReportCSVEmailTest extends WC_Unit_Test_Case {
 			$content,
 			'The plain text email should tell the merchant how long the link lasts.'
 		);
+	}
+
+	/**
+	 * @testdox The email says which period the report covers.
+	 *
+	 * @testWith ["get_content_html"]
+	 *           ["get_content_plain"]
+	 *
+	 * @param string $method Method that renders the email body.
+	 */
+	public function test_email_states_the_date_range( string $method ): void {
+		$content = $this->create_email( 'June 1, 2025 - June 30, 2025' )->$method();
+
+		$this->assertStringContainsString(
+			'Date range: June 1, 2025 - June 30, 2025',
+			$content,
+			'The email should say which period the report covers.'
+		);
+	}
+
+	/**
+	 * @testdox A report without a date range says nothing about one.
+	 *
+	 * @testWith ["get_content_html"]
+	 *           ["get_content_plain"]
+	 *
+	 * @param string $method Method that renders the email body.
+	 */
+	public function test_email_omits_an_empty_date_range( string $method ): void {
+		$content = $this->create_email()->$method();
+
+		$this->assertStringNotContainsString(
+			'Date range:',
+			$content,
+			'Reports that are not limited to a period should not mention a date range.'
+		);
+	}
+
+	/**
+	 * @testdox The subject says which period the report covers, so two exports of the same report can be told apart unopened.
+	 */
+	public function test_subject_states_the_date_range(): void {
+		$subject = $this->trigger_and_get_subject( 'June 1, 2025 - June 30, 2025' );
+
+		$this->assertStringContainsString(
+			'Your Orders Report for June 1, 2025 - June 30, 2025 is ready',
+			$subject,
+			'The subject should name the period the report covers.'
+		);
+	}
+
+	/**
+	 * @testdox A report without a date range keeps the plain subject.
+	 */
+	public function test_subject_without_a_date_range(): void {
+		$subject = $this->trigger_and_get_subject();
+
+		$this->assertStringContainsString(
+			'Your Orders Report download is ready',
+			$subject,
+			'Reports that are not limited to a period should keep the original subject.'
+		);
+	}
+
+	/**
+	 * Send the email to a user and return the subject it went out with.
+	 *
+	 * @param string $date_range Optional. Date range the report covers, formatted for display.
+	 * @return string
+	 */
+	private function trigger_and_get_subject( string $date_range = '' ): string {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$mailer  = tests_retrieve_phpmailer_instance();
+
+		( new ReportCSVEmail() )->trigger(
+			$user_id,
+			'orders',
+			'https://example.org/?action=woocommerce_admin_download_report_csv&filename=wc-orders-report-export',
+			$date_range
+		);
+
+		$sent = end( $mailer->mock_sent );
+
+		return $sent ? $sent['subject'] : '';
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -153,6 +153,7 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	 *
 	 * @testWith ["2025-06-01T00:00:00", "2025-06-30T23:59:59", "2025-06-01", "2025-06-30"]
 	 *           ["2025-06-01", "2025-06-01", "2025-06-01", "2025-06-01"]
+	 *           ["2024-02-01T00:00:00", "2024-02-29T23:59:59", "2024-02-01", "2024-02-29"]
 	 *
 	 * @param string $after           The export's `after` argument.
 	 * @param string $before          The export's `before` argument.

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -178,11 +178,17 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Arguments without a usable date range produce no range.
 	 *
+	 * A date that does not exist counts as unusable. Left alone it would roll over, so an export
+	 * run for June 31 would be labelled and named July 1.
+	 *
 	 * @testWith [{}]
 	 *           [{"after": "2025-06-01T00:00:00"}]
 	 *           [{"after": "2025-06-01T00:00:00", "before": ""}]
 	 *           [{"after": "2025-06-01T00:00:00", "before": "last month"}]
 	 *           [{"after": "2025-06-01T00:00:00", "before": ["2025-06-30"]}]
+	 *           [{"after": "2025-06-31T00:00:00", "before": "2025-06-30T23:59:59"}]
+	 *           [{"after": "2025-06-01T00:00:00", "before": "2025-13-45T00:00:00"}]
+	 *           [{"after": "2025-02-29T00:00:00", "before": "2025-03-01T00:00:00"}]
 	 *
 	 * @param array $report_args Report parameters the export was queued with.
 	 */

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -149,6 +149,109 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A report's date range is read from the arguments it was exported with.
+	 *
+	 * @testWith ["2025-06-01T00:00:00", "2025-06-30T23:59:59", "2025-06-01", "2025-06-30"]
+	 *           ["2025-06-01", "2025-06-01", "2025-06-01", "2025-06-01"]
+	 *
+	 * @param string $after           The export's `after` argument.
+	 * @param string $before          The export's `before` argument.
+	 * @param string $expected_after  Expected first day of the range.
+	 * @param string $expected_before Expected last day of the range.
+	 */
+	public function test_date_range_is_read_from_report_args( string $after, string $before, string $expected_after, string $expected_before ): void {
+		$this->assertSame(
+			array(
+				'after'  => $expected_after,
+				'before' => $expected_before,
+			),
+			ReportExporter::get_export_date_range(
+				array(
+					'after'  => $after,
+					'before' => $before,
+				)
+			),
+			'The range should be the dates the report was run for, as written.'
+		);
+	}
+
+	/**
+	 * @testdox Arguments without a usable date range produce no range.
+	 *
+	 * @testWith [{}]
+	 *           [{"after": "2025-06-01T00:00:00"}]
+	 *           [{"after": "2025-06-01T00:00:00", "before": ""}]
+	 *           [{"after": "2025-06-01T00:00:00", "before": "last month"}]
+	 *           [{"after": "2025-06-01T00:00:00", "before": ["2025-06-30"]}]
+	 *
+	 * @param array $report_args Report parameters the export was queued with.
+	 */
+	public function test_report_args_without_a_date_range( array $report_args ): void {
+		$this->assertSame(
+			array(),
+			ReportExporter::get_export_date_range( $report_args ),
+			'A report that is not limited to a period should report no date range.'
+		);
+	}
+
+	/**
+	 * @testdox The date range is labelled in the store's date format.
+	 */
+	public function test_date_range_label_uses_the_store_date_format(): void {
+		update_option( 'date_format', 'F j, Y' );
+
+		$this->assertSame(
+			'June 1, 2025 - June 30, 2025',
+			ReportExporter::get_export_date_range_label(
+				array(
+					'after'  => '2025-06-01T00:00:00',
+					'before' => '2025-06-30T23:59:59',
+				)
+			),
+			'The label should read as the merchant picked the range.'
+		);
+	}
+
+	/**
+	 * @testdox A single day range is labelled as one date rather than a range.
+	 */
+	public function test_single_day_date_range_label(): void {
+		update_option( 'date_format', 'F j, Y' );
+
+		$this->assertSame(
+			'June 1, 2025',
+			ReportExporter::get_export_date_range_label(
+				array(
+					'after'  => '2025-06-01T00:00:00',
+					'before' => '2025-06-01T23:59:59',
+				)
+			),
+			'A one day report should not repeat the same date twice.'
+		);
+	}
+
+	/**
+	 * @testdox An export is downloaded under a name that says which period it covers.
+	 */
+	public function test_download_is_named_after_the_period_it_covers(): void {
+		$filename = $this->create_export( 'wc-products-report-export-1234567890' );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( $filename );
+		$exporter->set_download_suffix( '2025-06-01-to-2025-06-30' );
+
+		$this->assertSame(
+			'wc-products-report-export-1234567890-2025-06-01-to-2025-06-30.csv',
+			$exporter->get_filename(),
+			'The download should be named after the period the report covers.'
+		);
+		$this->assertTrue(
+			$exporter->export_file_exists(),
+			'The stored export should still be found under the name it was written with.'
+		);
+	}
+
+	/**
 	 * @testdox Cleanup runs from the daily WooCommerce Admin event.
 	 */
 	public function test_cleanup_is_hooked_to_the_daily_event(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -314,6 +314,144 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A download link that names a date range is served under a name that says so.
+	 */
+	public function test_download_request_names_the_download_after_the_date_range(): void {
+		$this->act_as_reports_user();
+
+		$exporter = $this->request_export( $this->download_request( array( 'date_range' => '2025-06-01-to-2025-06-30' ) ) );
+
+		$this->assertNotNull( $exporter, 'A valid download request should be served.' );
+		$this->assertSame(
+			'wc-products-report-export-1234567890-2025-06-01-to-2025-06-30.csv',
+			$exporter->get_download_filename(),
+			'The date range on the link should reach the name the export is downloaded as.'
+		);
+		$this->assertSame(
+			'wc-products-report-export-1234567890.csv',
+			$exporter->get_filename(),
+			'The date range on the link should never change the name the export is stored under.'
+		);
+	}
+
+	/**
+	 * @testdox A download link without a date range keeps the stored export name.
+	 */
+	public function test_download_request_without_a_date_range(): void {
+		$this->act_as_reports_user();
+
+		$exporter = $this->request_export( $this->download_request() );
+
+		$this->assertNotNull( $exporter, 'A valid download request should be served.' );
+		$this->assertSame(
+			'wc-products-report-export-1234567890.csv',
+			$exporter->get_download_filename(),
+			'A link that names no period should download under the stored name, as it did before.'
+		);
+	}
+
+	/**
+	 * @testdox A hostile date range cannot escape the download name or the reports directory.
+	 *
+	 * @testWith ["../../../../etc/passwd", "wc-products-report-export-1234567890-etcpasswd.csv"]
+	 *           ["a\r\nX-Injected: 1", "wc-products-report-export-1234567890-a-X-Injected-1.csv"]
+	 *           ["setup.bat", "wc-products-report-export-1234567890-setup.bat_.csv"]
+	 *
+	 * @param string $date_range Date range as it arrives on the link.
+	 * @param string $expected   Expected download name.
+	 */
+	public function test_download_request_sanitises_the_date_range( string $date_range, string $expected ): void {
+		$this->act_as_reports_user();
+
+		$exporter = $this->request_export( $this->download_request( array( 'date_range' => $date_range ) ) );
+
+		$this->assertNotNull( $exporter, 'A valid download request should be served.' );
+		$this->assertSame(
+			$expected,
+			$exporter->get_download_filename(),
+			'The date range only names the download, so it must not carry separators or a second extension.'
+		);
+		$this->assertSame(
+			'wc-products-report-export-1234567890.csv',
+			$exporter->get_filename(),
+			'The date range must never reach the path the export is read from.'
+		);
+	}
+
+	/**
+	 * @testdox A download request is refused without the reports capability.
+	 */
+	public function test_download_request_requires_the_reports_capability(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			$this->request_export( $this->download_request() ),
+			'A user who cannot view reports should not be served an export.'
+		);
+	}
+
+	/**
+	 * @testdox Requests that do not ask for an export are left alone.
+	 *
+	 * @testWith [{}]
+	 *           [{"action": "edit", "filename": "wc-products-report-export-1234567890"}]
+	 *           [{"action": "woocommerce_admin_download_report_csv"}]
+	 *           [{"action": "woocommerce_admin_download_report_csv", "filename": ""}]
+	 *           [{"action": "woocommerce_admin_download_report_csv", "filename": ["x"]}]
+	 *
+	 * @param array $request Request parameters, as the download handler reads them.
+	 */
+	public function test_requests_that_do_not_ask_for_an_export( array $request ): void {
+		$this->act_as_reports_user();
+
+		$this->assertNull(
+			$this->request_export( $request ),
+			'The download handler should leave requests that are not report downloads alone.'
+		);
+	}
+
+	/**
+	 * Sign in as a user allowed to view reports.
+	 *
+	 * @return void
+	 */
+	private function act_as_reports_user(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Build the parameters of a valid download link.
+	 *
+	 * @param array $extra Parameters to add to the request.
+	 * @return array
+	 */
+	private function download_request( array $extra = array() ): array {
+		return array_merge(
+			array(
+				'action'   => ReportExporter::DOWNLOAD_EXPORT_ACTION,
+				'filename' => 'wc-products-report-export-1234567890',
+			),
+			$extra
+		);
+	}
+
+	/**
+	 * Build the exporter that a download request would be served by.
+	 *
+	 * Reaches the handler's own reading of the request, so that dropping the date range on the way
+	 * from the link to the download's name fails a test.
+	 *
+	 * @param array $request Request parameters, as the download handler reads them from `$_GET`.
+	 * @return ReportCSVExporter|null
+	 */
+	private function request_export( array $request ) {
+		$method = new \ReflectionMethod( ReportExporter::class, 'get_requested_export' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $request );
+	}
+
+	/**
 	 * @testdox The emailed download link names the period the export covers.
 	 */
 	public function test_emailed_link_carries_the_date_range(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -242,8 +242,13 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			'wc-products-report-export-1234567890-2025-06-01-to-2025-06-30.csv',
-			$exporter->get_filename(),
+			$exporter->get_download_filename(),
 			'The download should be named after the period the report covers.'
+		);
+		$this->assertSame(
+			$filename,
+			$exporter->get_filename(),
+			'Naming the download should leave the stored export name alone.'
 		);
 		$this->assertTrue(
 			$exporter->export_file_exists(),

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -257,6 +257,78 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The emailed download link names the period the export covers.
+	 */
+	public function test_emailed_link_carries_the_date_range(): void {
+		$sent = $this->email_completed_export(
+			array(
+				array(
+					'after'  => '2025-06-01T00:00:00',
+					'before' => '2025-06-30T23:59:59',
+				),
+			)
+		);
+
+		$this->assertStringContainsString(
+			'date_range=2025-06-01-to-2025-06-30',
+			$sent['body'],
+			'The emailed link should name the period the export covers.'
+		);
+	}
+
+	/**
+	 * @testdox An export queued before the date range was added still emails a working link.
+	 */
+	public function test_emailed_link_for_an_export_queued_without_report_args(): void {
+		// Exports queued by an earlier release carry three arguments, not four.
+		$sent = $this->email_completed_export( array() );
+
+		$this->assertStringContainsString(
+			'Your Products Report download is ready',
+			$sent['subject'],
+			'An export queued without report arguments should keep the original subject.'
+		);
+		$this->assertStringContainsString(
+			'action=woocommerce_admin_download_report_csv',
+			$sent['body'],
+			'An export queued without report arguments should still be emailed a download link.'
+		);
+		$this->assertStringNotContainsString(
+			'date_range=',
+			$sent['body'],
+			'An export with no known date range should not claim one.'
+		);
+	}
+
+	/**
+	 * Email the download link for a finished export and return the message that went out.
+	 *
+	 * Dispatched through the hook Action Scheduler fires, so the number of arguments a queued
+	 * action carries is what decides how the callback is reached.
+	 *
+	 * @param array $queued_args Arguments the queued action carries after the report type.
+	 * @return array The sent message.
+	 */
+	private function email_completed_export( array $queued_args ): array {
+		$user_id   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$export_id = (string) microtime( true );
+		$hook      = ReportExporter::get_action( 'email_report_download_link' );
+		$mailer    = tests_retrieve_phpmailer_instance();
+
+		ReportExporter::update_export_percentage_complete( 'products', $export_id, 100 );
+
+		$this->assertNotFalse( has_action( $hook ), 'The export email action should be registered.' );
+
+		do_action_ref_array( $hook, array_merge( array( $user_id, $export_id, 'products' ), $queued_args ) );
+
+		$sent = end( $mailer->mock_sent );
+
+		$this->assertIsArray( $sent, 'A finished export should be emailed to the user who asked for it.' );
+
+		return $sent;
+	}
+
+	/**
 	 * @testdox Cleanup runs from the daily WooCommerce Admin event.
 	 */
 	public function test_cleanup_is_hooked_to_the_daily_event(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -220,6 +220,56 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The date range is labelled in the store's timezone, not in UTC.
+	 *
+	 * A date format that names the timezone should name the merchant's own, and the date itself
+	 * should read the same whichever timezone the store keeps.
+	 *
+	 * @testWith ["Europe/Sofia", "Y-m-d T", "2025-06-01 EEST"]
+	 *           ["America/Los_Angeles", "Y-m-d T", "2025-06-01 PDT"]
+	 *           ["Pacific/Kiritimati", "F j, Y", "June 1, 2025"]
+	 *           ["Pacific/Midway", "F j, Y", "June 1, 2025"]
+	 *
+	 * @param string $timezone Store timezone.
+	 * @param string $format   Store date format.
+	 * @param string $expected Expected label for a one day report.
+	 */
+	public function test_date_range_label_uses_the_store_timezone( string $timezone, string $format, string $expected ): void {
+		update_option( 'timezone_string', $timezone );
+		update_option( 'date_format', $format );
+
+		$this->assertSame(
+			$expected,
+			ReportExporter::get_export_date_range_label(
+				array(
+					'after'  => '2025-06-01T00:00:00',
+					'before' => '2025-06-01T23:59:59',
+				)
+			),
+			'The label should read in the store timezone rather than UTC.'
+		);
+	}
+
+	/**
+	 * @testdox The date range label goes through the WooCommerce date format, so a store can filter it.
+	 */
+	public function test_date_range_label_uses_the_woocommerce_date_format(): void {
+		update_option( 'date_format', 'F j, Y' );
+		add_filter( 'woocommerce_date_format', fn() => 'd/m/Y' );
+
+		$this->assertSame(
+			'01/06/2025 - 30/06/2025',
+			ReportExporter::get_export_date_range_label(
+				array(
+					'after'  => '2025-06-01T00:00:00',
+					'before' => '2025-06-30T23:59:59',
+				)
+			),
+			'The label should honour woocommerce_date_format like the rest of WooCommerce date output.'
+		);
+	}
+
+	/**
 	 * @testdox A single day range is labelled as one date rather than a range.
 	 */
 	public function test_single_day_date_range_label(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

An emailed Analytics export says nothing about the period it covers, not in the email and not in the file name. Run the same report for six months and you get six emails and six files you cannot tell apart. The browser download already puts the range in the file name, only the emailed one does not.

The email subject and body now name the range, and the download link carries it so the file is saved as `wc-products-report-export-<id>-2025-06-01-to-2025-06-30.csv`. Reports without a range, like Stock, keep the old subject, body and file name.

Backward compatibility:

-   `ReportCSVEmail::trigger()` and `ReportExporter::email_report_download_link()` both take one new optional argument, so existing callers and already queued exports keep working.
-   `ReportCSVExporter` gains `set_download_suffix()` and `get_download_filename()`, and overrides `send_headers()` to name the download. `get_filename()` and `get_file_path()` are untouched, so a subclass that overrides `get_filename()` still decides where the export is written and read from.
-   `ReportExporter` gains `get_download_url()`, which now builds both the emailed link and the one the REST export status endpoint returns. Additive, and the status link is unchanged: the report arguments are not kept past the queued action, so it still cannot name the period.
-   The stored file name is unchanged, so links that were already emailed still resolve.
-   The email templates gained a `date_range` variable that an old theme override simply ignores.
-   The date range reaches the download handler as a query argument that only names the download. It never touches the file path.

This touches backward compatibility, so it needs an independent human review before it merges.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1990" height="980" alt="before" src="https://github.com/user-attachments/assets/40535ca8-cc59-4046-a3dd-3a21ca8db2b0" /> | <img width="1990" height="980" alt="after" src="https://github.com/user-attachments/assets/32d96538-089b-44ed-b341-e881d323c811" /> |
| File: `wc-products-report-export-17888699961278.csv` | File: `wc-products-report-export-17888699961278-2025-06-01-to-2025-06-30.csv` |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create enough products and orders that the Analytics Products report has more than one page of rows. The direct download only happens when everything fits on one page.
2. Go to Analytics > Products and pick a custom date range, for example June 1 to June 30.
3. Click Download. You should see the notice that the report will be emailed.
4. Run the pending actions in WooCommerce > Status > Scheduled Actions, or with `wp action-scheduler run`.
5. Open the email. The subject and the body should both name the date range.
6. Click the download link. The file name should end with the date range.
7. Repeat on Analytics > Stock. That report has no date range, so the email and the file name should look exactly as they did before.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Tested on a local install running WooCommerce 11.2.0-dev with seeded products and orders:

-   The real UI flow above, for Products over a custom range.
-   A download link that was emailed before this change, so without the new query argument. It still downloads under the old name.
-   A scheduled email action queued with the old three arguments. It does not fatal and keeps the old subject.
-   The Stock report, which has no date range.
-   Hostile values in the new query argument. They cannot leave the reports directory or inject a response header.
-   The label under several store timezones and date formats. It reads back as the merchant picked it, whatever the store timezone is.
-   The generated export still lands on disk under its plain name, and downloading it leaves it in place.

PHPCS and PHPStan are clean on the changed files. `ReportExporterTest` and `ReportCSVEmailTest` pass in wp-env, 45 tests. The old-export test earns its place: dropping the optional fourth argument from `email_report_download_link()` makes it fail with the `ArgumentCountError` a real queued action would hit.

There is one part of the issue I did not do. It also asks for a date column in the data set. The Products report is aggregated over the whole range, so there is no per row date to add, and a column repeating the same range on every row would change the CSV shape for anyone parsing these exports. Happy to revisit if we want it anyway.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code. The code, the tests and this description were drafted by the agent and are under my review.

