### PR TITLE
Retry failed nightly jobs up to three attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,8 @@ jobs:
           name: '${{ matrix.report.resultsBlobName }}__${{ strategy.job-index }}'
           path: ${{ env.ARTIFACTS_PATH }}
           retention-days: 7
+          # A failed report merge can leave the previous attempt's artifact behind.
+          overwrite: true
 
   evaluate-project-jobs:
     # In order to add a required status check we need a consistent job that we can grab onto.
@@ -519,7 +521,10 @@ jobs:
     runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs: ['project-jobs', 'woocommerce-plugin-build-artifact', 'project-lint-jobs', 'project-test-jobs', 'evaluate-project-jobs']
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' }}
+    # Match the three-attempt limit in retry-nightly-tests.yml before alerting on nightly failures.
+    if: >-
+      ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' &&
+          ( inputs.trigger != 'nightly-checks' || github.event_name != 'schedule' || github.run_attempt >= 3 ) }}
     env:
       NON_SUCCESSFUL_JOBS: ${{ needs.evaluate-project-jobs.outputs.non_successful_jobs }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,7 @@ jobs:
     timeout-minutes: 5
     needs: ['project-jobs', 'woocommerce-plugin-build-artifact', 'project-lint-jobs', 'project-test-jobs', 'evaluate-project-jobs']
     # Match the three-attempt limit in retry-nightly-tests.yml before alerting on nightly failures.
+    # Other workflows share this job and should still report failures immediately.
     if: >-
       ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' &&
           (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,10 @@ jobs:
     # Match the three-attempt limit in retry-nightly-tests.yml before alerting on nightly failures.
     if: >-
       ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce' &&
-          ( inputs.trigger != 'nightly-checks' || github.event_name != 'schedule' || github.run_attempt >= 3 ) }}
+          (
+            ( inputs.trigger == 'nightly-checks' && github.event_name == 'schedule' && github.run_attempt >= 3 ) ||
+            ( inputs.trigger != 'nightly-checks' || github.event_name != 'schedule' )
+          ) }}
     env:
       NON_SUCCESSFUL_JOBS: ${{ needs.evaluate-project-jobs.outputs.non_successful_jobs }}
     steps:

--- a/.github/workflows/retry-nightly-tests.yml
+++ b/.github/workflows/retry-nightly-tests.yml
@@ -1,0 +1,52 @@
+name: 'Retry nightly tests'
+
+on:
+    workflow_run:
+        workflows: ['Release checks run']
+        types: [completed]
+        branches: [trunk]
+
+permissions:
+    actions: write
+
+concurrency:
+    group: retry-nightly-tests-${{ github.event.workflow_run.id }}
+    cancel-in-progress: false
+
+jobs:
+    retry:
+        if: >-
+            ${{ github.repository == 'woocommerce/woocommerce' &&
+                github.event.workflow_run.event == 'schedule' &&
+                contains( fromJSON('["failure", "timed_out"]'), github.event.workflow_run.conclusion ) }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: 'Re-run failed jobs, up to three total attempts'
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: |
+                      const maxAttempts = 3;
+                      const completedRun = context.payload.workflow_run;
+                      const params = { ...context.repo, run_id: completedRun.id };
+                      const { data: run } = await github.rest.actions.getWorkflowRun( params );
+
+                      // A manual rerun or a delayed event may have advanced the run already.
+                      if (
+                          run.status !== 'completed' ||
+                          run.run_attempt !== completedRun.run_attempt ||
+                          run.event !== 'schedule' ||
+                          run.path !== '.github/workflows/tests-on-release.yml' ||
+                          ! [ 'failure', 'timed_out' ].includes( run.conclusion )
+                      ) {
+                          core.info( 'The nightly run is no longer eligible for a retry.' );
+                          return;
+                      }
+
+                      if ( run.run_attempt >= maxAttempts ) {
+                          core.info( `Stopping after ${ run.run_attempt } attempts: ${ run.html_url }` );
+                          return;
+                      }
+
+                      await github.rest.actions.reRunWorkflowFailedJobs( params );
+                      core.info( `Requested attempt ${ run.run_attempt + 1 }/${ maxAttempts }: ${ run.html_url }` );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Currently, the nightly job can fail due to flakiness rather than an actual issue. When this happens, a Slack notification is triggered, requiring human review to determine whether the failure is legitimate or simply flaky.

To reduce this noise, this PR introduces a retry mechanism for failed nightly CI jobs. If a job fails, it will be retried up to three times. Only if all three attempts fail will the CI be marked as failed and a Slack notification be sent.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Use a fork with GitHub Actions enabled.

1. Copy the temporary [smoke workflow](https://github.com/gigitux/woocommerce/blob/b568b64781bc547cc0ed8eec7426b8dc14627805/.github/workflows/retry-nightly-smoke.yml) and [retry controller](https://github.com/gigitux/woocommerce/blob/b568b64781bc547cc0ed8eec7426b8dc14627805/.github/workflows/retry-nightly-smoke-controller.yml) into the same paths on your fork's default branch. These are immutable links to the fixtures used for the live validation; the fixtures have since been removed from the fork's current branch.
2. In both files, replace `gigitux/woocommerce` with your fork's full repository name. If its default branch is not `trunk`, update the controller's branch filter. Commit these two test files to the fork's default branch. The fixtures adapt the production guards to `workflow_dispatch`, copy the attempt-three notification condition, and print notification markers instead of contacting Slack.
3. Open **Actions > Nightly retry smoke > Run workflow** in the fork. Leave `trigger` as `nightly-checks`, choose `pass_on_attempt=1`, and dispatch. Repeat with `2`, `3`, and `99` (always fail). For example, the persistent-failure case can also be dispatched with:

    ```sh
    gh workflow run retry-nightly-smoke.yml \
      --repo YOUR_USER/woocommerce \
      --ref YOUR_DEFAULT_BRANCH \
      -f pass_on_attempt=99
    ```

4. Check the run attempts and the **Nightly retry smoke controller** logs against the table below. Retries must happen automatically; do not click **Re-run jobs**. For `99`, the final controller must log `Stopping after 3 attempts`, with no fourth attempt.
5. Inspect the `notify` job. It must be skipped on attempts one and two. On attempt three, a recovered run must log `NO_SLACK_NOTIFICATION attempt=3`; a persistently failing run must log `WOULD_NOTIFY_SLACK attempt=3` exactly once.
6. Confirm the independent `stable` job retains its original execution timestamps and `STABLE_ATTEMPT=1` log across retries. Every artifact upload should succeed, leaving one `retry-smoke-result` artifact per run without a name-conflict error.
7. Remove the two temporary test workflows from the fork when finished.

| `pass_on_attempt` | Expected attempts | Final result | Notification marker |
| --- | --- | --- | --- |
| `1` | 1 | Success | None |
| `2` | 2 | Success | None |
| `3` | 3 | Success | None |
| `99` | 3 | Failure | Once, on attempt 3 |

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Live smoke tests completed on `gigitux/woocommerce` using GitHub-hosted Ubuntu runners:

| Scenario | Run | Verified outcome |
| --- | --- | --- |
| Pass immediately | [34212805777](https://github.com/gigitux/woocommerce/actions/runs/34212805777) | One attempt; no notification |
| Recover on attempt two | [34212807957](https://github.com/gigitux/woocommerce/actions/runs/34212807957) | Two attempts; no notification |
| Recover on attempt three | [34212810559](https://github.com/gigitux/woocommerce/actions/runs/34212810559) | Three attempts; no notification |
| Always fail | [34212812777](https://github.com/gigitux/woocommerce/actions/runs/34212812777) | Three attempts; notification marker only on attempt three |


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Only GitHub Actions workflows are modified. No package or code shipped to merchants is changed.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex authored the workflow changes and PR draft and ran the local checks and fork smoke tests.
