### PR TITLE
Fix: Sanitize stock notifications endpoint slug on save

### DIFF
--- a/plugins/woocommerce/changelog/68xxx-fix-stock-notifications-endpoint-slug-sanitize
+++ b/plugins/woocommerce/changelog/68xxx-fix-stock-notifications-endpoint-slug-sanitize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sanitize the stock notifications My Account endpoint slug when saved from settings.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1697,6 +1697,7 @@ add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_se
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_orders_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_view_order_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_order_withdrawal_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_stock_notifications_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_downloads_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_edit_account_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_edit_address_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -1178,6 +1178,19 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the stock notifications endpoint setting is sanitized on save.
+	 *
+	 * @return void
+	 */
+	public function test_stock_notifications_endpoint_setting_is_sanitized() {
+		$hook = 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_stock_notifications_endpoint';
+
+		$this->assertEquals( 10, has_filter( $hook, 'wc_sanitize_endpoint_slug' ) );
+		$this->assertEquals( 'restock-alerts', apply_filters( $hook, 'Restock Alerts' ) );
+		$this->assertEquals( 'stock-notifications', apply_filters( $hook, 'stock-notifications' ) );
+	}
+
+	/**
 	 * Test wc_remove_non_displayable_chars().
 	 *
 	 * @since 9.9.0

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -1178,19 +1178,6 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the stock notifications endpoint setting is sanitized on save.
-	 *
-	 * @return void
-	 */
-	public function test_stock_notifications_endpoint_setting_is_sanitized() {
-		$hook = 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_stock_notifications_endpoint';
-
-		$this->assertEquals( 10, has_filter( $hook, 'wc_sanitize_endpoint_slug' ) );
-		$this->assertEquals( 'restock-alerts', apply_filters( $hook, 'Restock Alerts' ) );
-		$this->assertEquals( 'stock-notifications', apply_filters( $hook, 'stock-notifications' ) );
-	}
-
-	/**
 	 * Test wc_remove_non_displayable_chars().
 	 *
 	 * @since 9.9.0

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -71,4 +71,15 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 		$this->assertSame( 'text', $settings[ $setting_index ]['type'] );
 		$this->assertSame( MyAccountEndpoint::ENDPOINT, $settings[ $setting_index ]['default'] );
 	}
+
+	/**
+	 * @testdox The My Account endpoint setting is sanitized as an endpoint slug on save.
+	 */
+	public function test_my_account_endpoint_setting_is_sanitized_on_save() {
+		$hook = 'woocommerce_admin_settings_sanitize_option_' . MyAccountEndpoint::ENDPOINT_OPTION;
+
+		$this->assertSame( 10, has_filter( $hook, 'wc_sanitize_endpoint_slug' ) );
+		$this->assertSame( 'restock-alerts', apply_filters( $hook, 'Restock Alerts' ) );
+		$this->assertSame( 'stock-notifications', apply_filters( $hook, 'stock-notifications' ) );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR #68291 added a configurable "Stock notifications" My Account endpoint slug (`woocommerce_myaccount_stock_notifications_endpoint`) but never hooked it up to `wc_sanitize_endpoint_slug`, unlike every other account endpoint option. Entering a value such as `Restock Alerts` saved the raw string and registered a non-functional `/my-account/Restock Alerts/` rewrite endpoint.

This PR registers the missing `woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_stock_notifications_endpoint` filter in `wc-formatting-functions.php`, alongside the existing endpoint slug sanitizers, and adds a unit test covering the wiring.

Bug introduced in PR #68291.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Settings > Advanced > Page setup > Account endpoints**.
2. Set the **Stock notifications** field to `Restock Alerts` and save.
3. Confirm the field now shows `restock-alerts` and that `/my-account/restock-alerts/` loads the stock notifications page.
4. Set the field to a valid slug like `stock-alerts`, save, and confirm it is stored unchanged.
5. (Optional) Repeat step 2 on `trunk` and confirm the raw `Restock Alerts` value is saved instead.

### Testing that has already taken place:

- Unit test `SettingsControllerTests::test_my_account_endpoint_setting_is_sanitized_on_save` verifies the filter is registered and that `Restock Alerts` becomes `restock-alerts` while a valid slug stays unchanged.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Changelog entry added manually: `plugins/woocommerce/changelog/68xxx-fix-stock-notifications-endpoint-slug-sanitize`.

### Use of AI Tools

Written with Claude Code, reviewed by the author.
