### PR TITLE
Fix warning when certain blocks were used in the Single Product template of a password-protected block

### DIFF
--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -126,13 +126,106 @@ class SingleProductTemplate extends AbstractTemplate {
 	/**
 	 * Replace the first single product template block with the password form. Remove all other single product template blocks.
 	 *
-	 * @param array   $parsed_blocks Array of parsed block objects.
-	 * @param boolean $is_already_replaced If the password form has already been added.
-	 * @return array Parsed blocks
+	 * @param array $parsed_blocks Array of parsed block objects.
+	 * @return array Parsed blocks.
 	 */
-	private static function replace_first_single_product_template_block_with_password_form( $parsed_blocks, $is_already_replaced ) {
-		// We want to replace the first single product template block with the password form. We also want to remove all other single product template blocks.
-		// This array doesn't contains all the blocks. For example, it missing the breadcrumbs blocks: it doesn't make sense replace the breadcrumbs with the password form.
+	private static function replace_first_single_product_template_block_with_password_form( $parsed_blocks ) {
+		$blocks              = array();
+		$is_already_replaced = false;
+
+		foreach ( $parsed_blocks as $block ) {
+			$processed           = self::process_block_for_password_form( $block, $is_already_replaced );
+			$is_already_replaced = $processed['is_already_replaced'];
+			$blocks              = array_merge( $blocks, $processed['blocks'] );
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Replace or remove a parsed block when rendering a password-protected product.
+	 *
+	 * @param array $block               Parsed block.
+	 * @param bool  $is_already_replaced If the password form has already been added.
+	 * @return array{blocks: array, is_already_replaced: bool} Replacement blocks (empty when removed).
+	 */
+	private static function process_block_for_password_form( $block, $is_already_replaced ) {
+		if ( self::is_password_protected_replacement_block( $block ) ) {
+			if ( $is_already_replaced ) {
+				return array(
+					'blocks'              => array(),
+					'is_already_replaced' => true,
+				);
+			}
+
+			return array(
+				'blocks'              => array( parse_blocks( '<!-- wp:html -->' . get_the_password_form() . '<!-- /wp:html -->' )[0] ),
+				'is_already_replaced' => true,
+			);
+		}
+
+		if ( empty( $block['innerBlocks'] ) ) {
+			return array(
+				'blocks'              => array( $block ),
+				'is_already_replaced' => $is_already_replaced,
+			);
+		}
+
+		$new_inner_blocks  = array();
+		$new_inner_content = array();
+		$inner_block_index = 0;
+		$inner_content     = isset( $block['innerContent'] ) && is_array( $block['innerContent'] )
+			? $block['innerContent']
+			: array_fill( 0, count( $block['innerBlocks'] ), null );
+
+		foreach ( $inner_content as $chunk ) {
+			if ( is_string( $chunk ) ) {
+				$new_inner_content[] = $chunk;
+				continue;
+			}
+
+			if ( ! isset( $block['innerBlocks'][ $inner_block_index ] ) ) {
+				continue;
+			}
+
+			$processed           = self::process_block_for_password_form( $block['innerBlocks'][ $inner_block_index ], $is_already_replaced );
+			$is_already_replaced = $processed['is_already_replaced'];
+			++$inner_block_index;
+
+			foreach ( $processed['blocks'] as $processed_block ) {
+				$new_inner_blocks[]  = $processed_block;
+				$new_inner_content[] = null;
+			}
+		}
+
+		if ( count( $new_inner_blocks ) === 0 ) {
+			return array(
+				'blocks'              => array(),
+				'is_already_replaced' => $is_already_replaced,
+			);
+		}
+
+		$block['innerBlocks']  = $new_inner_blocks;
+		$block['innerContent'] = $new_inner_content;
+
+		return array(
+			'blocks'              => array( $block ),
+			'is_already_replaced' => $is_already_replaced,
+		);
+	}
+
+	/**
+	 * Whether this block should be replaced with the password form (or removed after the first replacement).
+	 *
+	 * This list is not every block that can appear on a single product template. Blocks such as breadcrumbs
+	 * stay visible on password-protected products.
+	 *
+	 * @param array $block Parsed block.
+	 * @return bool
+	 */
+	private static function is_password_protected_replacement_block( $block ) {
+		$block_name = $block['blockName'] ?? '';
+
 		$single_product_template_blocks = array(
 			'woocommerce/product-image-gallery',
 			'woocommerce/product-details',
@@ -149,98 +242,13 @@ class SingleProductTemplate extends AbstractTemplate {
 			'core/post-excerpt',
 		);
 
-		return array_reduce(
-			$parsed_blocks,
-			function ( $carry, $block ) use ( $single_product_template_blocks ) {
-				if ( in_array( $block['blockName'], $single_product_template_blocks, true ) || ( 'core/pattern' === $block['blockName'] && isset( $block['attrs']['slug'] ) && 'woocommerce-blocks/related-products' === $block['attrs']['slug'] ) ) {
-					if ( $carry['is_already_replaced'] ) {
-						return array(
-							'blocks'              => $carry['blocks'],
-							'html_block'          => null,
-							'removed'             => true,
-							'is_already_replaced' => true,
+		if ( in_array( $block_name, $single_product_template_blocks, true ) ) {
+			return true;
+		}
 
-						);
-					}
-
-					return array(
-						'blocks'              => $carry['blocks'],
-						'html_block'          => parse_blocks( '<!-- wp:html -->' . get_the_password_form() . '<!-- /wp:html -->' )[0],
-						'removed'             => false,
-						'is_already_replaced' => $carry['is_already_replaced'],
-					);
-
-				}
-
-				if ( isset( $block['innerBlocks'] ) && count( $block['innerBlocks'] ) > 0 ) {
-					$index              = 0;
-					$new_inner_blocks   = array();
-					$new_inner_contents = $block['innerContent'];
-					foreach ( $block['innerContent'] as $inner_content ) {
-						// Don't process the closing tag of the block.
-						if ( count( $block['innerBlocks'] ) === $index ) {
-							break;
-						}
-
-						$blocks                       = self::replace_first_single_product_template_block_with_password_form( array( $block['innerBlocks'][ $index ] ), $carry['is_already_replaced'] );
-						$new_blocks                   = $blocks['blocks'];
-						$html_block                   = $blocks['html_block'];
-						$is_removed                   = $blocks['removed'];
-						$carry['is_already_replaced'] = $blocks['is_already_replaced'];
-
-						if ( isset( $html_block ) ) {
-							$new_inner_blocks             = array_merge( $new_inner_blocks, $new_blocks, array( $html_block ) );
-							$carry['is_already_replaced'] = true;
-						} else {
-							$new_inner_blocks = array_merge( $new_inner_blocks, $new_blocks );
-						}
-
-						if ( $is_removed ) {
-							unset( $new_inner_contents[ $index ] );
-							// The last element of the inner contents contains the closing tag of the block. We don't want to remove it.
-							if ( $index + 1 < count( $new_inner_contents ) ) {
-								unset( $new_inner_contents[ $index + 1 ] );
-							}
-							$new_inner_contents = array_values( $new_inner_contents );
-						}
-
-						$index++;
-					}
-
-					$block['innerBlocks']  = $new_inner_blocks;
-					$block['innerContent'] = $new_inner_contents;
-
-					if ( count( $new_inner_blocks ) === 0 ) {
-						return array(
-							'blocks'              => $carry['blocks'],
-							'html_block'          => null,
-							'removed'             => true,
-							'is_already_replaced' => $carry['is_already_replaced'],
-						);
-					}
-
-					return array(
-						'blocks'              => array_merge( $carry['blocks'], array( $block ) ),
-						'html_block'          => null,
-						'removed'             => false,
-						'is_already_replaced' => $carry['is_already_replaced'],
-					);
-				}
-
-				return array(
-					'blocks'              => array_merge( $carry['blocks'], array( $block ) ),
-					'html_block'          => null,
-					'removed'             => false,
-					'is_already_replaced' => $carry['is_already_replaced'],
-				);
-			},
-			array(
-				'blocks'              => array(),
-				'html_block'          => null,
-				'removed'             => false,
-				'is_already_replaced' => $is_already_replaced,
-			)
-		);
+		return 'core/pattern' === $block_name
+			&& isset( $block['attrs']['slug'] )
+			&& 'woocommerce-blocks/related-products' === $block['attrs']['slug'];
 	}
 
 	/**
@@ -251,8 +259,7 @@ class SingleProductTemplate extends AbstractTemplate {
 	 */
 	public static function add_password_form( $content ) {
 		$parsed_blocks     = parse_blocks( $content );
-		$blocks            = self::replace_first_single_product_template_block_with_password_form( $parsed_blocks, false );
-		$serialized_blocks = serialize_blocks( $blocks['blocks'] );
+		$serialized_blocks = serialize_blocks( self::replace_first_single_product_template_block_with_password_form( $parsed_blocks ) );
 
 		return $serialized_blocks;
 	}

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -164,7 +164,7 @@ class SingleProductTemplate extends AbstractTemplate {
 			);
 		}
 
-		if ( empty( $block['innerBlocks'] ) ) {
+		if ( empty( $block['innerBlocks'] ) || ! isset( $block['innerContent'] ) || ! is_array( $block['innerContent'] ) ) {
 			return array(
 				'blocks'              => array( $block ),
 				'is_already_replaced' => $is_already_replaced,
@@ -174,11 +174,8 @@ class SingleProductTemplate extends AbstractTemplate {
 		$new_inner_blocks  = array();
 		$new_inner_content = array();
 		$inner_block_index = 0;
-		$inner_content     = isset( $block['innerContent'] ) && is_array( $block['innerContent'] )
-			? $block['innerContent']
-			: array_fill( 0, count( $block['innerBlocks'] ), null );
 
-		foreach ( $inner_content as $chunk ) {
+		foreach ( $block['innerContent'] as $chunk ) {
 			if ( is_string( $chunk ) ) {
 				$new_inner_content[] = $chunk;
 				continue;

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -364,7 +364,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the password form is added when product blocks are at the top level of the template.
+	 * @testdox Adds the password form when product blocks are at the top level of the template.
 	 */
 	public function test_replace_top_level_single_product_blocks_with_input_form() {
 		$default_single_product_template = '

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -362,4 +362,32 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result )
 		);
 	}
+
+	/**
+	 * Test that the password form is added when product blocks are at the top level of the template.
+	 */
+	public function test_replace_top_level_single_product_blocks_with_input_form() {
+		$default_single_product_template = '
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+	<!-- wp:woocommerce/product-image-gallery /-->
+	<!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true} /-->
+	<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$expected_single_product_template = sprintf(
+			'
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+	<!-- wp:html -->%s<!-- /wp:html -->
+	<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->',
+			get_the_password_form()
+		);
+
+		$result = SingleProductTemplate::add_password_form(
+			$default_single_product_template
+		);
+
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result ),
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template )
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The logic we had in order to replace the product-related blocks with the password form was a bit brittle depending on the blocks that were present in the template. When a product-related block that was being removed and a non-related block that was kept were next to each other, that could produce the two arrays to get out of sync, ultimately causing PHP warnings.

This PR refactors that logic and breaks everything into smaller methods so it's easier to understand and ensures we always merge `innerBlocks` and `innerContent` with the correct index.

### How to test the changes in this Pull Request:

**Issue 1:**

1. In a theme that is not Purple, edit the Single Product template and add a paragraph in the right column:

<img width="2095" height="1061" alt="imatge" src="https://github.com/user-attachments/assets/58efbf43-49a3-45c0-86af-158222c3f888" />

2. Make a product to be password-protected.
3. Visit that product in the frontend.
4. Verify there are no warnings in the screen.

**Issue 2:**

1. In any theme, edit your Single Product template, making sure all the product-related blocks are in the root, instead of being under another block.

<img width="2095" height="1061" alt="imatge" src="https://github.com/user-attachments/assets/56af9aa5-086d-4217-bb7e-432507d23bd0" />

2. In the frontend, verify the password form is rendered.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->