### PR TITLE
Correctly hide patterns containing product-related blocks when products are password-protected

### DIFF
--- a/plugins/woocommerce/changelog/fix-password-protected-products-patterns
+++ b/plugins/woocommerce/changelog/fix-password-protected-products-patterns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly hide patterns containing product-related blocks when products are password-protected

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53842,18 +53842,6 @@ parameters:
 			path: src/Blocks/Utils/BlockTemplateUtils.php
 
 		-
-			message: '#^Parameter \#2 \$blocks of static method Automattic\\WooCommerce\\Blocks\\Utils\\BlockTemplateUtils\:\:has_block_including_patterns\(\) expects array\<Automattic\\WooCommerce\\Blocks\\Utils\\WP_Block\>, array\<int\|string, array\<string, array\|string\>\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Blocks/Utils/BlockTemplateUtils.php
-
-		-
-			message: '#^Parameter \$blocks of method Automattic\\WooCommerce\\Blocks\\Utils\\BlockTemplateUtils\:\:has_block_including_patterns\(\) has invalid type Automattic\\WooCommerce\\Blocks\\Utils\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Blocks/Utils/BlockTemplateUtils.php
-
-		-
 			message: '#^Parameter \$template of method Automattic\\WooCommerce\\Blocks\\Utils\\BlockTemplateUtils\:\:update_template_data\(\) has invalid type Automattic\\WooCommerce\\Blocks\\Utils\\WP_Block_Template\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -247,7 +247,7 @@ class SingleProductTemplate extends AbstractTemplate {
 			'core/pattern' !== $block_name ||
 			! isset( $block['attrs']['slug'] )
 		) {
-				return false;
+			return false;
 		}
 
 		// The 'Related Products' pattern of the Product Collection block is

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -250,13 +250,6 @@ class SingleProductTemplate extends AbstractTemplate {
 			return false;
 		}
 
-		// The 'Related Products' pattern of the Product Collection block is
-		// also considered a product-related block that should only be shown
-		// when not displaying the password form.
-		if ( 'woocommerce-blocks/related-products' === $block['attrs']['slug'] ) {
-			return true;
-		}
-
 		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $block['attrs']['slug'] );
 
 		if ( empty( $pattern['content'] ) ) {

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -243,9 +243,30 @@ class SingleProductTemplate extends AbstractTemplate {
 			return true;
 		}
 
-		return 'core/pattern' === $block_name
-			&& isset( $block['attrs']['slug'] )
-			&& 'woocommerce-blocks/related-products' === $block['attrs']['slug'];
+		if (
+			'core/pattern' !== $block_name ||
+			! isset( $block['attrs']['slug'] )
+		) {
+				return false;
+		}
+
+		// The 'Related Products' pattern of the Product Collection block is
+		// also considered a product-related block that should only be shown
+		// when not displaying the password form.
+		if ( 'woocommerce-blocks/related-products' === $block['attrs']['slug'] ) {
+			return true;
+		}
+
+		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $block['attrs']['slug'] );
+
+		if ( empty( $pattern['content'] ) ) {
+			return false;
+		}
+
+		return BlockTemplateUtils::has_block_including_patterns(
+			$single_product_template_blocks,
+			parse_blocks( $pattern['content'] )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -623,8 +623,8 @@ class BlockTemplateUtils {
 	 * Determines whether the provided $blocks contains any of the $block_names,
 	 * or if they contain a pattern that contains any of the $block_names.
 	 *
-	 * @param string[]   $block_names Full block types to look for.
-	 * @param WP_Block[] $blocks      Array of block objects.
+	 * @param string[] $block_names Full block types to look for.
+	 * @param array    $blocks      Array of blocks as returned by parse_blocks().
 	 * @return bool Whether the content contains the specified block.
 	 */
 	public static function has_block_including_patterns( $block_names, $blocks ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -390,4 +390,40 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template )
 		);
 	}
+
+	/**
+	 * @testdox Adds the password form when a pattern contains Single Product blocks.
+	 */
+	public function test_replace_pattern_with_single_product_blocks_with_input_form() {
+		register_block_pattern(
+			'test-single-product-pattern',
+			array(
+				'title'       => 'Test Single Product Pattern',
+				'description' => 'Test Pattern Description',
+				'content'     => '<!-- wp:woocommerce/product-price /-->',
+			)
+		);
+
+		$default_single_product_template = '
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+	<!-- wp:pattern {"slug":"test-single-product-pattern"} /-->
+	<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$expected_single_product_template = sprintf(
+			'
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+	<!-- wp:html -->%s<!-- /wp:html -->
+	<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->',
+			get_the_password_form()
+		);
+
+		$result = SingleProductTemplate::add_password_form(
+			$default_single_product_template
+		);
+
+		$this->assertEquals(
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $expected_single_product_template ),
+			TemplateContentUtils::strip_whitespace_and_password_form_ids( $result )
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The logic to replace product-related blocks with the password form in password-protected products was not working correctly if the blocks were inside a pattern. This PR fixes that so the whole pattern is replaced by the form.

### How to test the changes in this Pull Request:

1. The easiet way to test is to switch your theme to Purple.
2. Edit a product so it's password-protected.
3. Visit it in the frontend and verify the password form is displayed.

Before | After
--- | ---
<img width="2095" height="1061" alt="imatge" src="https://github.com/user-attachments/assets/27370c6d-bbc2-4b40-a3be-b98423fc306a" /> | <img width="2095" height="1061" alt="imatge" src="https://github.com/user-attachments/assets/1c196f0d-e78f-46a5-88b2-f33f079219e7" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->