### PR TITLE
Fix silent update failure on orders with decimal quantities and validate quantity stepping in admin editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-item-qty-step-validation
+++ b/plugins/woocommerce/changelog/fix-order-item-qty-step-validation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Validate product quantity stepping for order items in the admin order editor, showing the browser validation message instead of silently failing to update, allowing non-conforming existing quantities to stay editable, and validating step values in AJAX endpoints.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -319,7 +319,30 @@ jQuery( function ( $ ) {
 			$( document.body )
 				.on( 'wc_backbone_modal_loaded', this.backbone.init )
 				.on( 'wc_backbone_modal_before_response', this.backbone.validate_response )
-				.on( 'wc_backbone_modal_response', this.backbone.response );
+				.on( 'wc_backbone_modal_response', this.backbone.response )
+				.on( 'click', '#woocommerce-order-actions button.save_order, #publish', function( event ) {
+					if ( ! wc_meta_boxes_order_items.validate_quantity_inputs() ) {
+						event.preventDefault();
+						return false;
+					}
+				} );
+
+			$( '#woocommerce-order-items' ).closest( 'form' ).on( 'submit', function( event ) {
+				if ( ! wc_meta_boxes_order_items.validate_quantity_inputs() ) {
+					event.preventDefault();
+					return false;
+				}
+			} );
+
+			// When native constraint validation triggers on a hidden quantity input,
+			// reveal its row so the field is focusable and the error is visible.
+			document.addEventListener( 'invalid', function( event ) {
+				if ( $( event.target ).is( '#woocommerce-order-items input.quantity' ) ) {
+					var row = $( event.target ).closest( 'tr' );
+					row.find( '.view' ).hide();
+					row.find( '.edit' ).show();
+				}
+			}, true );
 		},
 
 		block: function() {
@@ -711,25 +734,23 @@ jQuery( function ( $ ) {
 		},
 
 		/**
-		 * Return the first of the given inputs whose value is below its min
-		 * attribute, or null when none is. Only the minimum (rangeUnderflow)
-		 * is checked; other constraints are deliberately ignored so they keep
-		 * their previous behaviour.
+		 * Return the first of the given inputs whose value violates its min
+		 * or step attribute, or null when none does.
 		 *
 		 * @param {NodeList|jQuery} inputs Quantity inputs to check.
-		 * @return {HTMLInputElement|null} First input below its minimum.
+		 * @return {HTMLInputElement|null} First input with an invalid quantity.
 		 */
 		find_input_with_qty_below_min: function( inputs ) {
 			return Array.prototype.find.call( inputs, function( input ) {
-				return input.validity.rangeUnderflow;
+				return input.validity.rangeUnderflow || input.validity.stepMismatch;
 			} ) || null;
 		},
 
 		/**
-		 * Check the quantity inputs in the items panel against their minimum,
-		 * revealing and reporting the first one below it.
+		 * Check the quantity inputs in the items panel against their minimum and step,
+		 * revealing and reporting the first invalid one.
 		 *
-		 * @return {boolean} True when every quantity input meets its minimum.
+		 * @return {boolean} True when every quantity input is valid.
 		 */
 		validate_quantity_inputs: function() {
 			var input = wc_meta_boxes_order_items.find_input_with_qty_below_min(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -106,13 +106,19 @@ $item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $i
 			/**
 			* Filter to change the product quantity stepping in the order editor of the admin area.
 			*
+			* In the 'edit' context the default is the product purchase quantity step,
+			* falling back to 'any' when the item's current quantity does not align with
+			* it (so orders created with decimal quantities via extensions or the API
+			* remain editable). Since 11.2.0 the filter also runs with the 'add' context
+			* when products are added to an order.
+			*
 			* @since   5.8.0
 			* @param   string      $step    The current step amount to be used in the quantity editor.
 			* @param   WC_Product  $product The product that is being edited.
-			* @param   string      $context The context in which the quantity editor is shown, 'edit' or 'refund'.
+			* @param   string      $context The context in which the quantity editor is shown, 'edit', 'refund' or 'add'.
 			*/
-			$step_edit   = apply_filters( 'woocommerce_quantity_input_step_admin', $step, $product, 'edit' );
 			$step_refund = apply_filters( 'woocommerce_quantity_input_step_admin', $step, $product, 'refund' );
+			$step_edit   = wc_get_container()->get( ItemQuantityLimits::class )->get_quantity_input_step( $item, $product );
 
 			/**
 			* Filter to change the product quantity minimum in the order editor of the admin area.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ItemQuantityLimits.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ItemQuantityLimits.php
@@ -11,11 +11,12 @@ use WC_Product;
 /**
  * Admin-side rules for the quantities an order line item accepts.
  *
- * The admin order editor renders quantity inputs with a minimum of 0, so
- * merchants cannot enter negative quantities. Orders created through the
- * REST API or by extensions may already contain negative quantities, so for
- * existing items the minimum is floored at the stored quantity to keep those
- * orders editable.
+ * The admin order editor renders quantity inputs with a minimum of 0 and
+ * stepping of 1 by default, so merchants cannot enter negative quantities
+ * or invalid quantity increments. Orders created through the REST API or
+ * by extensions may already contain negative or fractional quantities, so
+ * for existing items the minimum is floored at the stored quantity and
+ * stepping defaults to 'any' when non-conforming, to keep those orders editable.
  *
  * Covers product line items only: fee and shipping lines have no quantity
  * input in the admin editor, and posted quantities for them are ignored.
@@ -50,13 +51,60 @@ class ItemQuantityLimits {
 	}
 
 	/**
+	 * Get the quantity stepping accepted for an existing order item in the admin editor.
+	 *
+	 * When an existing item has a stored quantity that does not align with the product's
+	 * step (e.g. decimal quantities placed through the REST API or extensions), the default
+	 * step is 'any' to keep those orders editable.
+	 *
+	 * @since 11.2.0
+	 * @param WC_Order_Item         $item    Line item being edited.
+	 * @param WC_Product|false|null $product The item's product when the caller already
+	 *                                       resolved it; null to resolve it here.
+	 * @return string Numeric string or 'any', filtered through 'woocommerce_quantity_input_step_admin'.
+	 */
+	public function get_quantity_input_step( WC_Order_Item $item, $product = null ): string {
+		if ( null === $product ) {
+			$product = $item instanceof WC_Order_Item_Product ? $item->get_product() : false;
+		}
+
+		$base_step = $product ? $product->get_purchase_quantity_step() : 1;
+		$base_step = is_numeric( $base_step ) && (float) $base_step > 0 ? (float) $base_step : 1.0;
+
+		$stored_qty = (float) $item->get_quantity();
+		$min        = (float) $this->get_quantity_input_min( $item, $product );
+
+		// If the stored quantity does not align with the step, default to 'any'
+		// so existing orders remain editable and do not block the admin form submission.
+		$division = ( $stored_qty - $min ) / $base_step;
+		if ( abs( $division - round( $division ) ) > 0.000001 ) {
+			$default = 'any';
+		} else {
+			$default = (string) $base_step;
+		}
+
+		/**
+		 * This filter is documented in includes/admin/meta-boxes/views/html-order-item.php
+		 *
+		 * @since 5.8.0
+		 */
+		$step = apply_filters( 'woocommerce_quantity_input_step_admin', $default, $product, 'edit' );
+
+		if ( 'any' === $step || ( is_numeric( $step ) && (float) $step > 0 ) ) {
+			return (string) $step;
+		}
+
+		return $default;
+	}
+
+	/**
 	 * Validate the quantity requested for a product being added to an order.
 	 *
 	 * @since 11.2.0
 	 * @param float      $qty     Requested quantity.
 	 * @param WC_Product $product Product being added.
 	 * @return void
-	 * @throws \Exception When the quantity is below the allowed minimum.
+	 * @throws \Exception When the quantity is below the allowed minimum or violates step.
 	 */
 	public function validate_new_item_quantity( float $qty, WC_Product $product ): void {
 		/**
@@ -73,6 +121,25 @@ class ItemQuantityLimits {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- below_min_exception() strips and decodes the message for a JS alert.
 			throw $this->below_min_exception( $product->get_name(), $min );
 		}
+
+		$base_step = $product->get_purchase_quantity_step();
+		$base_step = is_numeric( $base_step ) && (float) $base_step > 0 ? (string) $base_step : '1';
+
+		/**
+		 * This filter is documented in includes/admin/meta-boxes/views/html-order-item.php
+		 *
+		 * @since 5.8.0
+		 */
+		$step = apply_filters( 'woocommerce_quantity_input_step_admin', $base_step, $product, 'add' );
+
+		if ( 'any' !== $step ) {
+			$step_num = is_numeric( $step ) && (float) $step > 0 ? (float) $step : (float) $base_step;
+			$division = ( $qty - $min ) / $step_num;
+			if ( abs( $division - round( $division ) ) > 0.000001 ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- step_mismatch_exception() strips and decodes the message for a JS alert.
+				throw $this->step_mismatch_exception( $product->get_name(), $step_num );
+			}
+		}
 	}
 
 	/**
@@ -85,23 +152,24 @@ class ItemQuantityLimits {
 	 * @param array    $items Posted items, as parsed from the serialized form data
 	 *                        (the same shape wc_save_order_items receives).
 	 * @return void
-	 * @throws \Exception When a quantity is below the item's allowed minimum.
+	 * @throws \Exception When a quantity is below the item's allowed minimum or violates step.
 	 */
 	public function validate_posted_item_quantities( WC_Order $order, array $items ): void {
 		if ( empty( $items['order_item_qty'] ) || ! is_array( $items['order_item_qty'] ) ) {
 			return;
 		}
 
-		$has_min_filter = has_filter( 'woocommerce_quantity_input_min_admin' );
-		$order_items    = null;
+		$has_min_filter  = has_filter( 'woocommerce_quantity_input_min_admin' );
+		$has_step_filter = has_filter( 'woocommerce_quantity_input_step_admin' ) || has_filter( 'woocommerce_quantity_input_step' );
+		$order_items     = null;
 
 		foreach ( $items['order_item_qty'] as $item_id => $posted_qty ) {
 			$qty = (float) wc_stock_amount( wp_unslash( $posted_qty ) );
 
-			// Without a filter the minimum is min( 0, stored quantity ), which is
-			// never above 0, so a non-negative quantity cannot fail: skip the
-			// per-item and product lookups on this hot path.
-			if ( $qty >= 0 && ! $has_min_filter ) {
+			// Fast path: when a non-negative integer quantity is posted and no filters
+			// are attached, it can neither violate the default minimum (0 or negative)
+			// nor the default step (1), so skip per-item and product lookups.
+			if ( $qty >= 0 && ! $has_min_filter && ! $has_step_filter && abs( $qty - round( $qty ) ) < 0.000001 ) {
 				continue;
 			}
 
@@ -120,6 +188,17 @@ class ItemQuantityLimits {
 			if ( $qty < $min ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- below_min_exception() strips and decodes the message for a JS alert.
 				throw $this->below_min_exception( $item->get_name(), $min );
+			}
+
+			$step = $this->get_quantity_input_step( $item );
+
+			if ( 'any' !== $step ) {
+				$step_num = (float) $step;
+				$division = ( $qty - $min ) / $step_num;
+				if ( abs( $division - round( $division ) ) > 0.000001 ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- step_mismatch_exception() strips and decodes the message for a JS alert.
+					throw $this->step_mismatch_exception( $item->get_name(), $step_num );
+				}
 			}
 		}
 	}
@@ -146,6 +225,34 @@ class ItemQuantityLimits {
 						__( 'The quantity of "%1$s" must be %2$s or higher.', 'woocommerce' ),
 						$name,
 						wc_format_localized_decimal( (string) $min )
+					),
+					ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+				)
+			)
+		);
+	}
+
+	/**
+	 * Build the exception for a quantity that does not match the allowed step.
+	 *
+	 * The message is plain text destined for a JS alert, never rendered as
+	 * HTML: entities are decoded first so stored names read naturally, then
+	 * any resulting markup is stripped.
+	 *
+	 * @since 11.2.0
+	 * @param string $name Product or order item name.
+	 * @param float  $step Allowed stepping value.
+	 * @return \Exception
+	 */
+	private function step_mismatch_exception( string $name, float $step ): \Exception {
+		return new \Exception(
+			wp_strip_all_tags(
+				html_entity_decode(
+					sprintf(
+						/* translators: 1: product or order item name, 2: step quantity */
+						__( 'The quantity of "%1$s" must be a multiple of %2$s.', 'woocommerce' ),
+						$name,
+						wc_format_localized_decimal( (string) $step )
 					),
 					ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
 				)

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ItemQuantityLimits.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ItemQuantityLimits.php
@@ -240,7 +240,6 @@ class ItemQuantityLimits {
 	 * HTML: entities are decoded first so stored names read naturally, then
 	 * any resulting markup is stripped.
 	 *
-	 * @since 11.2.0
 	 * @param string $name Product or order item name.
 	 * @param float  $step Allowed stepping value.
 	 * @return \Exception

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ItemQuantityLimits.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ItemQuantityLimits.php
@@ -164,7 +164,8 @@ class ItemQuantityLimits {
 		$order_items     = null;
 
 		foreach ( $items['order_item_qty'] as $item_id => $posted_qty ) {
-			$qty = (float) wc_stock_amount( wp_unslash( $posted_qty ) );
+			$raw_qty = wc_format_decimal( wp_unslash( $posted_qty ) );
+			$qty     = is_numeric( $raw_qty ) ? (float) $raw_qty : (float) wc_stock_amount( wp_unslash( $posted_qty ) );
 
 			// Fast path: when a non-negative integer quantity is posted and no filters
 			// are attached, it can neither violate the default minimum (0 or negative)

--- a/plugins/woocommerce/tests/e2e/tests/order/order-item-quantity-validation.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-item-quantity-validation.spec.ts
@@ -182,13 +182,16 @@ test.describe(
 			const modalContent = modal.locator( '.wc-backbone-modal-content' );
 			await expect( modalContent ).toBeVisible();
 
-			await modal
-				.locator( 'input[name="item_qty"]' )
-				.first()
-				.fill( '2.5' );
+			const qtyInput = modal.locator( 'input[name="item_qty"]' ).first();
+			await qtyInput.fill( '2.5' );
 			await modal.locator( '#btn-ok' ).click();
 
 			// With step validation, the modal stays open showing the browser message.
+			expect(
+				await qtyInput.evaluate(
+					( input: HTMLInputElement ) => input.validationMessage
+				)
+			).not.toBe( '' );
 			await expect( modalContent ).toBeVisible();
 		} );
 	}

--- a/plugins/woocommerce/tests/e2e/tests/order/order-item-quantity-validation.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-item-quantity-validation.spec.ts
@@ -137,5 +137,59 @@ test.describe(
 			await expect( qtyInput ).toBeVisible();
 			await expect( qtyInput ).toBeFocused();
 		} );
+
+		test( 'the items panel Save button refuses an invalid step quantity', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+			);
+
+			await page.locator( 'a.edit-order-item' ).first().click();
+			const qtyInput = page
+				.locator( 'input[name^="order_item_qty"]' )
+				.first();
+			await qtyInput.fill( '2.5' );
+
+			await page
+				.locator( '#woocommerce-order-items button.save-action' )
+				.click();
+
+			// The input reports its constraint violation instead of saving.
+			const message = await qtyInput.evaluate(
+				( input: HTMLInputElement ) => input.validationMessage
+			);
+			expect( message ).not.toBe( '' );
+
+			// The invalid quantity was not persisted.
+			await page.reload();
+			await expect(
+				page.locator( '#order_line_items td.quantity .view' ).first()
+			).toContainText( '2' );
+		} );
+
+		test( 'the add products modal blocks an invalid step quantity and stays open', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+			);
+
+			await page.locator( 'button.add-line-item' ).click();
+			await page.locator( 'button.add-order-item' ).click();
+
+			const modal = page.locator( '.wc-backbone-modal-add-products' );
+			const modalContent = modal.locator( '.wc-backbone-modal-content' );
+			await expect( modalContent ).toBeVisible();
+
+			await modal
+				.locator( 'input[name="item_qty"]' )
+				.first()
+				.fill( '2.5' );
+			await modal.locator( '#btn-ok' ).click();
+
+			// With step validation, the modal stays open showing the browser message.
+			await expect( modalContent ).toBeVisible();
+		} );
 	}
 );

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -2459,11 +2459,13 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	public function test_save_order_items_rejects_step_mismatch_quantity() {
 		$this->_setRole( 'administrator' );
 
-		$order        = \WC_Helper_Order::create_order();
-		$items        = array_values( $order->get_items() );
-		$item         = $items[0];
-		$item_id      = $item->get_id();
-		$original_qty = $item->get_quantity();
+		$order             = \WC_Helper_Order::create_order();
+		$items             = array_values( $order->get_items() );
+		$item              = $items[0];
+		$item_id           = $item->get_id();
+		$original_qty      = $item->get_quantity();
+		$original_total    = $item->get_total();
+		$original_subtotal = $item->get_subtotal();
 
 		$_POST['order_id'] = $order->get_id();
 		$_POST['security'] = wp_create_nonce( 'order-item' );
@@ -2482,6 +2484,8 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 
 		$fresh_item = \WC_Order_Factory::get_order_item( $item_id );
 		$this->assertEquals( $original_qty, $fresh_item->get_quantity() );
+		$this->assertEquals( $original_total, $fresh_item->get_total() );
+		$this->assertEquals( $original_subtotal, $fresh_item->get_subtotal() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -2427,6 +2427,64 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox add_order_item rejects a quantity violating step with a JSON error and adds nothing to the order.
+	 */
+	public function test_add_order_item_rejects_step_mismatch_quantity() {
+		$this->_setRole( 'administrator' );
+
+		$product            = \WC_Helper_Product::create_simple_product();
+		$order              = \WC_Helper_Order::create_order();
+		$initial_item_count = count( $order->get_items() );
+
+		$_POST['order_id'] = $order->get_id();
+		$_POST['security'] = wp_create_nonce( 'order-item' );
+		$_POST['data']     = array(
+			array(
+				'id'  => (string) $product->get_id(),
+				'qty' => '2.5',
+			),
+		);
+
+		$response = $this->do_ajax( 'woocommerce_add_order_item' );
+
+		$this->assertFalse( $response['success'] );
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertCount( $initial_item_count, $order->get_items() );
+	}
+
+	/**
+	 * @testdox save_order_items rejects a quantity violating step and leaves the stored item untouched.
+	 */
+	public function test_save_order_items_rejects_step_mismatch_quantity() {
+		$this->_setRole( 'administrator' );
+
+		$order        = \WC_Helper_Order::create_order();
+		$items        = array_values( $order->get_items() );
+		$item         = $items[0];
+		$item_id      = $item->get_id();
+		$original_qty = $item->get_quantity();
+
+		$_POST['order_id'] = $order->get_id();
+		$_POST['security'] = wp_create_nonce( 'order-item' );
+		$_POST['items']    = http_build_query(
+			array(
+				'order_item_id'  => array( $item_id ),
+				'order_item_qty' => array( $item_id => '2.5' ),
+				'line_total'     => array( $item_id => '25' ),
+				'line_subtotal'  => array( $item_id => '25' ),
+			)
+		);
+
+		$response = $this->do_ajax( 'woocommerce_save_order_items' );
+
+		$this->assertFalse( $response['success'] );
+
+		$fresh_item = \WC_Order_Factory::get_order_item( $item_id );
+		$this->assertEquals( $original_qty, $fresh_item->get_quantity() );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ItemQuantityLimitsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ItemQuantityLimitsTest.php
@@ -219,4 +219,156 @@ class ItemQuantityLimitsTest extends WC_Unit_Test_Case {
 			)
 		);
 	}
+
+	/**
+	 * @testdox get_quantity_input_step returns 1 for an item with an integer quantity and default product step.
+	 */
+	public function test_step_is_one_by_default_for_integer_quantity_item(): void {
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+
+		$this->assertSame( '1', $this->sut->get_quantity_input_step( $items[0] ) );
+	}
+
+	/**
+	 * @testdox get_quantity_input_step defaults to any when the stored quantity does not align with the step.
+	 */
+	public function test_step_defaults_to_any_for_stored_decimal_quantity(): void {
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+		$item  = $items[0];
+		$item->set_quantity( 2.5 );
+		$item->save();
+
+		$this->assertSame( 'any', $this->sut->get_quantity_input_step( $item ) );
+	}
+
+	/**
+	 * @testdox get_quantity_input_step applies the woocommerce_quantity_input_step_admin filter.
+	 */
+	public function test_step_is_filterable(): void {
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+
+		$callback = function () {
+			return '0.5';
+		};
+		add_filter( 'woocommerce_quantity_input_step_admin', $callback );
+		$step = $this->sut->get_quantity_input_step( $items[0] );
+		remove_filter( 'woocommerce_quantity_input_step_admin', $callback );
+
+		$this->assertSame( '0.5', $step );
+	}
+
+	/**
+	 * @testdox get_quantity_input_step falls back to the default when the filter returns an invalid value.
+	 */
+	public function test_step_falls_back_on_invalid_filter_value(): void {
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+
+		$callback = function () {
+			return array( 'not-a-step' );
+		};
+		add_filter( 'woocommerce_quantity_input_step_admin', $callback );
+		$step = $this->sut->get_quantity_input_step( $items[0] );
+		remove_filter( 'woocommerce_quantity_input_step_admin', $callback );
+
+		$this->assertSame( '1', $step );
+	}
+
+	/**
+	 * @testdox validate_new_item_quantity throws for a quantity that violates the step.
+	 */
+	public function test_validate_new_item_throws_for_step_mismatch(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+
+		$this->expectException( \Exception::class );
+		$this->sut->validate_new_item_quantity( 2.5, $product );
+	}
+
+	/**
+	 * @testdox validate_new_item_quantity accepts a quantity matching the product step.
+	 */
+	public function test_validate_new_item_accepts_valid_step_quantity(): void {
+		$this->expectNotToPerformAssertions();
+
+		$product = \WC_Helper_Product::create_simple_product();
+
+		$this->sut->validate_new_item_quantity( 2.0, $product );
+	}
+
+	/**
+	 * @testdox validate_new_item_quantity runs the step filter with the add context and the product.
+	 */
+	public function test_validate_new_item_passes_add_context_to_step_filter(): void {
+		$product  = \WC_Helper_Product::create_simple_product();
+		$captured = array();
+
+		$callback = function ( $step, $filter_product, $context ) use ( &$captured ) {
+			$captured = array( $filter_product, $context );
+			return $step;
+		};
+		add_filter( 'woocommerce_quantity_input_step_admin', $callback, 10, 3 );
+		$this->sut->validate_new_item_quantity( 1.0, $product );
+		remove_filter( 'woocommerce_quantity_input_step_admin', $callback );
+
+		$this->assertSame( $product->get_id(), $captured[0]->get_id() );
+		$this->assertSame( 'add', $captured[1] );
+	}
+
+	/**
+	 * @testdox validate_posted_item_quantities throws when a posted quantity violates the step.
+	 */
+	public function test_validate_posted_throws_for_step_mismatch(): void {
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+		$item  = $items[0];
+
+		$this->expectException( \Exception::class );
+		$this->sut->validate_posted_item_quantities(
+			$order,
+			array(
+				'order_item_qty' => array( $item->get_id() => '2.5' ),
+			)
+		);
+	}
+
+	/**
+	 * @testdox validate_posted_item_quantities accepts a valid step multiple.
+	 */
+	public function test_validate_posted_accepts_valid_step_quantity(): void {
+		$this->expectNotToPerformAssertions();
+
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+		$item  = $items[0];
+
+		$this->sut->validate_posted_item_quantities(
+			$order,
+			array(
+				'order_item_qty' => array( $item->get_id() => '3' ),
+			)
+		);
+	}
+
+	/**
+	 * @testdox validate_posted_item_quantities accepts an existing non-conforming decimal quantity.
+	 */
+	public function test_validate_posted_accepts_existing_decimal_quantity(): void {
+		$this->expectNotToPerformAssertions();
+
+		$order = WC_Helper_Order::create_order();
+		$items = array_values( $order->get_items() );
+		$item  = $items[0];
+		$item->set_quantity( 2.5 );
+		$item->save();
+
+		$this->sut->validate_posted_item_quantities(
+			$order,
+			array(
+				'order_item_qty' => array( $item->get_id() => '2.5' ),
+			)
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ItemQuantityLimitsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ItemQuantityLimitsTest.php
@@ -234,13 +234,20 @@ class ItemQuantityLimitsTest extends WC_Unit_Test_Case {
 	 * @testdox get_quantity_input_step defaults to any when the stored quantity does not align with the step.
 	 */
 	public function test_step_defaults_to_any_for_stored_decimal_quantity(): void {
-		$order = WC_Helper_Order::create_order();
-		$items = array_values( $order->get_items() );
-		$item  = $items[0];
-		$item->set_quantity( 2.5 );
-		$item->save();
+		remove_filter( 'woocommerce_stock_amount', 'intval' );
+		add_filter( 'woocommerce_stock_amount', 'floatval' );
+		try {
+			$order = WC_Helper_Order::create_order();
+			$items = array_values( $order->get_items() );
+			$item  = $items[0];
+			$item->set_quantity( 2.5 );
+			$item->save();
 
-		$this->assertSame( 'any', $this->sut->get_quantity_input_step( $item ) );
+			$this->assertSame( 'any', $this->sut->get_quantity_input_step( $item ) );
+		} finally {
+			remove_filter( 'woocommerce_stock_amount', 'floatval' );
+			add_filter( 'woocommerce_stock_amount', 'intval' );
+		}
 	}
 
 	/**
@@ -358,17 +365,24 @@ class ItemQuantityLimitsTest extends WC_Unit_Test_Case {
 	public function test_validate_posted_accepts_existing_decimal_quantity(): void {
 		$this->expectNotToPerformAssertions();
 
-		$order = WC_Helper_Order::create_order();
-		$items = array_values( $order->get_items() );
-		$item  = $items[0];
-		$item->set_quantity( 2.5 );
-		$item->save();
+		remove_filter( 'woocommerce_stock_amount', 'intval' );
+		add_filter( 'woocommerce_stock_amount', 'floatval' );
+		try {
+			$order = WC_Helper_Order::create_order();
+			$items = array_values( $order->get_items() );
+			$item  = $items[0];
+			$item->set_quantity( 2.5 );
+			$item->save();
 
-		$this->sut->validate_posted_item_quantities(
-			$order,
-			array(
-				'order_item_qty' => array( $item->get_id() => '2.5' ),
-			)
-		);
+			$this->sut->validate_posted_item_quantities(
+				$order,
+				array(
+					'order_item_qty' => array( $item->get_id() => '2.5' ),
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_stock_amount', 'floatval' );
+			add_filter( 'woocommerce_stock_amount', 'intval' );
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Issue:** 
Fixes an issue where clicking the **Update** button on the admin order edit screen silently did nothing when the order contained a line item with a decimal quantity (or any quantity not matching the product's step). The status dropdown appeared changed in the UI, but the update was never persisted.


**Root Cause**:
1. **Silent submit aborts:** By default, product quantity inputs have `step="1"`. When an order contains a decimal quantity, the input has `value="2.5"` and `step="1"`. Because the input sits inside a hidden container (`.edit` with `display: none`), the browser's native form validation fails, cannot focus the field, and **silently aborts** the entire form submission.
2. **Missing step checks:** The items panel "Save" button and the "Add products" modal only checked for negative quantities (`rangeUnderflow`), ignoring step violations completely.

**Solution**:
1. **Surfaces validation errors instead of silently failing:** - In `meta-boxes-order.js`, extended the validation helper to check both minimum (`rangeUnderflow`) and step (`stepMismatch`).
2. **Keeps existing decimal orders editable:** - Just like negative quantities floored the minimum at the stored quantity in #67921, `ItemQuantityLimits::get_quantity_input_step()` checks if an existing stored quantity does not align with the product's step. If so, it defaults to `step="any"` for that item.
3. **Validates stepping on the server:** - Added server-side step validation to `ItemQuantityLimits` for AJAX endpoints (`woocommerce_save_order_items` and `woocommerce_add_order_item`).
---

Closes #68170 .

### Screenshots or screen recordings:

<img width="1311" height="807" alt="Screenshot 2026-09-09 at 11 47 57 AM" src="https://github.com/user-attachments/assets/f1df114a-b62a-4fa1-9295-4bb18634eb59" />
<img width="1314" height="806" alt="Screenshot 2026-09-09 at 11 47 02 AM" src="https://github.com/user-attachments/assets/6de11838-3f47-4280-a7b3-ccafc95a1529" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### 1. Existing orders with decimal quantities (The original bug)
1. On a store that allows decimal quantities (e.g. with a decimal filter/plugin active), create or open an order that has a line item with quantity `2.5` (for a product with default step 1).
2. Open browser DevTools Console.
3. Change the order status from **Pending payment** to **Processing**.
4. Click **Update**.
* **Expected:** The order updates successfully, status is persisted as *Processing*, and there are no *"An invalid form control is not focusable"* errors in the console.

#### 2. Items panel AJAX "Save" button
1. Open an order with a regular step-1 product (e.g. quantity `1`).
2. Click the edit pencil icon next to the line item.
3. Change the quantity to `1.5`.
4. Click the blue **Save** button inside the items panel.
* **Expected:** The save is blocked, and the browser displays a validation bubble on the input (*"Please enter a valid value..."*).

#### 3. Main order "Update" button with an invalid step
1. On a regular step-1 item, edit the quantity to `1.5`.
2. Without clicking "Save" in the items panel, click the top-level **Update** button in the Order actions box.
* **Expected:** The form submission is halted, the field is focused with the browser validation bubble, and the status change is not silently swallowed.

#### 4. Add Products modal
1. In the items panel, click **Add item(s)** > **Add product(s)**.
2. Select any product with step 1.
3. In the quantity field inside the modal, type `2.5` and click **Add**.
* **Expected:** The modal does not close, and the field shows the browser validation bubble.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Use of AI Tools

- I used Google Antigravity to assist with coding and debugging.
- All code, logic, and tests were manually reviewed and verified across the test scenarios in `wp-env`, and I take full responsibility for the changes in this PR.
- 5 out of 4 Manual tests are present in the PR description, the last one was omited because it was an general testing for checking if `Normal Orders and Valid Values Still Work Cleanly`
