### PR TITLE
Stop force-enabling stock notifications in the PHPUnit bootstrap

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7704-stock-notifications-tests-off-by-default
+++ b/plugins/woocommerce/changelog/wooplug-7704-stock-notifications-tests-off-by-default
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Stop force-enabling the Back In Stock Notifications feature for the whole PHPUnit suite; affected tests now enable it themselves (no runtime change).

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -269,11 +269,6 @@ class WC_Unit_Tests_Bootstrap {
 		// set in time for ProductCacheController::on_init() to register its invalidation hooks.
 		update_option( 'woocommerce_feature_product_instance_caching_enabled', 'yes' );
 
-		// Enable Back In Stock Notifications during tests. Set here rather than in load_wc()
-		// because install_wc() includes uninstall.php, which deletes every 'woocommerce_%'
-		// option. This still runs on `setup_theme`, in time for the `init` feature check.
-		update_option( 'woocommerce_feature_customer_stock_notifications_enabled', 'yes' );
-
 		// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
 			$GLOBALS['wp_roles']->reinit();

--- a/plugins/woocommerce/tests/legacy/unit-tests/account/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/account/functions.php
@@ -73,14 +73,12 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_account_menu_items() {
 		$this->assertEquals(
 			array(
-				'dashboard'           => 'Dashboard',
-				'orders'              => 'Orders',
-				'downloads'           => 'Downloads',
-				// Back in Stock Notifications is enabled for the whole suite in bootstrap.php.
-				'stock-notifications' => 'Stock notifications',
-				'edit-address'        => 'Addresses',
-				'edit-account'        => 'Account details',
-				'customer-logout'     => 'Log out',
+				'dashboard'       => 'Dashboard',
+				'orders'          => 'Orders',
+				'downloads'       => 'Downloads',
+				'edit-address'    => 'Addresses',
+				'edit-account'    => 'Account details',
+				'customer-logout' => 'Log out',
 			),
 			wc_get_account_menu_items()
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-wc-query.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-wc-query.php
@@ -60,8 +60,6 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 			'add-payment-method'         => 'add-payment-method',
 			'delete-payment-method'      => 'delete-payment-method',
 			'set-default-payment-method' => 'set-default-payment-method',
-			// Back in Stock Notifications is enabled for the whole suite in bootstrap.php.
-			'stock-notifications'        => 'stock-notifications',
 		);
 		$this->assertEquals( $expected, $default_vars );
 

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -8,7 +8,6 @@
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
 
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
-use Automattic\WooCommerce\Internal\StockNotifications\Admin\SettingsController as StockNotificationsSettings;
 
 require_once __DIR__ . '/class-wc-settings-unit-test-case.php';
 
@@ -21,11 +20,6 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 	 * @testdox get_sections should get all the existing sections.
 	 */
 	public function test_get_sections() {
-		// Get customer stock notification settings.
-		// This is required because this class is loaded only in admin context,
-		// and this test doesn't run with an admin user.
-		wc_get_container()->get( StockNotificationsSettings::class );
-
 		$sut = new WC_Settings_Products();
 
 		$section_names = array_keys( $sut->get_sections() );
@@ -33,7 +27,6 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 		$expected = array(
 			'',
 			'inventory',
-			'customer_stock_notifications',
 			'downloadable',
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/StockNotifications/StockNotificationsDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/StockNotifications/StockNotificationsDataStoreTests.php
@@ -8,11 +8,14 @@ use Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificat
 
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 
 /**
  * Class StockNotificationsDataStoreTests.
  */
 class StockNotificationsDataStoreTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The data store instance.
@@ -26,6 +29,7 @@ class StockNotificationsDataStoreTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		$this->data_store = wc_get_container()->get( StockNotificationsDataStore::class );
 	}
 
@@ -37,6 +41,7 @@ class StockNotificationsDataStoreTests extends \WC_Unit_Test_Case {
 		global $wpdb;
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -6,12 +6,14 @@ namespace Automattic\WooCommerce\Tests\Internal\Email;
 use Automattic\WooCommerce\Internal\Email\DeferredEmailQueue;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification as StockNotification;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Unit_Test_Case;
 
 /**
  * Tests for the DeferredEmailQueue class.
  */
 class DeferredEmailQueueTest extends WC_Unit_Test_Case {
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The System Under Test.
@@ -32,6 +34,7 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		$this->sut = new DeferredEmailQueue();
 		$this->reset_queue_singleton();
 		add_filter(
@@ -55,6 +58,7 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 		remove_all_actions( 'woocommerce_deferred_email_test_unsaved_product_notification' );
 		$this->set_wc_emails_deferred_queue( null );
 		$this->delete_stock_notifications();
+		$this->restore_stock_notifications_feature_option();
 		$this->reset_queue_singleton();
 		parent::tearDown();
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -14,14 +14,49 @@ use WC_Settings_Products;
 class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 
 	/**
+	 * The controller whose hooks the tests exercise.
+	 *
+	 * @var StockNotificationsSettings
+	 */
+	private $controller;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Only AdminManager resolves the controller, and only in admin context. Built directly
+		// rather than through the container, whose cached instance loses its hooks after the first test.
+		$this->controller = new StockNotificationsSettings();
+	}
+
+	/**
+	 * @testdox The Customer stock notifications section is added to the Products tab right after Inventory.
+	 */
+	public function test_customer_stock_notifications_section_is_added_after_inventory() {
+		$sut = new WC_Settings_Products();
+
+		// Other features hook sections in too, so assert the position rather than the full list.
+		$section_ids = array_keys( $sut->get_sections() );
+		$inventory   = array_search( 'inventory', $section_ids, true );
+
+		$this->assertNotFalse( $inventory );
+		$this->assertSame( 'customer_stock_notifications', $section_ids[ $inventory + 1 ] );
+	}
+
+	/**
+	 * @testdox The Customer stock notifications section is appended when there is no Inventory section to follow.
+	 */
+	public function test_customer_stock_notifications_section_is_appended_without_inventory() {
+		$sections = $this->controller->add_customer_stock_notifications_section( array( '' => 'General' ) );
+
+		$this->assertSame( array( '', 'customer_stock_notifications' ), array_keys( $sections ) );
+	}
+
+	/**
 	 * @testdox get_settings('customer_stock_notifications') should return all the settings for the customer stock notifications section.
 	 */
 	public function test_get_customer_stock_notifications_settings_returns_all_settings() {
-		// Get customer stock notification settings.
-		// This is required because this class is loaded only in admin context,
-		// and this test doesn't run with an admin user.
-		wc_get_container()->get( StockNotificationsSettings::class );
-
 		$sut = new WC_Settings_Products();
 
 		$settings              = $sut->get_settings_for_section( 'customer_stock_notifications' );
@@ -43,10 +78,6 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 	 * @testdox The My Account endpoint setting is added to the Advanced tab, inside the account endpoints group, right after Downloads.
 	 */
 	public function test_my_account_endpoint_setting_is_added_to_the_advanced_tab() {
-		// Instantiated directly rather than through the container: the container caches the
-		// instance from the previous test, whose hooks the test case has since torn down.
-		new StockNotificationsSettings();
-
 		$sut = new WC_Settings_Advanced();
 
 		$settings = $sut->get_settings_for_section( '' );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/AsyncTasks/NotificationsProcessorTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/AsyncTasks/NotificationsProcessorTests.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailManager;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Product;
 use WC_Helper_Product;
 
@@ -20,6 +21,8 @@ use WC_Helper_Product;
  * Tests for NotificationsProcessor class
  */
 class NotificationsProcessorTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * @var NotificationsProcessor
@@ -31,6 +34,7 @@ class NotificationsProcessorTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		\WC()->queue()->cancel_all( JobManager::AS_JOB_SEND_STOCK_NOTIFICATIONS );
 
 		$eligibility_service = new EligibilityService();
@@ -51,6 +55,7 @@ class NotificationsProcessorTests extends \WC_Unit_Test_Case {
 		global $wpdb;
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/DataRetentionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/DataRetentionControllerTests.php
@@ -13,6 +13,8 @@ use Automattic\WooCommerce\Internal\StockNotifications\NotificationQuery;
  */
 class DataRetentionControllerTests extends \WC_Unit_Test_Case {
 
+	use StockNotificationsFeatureTrait;
+
 	/**
 	 * The controller instance.
 	 *
@@ -25,6 +27,7 @@ class DataRetentionControllerTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		$this->controller = new DataRetentionController();
 	}
 
@@ -32,9 +35,10 @@ class DataRetentionControllerTests extends \WC_Unit_Test_Case {
 	 * Clean up after tests
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
 		$this->controller->clear_daily_task();
 		delete_option( 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold' );
+		$this->restore_stock_notifications_feature_option();
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -9,12 +9,15 @@ use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancell
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Helper_Product;
 
 /**
  * EmailActionControllerTests tests.
  */
 class EmailActionControllerTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The System Under Test.
@@ -35,6 +38,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 
 		// Intercept redirects so headers aren't emitted, and throw so the trailing `exit;`
 		// in production code never runs during the test.
@@ -50,6 +54,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		remove_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailManagerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailManagerTests.php
@@ -6,12 +6,15 @@ namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Emails;
 use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailManager;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Helper_Product;
 
 /**
  * Tests for EmailManager wrapper methods.
  */
 class EmailManagerTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The System Under Test.
@@ -32,6 +35,7 @@ class EmailManagerTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 
 		// Short-circuit `wp_mail()` so the tests never attempt a real SMTP handoff.
 		// Returning a non-null value from `pre_wp_mail` signals WP core to skip the actual send.
@@ -40,7 +44,11 @@ class EmailManagerTests extends \WC_Unit_Test_Case {
 		$this->sut = new EmailManager();
 		$this->sut->init();
 
-		// Boot the mailer so email classes are registered.
+		// `WC_Emails` is a singleton that keeps whichever email list it built on its first
+		// construction for the rest of the process. Reset it so this test's registration
+		// via `woocommerce_email_classes` is actually picked up rather than an earlier
+		// test's (feature-disabled) build of the list.
+		$this->reset_email_singleton();
 		WC()->mailer();
 	}
 
@@ -50,7 +58,20 @@ class EmailManagerTests extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_filter( 'pre_wp_mail', array( $this, 'capture_pre_wp_mail' ), 10 );
 		$this->sent_to = array();
+		$this->restore_stock_notifications_feature_option();
+		// Discard this test's `WC_Emails` build so later tests rebuild their own from
+		// whatever filters are active for them, rather than inheriting this test's list.
+		$this->reset_email_singleton();
 		parent::tearDown();
+	}
+
+	/**
+	 * Reset the `WC_Emails` singleton so the next `WC()->mailer()` call rebuilds it.
+	 */
+	private function reset_email_singleton(): void {
+		$instance_property = ( new \ReflectionClass( \WC_Emails::class ) )->getProperty( 'instance' );
+		$instance_property->setAccessible( true );
+		$instance_property->setValue( null, null );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/FactoryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/FactoryTests.php
@@ -11,6 +11,24 @@ use Automattic\WooCommerce\Internal\StockNotifications\Factory;
  */
 class FactoryTests extends \WC_Unit_Test_Case {
 
+	use StockNotificationsFeatureTrait;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->enable_stock_notifications_feature();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tearDown(): void {
+		$this->restore_stock_notifications_feature_option();
+		parent::tearDown();
+	}
+
 	/**
 	 * Test the factory.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
@@ -12,12 +12,15 @@ use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Helper_Product;
 
 /**
  * Tests for the customer-facing MyAccount back-in-stock notifications endpoint.
  */
 class MyAccountEndpointTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * Location passed to the last suppressed redirect, or null if none happened.
@@ -31,6 +34,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		\wc_clear_notices();
 		$this->redirect_location = null;
 		add_filter( 'wp_redirect', array( $this, 'capture_redirect' ) );
@@ -51,6 +55,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 		if ( isset( $wp->query_vars[ MyAccountEndpoint::ENDPOINT ] ) ) {
 			unset( $wp->query_vars[ MyAccountEndpoint::ENDPOINT ] );
 		}
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/NotificationManagementServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/NotificationManagementServiceTests.php
@@ -8,12 +8,15 @@ use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\NotificationManagementService;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Helper_Product;
 
 /**
  * Tests for NotificationManagementService resend handler.
  */
 class NotificationManagementServiceTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The System Under Test.
@@ -34,6 +37,7 @@ class NotificationManagementServiceTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 
 		// Intercept redirects so headers aren't emitted, and throw so the trailing `exit;`
 		// in production code never runs during the test.
@@ -62,6 +66,7 @@ class NotificationManagementServiceTests extends \WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
 
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -10,12 +10,15 @@ use Automattic\WooCommerce\Internal\StockNotifications\Frontend\SignupService;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EligibilityService;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\StockManagementHelper;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Helper_Product;
 
 /**
  * Tests for SignupService email dispatch.
  */
 class SignupServiceTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * The System Under Test.
@@ -36,6 +39,7 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 
 		update_option( 'woocommerce_customer_stock_notifications_allow_signups', 'yes' );
 
@@ -64,6 +68,7 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
 
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/NotificationTests.php
@@ -11,6 +11,16 @@ use Automattic\WooCommerce\Internal\StockNotifications\Config;
  */
 class NotificationTests extends \WC_Unit_Test_Case {
 
+	use StockNotificationsFeatureTrait;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->enable_stock_notifications_feature();
+	}
+
 	/**
 	 * @after
 	 */
@@ -19,6 +29,7 @@ class NotificationTests extends \WC_Unit_Test_Case {
 		global $wpdb;
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Privacy/PrivacyEraserTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Privacy/PrivacyEraserTests.php
@@ -6,11 +6,31 @@ namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Privacy;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Privacy\PrivacyEraser;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 
 /**
  * PrivacyEraser tests.
  */
 class PrivacyEraserTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->enable_stock_notifications_feature();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tearDown(): void {
+		$this->restore_stock_notifications_feature_option();
+		parent::tearDown();
+	}
+
 	/**
 	 * Test that privacy eraser makes notification data anonymous.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsFeatureTrait.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsFeatureTrait.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications;
+
+use Automattic\WooCommerce\Internal\StockNotifications\StockNotifications;
+
+/**
+ * Enables the Back In Stock Notifications feature for a test's lifetime.
+ *
+ * The feature is off by default in the test suite (see WOOPLUG-7704), so any
+ * test that reads or writes a `Notification` must enable it itself, following
+ * the Order Withdrawal set_up()/tear_down() pattern. Tests build their own
+ * subject under test; only tests of the wiring itself call
+ * `init_stock_notifications_services()`.
+ */
+trait StockNotificationsFeatureTrait {
+
+	/**
+	 * The feature option's value before the test enabled it.
+	 *
+	 * @var mixed
+	 */
+	private $stock_notifications_original_feature_option;
+
+	/**
+	 * Enable the feature and register its data store, enough to read and write a Notification.
+	 *
+	 * Deliberately stops short of `maybe_init_services()`: hooking the container's
+	 * services would run real instances alongside the mocks a test injects into its own.
+	 */
+	private function enable_stock_notifications_feature(): void {
+		$this->stock_notifications_original_feature_option = get_option( StockNotifications::ENABLE_OPTION_NAME, false );
+		update_option( StockNotifications::ENABLE_OPTION_NAME, 'yes' );
+		add_filter( 'woocommerce_data_stores', array( wc_get_container()->get( StockNotifications::class ), 'register_data_stores' ) );
+	}
+
+	/**
+	 * Wire up every service `maybe_init_services()` gates. Only for tests of the wiring itself.
+	 *
+	 * Resets the container first: it caches each service, and the hooks a cached instance
+	 * added in an earlier test are gone once that test tore down, so only a fresh
+	 * resolution actually re-hooks.
+	 */
+	private function init_stock_notifications_services(): void {
+		$container = wc_get_container();
+		$container->reset_all_resolved();
+		$container->get( StockNotifications::class )->maybe_init_services();
+	}
+
+	/**
+	 * Restore the feature option to its pre-test value.
+	 */
+	private function restore_stock_notifications_feature_option(): void {
+		if ( false === $this->stock_notifications_original_feature_option ) {
+			delete_option( StockNotifications::ENABLE_OPTION_NAME );
+		} else {
+			update_option( StockNotifications::ENABLE_OPTION_NAME, $this->stock_notifications_original_feature_option );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockNotificationsTests.php
@@ -11,6 +11,15 @@ use Automattic\WooCommerce\Internal\StockNotifications\StockNotifications;
  * StockNotifications controller tests.
  */
 class StockNotificationsTests extends \WC_Unit_Test_Case {
+	use StockNotificationsFeatureTrait;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->enable_stock_notifications_feature();
+	}
 
 	/**
 	 * Clean up after tests.
@@ -19,6 +28,7 @@ class StockNotificationsTests extends \WC_Unit_Test_Case {
 		wc_get_container()->get( DataRetentionController::class )->clear_daily_task();
 		delete_option( 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold' );
 		delete_option( 'woocommerce_queue_flush_rewrite_rules' );
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 
@@ -50,6 +60,7 @@ class StockNotificationsTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_disabling_the_feature_clears_the_daily_task(): void {
 		update_option( 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold', 30 );
+		$this->fire_feature_changed( true );
 		$this->assertSame( 'daily', wp_get_schedule( DataRetentionController::DAILY_TASK_HOOK ) );
 
 		$this->fire_feature_changed( false );
@@ -79,11 +90,63 @@ class StockNotificationsTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_other_features_are_ignored(): void {
 		update_option( 'woocommerce_customer_stock_notifications_unverified_deletions_days_threshold', 30 );
+		$this->fire_feature_changed( true );
 		delete_option( 'woocommerce_queue_flush_rewrite_rules' );
 
 		$this->fire_feature_changed( false, 'some_other_feature' );
 
 		$this->assertSame( 'daily', wp_get_schedule( DataRetentionController::DAILY_TASK_HOOK ) );
 		$this->assertFalse( get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * @testdox Enabling the feature wires the hooks of container-resolved services.
+	 */
+	public function test_enabling_the_feature_wires_container_resolved_services(): void {
+		$this->init_stock_notifications_services();
+
+		$this->assertArrayHasKey( 'stock-notifications', wc_get_account_menu_items() );
+	}
+
+	/**
+	 * @testdox The stock notification data store is not registered while the feature is disabled.
+	 */
+	public function test_maybe_init_services_does_nothing_when_the_feature_is_disabled(): void {
+		$controller = wc_get_container()->get( StockNotifications::class );
+
+		// Undo what setUp() wired up, then re-run with the feature off.
+		remove_filter( 'woocommerce_data_stores', array( $controller, 'register_data_stores' ) );
+		update_option( StockNotifications::ENABLE_OPTION_NAME, 'no' );
+		$controller->maybe_init_services();
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Invalid data store.' );
+
+		new \WC_Data_Store( 'stock_notification' );
+	}
+
+	/**
+	 * @testdox register_data_stores re-checks the option, so a hooked callback stays inert once the feature is turned off.
+	 */
+	public function test_register_data_stores_ignores_a_hooked_callback_once_the_feature_is_disabled(): void {
+		$controller = wc_get_container()->get( StockNotifications::class );
+		$this->assertNotFalse( has_filter( 'woocommerce_data_stores', array( $controller, 'register_data_stores' ) ) );
+
+		update_option( StockNotifications::ENABLE_OPTION_NAME, 'no' );
+
+		$stores = array( 'product' => 'WC_Product_Data_Store_CPT' );
+
+		$this->assertSame( $stores, $controller->register_data_stores( $stores ) );
+	}
+
+	/**
+	 * @testdox The stock notification data store becomes available once the feature is enabled.
+	 */
+	public function test_maybe_init_services_registers_the_data_store_when_the_feature_is_enabled(): void {
+		$this->init_stock_notifications_services();
+
+		$store = new \WC_Data_Store( 'stock_notification' );
+
+		$this->assertSame( \Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificationsDataStore::class, $store->get_current_class_name() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockSyncControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/StockSyncControllerTests.php
@@ -16,6 +16,8 @@ use Automattic\WooCommerce\Internal\StockNotifications\AsyncTasks\JobManager;
  */
 class StockSyncControllerTests extends \WC_Unit_Test_Case {
 
+	use StockNotificationsFeatureTrait;
+
 	/**
 	 * @var StockSyncController
 	 */
@@ -26,6 +28,7 @@ class StockSyncControllerTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		$this->sut           = new StockSyncController();
 		$eligibility_service = new EligibilityService();
 		$eligibility_service->init( new StockManagementHelper() );
@@ -37,6 +40,7 @@ class StockSyncControllerTests extends \WC_Unit_Test_Case {
 	 * Tear down the test.
 	 */
 	public function tearDown(): void {
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 		unset( $this->sut );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Utilities/EligibilityServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Utilities/EligibilityServiceTests.php
@@ -8,12 +8,15 @@ use Automattic\WooCommerce\Internal\StockNotifications\Utilities\StockManagement
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Tests\Internal\StockNotifications\StockNotificationsFeatureTrait;
 use WC_Helper_Product;
 
 /**
  * Tests for NotificationEligibilityService
  */
 class EligibilityServiceTests extends \WC_Unit_Test_Case {
+
+	use StockNotificationsFeatureTrait;
 
 	/**
 	 * @var EligibilityService
@@ -25,6 +28,7 @@ class EligibilityServiceTests extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->enable_stock_notifications_feature();
 		$stock_management_helper = new StockManagementHelper();
 		$this->sut               = new EligibilityService();
 		$this->sut->init( $stock_management_helper );
@@ -39,6 +43,7 @@ class EligibilityServiceTests extends \WC_Unit_Test_Case {
 		global $wpdb;
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notificationmeta" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_stock_notifications" );
+		$this->restore_stock_notifications_feature_option();
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The PHPUnit bootstrap force-enabled the Back In Stock Notifications feature for the whole suite, so every test ran with the feature on and nothing covered the default, feature-off state. This removes that bootstrap-wide enable so the suite runs with the feature off by default, the same as a fresh store.

Tests that need the feature now opt in through a new `StockNotificationsFeatureTrait`. Its default level turns the option on and registers the `stock_notification` data store, which is all a test needs to read and write a `Notification`. It deliberately stops short of `maybe_init_services()`, because hooking the container's services would run real instances alongside the mocks tests inject into their own subject under test. Tests of the wiring itself call `init_stock_notifications_services()` explicitly.

Also included: coverage for the disabled state and the enable transition in `StockNotificationsTests`, coverage for the Products tab section placement in `SettingsControllerTests`, and legacy expectations in `WC_Tests_WC_Query` and `WC_Tests_Account_Functions` updated to assert the feature-off baseline. No runtime code changes.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run the whole suite, both testsuites: `pnpm test:php:env`.
2. Confirm it is green, including `tests/legacy/unit-tests/util/class-wc-tests-wc-query.php` and `tests/legacy/unit-tests/account/functions.php`, which live in the `wc-phpunit-legacy` testsuite.
3. Confirm `plugins/woocommerce/tests/legacy/bootstrap.php` no longer sets `woocommerce_feature_customer_stock_notifications_enabled`.
4. Optionally run `pnpm test:php:env -- --filter StockNotifications` and check `StockNotificationsTests` covers both the disabled state and the enable transition.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran every trait consumer plus `DeferredEmailQueueTest`, the settings, features, emails, and the two legacy classes through both testsuites in wp-env: 1456 tests, 5617 assertions, green.
- `lint:php:changes` and `lint:changes:branch` clean.
- Multi-agent AI review of the branch; findings addressed in this PR.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to write and iterate on the test changes and this description, under review and direction of the author. Multi-agent AI review was used on the branch.