### PR TITLE
Fix the Settings > Emails listing rendering without its table styles

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-listing-dataviews-styles
+++ b/plugins/woocommerce/changelog/fix-email-listing-dataviews-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the DataViews stylesheet on classic settings tabs so the Settings > Emails listing renders with its table styles again.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -1,3 +1,9 @@
+// DataViews styles for the Settings > Emails listing bundled into
+// settings-embed. It renders on a classic settings tab, which never loads the
+// @woocommerce/settings-ui stylesheet that carries its own DataViews CSS.
+// WOOPRD-3592 tracks converging on one DataViews copy.
+@import "@wordpress/dataviews/build-style/style.css";
+
 body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	background-color: var(--wpds-color-background-surface-neutral);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PR #67865 removed the `@wordpress/dataviews` stylesheet import from the settings-embed bundle as a duplicate of the import in `@woocommerce/settings-ui`. The settings-ui stylesheet only loads when the new Settings UI runtime resolves for the request. The Settings > Emails listing renders on a classic settings tab from the DataViews copy bundled into settings-embed, so it lost all of its table styles: squished columns, header buttons in link blue, no row borders.

This restores the import with a comment explaining why the classic bundle needs it. The Settings UI keeps its own DataViews 17 stylesheet. Both loading together on Settings UI pages is the transitional state recorded as intentional until the settings-embed consumers converge on a single DataViews copy; currently, there is no CSS conflict. **Please consider this PR a hotfix.**  I'll add a follow-up PR to load the assets needed for email dataviews separately.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related to #68476.

Bug introduced in PR #67865.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1000" height="741" alt="before-fix-clean-trunk-wp71" src="https://github.com/user-attachments/assets/974d41ca-4cd2-4587-8a5a-39f9064680d5" /> | <img width="1000" height="785" alt="after-fix" src="https://github.com/user-attachments/assets/e1ddbdca-b649-4ff9-a346-eb9a48858e6a" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block email editor: WooCommerce → Settings → Advanced → Features → "Block email editor".
2. Open WooCommerce → Settings → Emails.
3. Confirm the Email notifications table is styled: a full-width table with row separators, uppercase column headers, an "Updates" filter chip next to "Add filter", and a "⋮" actions menu on each row. On trunk the table sits squished to the left with blue header text and no borders.
4. Regression check: open WooCommerce → Settings → Payments → Direct bank transfer and confirm the form looks unchanged.
5. Optional, experimental Settings UI: with the `settings-ui` feature flag enabled, open WooCommerce → Settings → Products and confirm the page renders as before.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Local wp-env, WordPress 7.1, PHP 8.1, clean trunk build. Reproduced the unstyled listing, then confirmed with this change that the page's stylesheets contain the DataViews table rules again and the listing renders correctly.
- With the `settings-ui` feature flag on, Settings → Products renders correctly. Both DataViews stylesheets load, settings-ui last, which matches the state before #67865.
- Offline payment method forms (BACS) render identically with and without the DataViews rules, so they are unaffected either way.
- Stylelint passes on the changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to investigate the regression and draft the change, the changelog entry, and this description. The author reviewed and tested the result.
