### PR TITLE
Fix analytics chart previous year data offset by a leap day

### DIFF
--- a/packages/js/components/changelog/fix-wooplug-2204-chart-label-date-end
+++ b/packages/js/components/changelog/fix-wooplug-2204-chart-label-date-end
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for an optional `labelDateEnd` on Chart data points so a tooltip and screen reader label can describe a point covering a range of dates.

--- a/packages/js/components/src/chart/d3chart/utils/bar-chart.js
+++ b/packages/js/components/src/chart/d3chart/utils/bar-chart.js
@@ -5,6 +5,11 @@ import { get } from 'lodash';
 import { event as d3Event } from 'd3-selection';
 import moment from 'moment';
 
+/**
+ * Internal dependencies
+ */
+import { getDateLabel } from './index';
+
 export const drawBars = ( node, data, params, scales, formats, tooltip ) => {
 	const height = scales.yScale.range()[ 0 ];
 	const barGroup = node
@@ -78,8 +83,10 @@ export const drawBars = ( node, data, params, scales, formats, tooltip ) => {
 			let label = d.label || d.key;
 			if ( params.mode === 'time-comparison' ) {
 				const dayData = data.find( ( e ) => e.date === d.date );
-				label = formats.screenReaderFormat(
-					moment( dayData[ d.key ].labelDate ).toDate()
+				label = getDateLabel(
+					formats.screenReaderFormat,
+					dayData[ d.key ].labelDate,
+					dayData[ d.key ].labelDateEnd
 				);
 			}
 			return `${ label } ${ tooltip.valueFormat( d.value ) }`;

--- a/packages/js/components/src/chart/d3chart/utils/index.js
+++ b/packages/js/components/src/chart/d3chart/utils/index.js
@@ -4,6 +4,7 @@
 import { isNil } from 'lodash';
 import { format as d3Format } from 'd3-format';
 import { utcParse as d3UTCParse } from 'd3-time-format';
+import moment from 'moment';
 
 /**
  * Allows an overriding formatter or defaults to d3Format or d3TimeFormat
@@ -59,6 +60,26 @@ export const getUniqueDates = ( data, dateParser ) => {
 	const parseDate = d3UTCParse( dateParser );
 	const dates = new Set( data.map( ( d ) => d.date ) );
 	return [ ...dates ].sort( ( a, b ) => parseDate( a ) - parseDate( b ) );
+};
+
+/**
+ * Formats the date label of a data point. A point can cover a range of dates,
+ * for example a previous year 28th and 29th February folded into one point,
+ * in which case both ends are formatted and joined.
+ *
+ * @param {Function}    formatter    - date formatting function.
+ * @param {Date|string} labelDate    - date of the data point.
+ * @param {Date|string} labelDateEnd - optional last date the data point covers.
+ * @return {string} Formatted label.
+ */
+export const getDateLabel = ( formatter, labelDate, labelDateEnd ) => {
+	const toDate = ( date ) =>
+		date instanceof Date ? date : moment( date ).toDate();
+	const label = formatter( toDate( labelDate ) );
+	if ( labelDateEnd ) {
+		return `${ label } - ${ formatter( toDate( labelDateEnd ) ) }`;
+	}
+	return label;
 };
 
 /**

--- a/packages/js/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/js/components/src/chart/d3chart/utils/line-chart.js
@@ -149,7 +149,6 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'd', ( d ) => line( d.values ) );
 
 	const minDataPointSpacing = 36;
-
 	// eslint-disable-next-line no-unused-expressions
 	width / params.uniqueDates.length > minDataPointSpacing &&
 		series

--- a/packages/js/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/js/components/src/chart/d3chart/utils/line-chart.js
@@ -10,6 +10,7 @@ import { first, get } from 'lodash';
  * Internal dependencies
  */
 import { smallBreak, wideBreak } from './breakpoints';
+import { getDateLabel } from './index';
 
 /**
  * Describes getDateSpaces
@@ -97,6 +98,7 @@ export const getLineData = ( data, orderedKeys ) =>
 			date: d.date,
 			// To have actual date for the screenReader, we need to use label date.
 			labelDate: d[ row.key ].labelDate,
+			labelDateEnd: d[ row.key ].labelDateEnd,
 			focus: row.focus,
 			value: get( d, [ row.key, 'value' ], 0 ),
 			visible: row.visible,
@@ -147,6 +149,7 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'd', ( d ) => line( d.values ) );
 
 	const minDataPointSpacing = 36;
+
 	// eslint-disable-next-line no-unused-expressions
 	width / params.uniqueDates.length > minDataPointSpacing &&
 		series
@@ -174,10 +177,10 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'tabindex', '0' )
 			.attr( 'role', 'graphics-symbol' )
 			.attr( 'aria-label', ( d ) => {
-				const label = formats.screenReaderFormat(
-					d.labelDate instanceof Date
-						? d.labelDate
-						: moment( d.labelDate ).toDate()
+				const label = getDateLabel(
+					formats.screenReaderFormat,
+					d.labelDate,
+					d.labelDateEnd
 				);
 				return `${ label } ${ tooltip.valueFormat( d.value ) }`;
 			} )

--- a/packages/js/components/src/chart/d3chart/utils/test/index.js
+++ b/packages/js/components/src/chart/d3chart/utils/test/index.js
@@ -8,10 +8,37 @@ import { utcParse as d3UTCParse } from 'd3-time-format';
  */
 import dummyOrders from './fixtures/dummy-orders';
 import orderedKeys from './fixtures/dummy-ordered-keys';
-import { getOrderedKeys, isDataEmpty } from '../index';
+import { getDateLabel, getOrderedKeys, isDataEmpty } from '../index';
 
 const parseDate = d3UTCParse( '%Y-%m-%dT%H:%M:%S' );
 const testOrderedKeys = getOrderedKeys( dummyOrders );
+
+describe( 'getDateLabel', () => {
+	const formatter = ( date ) =>
+		`${ date.getFullYear() }-${ date.getMonth() + 1 }-${ date.getDate() }`;
+
+	it( 'formats a single date given as a string', () => {
+		expect( getDateLabel( formatter, '2020-02-28 00:00:00' ) ).toEqual(
+			'2020-2-28'
+		);
+	} );
+
+	it( 'formats a single date given as a Date', () => {
+		expect( getDateLabel( formatter, new Date( 2020, 1, 28 ) ) ).toEqual(
+			'2020-2-28'
+		);
+	} );
+
+	it( 'joins both ends when the point covers a date range', () => {
+		expect(
+			getDateLabel(
+				formatter,
+				'2020-02-28 00:00:00',
+				'2020-02-29 00:00:00'
+			)
+		).toEqual( '2020-2-28 - 2020-2-29' );
+	} );
+} );
 
 describe( 'parseDate', () => {
 	it( 'correctly parse date in the expected format', () => {

--- a/packages/js/components/src/chart/d3chart/utils/tooltip.js
+++ b/packages/js/components/src/chart/d3chart/utils/tooltip.js
@@ -4,6 +4,11 @@
 import { select as d3Select } from 'd3-selection';
 import moment from 'moment';
 
+/**
+ * Internal dependencies
+ */
+import { getDateLabel } from './index';
+
 class ChartTooltip {
 	constructor() {
 		this.ref = null;
@@ -109,10 +114,9 @@ class ChartTooltip {
 	}
 
 	getTooltipRowLabel( d, row ) {
-		if ( d[ row.key ].labelDate ) {
-			return this.labelFormat(
-				moment( d[ row.key ].labelDate ).toDate()
-			);
+		const { labelDate, labelDateEnd } = d[ row.key ];
+		if ( labelDate ) {
+			return getDateLabel( this.labelFormat, labelDate, labelDateEnd );
 		}
 		return row.label || row.key;
 	}

--- a/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
+++ b/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix the previous year comparison range for Year, Quarter, Month and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly, in Analytics, the Dashboard store performance indicators and leaderboards, and the date picker's comparison range label. The secondary range now also states how it was derived (`shift`, and `secondaryShift` on `DateValue`), and `getPreviousDate` accepts it.
+Fix to date previous year ranges ending a day early or late around 29th February, and expose how the secondary range was derived via `shift`.

--- a/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
+++ b/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `shift` to the secondary range returned by `getCurrentDates` (and `secondaryShift` to `DateValue`) stating whether it is a calendar year shift or a day offset of the primary range, and let `getPreviousDate` use it.

--- a/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
+++ b/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix to date previous year ranges ending a day early or late around 29th February, and expose how the secondary range was derived via `shift`.
+Fix to date previous year ranges ending a day early or late around 29th February, and expose how the secondary range was derived via `shift`. `getPreviousDate` now shifts by calendar dates, so previous period ranges starting on different sides of a DST change no longer come out a day short.

--- a/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
+++ b/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix the previous year comparison range for Year, Quarter and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly. The secondary range now also states how it was derived (`shift`, and `secondaryShift` on `DateValue`), and `getPreviousDate` accepts it.
+Fix the previous year comparison range for Year, Quarter, Month and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly, in Analytics, the Dashboard store performance indicators and leaderboards, and the date picker's comparison range label. The secondary range now also states how it was derived (`shift`, and `secondaryShift` on `DateValue`), and `getPreviousDate` accepts it.

--- a/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
+++ b/packages/js/date/changelog/add-wooplug-2204-secondary-range-shift
@@ -1,4 +1,4 @@
 Significance: minor
-Type: add
+Type: fix
 
-Add `shift` to the secondary range returned by `getCurrentDates` (and `secondaryShift` to `DateValue`) stating whether it is a calendar year shift or a day offset of the primary range, and let `getPreviousDate` use it.
+Fix the previous year comparison range for Year, Quarter and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly. The secondary range now also states how it was derived (`shift`, and `secondaryShift` on `DateValue`), and `getPreviousDate` accepts it.

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -537,7 +537,6 @@ export function getCurrentPeriod(
 	const primaryStart = getStoreTimeZoneMoment().startOf( period );
 	const primaryEnd = getStoreTimeZoneMoment();
 
-	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
 	let secondaryStart;
 	let secondaryEnd;
 	let secondaryShift: SecondaryShift = 'year';
@@ -550,11 +549,7 @@ export function getCurrentPeriod(
 		}
 	} else {
 		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
-		// Set the end time to 23:59:59.
-		secondaryEnd = secondaryStart
-			.clone()
-			.add( daysSoFar + 1, 'days' )
-			.subtract( 1, 'seconds' );
+		secondaryEnd = primaryEnd.clone().subtract( 1, 'years' ).endOf( 'day' );
 	}
 	return anchorRangeToStoreTimeZone( {
 		primaryStart,

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -817,7 +817,8 @@ const getCurrentDatesMemoized = memoize<
 		primaryStart,
 		primaryEnd,
 		secondaryStart,
-		secondaryEnd
+		secondaryEnd,
+		secondaryShift
 	) =>
 		[
 			period,
@@ -826,6 +827,7 @@ const getCurrentDatesMemoized = memoize<
 			primaryEnd && primaryEnd.format(),
 			secondaryStart && secondaryStart.format(),
 			secondaryEnd && secondaryEnd.format(),
+			secondaryShift,
 		].join( ':' )
 );
 

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -913,11 +913,19 @@ export const getPreviousDate = (
 		return dateMoment.clone().subtract( 1, 'years' );
 	}
 
-	const _date1 = moment( date1 );
-	const _date2 = moment( date2 );
-	const difference = _date1.diff( _date2, interval );
+	// Range boundaries are anchored to their own UTC offset, so two starts on
+	// different sides of a DST change differ by an hour as instants and the
+	// diff floors to one interval short. Compare and shift the wall-clock
+	// dates instead, then return a local moment like the year shift does.
+	const wallClock = ( value: moment.MomentInput ) =>
+		moment.utc( moment( value ).format( defaultDateTimeFormat ) );
+	const difference = wallClock( date1 ).diff( wallClock( date2 ), interval );
 
-	return dateMoment.clone().subtract( difference, interval );
+	return moment(
+		wallClock( date )
+			.subtract( difference, interval )
+			.format( defaultDateTimeFormat )
+	);
 };
 
 /**

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -890,18 +890,18 @@ export const getDateDifferenceInDays = (
 /**
  * Get the previous date for either the previous period of year.
  *
- * @param {string}                 date     - Base date
- * @param {string}                 date1    - primary start
- * @param {string}                 date2    - secondary start
+ * @param {moment.MomentInput}     date     - Base date
+ * @param {moment.MomentInput}     date1    - primary start
+ * @param {moment.MomentInput}     date2    - secondary start
  * @param {string}                 compare  - `previous_period`  or `previous_year`
  * @param {moment.unitOfTime.Diff} interval - interval
  * @param {SecondaryShift}         [shift]  - how the secondary range was derived, see `DataPickerOptions.shift`. Takes precedence over `compare` when given.
  * @return {Object}  - Calculated date
  */
 export const getPreviousDate = (
-	date: string,
-	date1: string,
-	date2: string,
+	date: moment.MomentInput,
+	date1: moment.MomentInput,
+	date2: moment.MomentInput,
 	compare = 'previous_year',
 	interval: moment.unitOfTime.Diff | moment.DurationInputArg2,
 	shift?: SecondaryShift

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -19,32 +19,46 @@ export const defaultDateTimeFormat = 'YYYY-MM-DDTHH:mm:ss';
  * DateValue Object
  *
  * @typedef  {Object} DateValue - DateValue data about the selected period.
- * @property {moment.Moment} primaryStart   - Primary start of the date range.
- * @property {moment.Moment} primaryEnd     - Primary end of the date range.
- * @property {moment.Moment} secondaryStart - Secondary start of the date range.
- * @property {moment.Moment} secondaryEnd   - Secondary End of the date range.
+ * @property {moment.Moment}  primaryStart     - Primary start of the date range.
+ * @property {moment.Moment}  primaryEnd       - Primary end of the date range.
+ * @property {moment.Moment}  secondaryStart   - Secondary start of the date range.
+ * @property {moment.Moment}  secondaryEnd     - Secondary End of the date range.
+ * @property {SecondaryShift} [secondaryShift] - How the secondary range was derived from the primary one.
  */
 export type DateValue = {
 	primaryStart: moment.Moment;
 	primaryEnd: moment.Moment;
 	secondaryStart: moment.Moment;
 	secondaryEnd: moment.Moment;
+	secondaryShift?: SecondaryShift;
 };
+
+/**
+ * How a secondary (comparison) date range relates to the primary one.
+ *
+ * `year`: the same calendar dates one year earlier, so a primary date maps to
+ * the secondary date with the same month and day.
+ * `offset`: shifted back by the distance between the two range starts, so a
+ * primary date maps to the secondary date the same number of days earlier.
+ */
+export type SecondaryShift = 'year' | 'offset';
 
 /**
  * DataPickerOptions Object
  *
  * @typedef  {Object}  DataPickerOptions - Describes the date range supplied by the date picker.
- * @property {string}        label  - The translated value of the period.
- * @property {string}        range  - The human readable value of a date range.
- * @property {moment.Moment} after  - Start of the date range.
- * @property {moment.Moment} before - End of the date range.
+ * @property {string}         label   - The translated value of the period.
+ * @property {string}         range   - The human readable value of a date range.
+ * @property {moment.Moment}  after   - Start of the date range.
+ * @property {moment.Moment}  before  - End of the date range.
+ * @property {SecondaryShift} [shift] - Secondary range only: how it was derived from the primary one.
  */
 export type DataPickerOptions = {
 	label: string;
 	range: string;
 	after: moment.Moment;
 	before: moment.Moment;
+	shift?: SecondaryShift;
 };
 
 /**
@@ -418,6 +432,7 @@ function anchorRangeToStoreTimeZone( range: DateValue ): DateValue {
 		primaryEnd: anchorToStoreTimeZone( range.primaryEnd ),
 		secondaryStart: anchorToStoreTimeZone( range.secondaryStart ),
 		secondaryEnd: anchorToStoreTimeZone( range.secondaryEnd ),
+		secondaryShift: range.secondaryShift,
 	};
 }
 
@@ -468,6 +483,7 @@ export function getLastPeriod(
 	const primaryEnd = primaryStart.clone().endOf( period );
 	let secondaryStart;
 	let secondaryEnd;
+	let secondaryShift: SecondaryShift = 'year';
 
 	if ( compare === 'previous_period' ) {
 		if ( period === 'year' ) {
@@ -480,6 +496,7 @@ export function getLastPeriod(
 			const daysDiff = primaryEnd.diff( primaryStart, 'days' );
 			secondaryEnd = primaryStart.clone().subtract( 1, 'days' );
 			secondaryStart = secondaryEnd.clone().subtract( daysDiff, 'days' );
+			secondaryShift = 'offset';
 		}
 	} else if ( period === 'week' ) {
 		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
@@ -499,6 +516,7 @@ export function getLastPeriod(
 		primaryEnd,
 		secondaryStart,
 		secondaryEnd,
+		secondaryShift,
 	} );
 }
 
@@ -522,10 +540,14 @@ export function getCurrentPeriod(
 	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
 	let secondaryStart;
 	let secondaryEnd;
+	let secondaryShift: SecondaryShift = 'year';
 
 	if ( compare === 'previous_period' ) {
 		secondaryStart = primaryStart.clone().subtract( 1, period );
 		secondaryEnd = primaryEnd.clone().subtract( 1, period );
+		if ( period !== 'year' ) {
+			secondaryShift = 'offset';
+		}
 	} else {
 		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
 		// Set the end time to 23:59:59.
@@ -539,6 +561,7 @@ export function getCurrentPeriod(
 		primaryEnd,
 		secondaryStart,
 		secondaryEnd,
+		secondaryShift,
 	} );
 }
 
@@ -597,6 +620,7 @@ const getDateValue = memoize<
 						primaryEnd: before,
 						secondaryStart,
 						secondaryEnd,
+						secondaryShift: 'offset',
 					};
 				}
 				return {
@@ -604,6 +628,7 @@ const getDateValue = memoize<
 					primaryEnd: before,
 					secondaryStart: after.clone().subtract( 1, 'years' ),
 					secondaryEnd: before.clone().subtract( 1, 'years' ),
+					secondaryShift: 'year',
 				};
 		}
 	},
@@ -727,6 +752,7 @@ export const getDateParamsFromQuery = (
  * @param {Object}           primaryEnd     - primary query start DateTime, in Moment instance.
  * @param {Object}           secondaryStart - secondary query start DateTime, in Moment instance.
  * @param {Object}           secondaryEnd   - secondary query start DateTime, in Moment instance.
+ * @param {SecondaryShift}   secondaryShift - how the secondary range was derived from the primary one.
  * @return {{primary: DataPickerOptions, secondary: DataPickerOptions}} - Primary and secondary DataPickerOptions objects
  */
 const getCurrentDatesMemoized = memoize<
@@ -738,6 +764,7 @@ const getCurrentDatesMemoized = memoize<
 			moment.Moment,
 			moment.Moment,
 			moment.Moment,
+			SecondaryShift | undefined,
 		]
 	) => {
 		primary: DataPickerOptions;
@@ -750,7 +777,8 @@ const getCurrentDatesMemoized = memoize<
 		primaryStart,
 		primaryEnd,
 		secondaryStart,
-		secondaryEnd
+		secondaryEnd,
+		secondaryShift
 	) => {
 		const primaryItem = find(
 			presetValues,
@@ -779,6 +807,7 @@ const getCurrentDatesMemoized = memoize<
 				range: getRangeLabel( secondaryStart, secondaryEnd ),
 				after: secondaryStart,
 				before: secondaryEnd,
+				shift: secondaryShift,
 			},
 		};
 	},
@@ -826,8 +855,13 @@ export const getCurrentDates = (
 		throw Error( 'Invalid date range' );
 	}
 
-	const { primaryStart, primaryEnd, secondaryStart, secondaryEnd } =
-		dateValue;
+	const {
+		primaryStart,
+		primaryEnd,
+		secondaryStart,
+		secondaryEnd,
+		secondaryShift,
+	} = dateValue;
 
 	return getCurrentDatesMemoized(
 		period,
@@ -835,7 +869,8 @@ export const getCurrentDates = (
 		primaryStart,
 		primaryEnd,
 		secondaryStart,
-		secondaryEnd
+		secondaryEnd,
+		secondaryShift
 	);
 };
 
@@ -863,6 +898,7 @@ export const getDateDifferenceInDays = (
  * @param {string}                 date2    - secondary start
  * @param {string}                 compare  - `previous_period`  or `previous_year`
  * @param {moment.unitOfTime.Diff} interval - interval
+ * @param {SecondaryShift}         [shift]  - how the secondary range was derived, see `DataPickerOptions.shift`. Takes precedence over `compare` when given.
  * @return {Object}  - Calculated date
  */
 export const getPreviousDate = (
@@ -870,11 +906,13 @@ export const getPreviousDate = (
 	date1: string,
 	date2: string,
 	compare = 'previous_year',
-	interval: moment.unitOfTime.Diff | moment.DurationInputArg2
+	interval: moment.unitOfTime.Diff | moment.DurationInputArg2,
+	shift?: SecondaryShift
 ) => {
 	const dateMoment = moment( date );
+	const yearShifted = shift ? shift === 'year' : compare === 'previous_year';
 
-	if ( compare === 'previous_year' ) {
+	if ( yearShifted ) {
 		return dateMoment.clone().subtract( 1, 'years' );
 	}
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1550,6 +1550,18 @@ describe( 'secondary range shift', () => {
 		).toBe( 'offset' );
 	} );
 
+	it( 'ends a year shifted current period on the same calendar day a year earlier', () => {
+		jest.useFakeTimers().setSystemTime( new Date( '2025-06-15T12:00:00' ) );
+		const { secondaryStart, secondaryEnd } = getCurrentPeriod(
+			'year',
+			'previous_year'
+		);
+		expect( secondaryStart.format( isoDateFormat ) ).toBe( '2024-01-01' );
+		expect( secondaryEnd.format( 'YYYY-MM-DD HH:mm:ss' ) ).toBe(
+			'2024-06-15 23:59:59'
+		);
+	} );
+
 	it( 'is exposed on the secondary date picker options', () => {
 		jest.useFakeTimers().setSystemTime( new Date( '2026-09-09T12:00:00' ) );
 		expect(

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -88,7 +88,9 @@ describe( 'toMoment', () => {
 
 	it( 'should handle isoFormat dates', () => {
 		const myMoment = toMoment( 'YYYY', '2018-04-15' );
-		if ( myMoment === null ) fail( 'myMoment should not be null' );
+		if ( myMoment === null ) {
+			fail( 'myMoment should not be null' );
+		}
 
 		expect( moment.isMoment( myMoment ) ).toBe( true );
 		expect( myMoment.isValid() ).toBe( true );
@@ -96,7 +98,9 @@ describe( 'toMoment', () => {
 
 	it( 'should handle local formats', () => {
 		const longDate = toMoment( 'MMMM D, YYYY', 'April 15, 2018' );
-		if ( longDate === null ) fail( 'longDate should not be null' );
+		if ( longDate === null ) {
+			fail( 'longDate should not be null' );
+		}
 
 		expect( moment.isMoment( longDate ) ).toBe( true );
 		expect( longDate.isValid() ).toBe( true );
@@ -105,7 +109,9 @@ describe( 'toMoment', () => {
 		expect( longDate.year() ).toBe( 2018 );
 
 		const shortDate = toMoment( 'DD/MM/YYYY', '15/04/2018' );
-		if ( shortDate === null ) fail( 'shortDate should not be null' );
+		if ( shortDate === null ) {
+			fail( 'shortDate should not be null' );
+		}
 
 		expect( moment.isMoment( shortDate ) ).toBe( true );
 		expect( shortDate.isValid() ).toBe( true );
@@ -1516,7 +1522,74 @@ describe( 'getDateDifferenceInDays', () => {
 	} );
 } );
 
+describe( 'secondary range shift', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'is a year shift for previous year and for the year presets, an offset otherwise', () => {
+		jest.useFakeTimers().setSystemTime( new Date( '2025-03-15T12:00:00' ) );
+
+		expect( getLastPeriod( 'month', 'previous_year' ).secondaryShift ).toBe(
+			'year'
+		);
+		expect(
+			getCurrentPeriod( 'week', 'previous_year' ).secondaryShift
+		).toBe( 'year' );
+		expect(
+			getLastPeriod( 'year', 'previous_period' ).secondaryShift
+		).toBe( 'year' );
+		expect(
+			getCurrentPeriod( 'year', 'previous_period' ).secondaryShift
+		).toBe( 'year' );
+		expect(
+			getLastPeriod( 'month', 'previous_period' ).secondaryShift
+		).toBe( 'offset' );
+		expect(
+			getCurrentPeriod( 'quarter', 'previous_period' ).secondaryShift
+		).toBe( 'offset' );
+	} );
+
+	it( 'is exposed on the secondary date picker options', () => {
+		const custom = {
+			period: 'custom',
+			after: '2024-12-01',
+			before: '2025-12-01',
+		};
+
+		expect(
+			getCurrentDates( { ...custom, compare: 'previous_year' } ).secondary
+				.shift
+		).toBe( 'year' );
+		expect(
+			getCurrentDates( { ...custom, compare: 'previous_period' } )
+				.secondary.shift
+		).toBe( 'offset' );
+	} );
+} );
+
 describe( 'getPreviousDate', () => {
+	it( 'should use the shift over the compare value when given', () => {
+		const yearShifted = getPreviousDate(
+			'2024-03-01',
+			'2024-01-01',
+			'2023-01-01',
+			'previous_period',
+			'day',
+			'year'
+		);
+		expect( yearShifted.format( isoDateFormat ) ).toBe( '2023-03-01' );
+
+		const offset = getPreviousDate(
+			'2025-03-01',
+			'2024-12-01',
+			'2023-12-01',
+			'previous_year',
+			'day',
+			'offset'
+		);
+		expect( offset.format( isoDateFormat ) ).toBe( '2024-02-29' );
+	} );
 	it( 'should return valid date for previous period by days', () => {
 		const date = '2018-08-21';
 		const primaryStart = '2018-08-25';

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1604,6 +1604,49 @@ describe( 'getPreviousDate', () => {
 		);
 		expect( offset.format( isoDateFormat ) ).toBe( '2024-02-29' );
 	} );
+	it( 'should shift by calendar dates when the range starts sit on different sides of a DST change', () => {
+		// Last quarter (Q2) against the previous period on a New York store:
+		// April starts in EDT, the last day of December in EST.
+		const primaryStart = moment( '2026-04-01T00:00:00-04:00' ).utcOffset(
+			-240,
+			true
+		);
+		const secondaryStart = moment( '2025-12-31T00:00:00-05:00' ).utcOffset(
+			-300,
+			true
+		);
+
+		expect(
+			getPreviousDate(
+				'2026-04-01 00:00:00',
+				primaryStart,
+				secondaryStart,
+				'previous_period',
+				'day',
+				'offset'
+			).format( isoDateFormat )
+		).toBe( '2025-12-31' );
+		expect(
+			getPreviousDate(
+				'2026-04-01 00:00:00',
+				primaryStart,
+				secondaryStart,
+				'previous_period',
+				'week'
+			).format( isoDateFormat )
+		).toBe( '2025-12-31' );
+
+		// Quarter to date against the previous period: April against January.
+		expect(
+			getPreviousDate(
+				'2026-05-01 00:00:00',
+				primaryStart,
+				moment( '2026-01-01T00:00:00-05:00' ).utcOffset( -300, true ),
+				'previous_period',
+				'month'
+			).format( isoDateFormat )
+		).toBe( '2026-02-01' );
+	} );
 	it( 'should return valid date for previous period by days', () => {
 		const date = '2018-08-21';
 		const primaryStart = '2018-08-25';

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1551,6 +1551,14 @@ describe( 'secondary range shift', () => {
 	} );
 
 	it( 'is exposed on the secondary date picker options', () => {
+		jest.useFakeTimers().setSystemTime( new Date( '2026-09-09T12:00:00' ) );
+		expect(
+			getCurrentDates( {
+				period: 'last_year',
+				compare: 'previous_period',
+			} ).secondary.shift
+		).toBe( 'year' );
+
 		const custom = {
 			period: 'custom',
 			after: '2024-12-01',

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -88,9 +88,7 @@ describe( 'toMoment', () => {
 
 	it( 'should handle isoFormat dates', () => {
 		const myMoment = toMoment( 'YYYY', '2018-04-15' );
-		if ( myMoment === null ) {
-			fail( 'myMoment should not be null' );
-		}
+		if ( myMoment === null ) fail( 'myMoment should not be null' );
 
 		expect( moment.isMoment( myMoment ) ).toBe( true );
 		expect( myMoment.isValid() ).toBe( true );
@@ -98,9 +96,7 @@ describe( 'toMoment', () => {
 
 	it( 'should handle local formats', () => {
 		const longDate = toMoment( 'MMMM D, YYYY', 'April 15, 2018' );
-		if ( longDate === null ) {
-			fail( 'longDate should not be null' );
-		}
+		if ( longDate === null ) fail( 'longDate should not be null' );
 
 		expect( moment.isMoment( longDate ) ).toBe( true );
 		expect( longDate.isValid() ).toBe( true );
@@ -109,9 +105,7 @@ describe( 'toMoment', () => {
 		expect( longDate.year() ).toBe( 2018 );
 
 		const shortDate = toMoment( 'DD/MM/YYYY', '15/04/2018' );
-		if ( shortDate === null ) {
-			fail( 'shortDate should not be null' );
-		}
+		if ( shortDate === null ) fail( 'shortDate should not be null' );
 
 		expect( moment.isMoment( shortDate ) ).toBe( true );
 		expect( shortDate.isValid() ).toBe( true );

--- a/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
+++ b/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix analytics chart previous year data showing one day late when the previous year range contains 29th February.
+Fix analytics chart previous year data showing one day late when the previous year range contains 29th February, and fix the previous year comparison range for Year, Quarter and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly.

--- a/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
+++ b/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix analytics chart previous year data showing one day late when the previous year range contains 29th February, and fix the previous year comparison range for Year, Quarter and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly.
+Fix analytics chart previous year data showing one day late when the previous year range contains 29th February, and fix the previous year comparison range for Year, Quarter, Month and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly, in Analytics, the Dashboard store performance indicators and leaderboards, and the date picker's comparison range label.

--- a/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
+++ b/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix analytics chart previous year data showing one day late when the previous year range contains 29th February.

--- a/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
+++ b/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix analytics chart previous year data showing one day late when the previous year range contains 29th February, and fix the previous year comparison range for Year, Quarter, Month and Week to date ending one day early or late when the period spans 29th February. Previous year totals and percentages on those views change accordingly, in Analytics, the Dashboard store performance indicators and leaderboards, and the date picker's comparison range label.
+Fix analytics previous year comparisons around 29th February: chart days no longer shift by a day, and to date ranges compare against the same calendar dates a year earlier.

--- a/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
+++ b/plugins/woocommerce/changelog/fix-wooplug-2204-analytics-leap-day-previous-year
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix analytics previous year comparisons around 29th February: chart days no longer shift by a day, and to date ranges compare against the same calendar dates a year earlier.
+Fix analytics previous year comparisons around 29th February: chart days no longer shift by a day, to date ranges compare against the same calendar dates a year earlier, and previous period day charts line up across a DST change.

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/index.js
@@ -102,7 +102,8 @@ export class ReportChart extends Component {
 			secondary,
 			query.compare,
 			selectedChart.key,
-			currentInterval
+			currentInterval,
+			selectedChart.type
 		);
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -3,9 +3,11 @@
  */
 import moment from 'moment';
 import {
+	getAllowedIntervalsForQuery,
 	getCurrentDates,
 	getCurrentPeriod,
 	getLastPeriod,
+	getPreviousDate,
 } from '@woocommerce/date';
 
 /**
@@ -374,6 +376,7 @@ describe( 'buildChartData', () => {
 	test.each( [
 		[ 'avg_items_per_order', 'average' ],
 		[ 'avg_order_value', 'currency' ],
+		[ 'conversion_rate', 'percent' ],
 	] )(
 		'should not fold the 29th Feb of the previous year for the %s average',
 		( key, type ) => {
@@ -629,6 +632,115 @@ describe( 'buildChartData across every date range shape', () => {
 						compare
 					)
 				);
+			} );
+		} );
+
+		expect( problems ).toEqual( [] );
+	} );
+
+	// Intervals coarser than a day are matched by position, so every point
+	// must be labelled with the interval it was actually plotted from.
+	function bucketIntervals( start, end, interval ) {
+		const intervals = [];
+		let bucketStart = start.clone();
+		while ( ! bucketStart.isAfter( end ) ) {
+			const nextStart = bucketStart
+				.clone()
+				.startOf( interval )
+				.add( 1, interval );
+			intervals.push( {
+				date_start: bucketStart.format( 'YYYY-MM-DD HH:mm:ss' ),
+				date_end: moment
+					.min( nextStart.clone().subtract( 1, 'seconds' ), end )
+					.format( 'YYYY-MM-DD HH:mm:ss' ),
+				subtotals: {
+					orders_count: Number( bucketStart.format( 'YYYYMMDDHH' ) ),
+				},
+			} );
+			bucketStart = nextStart;
+		}
+		return intervals;
+	}
+
+	test( 'every preset at every coarser interval labels the interval it plots', () => {
+		const problems = [];
+
+		clocks.forEach( ( clock ) => {
+			jest.useFakeTimers().setSystemTime( new Date( clock ) );
+			Object.entries( builders ).forEach( ( [ preset, build ] ) => {
+				compares.forEach( ( compare ) => {
+					const range = build( compare );
+					const primary = {
+						label: '',
+						range: '',
+						after: range.primaryStart,
+						before: range.primaryEnd,
+					};
+					const secondary = {
+						label: '',
+						range: '',
+						after: range.secondaryStart,
+						before: range.secondaryEnd,
+						shift: range.secondaryShift,
+					};
+					getAllowedIntervalsForQuery( { period: preset, compare } )
+						.filter( ( interval ) => interval !== 'day' )
+						.forEach( ( interval ) => {
+							const secondaryIntervals = bucketIntervals(
+								secondary.after,
+								secondary.before,
+								interval
+							);
+							const chartData = buildChartData(
+								{
+									data: {
+										totals: {},
+										intervals: bucketIntervals(
+											primary.after,
+											primary.before,
+											interval
+										),
+									},
+								},
+								{
+									data: {
+										totals: {},
+										intervals: secondaryIntervals,
+									},
+								},
+								primary,
+								secondary,
+								compare,
+								'orders_count',
+								interval,
+								'number'
+							);
+							chartData.forEach( ( point, index ) => {
+								const plotted = secondaryIntervals[ index ];
+								// Positional intervals keep the label they always had:
+								// the compare based one, with no shift applied.
+								const expectedLabel = getPreviousDate(
+									point.primary.labelDate,
+									primary.after,
+									secondary.after,
+									compare,
+									interval
+								).format( 'YYYY-MM-DD HH:mm:ss' );
+								const expectedValue = plotted
+									? plotted.subtotals.orders_count
+									: 0;
+								if (
+									point.secondary.labelDate !==
+										expectedLabel ||
+									point.secondary.value !== expectedValue
+								) {
+									problems.push(
+										`${ preset }/${ compare }/${ interval } at ${ clock } ${ point.date }: label ${ point.secondary.labelDate }, value ${ point.secondary.value }, expected ${ expectedLabel }`
+									);
+								}
+							} );
+						} );
+				} );
 			} );
 		} );
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -1,4 +1,14 @@
 /**
+ * External dependencies
+ */
+import moment from 'moment';
+import {
+	getCurrentDates,
+	getCurrentPeriod,
+	getLastPeriod,
+} from '@woocommerce/date';
+
+/**
  * Internal dependencies
  */
 import { buildChartData } from '../utils';
@@ -57,7 +67,8 @@ function buildDayChartData(
 	secondaryIntervals,
 	key = 'orders_count',
 	type = 'number',
-	compare = 'previous_year'
+	compare = 'previous_year',
+	shift
 ) {
 	return buildChartData(
 		{ data: { totals: {}, intervals: primaryIntervals } },
@@ -73,6 +84,7 @@ function buildDayChartData(
 			range: '',
 			after: secondaryIntervals[ 0 ].date_start,
 			before: '',
+			shift,
 		},
 		compare,
 		key,
@@ -480,12 +492,46 @@ describe( 'buildChartData', () => {
 		} );
 	} );
 
-	test( 'should not pad under previous period when the primary range has the 29th Feb', () => {
+	test( 'should show zero for a day missing from the comparison data without shifting the rest', () => {
+		const primary = generateDayIntervals( '2021-02-27', '2021-03-02' );
+		const secondary = generateDayIntervals( '2020-02-27', '2020-03-02', {
+			'2020-02-27': 1,
+			'2020-02-28': 2,
+			'2020-02-29': 3,
+			'2020-03-01': 4,
+			'2020-03-02': 5,
+		} ).filter(
+			( interval ) => ! interval.date_start.startsWith( '2020-02-28' )
+		);
+
+		const chartData = buildDayChartData( primary, secondary );
+
+		expect( secondaryByDate( chartData, '2021-02-27' ) ).toEqual( {
+			labelDate: '2020-02-27 00:00:00',
+			value: 1,
+		} );
+		expect( secondaryByDate( chartData, '2021-02-28' ) ).toEqual( {
+			labelDate: '2020-02-28 00:00:00',
+			value: 0,
+		} );
+		expect( secondaryByDate( chartData, '2021-03-01' ) ).toEqual( {
+			labelDate: '2020-03-01 00:00:00',
+			value: 4,
+		} );
+		expect( secondaryByDate( chartData, '2021-03-02' ) ).toEqual( {
+			labelDate: '2020-03-02 00:00:00',
+			value: 5,
+		} );
+	} );
+
+	test( 'should pad the 29th Feb under a year shifted previous period', () => {
+		// Last year 2024 compared to the previous period is the whole of 2023.
 		const primary = generateDayIntervals( '2024-01-01', '2024-12-31' );
 		const secondary = generateDayIntervals( '2023-01-01', '2023-12-31', {
 			'2023-02-28': 5,
 			'2023-03-01': 1,
 			'2023-03-02': 2,
+			'2023-12-31': 9,
 		} );
 
 		const chartData = buildDayChartData(
@@ -493,7 +539,8 @@ describe( 'buildChartData', () => {
 			secondary,
 			'orders_count',
 			'number',
-			'previous_period'
+			'previous_period',
+			'year'
 		);
 
 		expect( secondaryByDate( chartData, '2024-02-28' ) ).toEqual( {
@@ -501,12 +548,16 @@ describe( 'buildChartData', () => {
 			value: 5,
 		} );
 		expect( secondaryByDate( chartData, '2024-02-29' ) ).toEqual( {
+			labelDate: '-',
+			value: 0,
+		} );
+		expect( secondaryByDate( chartData, '2024-03-01' ) ).toEqual( {
 			labelDate: '2023-03-01 00:00:00',
 			value: 1,
 		} );
-		expect( secondaryByDate( chartData, '2024-03-01' ) ).toEqual( {
-			labelDate: '2023-03-02 00:00:00',
-			value: 2,
+		expect( secondaryByDate( chartData, '2024-12-31' ) ).toEqual( {
+			labelDate: '2023-12-31 00:00:00',
+			value: 9,
 		} );
 	} );
 
@@ -570,5 +621,196 @@ describe( 'buildChartData', () => {
 			labelDate: '2023-03-02 00:00:00',
 			value: 3,
 		} );
+	} );
+} );
+
+describe( 'buildChartData across every date range shape', () => {
+	// Every day gets a value only it can produce, so a chart value can be
+	// traced back to the day it came from.
+	const valueOf = ( day ) => Number( day.replace( /-/g, '' ) );
+
+	const builders = {
+		today: ( compare ) => getCurrentPeriod( 'day', compare ),
+		yesterday: ( compare ) => getLastPeriod( 'day', compare ),
+		week: ( compare ) => getCurrentPeriod( 'week', compare ),
+		last_week: ( compare ) => getLastPeriod( 'week', compare ),
+		month: ( compare ) => getCurrentPeriod( 'month', compare ),
+		last_month: ( compare ) => getLastPeriod( 'month', compare ),
+		quarter: ( compare ) => getCurrentPeriod( 'quarter', compare ),
+		last_quarter: ( compare ) => getLastPeriod( 'quarter', compare ),
+		year: ( compare ) => getCurrentPeriod( 'year', compare ),
+		last_year: ( compare ) => getLastPeriod( 'year', compare ),
+	};
+	const clocks = [
+		'2021-02-28T12:00:00',
+		'2024-02-29T12:00:00',
+		'2024-03-15T12:00:00',
+		'2025-03-15T12:00:00',
+		'2025-12-31T12:00:00',
+		'2026-09-09T12:00:00',
+	];
+	const customRanges = [
+		[ '2021-01-01', '2021-03-31' ],
+		[ '2021-02-01', '2021-02-28' ],
+		[ '2024-02-01', '2024-03-31' ],
+		[ '2024-01-01', '2025-01-31' ],
+		[ '2024-12-01', '2025-12-01' ],
+		[ '2016-01-01', '2019-12-31' ],
+	];
+	const compares = [ 'previous_period', 'previous_year' ];
+
+	function pickerFor( start, end, shift ) {
+		return {
+			label: '',
+			range: '',
+			after: start.clone().startOf( 'day' ),
+			before: end.clone().startOf( 'day' ),
+			shift,
+		};
+	}
+
+	function daysBetween( picker ) {
+		const days = [];
+		const day = picker.after.clone();
+		while ( ! day.isAfter( picker.before, 'day' ) ) {
+			days.push( day.format( 'YYYY-MM-DD' ) );
+			day.add( 1, 'days' );
+		}
+		return days;
+	}
+
+	function intervalsFor( picker ) {
+		return daysBetween( picker ).map( ( day ) =>
+			generateDateInterval( day, day, day, {
+				orders_count: valueOf( day ),
+			} )
+		);
+	}
+
+	function problemsFor( name, primary, secondary, compare ) {
+		const chartData = buildChartData(
+			{ data: { totals: {}, intervals: intervalsFor( primary ) } },
+			{ data: { totals: {}, intervals: intervalsFor( secondary ) } },
+			primary,
+			secondary,
+			compare,
+			'orders_count',
+			'day',
+			'number'
+		);
+		const secondaryDays = daysBetween( secondary );
+		const problems = [];
+
+		chartData.forEach( ( point ) => {
+			const { labelDate, labelDateEnd, value } = point.secondary;
+			let expected = 0;
+			[ labelDate, labelDateEnd ]
+				.filter( Boolean )
+				.map( ( date ) => date.slice( 0, 10 ) )
+				.forEach( ( day ) => {
+					if ( secondaryDays.includes( day ) ) {
+						expected += valueOf( day );
+					}
+				} );
+			if ( value !== expected ) {
+				problems.push(
+					`${ name } ${
+						point.date
+					}: shows ${ value } under "${ labelDate }${
+						labelDateEnd ? ` - ${ labelDateEnd }` : ''
+					}", expected ${ expected }`
+				);
+			}
+		} );
+
+		// No comparison day up to the last labelled one may go missing. Under
+		// a year shift the 29th Feb right after the last label is folded into
+		// it, so it counts too.
+		const lastLabel = (
+			chartData
+				.map( ( point ) => point.secondary.labelDate )
+				.filter( ( labelDate ) => labelDate !== '-' )
+				.sort()
+				.pop() || ''
+		).slice( 0, 10 );
+		const yearShifted = secondary.shift === 'year';
+		const expectedTotal = secondaryDays
+			.filter(
+				( day ) =>
+					day <= lastLabel ||
+					( yearShifted &&
+						day.slice( 5 ) === '02-29' &&
+						moment( day )
+							.subtract( 1, 'days' )
+							.format( 'YYYY-MM-DD' ) <= lastLabel )
+			)
+			.reduce( ( total, day ) => total + valueOf( day ), 0 );
+		const chartTotal = chartData.reduce(
+			( total, point ) => total + point.secondary.value,
+			0
+		);
+		if ( chartTotal !== expectedTotal ) {
+			problems.push(
+				`${ name }: chart total ${ chartTotal }, comparison days total ${ expectedTotal }`
+			);
+		}
+
+		return problems;
+	}
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	test( 'every preset at every clock shows each comparison value under its own date', () => {
+		const problems = [];
+
+		clocks.forEach( ( clock ) => {
+			jest.useFakeTimers().setSystemTime( new Date( clock ) );
+			Object.entries( builders ).forEach( ( [ preset, build ] ) => {
+				compares.forEach( ( compare ) => {
+					const range = build( compare );
+					problems.push(
+						...problemsFor(
+							`${ preset }/${ compare } at ${ clock }`,
+							pickerFor( range.primaryStart, range.primaryEnd ),
+							pickerFor(
+								range.secondaryStart,
+								range.secondaryEnd,
+								range.secondaryShift
+							),
+							compare
+						)
+					);
+				} );
+			} );
+		} );
+
+		expect( problems ).toEqual( [] );
+	} );
+
+	test( 'every custom range shows each comparison value under its own date', () => {
+		const problems = [];
+
+		customRanges.forEach( ( [ after, before ] ) => {
+			compares.forEach( ( compare ) => {
+				const { primary, secondary } = getCurrentDates( {
+					period: 'custom',
+					compare,
+					after,
+					before,
+				} );
+				problems.push(
+					...problemsFor(
+						`custom ${ after }..${ before }/${ compare }`,
+						primary,
+						secondary,
+						compare
+					)
+				);
+			} );
+		} );
+
+		expect( problems ).toEqual( [] );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -66,9 +66,7 @@ function buildDayChartData(
 	primaryIntervals,
 	secondaryIntervals,
 	key = 'orders_count',
-	type = 'number',
-	compare = 'previous_year',
-	shift
+	type = 'number'
 ) {
 	return buildChartData(
 		{ data: { totals: {}, intervals: primaryIntervals } },
@@ -80,13 +78,13 @@ function buildDayChartData(
 			before: '',
 		},
 		{
-			label: 'Previous period',
+			label: 'Previous year',
 			range: '',
 			after: secondaryIntervals[ 0 ].date_start,
 			before: '',
-			shift,
+			shift: 'year',
 		},
-		compare,
+		'previous_year',
 		key,
 		'day',
 		type
@@ -373,49 +371,6 @@ describe( 'buildChartData', () => {
 		} );
 	} );
 
-	test( 'should fold the 29th Feb of the previous year when the primary range ends in February', () => {
-		const primary = generateDayIntervals( '2021-02-01', '2021-02-28' );
-		const secondary = generateDayIntervals( '2020-02-01', '2020-02-29', {
-			'2020-02-28': 5,
-			'2020-02-29': 1,
-		} );
-
-		const chartData = buildDayChartData( primary, secondary );
-
-		expect( chartData ).toHaveLength( 28 );
-		expect( secondaryByDate( chartData, '2021-02-28' ) ).toEqual( {
-			labelDate: '2020-02-28 00:00:00',
-			labelDateEnd: '2020-02-29 00:00:00',
-			value: 6,
-		} );
-	} );
-
-	test( 'should fold the 29th Feb of the previous year when both ranges span a leap year', () => {
-		// Both ranges touch 2024, but only the previous year range contains the leap day.
-		const primary = generateDayIntervals( '2024-12-31', '2025-03-02' );
-		const secondary = generateDayIntervals( '2023-12-31', '2024-03-02', {
-			'2024-02-29': 1,
-			'2024-03-01': 2,
-			'2024-03-02': 3,
-		} );
-
-		const chartData = buildDayChartData( primary, secondary );
-
-		expect( secondaryByDate( chartData, '2025-02-28' ) ).toEqual( {
-			labelDate: '2024-02-28 00:00:00',
-			labelDateEnd: '2024-02-29 00:00:00',
-			value: 1,
-		} );
-		expect( secondaryByDate( chartData, '2025-03-01' ) ).toEqual( {
-			labelDate: '2024-03-01 00:00:00',
-			value: 2,
-		} );
-		expect( secondaryByDate( chartData, '2025-03-02' ) ).toEqual( {
-			labelDate: '2024-03-02 00:00:00',
-			value: 3,
-		} );
-	} );
-
 	test.each( [
 		[ 'avg_items_per_order', 'average' ],
 		[ 'avg_order_value', 'currency' ],
@@ -457,41 +412,6 @@ describe( 'buildChartData', () => {
 		}
 	);
 
-	test( 'should not fold under previous period when the comparison range has the 29th Feb', () => {
-		const primary = generateDayIntervals( '2024-12-01', '2025-12-01' );
-		const secondary = generateDayIntervals( '2023-12-01', '2024-11-30', {
-			'2024-02-28': 5,
-			'2024-02-29': 1,
-			'2024-03-01': 2,
-			'2024-11-30': 9,
-		} );
-
-		const chartData = buildDayChartData(
-			primary,
-			secondary,
-			'orders_count',
-			'number',
-			'previous_period'
-		);
-
-		expect( secondaryByDate( chartData, '2025-02-28' ) ).toEqual( {
-			labelDate: '2024-02-28 00:00:00',
-			value: 5,
-		} );
-		expect( secondaryByDate( chartData, '2025-03-01' ) ).toEqual( {
-			labelDate: '2024-02-29 00:00:00',
-			value: 1,
-		} );
-		expect( secondaryByDate( chartData, '2025-03-02' ) ).toEqual( {
-			labelDate: '2024-03-01 00:00:00',
-			value: 2,
-		} );
-		expect( secondaryByDate( chartData, '2025-12-01' ) ).toEqual( {
-			labelDate: '2024-11-30 00:00:00',
-			value: 9,
-		} );
-	} );
-
 	test( 'should show zero for a day missing from the comparison data without shifting the rest', () => {
 		const primary = generateDayIntervals( '2021-02-27', '2021-03-02' );
 		const secondary = generateDayIntervals( '2020-02-27', '2020-03-02', {
@@ -521,105 +441,6 @@ describe( 'buildChartData', () => {
 		expect( secondaryByDate( chartData, '2021-03-02' ) ).toEqual( {
 			labelDate: '2020-03-02 00:00:00',
 			value: 5,
-		} );
-	} );
-
-	test( 'should pad the 29th Feb under a year shifted previous period', () => {
-		// Last year 2024 compared to the previous period is the whole of 2023.
-		const primary = generateDayIntervals( '2024-01-01', '2024-12-31' );
-		const secondary = generateDayIntervals( '2023-01-01', '2023-12-31', {
-			'2023-02-28': 5,
-			'2023-03-01': 1,
-			'2023-03-02': 2,
-			'2023-12-31': 9,
-		} );
-
-		const chartData = buildDayChartData(
-			primary,
-			secondary,
-			'orders_count',
-			'number',
-			'previous_period',
-			'year'
-		);
-
-		expect( secondaryByDate( chartData, '2024-02-28' ) ).toEqual( {
-			labelDate: '2023-02-28 00:00:00',
-			value: 5,
-		} );
-		expect( secondaryByDate( chartData, '2024-02-29' ) ).toEqual( {
-			labelDate: '-',
-			value: 0,
-		} );
-		expect( secondaryByDate( chartData, '2024-03-01' ) ).toEqual( {
-			labelDate: '2023-03-01 00:00:00',
-			value: 1,
-		} );
-		expect( secondaryByDate( chartData, '2024-12-31' ) ).toEqual( {
-			labelDate: '2023-12-31 00:00:00',
-			value: 9,
-		} );
-	} );
-
-	test( 'should leave data alone under previous period when both ranges have the 29th Feb', () => {
-		const primary = generateDayIntervals( '2016-01-01', '2019-12-31', {
-			'2016-02-29': 7,
-		} );
-		const secondary = generateDayIntervals( '2012-01-01', '2015-12-31', {
-			'2012-02-28': 28,
-			'2012-02-29': 29,
-			'2012-03-01': 301,
-		} );
-
-		const chartData = buildDayChartData(
-			primary,
-			secondary,
-			'orders_count',
-			'number',
-			'previous_period'
-		);
-
-		expect( chartData ).toHaveLength( 1461 );
-		expect( secondaryByDate( chartData, '2016-02-28' ) ).toEqual( {
-			labelDate: '2012-02-28 00:00:00',
-			value: 28,
-		} );
-		expect( secondaryByDate( chartData, '2016-02-29' ) ).toEqual( {
-			labelDate: '2012-02-29 00:00:00',
-			value: 29,
-		} );
-		expect( secondaryByDate( chartData, '2016-03-01' ) ).toEqual( {
-			labelDate: '2012-03-01 00:00:00',
-			value: 301,
-		} );
-	} );
-
-	test( 'should bump up data since 29th Feb when both ranges span a leap year', () => {
-		// Both ranges touch 2024, but only the primary range contains the leap day.
-		const primary = generateDayIntervals( '2024-02-27', '2025-01-02' );
-		const secondary = generateDayIntervals( '2023-02-27', '2024-01-02', {
-			'2023-02-28': 1,
-			'2023-03-01': 2,
-			'2023-03-02': 3,
-		} );
-
-		const chartData = buildDayChartData( primary, secondary );
-
-		expect( secondaryByDate( chartData, '2024-02-28' ) ).toEqual( {
-			labelDate: '2023-02-28 00:00:00',
-			value: 1,
-		} );
-		expect( secondaryByDate( chartData, '2024-02-29' ) ).toEqual( {
-			labelDate: '-',
-			value: 0,
-		} );
-		expect( secondaryByDate( chartData, '2024-03-01' ) ).toEqual( {
-			labelDate: '2023-03-01 00:00:00',
-			value: 2,
-		} );
-		expect( secondaryByDate( chartData, '2024-03-02' ) ).toEqual( {
-			labelDate: '2023-03-02 00:00:00',
-			value: 3,
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -56,14 +56,25 @@ function buildDayChartData(
 	primaryIntervals,
 	secondaryIntervals,
 	key = 'orders_count',
-	type = 'number'
+	type = 'number',
+	compare = 'previous_year'
 ) {
 	return buildChartData(
 		{ data: { totals: {}, intervals: primaryIntervals } },
 		{ data: { totals: {}, intervals: secondaryIntervals } },
-		{ label: 'Custom', range: '', after: '', before: '' },
-		{ label: 'Previous year', range: '', after: '', before: '' },
-		'previous_year',
+		{
+			label: 'Custom',
+			range: '',
+			after: primaryIntervals[ 0 ].date_start,
+			before: '',
+		},
+		{
+			label: 'Previous period',
+			range: '',
+			after: secondaryIntervals[ 0 ].date_start,
+			before: '',
+		},
+		compare,
 		key,
 		'day',
 		type
@@ -433,6 +444,41 @@ describe( 'buildChartData', () => {
 			} );
 		}
 	);
+
+	test( 'should leave data alone when both ranges have the 29th Feb at the same position', () => {
+		// A four year custom range compared to the previous period: both sides are
+		// 1461 days long and both contain a leap day at the same index.
+		const primary = generateDayIntervals( '2016-01-01', '2019-12-31', {
+			'2016-02-29': 7,
+		} );
+		const secondary = generateDayIntervals( '2012-01-01', '2015-12-31', {
+			'2012-02-28': 28,
+			'2012-02-29': 29,
+			'2012-03-01': 301,
+		} );
+
+		const chartData = buildDayChartData(
+			primary,
+			secondary,
+			'orders_count',
+			'number',
+			'previous_period'
+		);
+
+		expect( chartData ).toHaveLength( 1461 );
+		expect( secondaryByDate( chartData, '2016-02-28' ) ).toEqual( {
+			labelDate: '2012-02-28 00:00:00',
+			value: 28,
+		} );
+		expect( secondaryByDate( chartData, '2016-02-29' ) ).toEqual( {
+			labelDate: '2012-02-29 00:00:00',
+			value: 29,
+		} );
+		expect( secondaryByDate( chartData, '2016-03-01' ) ).toEqual( {
+			labelDate: '2012-03-01 00:00:00',
+			value: 301,
+		} );
+	} );
 
 	test( 'should bump up data since 29th Feb when both ranges span a leap year', () => {
 		// Both ranges touch 2024, but only the primary range contains the leap day.

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -482,6 +482,14 @@ describe( 'buildChartData across every date range shape', () => {
 		[ '2016-01-01', '2019-12-31' ],
 	];
 	const compares = [ 'previous_period', 'previous_year' ];
+	// Zones on both hemispheres, so a preset crosses a DST change in some
+	// clock whichever direction the clocks move. A store without a zone keeps
+	// the plain browser time path covered.
+	const storeTimeZones = [
+		undefined,
+		'America/New_York',
+		'Australia/Sydney',
+	];
 
 	function pickerFor( start, end, shift ) {
 		return {
@@ -582,30 +590,41 @@ describe( 'buildChartData across every date range shape', () => {
 		return problems;
 	}
 
+	const originalSettings = global.window.wcSettings;
+
 	afterEach( () => {
 		jest.useRealTimers();
+		global.window.wcSettings = originalSettings;
 	} );
 
-	test( 'every preset at every clock shows each comparison value under its own date', () => {
+	test( 'every preset at every clock and store time zone shows each comparison value under its own date', () => {
 		const problems = [];
 
-		clocks.forEach( ( clock ) => {
-			jest.useFakeTimers().setSystemTime( new Date( clock ) );
-			Object.entries( builders ).forEach( ( [ preset, build ] ) => {
-				compares.forEach( ( compare ) => {
-					const range = build( compare );
-					problems.push(
-						...problemsFor(
-							`${ preset }/${ compare } at ${ clock }`,
-							pickerFor( range.primaryStart, range.primaryEnd ),
-							pickerFor(
-								range.secondaryStart,
-								range.secondaryEnd,
-								range.secondaryShift
-							),
-							compare
-						)
-					);
+		storeTimeZones.forEach( ( timeZone ) => {
+			global.window.wcSettings = { ...originalSettings, timeZone };
+			clocks.forEach( ( clock ) => {
+				jest.useFakeTimers().setSystemTime( new Date( clock ) );
+				Object.entries( builders ).forEach( ( [ preset, build ] ) => {
+					compares.forEach( ( compare ) => {
+						const range = build( compare );
+						problems.push(
+							...problemsFor(
+								`${ preset }/${ compare } at ${ clock } in ${
+									timeZone || 'browser time'
+								}`,
+								pickerFor(
+									range.primaryStart,
+									range.primaryEnd
+								),
+								pickerFor(
+									range.secondaryStart,
+									range.secondaryEnd,
+									range.secondaryShift
+								),
+								compare
+							)
+						);
+					} );
 				} );
 			} );
 		} );

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -613,6 +613,36 @@ describe( 'buildChartData across every date range shape', () => {
 		expect( problems ).toEqual( [] );
 	} );
 
+	test( 'pins a comparison value to a hardcoded calendar day', () => {
+		jest.useFakeTimers().setSystemTime( new Date( '2026-09-09T12:00:00' ) );
+		const range = builders.last_year( 'previous_period' );
+		const primary = pickerFor( range.primaryStart, range.primaryEnd );
+		const secondary = pickerFor(
+			range.secondaryStart,
+			range.secondaryEnd,
+			range.secondaryShift
+		);
+		const chartData = buildChartData(
+			{ data: { totals: {}, intervals: intervalsFor( primary ) } },
+			{ data: { totals: {}, intervals: intervalsFor( secondary ) } },
+			primary,
+			secondary,
+			'previous_period',
+			'orders_count',
+			'day',
+			'number'
+		);
+
+		expect( secondaryByDate( chartData, '2025-03-01' ) ).toEqual( {
+			labelDate: '2024-03-01 00:00:00',
+			value: 20240301,
+		} );
+		expect( secondaryByDate( chartData, '2025-12-31' ) ).toEqual( {
+			labelDate: '2024-12-31 00:00:00',
+			value: 20241231,
+		} );
+	} );
+
 	test( 'every custom range shows each comparison value under its own date', () => {
 		const problems = [];
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -31,7 +31,12 @@ function formatDay( date ) {
 	return `${ date.getFullYear() }-${ month }-${ day }`;
 }
 
-function generateDayIntervals( startDate, endDate, ordersByDate = {} ) {
+function generateDayIntervals(
+	startDate,
+	endDate,
+	valuesByDate = {},
+	key = 'orders_count'
+) {
 	const intervals = [];
 	const day = new Date( `${ startDate }T00:00:00` );
 	const end = new Date( `${ endDate }T00:00:00` );
@@ -39,7 +44,7 @@ function generateDayIntervals( startDate, endDate, ordersByDate = {} ) {
 		const date = formatDay( day );
 		intervals.push(
 			generateDateInterval( date, date, date, {
-				orders_count: ordersByDate[ date ] || 0,
+				[ key ]: valuesByDate[ date ] || 0,
 			} )
 		);
 		day.setDate( day.getDate() + 1 );
@@ -47,24 +52,28 @@ function generateDayIntervals( startDate, endDate, ordersByDate = {} ) {
 	return intervals;
 }
 
-function buildDayChartData( primaryIntervals, secondaryIntervals ) {
+function buildDayChartData(
+	primaryIntervals,
+	secondaryIntervals,
+	key = 'orders_count',
+	type = 'number'
+) {
 	return buildChartData(
 		{ data: { totals: {}, intervals: primaryIntervals } },
 		{ data: { totals: {}, intervals: secondaryIntervals } },
 		{ label: 'Custom', range: '', after: '', before: '' },
 		{ label: 'Previous year', range: '', after: '', before: '' },
 		'previous_year',
-		'orders_count',
-		'day'
+		key,
+		'day',
+		type
 	);
 }
 
 function secondaryByDate( chartData, date ) {
 	const entry = chartData.find( ( d ) => d.date === `${ date }T00:00:00` );
-	return {
-		labelDate: entry.secondary.labelDate,
-		value: entry.secondary.value,
-	};
+	const { labelDate, labelDateEnd, value } = entry.secondary;
+	return { labelDate, labelDateEnd, value };
 }
 
 describe( 'buildChartData', () => {
@@ -310,9 +319,10 @@ describe( 'buildChartData', () => {
 		] );
 	} );
 
-	test( 'should drop the 29th Feb from previous year data when the primary range has no leap day', () => {
+	test( 'should fold the 29th Feb of the previous year into the 28th when the primary range has no leap day', () => {
 		const primary = generateDayIntervals( '2021-02-27', '2021-03-02' );
 		const secondary = generateDayIntervals( '2020-02-27', '2020-03-02', {
+			'2020-02-28': 5,
 			'2020-02-29': 1,
 			'2020-03-01': 2,
 			'2020-03-02': 3,
@@ -321,9 +331,14 @@ describe( 'buildChartData', () => {
 		const chartData = buildDayChartData( primary, secondary );
 
 		expect( chartData ).toHaveLength( 4 );
+		expect( secondaryByDate( chartData, '2021-02-27' ) ).toEqual( {
+			labelDate: '2020-02-27 00:00:00',
+			value: 0,
+		} );
 		expect( secondaryByDate( chartData, '2021-02-28' ) ).toEqual( {
 			labelDate: '2020-02-28 00:00:00',
-			value: 0,
+			labelDateEnd: '2020-02-29 00:00:00',
+			value: 6,
 		} );
 		expect( secondaryByDate( chartData, '2021-03-01' ) ).toEqual( {
 			labelDate: '2020-03-01 00:00:00',
@@ -335,7 +350,24 @@ describe( 'buildChartData', () => {
 		} );
 	} );
 
-	test( 'should drop the 29th Feb from previous year data when both ranges span a leap year', () => {
+	test( 'should fold the 29th Feb of the previous year when the primary range ends in February', () => {
+		const primary = generateDayIntervals( '2021-02-01', '2021-02-28' );
+		const secondary = generateDayIntervals( '2020-02-01', '2020-02-29', {
+			'2020-02-28': 5,
+			'2020-02-29': 1,
+		} );
+
+		const chartData = buildDayChartData( primary, secondary );
+
+		expect( chartData ).toHaveLength( 28 );
+		expect( secondaryByDate( chartData, '2021-02-28' ) ).toEqual( {
+			labelDate: '2020-02-28 00:00:00',
+			labelDateEnd: '2020-02-29 00:00:00',
+			value: 6,
+		} );
+	} );
+
+	test( 'should fold the 29th Feb of the previous year when both ranges span a leap year', () => {
 		// Both ranges touch 2024, but only the previous year range contains the leap day.
 		const primary = generateDayIntervals( '2024-12-31', '2025-03-02' );
 		const secondary = generateDayIntervals( '2023-12-31', '2024-03-02', {
@@ -348,7 +380,8 @@ describe( 'buildChartData', () => {
 
 		expect( secondaryByDate( chartData, '2025-02-28' ) ).toEqual( {
 			labelDate: '2024-02-28 00:00:00',
-			value: 0,
+			labelDateEnd: '2024-02-29 00:00:00',
+			value: 1,
 		} );
 		expect( secondaryByDate( chartData, '2025-03-01' ) ).toEqual( {
 			labelDate: '2024-03-01 00:00:00',
@@ -359,6 +392,47 @@ describe( 'buildChartData', () => {
 			value: 3,
 		} );
 	} );
+
+	test.each( [
+		[ 'avg_items_per_order', 'average' ],
+		[ 'avg_order_value', 'currency' ],
+	] )(
+		'should not fold the 29th Feb of the previous year for the %s average',
+		( key, type ) => {
+			const primary = generateDayIntervals( '2021-02-27', '2021-03-02' );
+			const secondary = generateDayIntervals(
+				'2020-02-27',
+				'2020-03-02',
+				{
+					'2020-02-28': 5,
+					'2020-02-29': 1,
+					'2020-03-01': 2,
+					'2020-03-02': 3,
+				},
+				key
+			);
+
+			const chartData = buildDayChartData(
+				primary,
+				secondary,
+				key,
+				type
+			);
+
+			expect( secondaryByDate( chartData, '2021-02-28' ) ).toEqual( {
+				labelDate: '2020-02-28 00:00:00',
+				value: 5,
+			} );
+			expect( secondaryByDate( chartData, '2021-03-01' ) ).toEqual( {
+				labelDate: '2020-03-01 00:00:00',
+				value: 2,
+			} );
+			expect( secondaryByDate( chartData, '2021-03-02' ) ).toEqual( {
+				labelDate: '2020-03-02 00:00:00',
+				value: 3,
+			} );
+		}
+	);
 
 	test( 'should bump up data since 29th Feb when both ranges span a leap year', () => {
 		// Both ranges touch 2024, but only the primary range contains the leap day.

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -25,6 +25,48 @@ function generateDateInterval( interval, startDate, endDate, subtotals ) {
 	};
 }
 
+function formatDay( date ) {
+	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
+	const day = String( date.getDate() ).padStart( 2, '0' );
+	return `${ date.getFullYear() }-${ month }-${ day }`;
+}
+
+function generateDayIntervals( startDate, endDate, ordersByDate = {} ) {
+	const intervals = [];
+	const day = new Date( `${ startDate }T00:00:00` );
+	const end = new Date( `${ endDate }T00:00:00` );
+	while ( day <= end ) {
+		const date = formatDay( day );
+		intervals.push(
+			generateDateInterval( date, date, date, {
+				orders_count: ordersByDate[ date ] || 0,
+			} )
+		);
+		day.setDate( day.getDate() + 1 );
+	}
+	return intervals;
+}
+
+function buildDayChartData( primaryIntervals, secondaryIntervals ) {
+	return buildChartData(
+		{ data: { totals: {}, intervals: primaryIntervals } },
+		{ data: { totals: {}, intervals: secondaryIntervals } },
+		{ label: 'Custom', range: '', after: '', before: '' },
+		{ label: 'Previous year', range: '', after: '', before: '' },
+		'previous_year',
+		'orders_count',
+		'day'
+	);
+}
+
+function secondaryByDate( chartData, date ) {
+	const entry = chartData.find( ( d ) => d.date === `${ date }T00:00:00` );
+	return {
+		labelDate: entry.secondary.labelDate,
+		value: entry.secondary.value,
+	};
+}
+
 describe( 'buildChartData', () => {
 	test( 'should bump up data since 29th Feb for previous year and compare by day', () => {
 		const primaryData = {
@@ -266,6 +308,85 @@ describe( 'buildChartData', () => {
 				},
 			},
 		] );
+	} );
+
+	test( 'should drop the 29th Feb from previous year data when the primary range has no leap day', () => {
+		const primary = generateDayIntervals( '2021-02-27', '2021-03-02' );
+		const secondary = generateDayIntervals( '2020-02-27', '2020-03-02', {
+			'2020-02-29': 1,
+			'2020-03-01': 2,
+			'2020-03-02': 3,
+		} );
+
+		const chartData = buildDayChartData( primary, secondary );
+
+		expect( chartData ).toHaveLength( 4 );
+		expect( secondaryByDate( chartData, '2021-02-28' ) ).toEqual( {
+			labelDate: '2020-02-28 00:00:00',
+			value: 0,
+		} );
+		expect( secondaryByDate( chartData, '2021-03-01' ) ).toEqual( {
+			labelDate: '2020-03-01 00:00:00',
+			value: 2,
+		} );
+		expect( secondaryByDate( chartData, '2021-03-02' ) ).toEqual( {
+			labelDate: '2020-03-02 00:00:00',
+			value: 3,
+		} );
+	} );
+
+	test( 'should drop the 29th Feb from previous year data when both ranges span a leap year', () => {
+		// Both ranges touch 2024, but only the previous year range contains the leap day.
+		const primary = generateDayIntervals( '2024-12-31', '2025-03-02' );
+		const secondary = generateDayIntervals( '2023-12-31', '2024-03-02', {
+			'2024-02-29': 1,
+			'2024-03-01': 2,
+			'2024-03-02': 3,
+		} );
+
+		const chartData = buildDayChartData( primary, secondary );
+
+		expect( secondaryByDate( chartData, '2025-02-28' ) ).toEqual( {
+			labelDate: '2024-02-28 00:00:00',
+			value: 0,
+		} );
+		expect( secondaryByDate( chartData, '2025-03-01' ) ).toEqual( {
+			labelDate: '2024-03-01 00:00:00',
+			value: 2,
+		} );
+		expect( secondaryByDate( chartData, '2025-03-02' ) ).toEqual( {
+			labelDate: '2024-03-02 00:00:00',
+			value: 3,
+		} );
+	} );
+
+	test( 'should bump up data since 29th Feb when both ranges span a leap year', () => {
+		// Both ranges touch 2024, but only the primary range contains the leap day.
+		const primary = generateDayIntervals( '2024-02-27', '2025-01-02' );
+		const secondary = generateDayIntervals( '2023-02-27', '2024-01-02', {
+			'2023-02-28': 1,
+			'2023-03-01': 2,
+			'2023-03-02': 3,
+		} );
+
+		const chartData = buildDayChartData( primary, secondary );
+
+		expect( secondaryByDate( chartData, '2024-02-28' ) ).toEqual( {
+			labelDate: '2023-02-28 00:00:00',
+			value: 1,
+		} );
+		expect( secondaryByDate( chartData, '2024-02-29' ) ).toEqual( {
+			labelDate: '-',
+			value: 0,
+		} );
+		expect( secondaryByDate( chartData, '2024-03-01' ) ).toEqual( {
+			labelDate: '2023-03-01 00:00:00',
+			value: 2,
+		} );
+		expect( secondaryByDate( chartData, '2024-03-02' ) ).toEqual( {
+			labelDate: '2023-03-02 00:00:00',
+			value: 3,
+		} );
 	} );
 } );
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { buildChartData, dataContainsLeapYear } from '../utils';
+import { buildChartData } from '../utils';
 
 function generateDateInterval( interval, startDate, endDate, subtotals ) {
 	const subtotalsDefault = {
@@ -507,71 +507,5 @@ describe( 'buildChartData', () => {
 			labelDate: '2023-03-02 00:00:00',
 			value: 3,
 		} );
-	} );
-} );
-
-describe( 'dataContainsLeapYear', () => {
-	it( 'should return false when intervals are empty', () => {
-		const data = {
-			data: {
-				intervals: [],
-			},
-		};
-		expect( dataContainsLeapYear( data ) ).toBe( false );
-	} );
-
-	it( 'should return false when intervals are undefined', () => {
-		const data = {
-			data: {},
-		};
-		expect( dataContainsLeapYear( data ) ).toBe( false );
-	} );
-
-	it( 'should return false when interval does not include a leap year', () => {
-		const data = {
-			data: {
-				intervals: [
-					{ date_start: '2019-01-01', date_end: '2019-01-01' },
-					{ date_start: '2019-12-31', date_end: '2019-12-31' },
-				],
-			},
-		};
-		expect( dataContainsLeapYear( data ) ).toBe( false );
-	} );
-
-	// Test with multiple intervals where none include a leap year
-	it( 'should return false when no intervals include a leap year', () => {
-		const data = {
-			data: {
-				intervals: [
-					{ date_start: '2019-01-01', date_end: '2019-06-30' },
-					{ date_start: '2019-07-01', date_end: '2019-12-31' },
-				],
-			},
-		};
-		expect( dataContainsLeapYear( data ) ).toBe( false );
-	} );
-
-	// Test with multiple intervals where one includes a leap year
-	it( 'should return true when any interval includes a leap year', () => {
-		const data = {
-			data: {
-				intervals: [
-					{ date_start: '2020-01-01', date_end: '2020-01-01' },
-					{ date_start: '2020-01-02', date_end: '2020-01-02' },
-				],
-			},
-		};
-		expect( dataContainsLeapYear( data ) ).toBe( true );
-	} );
-
-	// Test with malformed date formats
-	it( 'should handle invalid date formats gracefully', () => {
-		const data = {
-			data: {
-				intervals: [ { date_start: null, date_end: '2020-99-99' } ],
-			},
-		};
-		expect( dataContainsLeapYear( data ) ).toBe( false );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/test/utils.js
@@ -445,9 +445,72 @@ describe( 'buildChartData', () => {
 		}
 	);
 
-	test( 'should leave data alone when both ranges have the 29th Feb at the same position', () => {
-		// A four year custom range compared to the previous period: both sides are
-		// 1461 days long and both contain a leap day at the same index.
+	test( 'should not fold under previous period when the comparison range has the 29th Feb', () => {
+		const primary = generateDayIntervals( '2024-12-01', '2025-12-01' );
+		const secondary = generateDayIntervals( '2023-12-01', '2024-11-30', {
+			'2024-02-28': 5,
+			'2024-02-29': 1,
+			'2024-03-01': 2,
+			'2024-11-30': 9,
+		} );
+
+		const chartData = buildDayChartData(
+			primary,
+			secondary,
+			'orders_count',
+			'number',
+			'previous_period'
+		);
+
+		expect( secondaryByDate( chartData, '2025-02-28' ) ).toEqual( {
+			labelDate: '2024-02-28 00:00:00',
+			value: 5,
+		} );
+		expect( secondaryByDate( chartData, '2025-03-01' ) ).toEqual( {
+			labelDate: '2024-02-29 00:00:00',
+			value: 1,
+		} );
+		expect( secondaryByDate( chartData, '2025-03-02' ) ).toEqual( {
+			labelDate: '2024-03-01 00:00:00',
+			value: 2,
+		} );
+		expect( secondaryByDate( chartData, '2025-12-01' ) ).toEqual( {
+			labelDate: '2024-11-30 00:00:00',
+			value: 9,
+		} );
+	} );
+
+	test( 'should not pad under previous period when the primary range has the 29th Feb', () => {
+		const primary = generateDayIntervals( '2024-01-01', '2024-12-31' );
+		const secondary = generateDayIntervals( '2023-01-01', '2023-12-31', {
+			'2023-02-28': 5,
+			'2023-03-01': 1,
+			'2023-03-02': 2,
+		} );
+
+		const chartData = buildDayChartData(
+			primary,
+			secondary,
+			'orders_count',
+			'number',
+			'previous_period'
+		);
+
+		expect( secondaryByDate( chartData, '2024-02-28' ) ).toEqual( {
+			labelDate: '2023-02-28 00:00:00',
+			value: 5,
+		} );
+		expect( secondaryByDate( chartData, '2024-02-29' ) ).toEqual( {
+			labelDate: '2023-03-01 00:00:00',
+			value: 1,
+		} );
+		expect( secondaryByDate( chartData, '2024-03-01' ) ).toEqual( {
+			labelDate: '2023-03-02 00:00:00',
+			value: 2,
+		} );
+	} );
+
+	test( 'should leave data alone under previous period when both ranges have the 29th Feb', () => {
 		const primary = generateDayIntervals( '2016-01-01', '2019-12-31', {
 			'2016-02-29': 7,
 		} );

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -91,6 +91,30 @@ function isFirstOfMarch( date ) {
 }
 
 /**
+ * Returns true if the date is the 28th of February.
+ *
+ * @param {moment.Moment} date Date to check
+ * @return {boolean} True if the date is the 28th of February.
+ */
+function isTwentyEighthOfFebruary( date ) {
+	return date.month() === 1 && date.date() === 28;
+}
+
+/**
+ * Returns true if the values of a chart metric can be added up across days.
+ * Averages cannot. Core names them `avg_*` and types most of them as
+ * `average`, but `avg_order_value` is typed as `currency` for formatting,
+ * so both signals are checked.
+ *
+ * @param {string} key  Chart key, e.x: `orders_count`
+ * @param {string} type Chart type, e.x: `number`
+ * @return {boolean} True if the values can be summed.
+ */
+function isAdditiveMetric( key, type ) {
+	return type !== 'average' && ! key.startsWith( 'avg_' );
+}
+
+/**
  * Builds chart data for the given parameters.
  *
  * @param {Object} primaryData         Primary data
@@ -100,6 +124,7 @@ function isFirstOfMarch( date ) {
  * @param {string} comparison          Comparison type, e.x: `previous_year`
  * @param {string} selectedChartKey    Chart key, e.x: `orders_count`
  * @param {string} currentInterval     Chart interval, e.x: `day`
+ * @param {string} selectedChartType   Chart type, e.x: `number`
  * @return {Object} Chart data
  */
 export function buildChartData(
@@ -109,7 +134,8 @@ export function buildChartData(
 	secondaryDatePicker,
 	comparison,
 	selectedChartKey,
-	currentInterval
+	currentInterval,
+	selectedChartType
 ) {
 	const primaryDataIntervals = [ ...primaryData.data.intervals ];
 	const secondaryDataIntervals = [ ...secondaryData.data.intervals ];
@@ -127,7 +153,7 @@ export function buildChartData(
 		const primaryLabelDate = interval.date_start;
 		const primaryValue = interval.subtotals[ selectedChartKey ] || 0;
 
-		let secondaryInterval = secondaryDataIntervals[ index ];
+		const secondaryInterval = secondaryDataIntervals[ index ];
 		const secondaryLabel = `${ secondaryDatePicker.label } (${ secondaryDatePicker.range })`;
 
 		const secondaryDateMoment = getPreviousDate(
@@ -140,6 +166,7 @@ export function buildChartData(
 		let secondaryLabelDate = secondaryDateMoment.format(
 			'YYYY-MM-DD HH:mm:ss'
 		);
+		let secondaryLabelDateEnd;
 		let secondaryValue =
 			( secondaryInterval &&
 				secondaryInterval.subtotals[ selectedChartKey ] ) ||
@@ -148,6 +175,7 @@ export function buildChartData(
 		if ( currentInterval === 'day' && secondaryInterval ) {
 			const primaryDate = moment( interval.date_start );
 			const secondaryDate = moment( secondaryInterval.date_start );
+			const nextSecondaryInterval = secondaryDataIntervals[ index + 1 ];
 
 			if ( isLeapDay( primaryDate ) && isFirstOfMarch( secondaryDate ) ) {
 				// The secondary range has no leap day, so its intervals run one short
@@ -158,19 +186,24 @@ export function buildChartData(
 				secondaryValue = 0;
 				secondaryDataIntervals.splice( index, 0, secondaryInterval );
 			} else if (
-				isLeapDay( secondaryDate ) &&
-				isFirstOfMarch( primaryDate )
+				isTwentyEighthOfFebruary( primaryDate ) &&
+				nextSecondaryInterval &&
+				isLeapDay( moment( nextSecondaryInterval.date_start ) )
 			) {
 				// The secondary range has a leap day the primary range lacks, so its
 				// intervals run one long from here on. The x-axis is built from the
-				// primary dates, so the leap day has no slot to render in: drop it
-				// so later days line up again.
-				secondaryDataIntervals.splice( index, 1 );
-				secondaryInterval = secondaryDataIntervals[ index ];
-				secondaryValue =
-					( secondaryInterval &&
-						secondaryInterval.subtotals[ selectedChartKey ] ) ||
-					0;
+				// primary dates, so the leap day has no slot of its own. Fold it into
+				// the 28th and label the point as covering both days, so the line
+				// still accounts for everything the legend total counts. Averages
+				// cannot be folded, so for those the 29th is left out of the line.
+				// Either way the extra interval is removed so later days line up.
+				if ( isAdditiveMetric( selectedChartKey, selectedChartType ) ) {
+					secondaryValue +=
+						nextSecondaryInterval.subtotals[ selectedChartKey ] ||
+						0;
+					secondaryLabelDateEnd = nextSecondaryInterval.date_start;
+				}
+				secondaryDataIntervals.splice( index + 1, 1 );
 			}
 		}
 
@@ -184,6 +217,9 @@ export function buildChartData(
 			secondary: {
 				label: secondaryLabel,
 				labelDate: secondaryLabelDate,
+				...( secondaryLabelDateEnd && {
+					labelDateEnd: secondaryLabelDateEnd,
+				} ),
 				value: secondaryValue,
 			},
 		} );

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -175,6 +175,7 @@ export function buildChartData(
 		if ( currentInterval === 'day' && secondaryInterval ) {
 			const primaryDate = moment( interval.date_start );
 			const secondaryDate = moment( secondaryInterval.date_start );
+			const nextPrimaryInterval = primaryDataIntervals[ index + 1 ];
 			const nextSecondaryInterval = secondaryDataIntervals[ index + 1 ];
 
 			if ( isLeapDay( primaryDate ) && isFirstOfMarch( secondaryDate ) ) {
@@ -188,11 +189,17 @@ export function buildChartData(
 			} else if (
 				isTwentyEighthOfFebruary( primaryDate ) &&
 				nextSecondaryInterval &&
-				isLeapDay( moment( nextSecondaryInterval.date_start ) )
+				isLeapDay( moment( nextSecondaryInterval.date_start ) ) &&
+				! (
+					nextPrimaryInterval &&
+					isLeapDay( moment( nextPrimaryInterval.date_start ) )
+				)
 			) {
 				// The secondary range has a leap day the primary range lacks, so its
-				// intervals run one long from here on. The x-axis is built from the
-				// primary dates, so the leap day has no slot of its own. Fold it into
+				// intervals run one long from here on. When both ranges have the leap
+				// day at this position (an equal-length previous period spanning two
+				// leap years) they already line up and nothing is done. Otherwise the
+				// x-axis, built from the primary dates, has no slot for it. Fold it into
 				// the 28th and label the point as covering both days, so the line
 				// still accounts for everything the legend total counts. Averages
 				// cannot be folded, so for those the 29th is left out of the line.

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -145,6 +145,7 @@ export function buildChartData(
 			secondaryInterval = secondaryDataIntervals[ index ];
 		} else if (
 			yearShifted &&
+			index > 0 &&
 			secondaryDateMoment.date() !== moment( interval.date_start ).date()
 		) {
 			// A primary 29th February has no counterpart a year earlier: moment

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -53,16 +53,18 @@ export function createDateFormatter( format ) {
 
 /**
  * Returns true if the values of a chart metric can be added up across days.
- * Averages cannot. Core names them `avg_*` and types most of them as
- * `average`, but `avg_order_value` is typed as `currency` for formatting,
- * so both signals are checked.
+ * Averages and percentages cannot. Core names averages `avg_*` and types most
+ * of them as `average`, but `avg_order_value` is typed as `currency` for
+ * formatting, so both signals are checked.
  *
  * @param {string} key  Chart key, e.x: `orders_count`
  * @param {string} type Chart type, e.x: `number`
  * @return {boolean} True if the values can be summed.
  */
 function isAdditiveMetric( key, type ) {
-	return type !== 'average' && ! key.startsWith( 'avg_' );
+	return (
+		type !== 'average' && type !== 'percent' && ! key.startsWith( 'avg_' )
+	);
 }
 
 /**
@@ -131,7 +133,7 @@ export function buildChartData(
 			secondaryDatePicker.after,
 			comparison,
 			currentInterval,
-			shift
+			matchByDate ? shift : undefined
 		);
 		let secondaryLabelDate = secondaryDateMoment.format(
 			'YYYY-MM-DD HH:mm:ss'

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -52,36 +52,6 @@ export function createDateFormatter( format ) {
 }
 
 /**
- * Returns true if the date is the 29th of February.
- *
- * @param {moment.Moment} date Date to check
- * @return {boolean} True if the date is a leap day.
- */
-function isLeapDay( date ) {
-	return date.month() === 1 && date.date() === 29;
-}
-
-/**
- * Returns true if the date is the 1st of March.
- *
- * @param {moment.Moment} date Date to check
- * @return {boolean} True if the date is the first of March.
- */
-function isFirstOfMarch( date ) {
-	return date.month() === 2 && date.date() === 1;
-}
-
-/**
- * Returns true if the date is the 28th of February.
- *
- * @param {moment.Moment} date Date to check
- * @return {boolean} True if the date is the 28th of February.
- */
-function isTwentyEighthOfFebruary( date ) {
-	return date.month() === 1 && date.date() === 28;
-}
-
-/**
  * Returns true if the values of a chart metric can be added up across days.
  * Averages cannot. Core names them `avg_*` and types most of them as
  * `average`, but `avg_order_value` is typed as `currency` for formatting,
@@ -118,8 +88,28 @@ export function buildChartData(
 	currentInterval,
 	selectedChartType
 ) {
-	const primaryDataIntervals = [ ...primaryData.data.intervals ];
-	const secondaryDataIntervals = [ ...secondaryData.data.intervals ];
+	const primaryDataIntervals = primaryData.data.intervals;
+	const secondaryDataIntervals = secondaryData.data.intervals;
+	const shift = secondaryDatePicker.shift;
+	const yearShifted = shift
+		? shift === 'year'
+		: comparison === 'previous_year';
+
+	// Day intervals are matched by date, so a secondary range that is a leap
+	// day longer or shorter than the primary one cannot push later days out of
+	// line. Coarser intervals do not start on comparable dates (a week starts
+	// on its own weekday), so those keep matching by position.
+	const matchByDate = currentInterval === 'day';
+	const secondaryIntervalsByDate = new Map(
+		matchByDate
+			? secondaryDataIntervals.map( ( secondaryInterval ) => [
+					moment( secondaryInterval.date_start ).format(
+						'YYYY-MM-DD'
+					),
+					secondaryInterval,
+			  ] )
+			: []
+	);
 
 	const chartData = [];
 
@@ -134,59 +124,62 @@ export function buildChartData(
 		const primaryLabelDate = interval.date_start;
 		const primaryValue = interval.subtotals[ selectedChartKey ] || 0;
 
-		const secondaryInterval = secondaryDataIntervals[ index ];
 		const secondaryLabel = `${ secondaryDatePicker.label } (${ secondaryDatePicker.range })`;
-
 		const secondaryDateMoment = getPreviousDate(
 			interval.date_start,
 			primaryDatePicker.after,
 			secondaryDatePicker.after,
 			comparison,
-			currentInterval
+			currentInterval,
+			shift
 		);
 		let secondaryLabelDate = secondaryDateMoment.format(
 			'YYYY-MM-DD HH:mm:ss'
 		);
 		let secondaryLabelDateEnd;
+		let secondaryInterval;
+
+		if ( ! matchByDate ) {
+			secondaryInterval = secondaryDataIntervals[ index ];
+		} else if (
+			yearShifted &&
+			secondaryDateMoment.date() !== moment( interval.date_start ).date()
+		) {
+			// A primary 29th February has no counterpart a year earlier: moment
+			// clamps it to the 28th, which already belongs to the primary 28th.
+			// The label renders as "Invalid date", which is desirable since
+			// 29th February is not a valid date for non-leap years.
+			secondaryLabelDate = '-';
+		} else {
+			secondaryInterval = secondaryIntervalsByDate.get(
+				secondaryDateMoment.format( 'YYYY-MM-DD' )
+			);
+		}
+
 		let secondaryValue =
 			( secondaryInterval &&
 				secondaryInterval.subtotals[ selectedChartKey ] ) ||
 			0;
 
-		// Only a previous year comparison can leave the two ranges a leap day
-		// apart. Previous period ranges are equal length by construction.
 		if (
-			currentInterval === 'day' &&
-			comparison === 'previous_year' &&
-			secondaryInterval
+			matchByDate &&
+			yearShifted &&
+			secondaryInterval &&
+			isAdditiveMetric( selectedChartKey, selectedChartType )
 		) {
-			const primaryDate = moment( interval.date_start );
-			const secondaryDate = moment( secondaryInterval.date_start );
-			const nextSecondaryInterval = secondaryDataIntervals[ index + 1 ];
-
-			if ( isLeapDay( primaryDate ) && isFirstOfMarch( secondaryDate ) ) {
-				// The secondary range has no leap day, so its intervals run one short
-				// from here on. Pad it with a blank slot so later days line up again.
-				// The label renders as "Invalid date", which is desirable since
-				// 29th February is not a valid date for non-leap years.
-				secondaryLabelDate = '-';
-				secondaryValue = 0;
-				secondaryDataIntervals.splice( index, 0, secondaryInterval );
-			} else if (
-				isTwentyEighthOfFebruary( primaryDate ) &&
-				nextSecondaryInterval &&
-				isLeapDay( moment( nextSecondaryInterval.date_start ) )
-			) {
-				// The x-axis has no column for the secondary leap day. Fold it into
-				// the 28th so the line still adds up to the legend total. Averages
-				// cannot be added, so those only drop the extra interval.
-				if ( isAdditiveMetric( selectedChartKey, selectedChartType ) ) {
-					secondaryValue +=
-						nextSecondaryInterval.subtotals[ selectedChartKey ] ||
-						0;
-					secondaryLabelDateEnd = nextSecondaryInterval.date_start;
-				}
-				secondaryDataIntervals.splice( index + 1, 1 );
+			// A secondary 29th February has no column on a non-leap primary axis.
+			// Fold it into the 28th so the line still adds up to the legend total.
+			const dayAfter = secondaryDateMoment.clone().add( 1, 'days' );
+			const leapDayInterval =
+				dayAfter.month() === 1 && dayAfter.date() === 29
+					? secondaryIntervalsByDate.get(
+							dayAfter.format( 'YYYY-MM-DD' )
+					  )
+					: undefined;
+			if ( leapDayInterval ) {
+				secondaryValue +=
+					leapDayInterval.subtotals[ selectedChartKey ] || 0;
+				secondaryLabelDateEnd = leapDayInterval.date_start;
 			}
 		}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -153,10 +153,15 @@ export function buildChartData(
 				secondaryInterval.subtotals[ selectedChartKey ] ) ||
 			0;
 
-		if ( currentInterval === 'day' && secondaryInterval ) {
+		// Only a previous year comparison can leave the two ranges a leap day
+		// apart. Previous period ranges are equal length by construction.
+		if (
+			currentInterval === 'day' &&
+			comparison === 'previous_year' &&
+			secondaryInterval
+		) {
 			const primaryDate = moment( interval.date_start );
 			const secondaryDate = moment( secondaryInterval.date_start );
-			const nextPrimaryInterval = primaryDataIntervals[ index + 1 ];
 			const nextSecondaryInterval = secondaryDataIntervals[ index + 1 ];
 
 			if ( isLeapDay( primaryDate ) && isFirstOfMarch( secondaryDate ) ) {
@@ -170,21 +175,11 @@ export function buildChartData(
 			} else if (
 				isTwentyEighthOfFebruary( primaryDate ) &&
 				nextSecondaryInterval &&
-				isLeapDay( moment( nextSecondaryInterval.date_start ) ) &&
-				! (
-					nextPrimaryInterval &&
-					isLeapDay( moment( nextPrimaryInterval.date_start ) )
-				)
+				isLeapDay( moment( nextSecondaryInterval.date_start ) )
 			) {
-				// The secondary range has a leap day the primary range lacks, so its
-				// intervals run one long from here on. When both ranges have the leap
-				// day at this position (an equal-length previous period spanning two
-				// leap years) they already line up and nothing is done. Otherwise the
-				// x-axis, built from the primary dates, has no slot for it. Fold it into
-				// the 28th and label the point as covering both days, so the line
-				// still accounts for everything the legend total counts. Averages
-				// cannot be folded, so for those the 29th is left out of the line.
-				// Either way the extra interval is removed so later days line up.
+				// The x-axis has no column for the secondary leap day. Fold it into
+				// the 28th so the line still adds up to the legend total. Averages
+				// cannot be added, so those only drop the extra interval.
 				if ( isAdditiveMetric( selectedChartKey, selectedChartType ) ) {
 					secondaryValue +=
 						nextSecondaryInterval.subtotals[ selectedChartKey ] ||

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -2,13 +2,10 @@
  * External dependencies
  */
 import { find, get } from 'lodash';
+import moment from 'moment';
 import { flattenFilters } from '@woocommerce/navigation';
 import { format as formatDate } from '@wordpress/date';
-import {
-	containsLeapYear,
-	getPreviousDate,
-	isLeapYear,
-} from '@woocommerce/date';
+import { containsLeapYear, getPreviousDate } from '@woocommerce/date';
 
 export const DEFAULT_FILTER = 'all';
 
@@ -74,6 +71,26 @@ export function dataContainsLeapYear( data ) {
 }
 
 /**
+ * Returns true if the date is the 29th of February.
+ *
+ * @param {moment.Moment} date Date to check
+ * @return {boolean} True if the date is a leap day.
+ */
+function isLeapDay( date ) {
+	return date.month() === 1 && date.date() === 29;
+}
+
+/**
+ * Returns true if the date is the 1st of March.
+ *
+ * @param {moment.Moment} date Date to check
+ * @return {boolean} True if the date is the first of March.
+ */
+function isFirstOfMarch( date ) {
+	return date.month() === 2 && date.date() === 1;
+}
+
+/**
  * Builds chart data for the given parameters.
  *
  * @param {Object} primaryData         Primary data
@@ -94,8 +111,6 @@ export function buildChartData(
 	selectedChartKey,
 	currentInterval
 ) {
-	const primarydataContainsLeapYear = dataContainsLeapYear( primaryData );
-	const secondarydataContainsLeapYear = dataContainsLeapYear( secondaryData );
 	const primaryDataIntervals = [ ...primaryData.data.intervals ];
 	const secondaryDataIntervals = [ ...secondaryData.data.intervals ];
 
@@ -112,7 +127,7 @@ export function buildChartData(
 		const primaryLabelDate = interval.date_start;
 		const primaryValue = interval.subtotals[ selectedChartKey ] || 0;
 
-		const secondaryInterval = secondaryDataIntervals[ index ];
+		let secondaryInterval = secondaryDataIntervals[ index ];
 		const secondaryLabel = `${ secondaryDatePicker.label } (${ secondaryDatePicker.range })`;
 
 		const secondaryDateMoment = getPreviousDate(
@@ -130,45 +145,32 @@ export function buildChartData(
 				secondaryInterval.subtotals[ selectedChartKey ] ) ||
 			0;
 
-		if ( currentInterval === 'day' ) {
-			if (
-				primarydataContainsLeapYear &&
-				! secondarydataContainsLeapYear &&
-				secondaryDataIntervals?.[ index ]
-			) {
-				// Only fix the data if the date is in 29th Feb and secondary data is in 1st March,
-				// which signifies incorrect comparison.
-				const primaryDate = new Date( interval.date_start );
-				const secondaryDate = new Date(
-					secondaryDataIntervals[ index ].date_start
-				);
-				if (
-					isLeapYear( primaryDate.getFullYear() ) &&
-					primaryDate.getMonth() === 1 &&
-					primaryDate.getDate() === 29 &&
-					secondaryDate.getMonth() === 2 &&
-					secondaryDate.getDate() === 1
-				) {
-					// This is going to be displayed as "Invalid date" label from D3.js, but desirable imo since
-					// 29th February is not a valid date for non-leap years.
-					secondaryLabelDate = '-';
-					secondaryValue = 0;
+		if ( currentInterval === 'day' && secondaryInterval ) {
+			const primaryDate = moment( interval.date_start );
+			const secondaryDate = moment( secondaryInterval.date_start );
 
-					// Move the data up by 1 day for the missing leap day
-					// so everything else is shifted to the right correctly.
-					secondaryDataIntervals.splice(
-						index,
-						0,
-						secondaryDataIntervals[ index ]
-					);
-				}
+			if ( isLeapDay( primaryDate ) && isFirstOfMarch( secondaryDate ) ) {
+				// The secondary range has no leap day, so its intervals run one short
+				// from here on. Pad it with a blank slot so later days line up again.
+				// The label renders as "Invalid date", which is desirable since
+				// 29th February is not a valid date for non-leap years.
+				secondaryLabelDate = '-';
+				secondaryValue = 0;
+				secondaryDataIntervals.splice( index, 0, secondaryInterval );
 			} else if (
-				! primarydataContainsLeapYear &&
-				secondarydataContainsLeapYear
+				isLeapDay( secondaryDate ) &&
+				isFirstOfMarch( primaryDate )
 			) {
-				// Todo: Do something about secondary data having leap year while first does not.
-				// Currently, there are issues to render chart where primary data does not have the date since
-				// the x-axis is based on primary data.
+				// The secondary range has a leap day the primary range lacks, so its
+				// intervals run one long from here on. The x-axis is built from the
+				// primary dates, so the leap day has no slot to render in: drop it
+				// so later days line up again.
+				secondaryDataIntervals.splice( index, 1 );
+				secondaryInterval = secondaryDataIntervals[ index ];
+				secondaryValue =
+					( secondaryInterval &&
+						secondaryInterval.subtotals[ selectedChartKey ] ) ||
+					0;
 			}
 		}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/utils.js
@@ -5,7 +5,7 @@ import { find, get } from 'lodash';
 import moment from 'moment';
 import { flattenFilters } from '@woocommerce/navigation';
 import { format as formatDate } from '@wordpress/date';
-import { containsLeapYear, getPreviousDate } from '@woocommerce/date';
+import { getPreviousDate } from '@woocommerce/date';
 
 export const DEFAULT_FILTER = 'all';
 
@@ -49,25 +49,6 @@ export function getChartMode( selectedFilter, query ) {
 
 export function createDateFormatter( format ) {
 	return ( date ) => formatDate( format, date );
-}
-
-/**
- * Returns true if the data contains a leap year.
- *
- * @param {Object} data Chart interval data
- * @return {boolean} True if data contains a leap year.
- */
-export function dataContainsLeapYear( data ) {
-	if ( data?.data?.intervals?.length > 1 ) {
-		const start = data.data.intervals[ 0 ].date_start;
-		const end =
-			data.data.intervals[ data.data.intervals.length - 1 ].date_end;
-
-		if ( containsLeapYear( start, end ) ) {
-			return true;
-		}
-	}
-	return false;
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Time-comparison charts paired current and comparison intervals by array position. A leap day on one side put every later comparison value under the next day's label. #45874 patched one direction, and the comparison range can be built by day offset or by calendar year depending on preset, so position repairs kept missing shapes.

Now `@woocommerce/date` says how it built the comparison range (`secondary.shift`: `year` or `offset`), and the chart matches each day by the date its label names. Two days have no match: a primary 29th Feb shows blank, a comparison 29th Feb folds into the 28th with a "Feb 28 - Feb 29" label (`Chart` gains an optional `labelDateEnd` for it).

- Fold, not drop: the legend total includes the 29th, the line has to as well.
- 28th, not 1st March: it is a February order, and week/month views already bucket it there.
- Averages are not folded (`avg_*` keys, `average` or `percent` type, `avg_order_value` is typed `currency` so the prefix is checked too). Heuristic: a third-party rate chart keyed like a count would sum two days on that one point.

### Reported numbers change

- Year, Quarter, Month and Week to date vs Previous year fetched the comparison range by day count. Off by one day whenever the period spans 29th Feb.
- One day short: Mar 1 - Dec 31 of the year after a leap year (2025, 2029). One day long: Feb 29 - Dec 31 of a leap year (2024, 2028). Month to date only on 29th Feb itself.
- Now ends on the same calendar day a year earlier.
- Moves previous year totals, percentages, table totals and chart legend on those views by that day's data. Same for the Dashboard store performance indicators and leaderboards, which build their comparison query from the same range.
- The date picker's comparison range label changes with it, for example "Previous year (Jan 1 - Jun 16, 2023)" becomes "(Jan 1 - Jun 15, 2023)" on 15th June 2024. Screenshot below.

### BC

- `secondaryShift` on `DateValue`, `shift` on `getCurrentDates().secondary`, trailing `shift` on `getPreviousDate`. All optional, additive. Existing `getPreviousDate` calls unchanged. Consumers that serialise or deep-compare `DateValue` / the secondary picker see the new property.
- `getCurrentPeriod()` and `getCurrentDates()` from the published `@woocommerce/date` package return a different previous year `secondaryEnd` whenever the range spans 29th Feb (see above). Extensions building their own comparison queries from them inherit the corrected range.
- Known: a range starting on 29th Feb has no 28th Feb column, so its first point shows the previous year's 28th Feb under that label.

Closes #47503.

(For Bug Fixes) Bug introduced in PR #45874.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1160" height="355" alt="before-feb29-order-shown-on-mar-1" src="https://github.com/user-attachments/assets/a8fcc7a9-1c68-4cc5-bdfa-d95fe84707cb" /> | <img width="1160" height="355" alt="after-feb-28-29-folded" src="https://github.com/user-attachments/assets/d7ca112d-ae7c-4c30-914b-38d2a458049d" /> |

| Before | After |
| ------ | ----- |
| <img width="1160" height="355" alt="before-mar-10-order-shown-on-mar-11" src="https://github.com/user-attachments/assets/9591397f-f2e6-4a95-bab7-bbb829468ba7" /> | <img width="1160" height="355" alt="after-mar-10-correct" src="https://github.com/user-attachments/assets/efcacb11-37fa-4c29-875c-a81a34ef9316" /> |

Date picker, Year to date vs Previous year, browser clock 15 June 2024:

| Before | After |
| ------ | ----- |
| <img width="299" height="51" alt="picker-before" src="https://github.com/user-attachments/assets/273cf2d6-492c-4e72-b43b-067fb68d8b2b" /> | <img width="299" height="51" alt="picker-after" src="https://github.com/user-attachments/assets/e904fae6-f3d4-4d13-82f9-b96125a7c4f2" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create two completed orders dated `2020-02-29` and `2020-03-10` (for example with [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator): `wp wc generate orders 1 --date-start=2020-02-29 --date-end=2020-02-29 --status=completed` and the same for `2020-03-10`). Make sure they are imported into Analytics (Analytics > Settings > Import historical data if they do not show up).
2. Go to Analytics > Settings, set **Date type** to **Date created**, save.
3. Go to Analytics > Orders, pick the **Custom** date range `01/01/2021` to `03/31/2021`, compare to **Previous year**, chart **By day**, update.
4. Hover the chart on **Feb 28, 2021**: the previous year row should read **February 28, 2020 - February 29, 2020: 1**. On trunk that order shows under March 1, 2020 instead.
5. Hover **Mar 10, 2021**: the previous year row should read **March 10, 2020: 1**. On trunk it shows under March 11, 2020.
6. The **Previous year** legend total should be **2**, matching the two spikes on the line.
7. Switch the chart to **Average order value** and hover **Feb 28, 2021**: the previous year row should read **February 28, 2020** only, with the 28th's own value, and no day after it should be shifted.
8. Regression check for #45874: set the custom range to `02/01/2020` to `03/31/2020`, compare to previous year, by day. Hovering **Feb 29, 2020** should show `Invalid date: 0` for the previous year row, and **Mar 1, 2020** should show **March 1, 2019** data.
9. Previous period on a year preset: pick **Last year**, compare to **Previous period**, by day. Hover any day from March on: the previous period row should name the same calendar day a year earlier, and the last day of the year should still have a value. On trunk every day from 1st March is one day off and 31st December has none.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Steps 1-6 above on a local site (Valet, PHP 8.2, WP 7.1, HPOS off), reproduced on trunk and verified fixed on this branch by hovering the chart with Playwright. Steps 7-9 were not re-run manually, they are covered by unit tests.
- Unit tests: a matrix drives every preset, both compare modes, six clock dates around leap days and six custom ranges through the real `@woocommerce/date` builders and checks every chart point against the day its label names, plus every coarser interval against the interval it plots. Fails on the previous approach. Targeted tests: the average and percent keys, a day missing from the API data, the month interval, the unchanged #45874 case, the new `shift` per builder and the range end, `getDateLabel`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually, one for `plugins/woocommerce` and one for `@woocommerce/components`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code (Claude Fable 5.1): investigation, the fix, tests, and this description, reviewed and verified by me.










