### PR TITLE
Fix the Settings > Emails listing styles by loading the listing on demand

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-listing-dataviews-styles
+++ b/plugins/woocommerce/changelog/fix-email-listing-dataviews-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the table styles on the Settings > Emails listing.

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill-load-error.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill-load-error.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * The list view loads as its own chunk. When that request fails the fill must
+ * keep the rest of the slot (description, "Edit template" button) and show a
+ * notice instead of unmounting everything.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	EmailListingFill,
+	type EmailType,
+} from '../settings-email-listing-slotfill';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	createSlotFill: () => ( {
+		Fill: ( { children }: { children: React.ReactNode } ) => (
+			<div>{ children }</div>
+		),
+	} ),
+	Button: ( { children }: { children: React.ReactNode } ) => (
+		<button>{ children }</button>
+	),
+	Notice: ( { children }: { children: React.ReactNode } ) => (
+		<div role="alert">{ children }</div>
+	),
+} ) );
+
+// Stands in for a chunk request that fails: the dynamic import rejects.
+jest.mock( '../settings-email-listing-listview', () => {
+	throw new Error( 'Loading chunk failed' );
+} );
+
+jest.mock( '../settings-email-listing-data', () => ( {
+	recreateEmailPostRequest: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	dispatch: () => ( { createErrorNotice: jest.fn() } ),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: ( path: string ) => `https://example.com/wp-admin/${ path }`,
+} ) );
+
+const email: EmailType = {
+	id: 'new-order',
+	post_id: '123',
+	file_template_preview_url: null,
+	title: 'New order',
+	description: '',
+	enabled: true,
+	manual: false,
+	email_key: 'new_order',
+	email_class_name: 'WC_Email_New_Order',
+	recipients: { to: '', cc: '', bcc: '' },
+	status: 'enabled',
+	templateStatus: null,
+	templateVersion: null,
+	currentVersion: null,
+	wasBackfilled: false,
+};
+
+describe( 'EmailListingFill when the list view chunk fails to load', () => {
+	it( 'shows a notice and keeps the rest of the fill', async () => {
+		render(
+			<EmailListingFill
+				emailTypes={ [ email ] }
+				editTemplateUrl={ null }
+				emailTemplateId={ null }
+			/>
+		);
+
+		expect(
+			await screen.findByText( /email list could not be loaded/i )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( /Manage email notifications/ )
+		).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill.test.tsx
@@ -110,7 +110,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 		window.sessionStorage.clear();
 	} );
 
-	it( 'fires one block_email_list_viewed on mount with eligible_count and total_count', () => {
+	it( 'fires one block_email_list_viewed on mount with eligible_count and total_count', async () => {
 		render(
 			<EmailListingFill
 				emailTypes={ [ baseEmail, eligibleEmail ] }
@@ -118,6 +118,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 				emailTemplateId={ null }
 			/>
 		);
+		await screen.findByTestId( 'listview' );
 
 		expect( recordEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordEventMock ).toHaveBeenCalledWith(
@@ -130,7 +131,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 		);
 	} );
 
-	it( 'dedups within a session: a second mount in the same tab does not refire', () => {
+	it( 'dedups within a session: a second mount in the same tab does not refire', async () => {
 		const { unmount } = render(
 			<EmailListingFill
 				emailTypes={ [ eligibleEmail ] }
@@ -138,6 +139,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 				emailTemplateId={ null }
 			/>
 		);
+		await screen.findByTestId( 'listview' );
 		unmount();
 		render(
 			<EmailListingFill
@@ -146,11 +148,12 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 				emailTemplateId={ null }
 			/>
 		);
+		await screen.findByTestId( 'listview' );
 
 		expect( recordEventMock ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'still fires when sessionStorage is unavailable (privacy-mode fallback)', () => {
+	it( 'still fires when sessionStorage is unavailable (privacy-mode fallback)', async () => {
 		const setItemSpy = jest
 			.spyOn( window.sessionStorage.__proto__, 'setItem' )
 			.mockImplementation( () => {
@@ -165,6 +168,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 					emailTemplateId={ null }
 				/>
 			);
+			await screen.findByTestId( 'listview' );
 
 			expect( recordEventMock ).toHaveBeenCalledTimes( 1 );
 		} finally {
@@ -172,7 +176,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 		}
 	} );
 
-	it( 'reports eligible_count=0 when no rows are eligible', () => {
+	it( 'reports eligible_count=0 when no rows are eligible', async () => {
 		render(
 			<EmailListingFill
 				emailTypes={ [ baseEmail, baseEmail ] }
@@ -180,6 +184,7 @@ describe( 'EmailListingFill — list-page Tracks instrumentation', () => {
 				emailTemplateId={ null }
 			/>
 		);
+		await screen.findByTestId( 'listview' );
 
 		expect( recordEventMock ).toHaveBeenCalledWith(
 			'block_email_list_viewed',

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-data.ts
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-data.ts
@@ -7,7 +7,7 @@ import { settingsStore } from '@woocommerce/data';
 import { useState, useCallback, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 // @ts-expect-error - We need to use this /wp see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#dataviews
-import { View } from '@wordpress/dataviews/wp';
+import type { View } from '@wordpress/dataviews/wp';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-rtl.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-rtl.scss
@@ -1,0 +1,4 @@
+// Right-to-left twin of settings-email-listing.scss. The fill loads one of the
+// two by text direction, because chunk stylesheets bypass the RTL swap
+// WordPress applies to registered styles.
+@import "@wordpress/dataviews/build-style/style-rtl.css";

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
@@ -202,8 +202,8 @@ const EditTemplateButton = ( {
 // Same look as the server-rendered placeholder the slot shows before this
 // fill mounts, so the switch to React is not visible.
 const ListViewPlaceholder = () => (
-	<div className="woocommerce-email-listing-placeholder">
-		<h3>{ __( 'Loading…', 'woocommerce' ) }</h3>
+	<div className="woocommerce-email-listing-placeholder" role="status">
+		<p>{ __( 'Loading…', 'woocommerce' ) }</p>
 	</div>
 );
 

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { createSlotFill, Button } from '@wordpress/components';
+import { createSlotFill, Button, Notice } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { useEffect, useState } from '@wordpress/element';
+import { lazy, Suspense, useEffect, useState } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { getAdminLink } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -13,10 +13,47 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { SETTINGS_SLOT_FILL_CONSTANT } from '~/settings/settings-slots';
-import { ListView } from './settings-email-listing-listview';
+import type { ListView as ListViewComponent } from './settings-email-listing-listview';
 import { recreateEmailPostRequest } from './settings-email-listing-data';
 import { shouldShowReviewUpdate } from './settings-email-listing-update-state';
 import { VIEWED_FROM_EMAIL_LIST } from '../wp-admin-scripts/email-editor-integration/tracks/build-shared-payload';
+
+// Shown in place of the list when its chunk fails to load. Without it the
+// failure would unmount the whole slot, description and button included.
+const ListViewLoadError: typeof ListViewComponent = () => (
+	<Notice status="error" isDismissible={ false }>
+		{ __(
+			'The email list could not be loaded. Reload the page to try again.',
+			'woocommerce'
+		) }
+	</Notice>
+);
+
+// The list view carries the DataViews runtime, so it loads as its own chunk.
+// Only this fill renders it, and only on the Emails tab with the block email
+// editor enabled. Its stylesheet is a separate chunk picked by text direction,
+// because the chunk runtime bypasses the RTL swap WordPress applies to
+// registered styles. Both are awaited, so the list never renders unstyled.
+const ListView = lazy( () =>
+	Promise.all( [
+		import(
+			/* webpackChunkName: "settings-email-listing" */ './settings-email-listing-listview'
+		),
+		isRTL()
+			? import(
+					/* webpackChunkName: "settings-email-listing-styles-rtl" */ './settings-email-listing-rtl.scss'
+			  )
+			: import(
+					/* webpackChunkName: "settings-email-listing-styles" */ './settings-email-listing.scss'
+			  ),
+	] )
+		.then( ( [ module ] ) => ( { default: module.ListView } ) )
+		.catch( ( error ) => {
+			// eslint-disable-next-line no-console
+			console.error( error );
+			return { default: ListViewLoadError };
+		} )
+);
 
 export type Recipients = {
 	to: string;
@@ -162,6 +199,14 @@ const EditTemplateButton = ( {
 	);
 };
 
+// Same look as the server-rendered placeholder the slot shows before this
+// fill mounts, so the switch to React is not visible.
+const ListViewPlaceholder = () => (
+	<div className="woocommerce-email-listing-placeholder">
+		<h3>{ __( 'Loading…', 'woocommerce' ) }</h3>
+	</div>
+);
+
 export const EmailListingFill: React.FC< {
 	emailTypes: EmailType[];
 	editTemplateUrl: string | null;
@@ -220,7 +265,9 @@ export const EmailListingFill: React.FC< {
 					templateSessionEmailTypeId={ emailTypes[ 0 ]?.id ?? null }
 				/>
 			</div>
-			<ListView emailTypes={ emailTypes } />
+			<Suspense fallback={ <ListViewPlaceholder /> }>
+				<ListView emailTypes={ emailTypes } />
+			</Suspense>
 		</Fill>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing.scss
@@ -1,0 +1,5 @@
+// Styles for the DataViews runtime bundled into this chunk (the `/wp` build
+// pinned by the admin catalog). @woocommerce/settings-ui ships a different
+// DataViews major with its own stylesheet, so the two are not interchangeable
+// and this import must not be dropped as a duplicate of that one.
+@import "@wordpress/dataviews/build-style/style.css";

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -7,6 +7,13 @@
 	.dataviews-wrapper {
 		background-color: $white;
 	}
+	.woocommerce-email-listing-placeholder {
+		align-items: center;
+		display: flex;
+		height: 40px;
+		justify-content: center;
+		padding: 12px;
+	}
 	.woocommerce-email-listing-description {
 		display: inline-block;
 		margin-top: 4px;

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -13,6 +13,14 @@
 		height: 40px;
 		justify-content: center;
 		padding: 12px;
+
+		// Heading-sized text: the default paragraph size reads too small for a
+		// page-level loading message.
+		p {
+			font-size: 1.3em;
+			font-weight: 600;
+			margin: 0;
+		}
 	}
 	.woocommerce-email-listing-description {
 		display: inline-block;

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -668,15 +668,8 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			data-edit-template-url="<?php echo esc_attr( $edit_template_url ); ?>"
 			data-email-template-id="<?php echo esc_attr( $email_template_id ); ?>"
 		>
-			<div style="
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			padding: 12px;
-			height: 40px;
-			width: 100%;
-			">
-				<h3> <?php esc_html_e( 'Loading&hellip;', 'woocommerce' ); ?>  </h3>
+			<div class="woocommerce-email-listing-placeholder" role="status">
+				<p><?php esc_html_e( 'Loading&hellip;', 'woocommerce' ); ?></p>
 			</div>
 		</div>
 		<div>

--- a/plugins/woocommerce/tests/e2e/tests/email/settings-email-listing.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/settings-email-listing.spec.ts
@@ -45,6 +45,13 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 
 		await expect( listViewLocator ).toBeVisible();
 
+		// The listing's DataViews styles ship in its lazy chunk. Without them
+		// the table falls back to the browser default (border-collapse:
+		// separate) and renders as plain, unstyled rows.
+		await expect(
+			listViewLocator.locator( '.dataviews-view-table' )
+		).toHaveCSS( 'border-collapse', 'collapse' );
+
 		// Check that "New order" email type exists within the list view
 		await expect( listViewLocator.getByText( /New order/ ) ).toBeVisible();
 
@@ -145,5 +152,35 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 		await expect( popup.locator( 'body' ) ).toContainText(
 			'All Rights Reserved'
 		);
+	} );
+
+	test( 'Email listing assets load only where the listing renders', async ( {
+		page,
+		baseURL,
+	} ) => {
+		// The chunk's stylesheet link is its durable footprint: webpack removes
+		// the chunk script element once it has run. On these pages the listing
+		// fill never registers, because its slot element is not rendered, so no
+		// code path can request the chunk at all.
+		const listingAssets = () =>
+			page.locator( 'link[href*="settings-email-listing"]' );
+
+		// Other settings tabs run the same settings-embed script but never
+		// fetch the listing chunk.
+		await setBlockEmailEditorFeatureFlag( baseURL, 'yes' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=general' );
+		await expect(
+			page.locator( 'script[src*="settings-embed"]' )
+		).toHaveCount( 1 );
+		await expect( listingAssets() ).toHaveCount( 0 );
+
+		// With the block email editor off there is no listing slot, so the
+		// Emails tab does not fetch the chunk either.
+		await setBlockEmailEditorFeatureFlag( baseURL, 'no' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+		await expect(
+			page.locator( '#wc_settings_email_listing_slotfill' )
+		).toHaveCount( 0 );
+		await expect( listingAssets() ).toHaveCount( 0 );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PR #67865 removed the `@wordpress/dataviews` stylesheet import from the settings-embed bundle as a duplicate of the import in `@woocommerce/settings-ui`. The settings-ui stylesheet only loads when the new Settings UI is active, so the Settings > Emails listing, which renders on a classic settings tab, lost all of its table styles: squished columns, header buttons in link blue, no row borders.

Rather than putting the stylesheet back into the shared bundle, the fill now loads its list view through lazy() with a Suspense placeholder. Webpack splits the list view, the DataViews /wp runtime and the DataViews stylesheet into chunks that load only when the fill renders, which is the Emails tab with the block email editor enabled. A failed chunk request shows a notice instead of unmounting the slot. The "Loading…" placeholder, both the server-rendered one and the one shown while the chunk loads, is now a status message rather than a heading, so screen readers announce it and it stays out of the page outline.

Two things follow:

- Every other settings tab stops shipping about 2 MB of code it never executed, because the settings-embed script runs on all of them.
- The experimental Settings UI pages no longer receive the DataViews 10 stylesheet next to their own DataViews 17 stylesheet.

Chunk stylesheets are injected by the webpack runtime, which bypasses the RTL swap WordPress applies to registered styles, so a chunk stylesheet always arrives in its left-to-right form. The fill therefore loads the DataViews stylesheet as its own chunk and picks the left-to-right or right-to-left file with `isRTL()`, using the RTL build the DataViews package ships. The other lazy chunk stylesheets in the admin client have the same gap today; fixing that generally is left for a follow-up.

Sizes from a clean production build, minified (gzipped in brackets):

| Asset | Before | After |
| ----- | ------ | ----- |
| `settings-embed.js`, every settings tab | 2.14 MiB (422 KB) | 261 KiB (92 KB) |
| Listing chunks, Emails tab only | in the entry | 1.94 MB + 30 KB + 6 KB (320 KB + 9 KB + 2 KB) |
| Listing stylesheet chunk, Emails tab only | missing (the bug) | 62 KB (8 KB), one of two by text direction |

The Emails tab downloads about the same total as before the regression, split across requests.

Backward compatibility: no script or style handles change. The `wc-admin-style` stylesheet no longer carries DataViews rules; the offline payment method forms that share the bundle were verified to render identically with and without them.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #68476.

Bug introduced in PR #67865.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1000" height="741" alt="before-fix-clean-trunk-wp71" src="https://github.com/user-attachments/assets/75572058-0321-40a3-9072-067777de788d" />| <img width="1000" height="785" alt="after-fix" src="https://github.com/user-attachments/assets/e0e55db4-4fb5-434f-824d-fb4b121e5a7f" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block email editor: WooCommerce → Settings → Advanced → Features → "Block email editor".
2. Open WooCommerce → Settings → Emails with the browser's network panel open. Confirm the Email notifications table renders styled (full width, row separators, uppercase headers, an "Updates" filter chip) and that the network panel shows requests for `chunks/settings-email-listing.js`, `chunks/settings-email-listing-styles.style.css` and two numbered chunks. On trunk the table sits squished to the left with blue header text and no borders.
3. Open WooCommerce → Settings → General. Confirm no `settings-email-listing` requests appear and the page works as before.
4. Disable the block email editor and open WooCommerce → Settings → Emails. Confirm the classic email table shows and no `settings-email-listing` requests appear.
5. Regression check: open WooCommerce → Settings → Payments → Direct bank transfer and confirm the form looks unchanged.
6. RTL: switch the site language to a right-to-left one (Settings → General → Site Language, e.g. עברית), reload WooCommerce → Settings → Emails and confirm the table mirrors (headers right-aligned) and the network panel shows `settings-email-listing-styles-rtl.style.css` instead of the left-to-right file, with no failed requests. Switch the language back.
7. Optional, experimental Settings UI: with the `settings-ui` feature flag enabled, open WooCommerce → Settings → Products and confirm it renders as before. Only the settings-ui stylesheet should contain DataViews rules.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Local wp-env, WordPress 7.1, PHP 8.1, clean production build. Reproduced the unstyled listing on trunk, then verified in the browser that the Emails tab fetches the listing chunks and renders the styled table, and that the General tab fetches none of them.
- Verified the offline payment forms render identically with the DataViews rules present and removed.
- Verified in Hebrew (he_IL) that the fill loads the right-to-left stylesheet chunk and the table mirrors, with no failed requests.
- With the `settings-ui` feature flag on, Settings → Products renders correctly.
- `ts:check`, eslint and stylelint on the changed files, and the `client/settings-email` Jest suite (52 tests, including a new one for a failed chunk request) pass. Reviewed locally with specialist review passes; their findings drove the placeholder, the fallback notice and the RTL handling.
- The e2e assertions were added but not run locally; CI runs the `tests/email` specs in the serial project.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to investigate the regression, draft the change, the e2e assertions, the changelog entry, and this description, and to measure the bundle sizes. The author reviewed and tested the result.


