### PR TITLE
Fix the webhooks REST API ignoring the offset parameter

### DIFF
--- a/plugins/woocommerce/changelog/66818-webhooks-rest-offset
+++ b/plugins/woocommerce/changelog/66818-webhooks-rest-offset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply the offset parameter when listing webhooks through the REST API, in wc/v1, wc/v2, and wc/v3.

--- a/plugins/woocommerce/changelog/66818-webhooks-rest-offset-links
+++ b/plugins/woocommerce/changelog/66818-webhooks-rest-offset-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the pagination links returned when listing webhooks by offset through the REST API, which led back to the same results.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
@@ -252,6 +252,8 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 
 		if ( empty( $request['offset'] ) ) {
 			$args['offset'] = 1 < $request['page'] ? ( $request['page'] - 1 ) * $args['limit'] : 0;
+		} else {
+			$args['offset'] = $request['offset'];
 		}
 
 		/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
@@ -282,7 +282,11 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 		$page           = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
 		$total_webhooks = $results->total;
 		$max_pages      = $results->max_num_pages;
-		$base           = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+		// The links below navigate by page, so the caller's offset must not ride along in
+		// them: it takes precedence over the page and would return this same slice again.
+		$link_params = $request->get_query_params();
+		unset( $link_params['offset'] );
+		$base = add_query_arg( $link_params, rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
 
 		$response->header( 'X-WP-Total', $total_webhooks );
 		$response->header( 'X-WP-TotalPages', $max_pages );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
@@ -307,9 +307,9 @@ class WC_REST_Webhooks_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox An offset request reports the page it lands on in its pagination headers.
+	 * @testdox An offset request reports the whole result set in its pagination headers.
 	 */
-	public function test_offset_reports_the_page_it_lands_on(): void {
+	public function test_offset_reports_the_full_total_in_its_headers(): void {
 		wp_set_current_user( 1 );
 		$this->create_webhooks( 5 );
 
@@ -322,10 +322,27 @@ class WC_REST_Webhooks_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 5, $headers['X-WP-Total'] );
 		$this->assertEquals( 3, $headers['X-WP-TotalPages'] );
+	}
 
-		// Offset 2 over pages of 2 is page 2, so the links either side point at pages 1 and 3.
-		$this->assertSame( '1', $this->link_page( $headers['Link'], 'prev' ) );
-		$this->assertSame( '3', $this->link_page( $headers['Link'], 'next' ) );
+	/**
+	 * @testdox The links an offset request advertises lead to the pages either side of it.
+	 */
+	public function test_offset_pagination_links_lead_to_the_adjacent_pages(): void {
+		wp_set_current_user( 1 );
+		$webhook_ids = $this->create_webhooks( 5 );
+
+		$headers = $this->request_webhooks(
+			array(
+				'per_page' => 2,
+				'offset'   => 2,
+			)
+		)->get_headers();
+
+		// Offset 2 over pages of 2 is page 2, so the links either side are pages 1 and 3.
+		// Following them has to move: an offset left in the link would win over its page
+		// and hand back the offset-2 slice again.
+		$this->assertSame( array_slice( $webhook_ids, 0, 2 ), $this->follow_link( $headers['Link'], 'prev' ) );
+		$this->assertSame( array_slice( $webhook_ids, 4, 2 ), $this->follow_link( $headers['Link'], 'next' ) );
 	}
 
 	/**
@@ -384,20 +401,27 @@ class WC_REST_Webhooks_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * The page a pagination link points at.
+	 * Request a pagination link and return the webhook IDs it yields.
+	 *
+	 * The header holds one or more `<url>; rel="name"` entries separated by commas.
 	 *
 	 * @param string $link_header The Link header of a list response.
-	 * @param string $rel The link relation to read, such as `prev` or `next`.
-	 * @return string|null The page parameter of that link, or null when the header has no such link.
+	 * @param string $rel The link relation to follow, such as `prev` or `next`.
+	 * @return int[]
 	 */
-	private function link_page( string $link_header, string $rel ): ?string {
-		if ( ! preg_match( '/<([^>]+)>; rel="' . preg_quote( $rel, '/' ) . '"/', $link_header, $matches ) ) {
-			return null;
-		}
+	private function follow_link( string $link_header, string $rel ): array {
+		$matched = preg_match( '/<(?P<url>[^>]+)>; rel="' . preg_quote( $rel, '/' ) . '"/', $link_header, $matches );
 
-		$query = wp_parse_args( (string) wp_parse_url( $matches[1], PHP_URL_QUERY ) );
+		$this->assertSame( 1, $matched, "The Link header advertises no {$rel} link." );
 
-		return isset( $query['page'] ) ? (string) $query['page'] : null;
+		$request = new WP_REST_Request( 'GET', '/wc/v3/webhooks' );
+		$request->set_query_params( wp_parse_args( (string) wp_parse_url( $matches['url'], PHP_URL_QUERY ) ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		return wp_list_pluck( $response->get_data(), 'id' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
@@ -233,6 +233,174 @@ class WC_REST_Webhooks_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The offset parameter skips that many webhooks.
+	 */
+	public function test_offset_skips_the_given_number_of_webhooks(): void {
+		wp_set_current_user( 1 );
+		$webhook_ids = $this->create_webhooks( 5 );
+
+		$this->assertSame(
+			array_slice( $webhook_ids, 2, 2 ),
+			$this->listed_webhook_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => 2,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox An offset takes precedence over the page parameter.
+	 */
+	public function test_offset_takes_precedence_over_page(): void {
+		wp_set_current_user( 1 );
+		$webhook_ids = $this->create_webhooks( 5 );
+
+		$this->assertSame(
+			array_slice( $webhook_ids, 2, 2 ),
+			$this->listed_webhook_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => 2,
+					'page'     => 1,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox An offset of zero leaves the page parameter in charge.
+	 */
+	public function test_zero_offset_leaves_paging_to_the_page_parameter(): void {
+		wp_set_current_user( 1 );
+		$webhook_ids = $this->create_webhooks( 5 );
+
+		$this->assertSame(
+			array_slice( $webhook_ids, 2, 2 ),
+			$this->listed_webhook_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => 0,
+					'page'     => 2,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox An offset past the last webhook returns nothing.
+	 */
+	public function test_offset_past_the_end_returns_no_webhooks(): void {
+		wp_set_current_user( 1 );
+		$webhook_ids = $this->create_webhooks( 5 );
+
+		$this->assertSame(
+			array(),
+			$this->listed_webhook_ids(
+				array(
+					'per_page' => 2,
+					'offset'   => count( $webhook_ids ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox An offset request reports the page it lands on in its pagination headers.
+	 */
+	public function test_offset_reports_the_page_it_lands_on(): void {
+		wp_set_current_user( 1 );
+		$this->create_webhooks( 5 );
+
+		$headers = $this->request_webhooks(
+			array(
+				'per_page' => 2,
+				'offset'   => 2,
+			)
+		)->get_headers();
+
+		$this->assertEquals( 5, $headers['X-WP-Total'] );
+		$this->assertEquals( 3, $headers['X-WP-TotalPages'] );
+
+		// Offset 2 over pages of 2 is page 2, so the links either side point at pages 1 and 3.
+		$this->assertSame( '1', $this->link_page( $headers['Link'], 'prev' ) );
+		$this->assertSame( '3', $this->link_page( $headers['Link'], 'next' ) );
+	}
+
+	/**
+	 * Create webhooks, returning their IDs in creation order.
+	 *
+	 * @param int $count How many webhooks to create.
+	 * @return int[]
+	 */
+	private function create_webhooks( int $count ): array {
+		$webhook_ids = array();
+
+		for ( $i = 1; $i <= $count; $i++ ) {
+			$webhook = new WC_Webhook();
+			$webhook->set_name( 'paginated webhook ' . $i );
+			$webhook->set_status( 'active' );
+			$webhook->set_topic( 'order.created' );
+			$webhook->set_delivery_url( self::PING_URL_PREFIX . 'paginated-' . $i );
+			$webhook->save();
+			$webhook_ids[] = $webhook->get_id();
+		}
+
+		return $webhook_ids;
+	}
+
+	/**
+	 * List webhooks oldest first, so a slice of the created IDs is the expected result.
+	 *
+	 * @param array $query_params Query parameters to add to the request.
+	 * @return WP_REST_Response
+	 */
+	private function request_webhooks( array $query_params ) {
+		return $this->do_rest_get_request(
+			'webhooks',
+			array_merge(
+				array(
+					'orderby' => 'id',
+					'order'   => 'asc',
+				),
+				$query_params
+			)
+		);
+	}
+
+	/**
+	 * The IDs a webhook list request returns.
+	 *
+	 * @param array $query_params Query parameters to add to the request.
+	 * @return int[]
+	 */
+	private function listed_webhook_ids( array $query_params ): array {
+		$response = $this->request_webhooks( $query_params );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		return wp_list_pluck( $response->get_data(), 'id' );
+	}
+
+	/**
+	 * The page a pagination link points at.
+	 *
+	 * @param string $link_header The Link header of a list response.
+	 * @param string $rel The link relation to read, such as `prev` or `next`.
+	 * @return string|null The page parameter of that link, or null when the header has no such link.
+	 */
+	private function link_page( string $link_header, string $rel ): ?string {
+		if ( ! preg_match( '/<([^>]+)>; rel="' . preg_quote( $rel, '/' ) . '"/', $link_header, $matches ) ) {
+			return null;
+		}
+
+		$query = wp_parse_args( (string) wp_parse_url( $matches[1], PHP_URL_QUERY ) );
+
+		return isset( $query['page'] ) ? (string) $query['page'] : null;
+	}
+
+	/**
 	 * Answer a webhook ping with a 200 so no delivery leaves the test.
 	 *
 	 * @param array  $request Request arguments.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The webhooks endpoints have documented an `offset` collection parameter since 3.3, but `get_items()` only derived an offset from `page`. That branch ran when `offset` was absent, and nothing copied a supplied `offset` into the arguments for `search_webhooks()`, so a request sending an offset queried from row zero and got the first page back. There was no way to page through webhooks by offset.

Copy the requested offset into the query arguments, letting an explicit `offset` win over `page` — the same precedence the taxes and customers controllers, WP core's `WP_REST_Posts_Controller`, and `WP_Query` itself already use. The parameter description now says so. `WC_REST_Webhooks_V2_Controller` and `WC_REST_Webhooks_Controller` inherit `get_items()`, so this covers wc/v1, wc/v2, and wc/v3.

That also removes an `Undefined array key` warning on PHP 8, raised by reading the never-written `offset` key further down the method. On a site with `WP_DEBUG_DISPLAY` on, the warning prints before the headers, so the response is not valid JSON.

A second commit fixes the `prev` and `next` links, which carried the caller's offset alongside the page they point at. Because offset wins, following either link returned the slice the caller was already on, so an offset-based client could not walk the collection through the headers. Dropping the offset from the link base lets the page decide. The links were equally useless before this PR — they returned the first page instead — so this is a long-standing bug rather than a regression, and the same pattern sits in the taxes and customers controllers and in WP core's `WP_REST_Posts_Controller`. This change is scoped to webhooks.

Backward compatibility: the `offset` parameter is already registered, documented, and sanitized with `absint`, and `offset=0` still defers to `page`. The `Link` header changes only for requests that send an offset, where it currently leads nowhere.

#68041 was an earlier draft of this fix, opened and then withdrawn. This reworks it against current trunk, where the webhooks controller test class already exists, so the new cases go there.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66818.

(For Bug Fixes) Bug introduced in PR #17939.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create at least five webhooks, through WooCommerce > Settings > Advanced > Webhooks or `POST /wp-json/wc/v3/webhooks`.
2. Request `GET /wp-json/wc/v3/webhooks?per_page=2&offset=2&orderby=id&order=asc`. It should return the third and fourth webhooks; before this change it returned the first and second, whatever the offset.
3. Swap `offset=2` for `page=2` and confirm the same two come back.
4. Request it with `offset=0&page=2` and confirm `page` still drives the result when the offset is zero.
5. Read the `Link` header from step 2 and request the `prev` and `next` URLs it advertises. They should return the first page and the last webhook; before this change both returned the same two webhooks as step 2, because they carried the offset.
6. With `WP_DEBUG` on, confirm step 2 no longer logs `Undefined array key "offset"`, then repeat step 2 against `/wp-json/wc/v2/webhooks` and `/wp-json/wc/v1/webhooks`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Environment: wp-env, PHP 8.1, WordPress latest, HPOS on.

**Automated**

-   Six cases added to `WC_REST_Webhooks_Controller_Tests`, covering the scenarios in the table below plus the pagination links. The link case dispatches the `prev` and `next` URLs the response advertises rather than reading the page number out of them, so it fails if a link leads back to the same slice.
-   The tests came before the fix. Four error without it, at the `Undefined array key "offset"` line — `phpunit.xml` sets `convertWarningsToExceptions`, so the PHP 8 warning fails a test on its own. The `offset=0` case passes before and after, as intended.
-   `--filter Webhook`: 103 tests pass, with one pre-existing skip (a flaky HPOS order webhook test).
-   `--filter REST`: 2139 tests, one failure — `RestAbilityFactoryTest::test_register_controller_abilities_marks_rest_abilities_for_deprecated_mcp`, unrelated: it fails in isolation on this branch, and this PR touches no file it exercises.
-   phpcs on the changed files, `lint:changes:branch`, and PHPStan on the controller are all clean.

**Manual**

Seeded five webhooks with IDs 1-5 and issued the requests from the browser against a wp-env site. Every query carries `per_page=2&orderby=id&order=asc`, and every response reported `X-WP-Total: 5` and `X-WP-TotalPages: 3`.

| Query | IDs returned |
| --- | --- |
| `offset=0` | 1, 2 |
| `offset=2` | 3, 4 |
| `offset=4` | 5 |
| `offset=5` | none |
| `page=2` | 3, 4 |
| `offset=2&page=1` | 3, 4 |
| `offset=0&page=2` | 3, 4 |

`offset=2` returns the same slice on `wc/v1`, `wc/v2` and `wc/v3`. Following the links it advertises now moves: `prev` returns 1, 2 and `next` returns 5. Before the link fix both returned 3, 4.

Removing the `else` again on the running site reproduced the reported bug: `offset=2` returned IDs 1 and 2. With `WP_DEBUG_DISPLAY` on it also broke the response outright — a debug-enabled staging site gets an unparseable body rather than a quietly wrong page:

```
Warning: Undefined array key "offset" in .../class-wc-rest-webhooks-v1-controller.php on line 280
Warning: Cannot modify header information - headers already sent by (output started at .../class-wc-rest-webhooks-v1-controller.php:280)
```

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually, in `plugins/woocommerce/changelog/66818-webhooks-rest-offset`.

</details>

### Use of AI Tools

Claude Code (Opus 5) investigated the root cause, wrote the fix and its tests, and drafted this description. I directed the work, reviewed the change, and ran the tests, linting, and static analysis locally.

