### PR TITLE
Send the correct stock notification when a failed send is retried

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -173,6 +173,20 @@ abstract class Notification {
 	}
 
 	/**
+	 * Extra fields that identify this notification beyond its type and resource
+	 * ID, in the form {@see self::from_array()} accepts.
+	 *
+	 * Identity only, for the reasons {@see self::get_safety_net_args()} gives.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @since 11.2.0
+	 */
+	public function get_identity_data(): array {
+		return array();
+	}
+
+	/**
 	 * Canonical positional ActionScheduler arguments for the safety-net job.
 	 *
 	 * Single source of truth shared by the scheduler (and its dedupe guard) and

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -208,9 +208,8 @@ abstract class Notification {
 		$args          = array( $this->get_type(), $this->get_resource_id() );
 		$identity_data = $this->get_identity_data();
 
-		// Appended only when there is any, so a type without identity data keeps
-		// the exact argument list it had before this field existed and an
-		// in-flight safety net still cancels.
+		// Skipped when empty so an in-flight safety net for a type without
+		// identity data still cancels.
 		if ( ! empty( $identity_data ) ) {
 			$args[] = $identity_data;
 		}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -205,7 +205,17 @@ abstract class Notification {
 	 * @since 10.9.0
 	 */
 	public function get_safety_net_args(): array {
-		return array( $this->get_type(), $this->get_resource_id() );
+		$args          = array( $this->get_type(), $this->get_resource_id() );
+		$identity_data = $this->get_identity_data();
+
+		// Appended only when there is any, so a type without identity data keeps
+		// the exact argument list it had before this field existed and an
+		// in-flight safety net still cancels.
+		if ( ! empty( $identity_data ) ) {
+			$args[] = $identity_data;
+		}
+
+		return $args;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -155,32 +155,6 @@ class StockNotification extends Notification {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * Appends `event_type` because it is part of this notification's identity
-	 * (see {@see self::get_identifier()}): the same product can have distinct
-	 * low_stock / out_of_stock / on_backorder safety nets pending at once, and
-	 * the callback needs it to reconstruct the correct subtype.
-	 *
-	 * `stock_quantity_at_trigger` is deliberately omitted — it is volatile
-	 * payload data, not identity, and does not round-trip through every cancel
-	 * path, so including it in the match key would risk breaking cancellation.
-	 * The safety-net fallback message reads current product stock when it is
-	 * absent (see {@see self::build_message()}).
-	 *
-	 * @return array<int, mixed>
-	 *
-	 * @since 10.9.0
-	 */
-	public function get_safety_net_args(): array {
-		return array(
-			$this->get_type(),
-			$this->get_resource_id(),
-			$this->get_identity_data(),
-		);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * Without it a rebuilt stock notification falls back to the constructor's
 	 * low_stock default and reads and writes another event's delivery state.
 	 *

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -174,8 +174,22 @@ class StockNotification extends Notification {
 		return array(
 			$this->get_type(),
 			$this->get_resource_id(),
-			array( 'event_type' => $this->event_type ),
+			$this->get_identity_data(),
 		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Without it a rebuilt stock notification falls back to the constructor's
+	 * low_stock default and reads and writes another event's delivery state.
+	 *
+	 * @return array{event_type: string}
+	 *
+	 * @since 11.2.0
+	 */
+	public function get_identity_data(): array {
+		return array( 'event_type' => $this->event_type );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -266,7 +266,7 @@ class NotificationProcessor {
 	 *
 	 * @param string $type        The notification type.
 	 * @param int    $resource_id The resource ID.
-	 * @param array  $extra       Optional subclass-specific extras (e.g. event_type, stock_quantity_at_trigger).
+	 * @param array  $extra       Identity fields from {@see Notification::get_identity_data()}.
 	 *                            Empty for notification types whose state is fully described by type + resource_id.
 	 * @return void
 	 *

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
@@ -111,6 +111,9 @@ class NotificationRetryHandler {
 			return;
 		}
 
+		// Action Scheduler dispatches array_values( $args ), so these keys are
+		// decorative and the order alone decides which handle_retry() parameter
+		// each value lands in.
 		$args = array(
 			'type'        => $notification->get_type(),
 			'resource_id' => $notification->get_resource_id(),
@@ -119,8 +122,10 @@ class NotificationRetryHandler {
 
 		$identity_data = $notification->get_identity_data();
 
-		// Appended only when there is any, so `$unique` still matches a retry
-		// scheduled before this field existed.
+		// Appended only when there is any, so orders and reviews keep the exact
+		// argument list they had before this field existed and `$unique` still
+		// matches a retry scheduled before it. Stock retries do change, so
+		// during the deploy both formats can be pending for one product.
 		if ( ! empty( $identity_data ) ) {
 			$args['extra'] = $identity_data;
 		}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
@@ -63,7 +63,7 @@ class NotificationRetryHandler {
 	 * @since 10.8.0
 	 */
 	public function register(): void {
-		add_action( self::RETRY_HOOK, array( $this, 'handle_retry' ), 10, 3 );
+		add_action( self::RETRY_HOOK, array( $this, 'handle_retry' ), 10, 4 );
 	}
 
 	/**
@@ -111,14 +111,24 @@ class NotificationRetryHandler {
 			return;
 		}
 
+		$args = array(
+			'type'        => $notification->get_type(),
+			'resource_id' => $notification->get_resource_id(),
+			'attempt'     => $next_attempt,
+		);
+
+		$identity_data = $notification->get_identity_data();
+
+		// Appended only when there is any, so `$unique` still matches a retry
+		// scheduled before this field existed.
+		if ( ! empty( $identity_data ) ) {
+			$args['extra'] = $identity_data;
+		}
+
 		as_schedule_single_action(
 			time() + $delay,
 			self::RETRY_HOOK,
-			array(
-				'type'        => $notification->get_type(),
-				'resource_id' => $notification->get_resource_id(),
-				'attempt'     => $next_attempt,
-			),
+			$args,
 			NotificationProcessor::ACTION_SCHEDULER_GROUP,
 			true
 		);
@@ -127,23 +137,29 @@ class NotificationRetryHandler {
 	/**
 	 * ActionScheduler callback for retry jobs.
 	 *
-	 * Reconstructs the notification from the stored type and resource ID,
-	 * then delegates to the processor with is_retry=true.
+	 * Reconstructs the notification from the stored identity, then delegates to
+	 * the processor with is_retry=true.
+	 *
+	 * `$extra` defaults to empty so retries scheduled before it was added still
+	 * run, rebuilding a stock notification as low_stock as they always did.
 	 *
 	 * @param string $type        The notification type.
 	 * @param int    $resource_id The resource ID.
 	 * @param int    $attempt     The current retry attempt number (1-based).
+	 * @param array  $extra       Identity fields from {@see Notification::get_identity_data()}.
 	 * @return void
 	 *
 	 * @since 10.8.0
 	 */
-	public function handle_retry( string $type, int $resource_id, int $attempt ): void {
+	public function handle_retry( string $type, int $resource_id, int $attempt, array $extra = array() ): void {
 		try {
+			// `+` rather than array_merge for the reason given in
+			// NotificationProcessor::handle_safety_net().
 			$notification = Notification::from_array(
 				array(
 					'type'        => $type,
 					'resource_id' => $resource_id,
-				)
+				) + $extra
 			);
 		} catch ( Exception $e ) {
 			wc_get_logger()->error(

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
@@ -178,4 +178,59 @@ class NotificationTest extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( NewOrderNotification::class, $notification );
 		$this->assertSame( 42, $notification->get_resource_id() );
 	}
+
+	/**
+	 * Action Scheduler matches the safety-net cancel call and the retry dedupe
+	 * guard on the exact serialized arguments, and both derive from
+	 * get_identity_data(). A subclass that returns anything varying between two
+	 * instances of the same notification would stop those matching, which leaves
+	 * an uncancelled safety net to re-send and a row per trigger in
+	 * wp_actionscheduler_actions.
+	 *
+	 * @testdox Should return identity data that does not vary with volatile constructor state.
+	 * @dataProvider provider_notification_identity_pairs
+	 *
+	 * @param callable $build              Builds a notification from a volatile value.
+	 * @param bool     $has_volatile_state Whether this subclass has volatile state for $build to vary.
+	 */
+	public function test_get_identity_data_ignores_volatile_state( callable $build, bool $has_volatile_state ): void {
+		$one   = $build( 1 );
+		$other = $build( 999 );
+
+		if ( $has_volatile_state ) {
+			$this->assertNotSame(
+				$one->to_array(),
+				$other->to_array(),
+				'The provider case has to vary the volatile state, or the assertion below proves nothing.'
+			);
+		}
+
+		$this->assertSame( $one->get_identity_data(), $other->get_identity_data() );
+	}
+
+	/**
+	 * @testdox Should have an identity data case for every notification subclass.
+	 */
+	public function test_identity_data_provider_covers_every_subclass(): void {
+		$this->assertEqualsCanonicalizing(
+			array_keys( Notification::NOTIFICATION_CLASSES ),
+			array_keys( $this->provider_notification_identity_pairs() ),
+			'A new Notification subclass needs a case in the provider, so its identity data is checked too.'
+		);
+	}
+
+	/**
+	 * One entry per Notification subclass, each a callable that builds the same
+	 * notification from a volatile value, and a flag saying whether the subclass
+	 * has any volatile state for the callable to vary.
+	 *
+	 * @return array<string, array{callable, bool}>
+	 */
+	public function provider_notification_identity_pairs(): array {
+		return array(
+			'store_order'  => array( fn() => new NewOrderNotification( 42 ), false ),
+			'store_review' => array( fn() => new NewReviewNotification( 42 ), false ),
+			'store_stock'  => array( fn( int $volatile ) => new StockNotification( 42, StockNotification::EVENT_LOW_STOCK, $volatile ), true ),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
@@ -209,6 +209,24 @@ class NotificationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Action Scheduler matches a scheduled action on its serialized arguments, so
+	 * the schedule and cancel paths agreeing is not enough. Both derive from
+	 * get_safety_net_args(), so a change there moves them together and stays
+	 * green while silently dropping the event type from every stock safety net.
+	 * These are the literal arguments that have to be stored.
+	 *
+	 * @testdox Should build the expected safety-net arguments for each notification subclass.
+	 * @dataProvider provider_notification_identity_pairs
+	 *
+	 * @param callable          $build              Builds a notification from a volatile value.
+	 * @param bool              $has_volatile_state Unused here; see the identity data test.
+	 * @param array<int, mixed> $expected_args      The safety-net arguments this subclass must produce.
+	 */
+	public function test_get_safety_net_args( callable $build, bool $has_volatile_state, array $expected_args ): void {
+		$this->assertSame( $expected_args, $build( 1 )->get_safety_net_args() );
+	}
+
+	/**
 	 * @testdox Should have an identity data case for every notification subclass.
 	 */
 	public function test_identity_data_provider_covers_every_subclass(): void {
@@ -220,17 +238,18 @@ class NotificationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * One entry per Notification subclass, each a callable that builds the same
-	 * notification from a volatile value, and a flag saying whether the subclass
-	 * has any volatile state for the callable to vary.
+	 * One entry per Notification subclass: a callable that builds the same
+	 * notification from a volatile value, a flag saying whether the subclass has
+	 * any volatile state for the callable to vary, and the exact safety-net
+	 * arguments Action Scheduler has to store for it.
 	 *
-	 * @return array<string, array{callable, bool}>
+	 * @return array<string, array{callable, bool, array<int, mixed>}>
 	 */
 	public function provider_notification_identity_pairs(): array {
 		return array(
-			'store_order'  => array( fn() => new NewOrderNotification( 42 ), false ),
-			'store_review' => array( fn() => new NewReviewNotification( 42 ), false ),
-			'store_stock'  => array( fn( int $volatile ) => new StockNotification( 42, StockNotification::EVENT_LOW_STOCK, $volatile ), true ),
+			'store_order'  => array( fn() => new NewOrderNotification( 42 ), false, array( 'store_order', 42 ) ),
+			'store_review' => array( fn() => new NewReviewNotification( 42 ), false, array( 'store_review', 42 ) ),
+			'store_stock'  => array( fn( int $volatile ) => new StockNotification( 42, StockNotification::EVENT_LOW_STOCK, $volatile ), true, array( 'store_stock', 42, array( 'event_type' => StockNotification::EVENT_LOW_STOCK ) ) ),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
@@ -8,11 +8,14 @@ use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataS
 use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
 use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
+use stdClass;
+use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -247,5 +250,187 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 		$this->sut->handle_retry( 'unknown_type', 1, 1 );
 
 		$this->assertLogged( 'error', 'Retry failed:', array( 'source' => PushNotifications::FEATURE_NAME ) );
+	}
+
+	/**
+	 * @testdox Should carry the stock event type in the scheduled retry arguments.
+	 */
+	public function test_schedule_carries_the_stock_event_type(): void {
+		$product      = WC_Helper_Product::create_simple_product();
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_OUT_OF_STOCK );
+
+		$this->sut->schedule( $notification, null, 0 );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_stock',
+				'resource_id' => $product->get_id(),
+				'attempt'     => 1,
+				'extra'       => array( 'event_type' => StockNotification::EVENT_OUT_OF_STOCK ),
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertNotFalse( $scheduled, 'The retry should record the event type it was scheduled for.' );
+	}
+
+	/**
+	 * Action Scheduler deduplicates a unique action on its serialized arguments,
+	 * so without the event type a second stock event for the same product would
+	 * match the first and never be scheduled.
+	 *
+	 * @testdox Should schedule a separate retry for each stock event type on one product.
+	 */
+	public function test_schedule_keeps_a_separate_retry_per_stock_event_type(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->sut->schedule( new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK ), null, 0 );
+		$this->sut->schedule( new StockNotification( $product->get_id(), StockNotification::EVENT_OUT_OF_STOCK ), null, 0 );
+
+		foreach ( array( StockNotification::EVENT_LOW_STOCK, StockNotification::EVENT_OUT_OF_STOCK ) as $event_type ) {
+			$this->assertNotFalse(
+				as_next_scheduled_action(
+					NotificationRetryHandler::RETRY_HOOK,
+					array(
+						'type'        => 'store_stock',
+						'resource_id' => $product->get_id(),
+						'attempt'     => 1,
+						'extra'       => array( 'event_type' => $event_type ),
+					),
+					NotificationProcessor::ACTION_SCHEDULER_GROUP
+				),
+				sprintf( 'A retry should be scheduled for %s.', $event_type )
+			);
+		}
+	}
+
+	/**
+	 * The argument list stays byte-identical for types with no identity data, so
+	 * a retry scheduled before this field existed still deduplicates against one
+	 * scheduled after it.
+	 *
+	 * @testdox Should omit the extra argument for notification types with no identity data.
+	 */
+	public function test_schedule_omits_the_extra_argument_for_simple_types(): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, null, 0 );
+
+		$this->assertNotFalse(
+			as_next_scheduled_action(
+				NotificationRetryHandler::RETRY_HOOK,
+				array(
+					'type'        => 'store_order',
+					'resource_id' => $this->order_id,
+					'attempt'     => 1,
+				),
+				NotificationProcessor::ACTION_SCHEDULER_GROUP
+			)
+		);
+	}
+
+	/**
+	 * @testdox Should rebuild the retried notification with the stock event type it was scheduled for.
+	 */
+	public function test_handle_retry_rebuilds_the_stock_event_type(): void {
+		$product  = WC_Helper_Product::create_simple_product();
+		$captured = $this->stub_processor_with_successful_dispatch();
+
+		$this->sut->handle_retry(
+			'store_stock',
+			$product->get_id(),
+			1,
+			array( 'event_type' => StockNotification::EVENT_OUT_OF_STOCK )
+		);
+
+		$this->assertSame( StockNotification::EVENT_OUT_OF_STOCK, $captured->notification->get_event_type() );
+
+		$refreshed = wc_get_product( $product->get_id() );
+		$this->assertNotEmpty( $refreshed->get_meta( NotificationProcessor::SENT_META_KEY . '_out_of_stock' ) );
+		$this->assertEmpty( $refreshed->get_meta( NotificationProcessor::SENT_META_KEY . '_low_stock' ) );
+
+		$this->reset_container_replacements();
+	}
+
+	/**
+	 * @testdox Should ignore type and resource_id keys smuggled into the extra argument.
+	 */
+	public function test_handle_retry_extra_cannot_override_positional_params(): void {
+		$product  = WC_Helper_Product::create_simple_product();
+		$captured = $this->stub_processor_with_successful_dispatch();
+
+		$this->sut->handle_retry(
+			'store_stock',
+			$product->get_id(),
+			1,
+			array(
+				'event_type'  => StockNotification::EVENT_LOW_STOCK,
+				'type'        => 'store_order',
+				'resource_id' => 999999,
+			)
+		);
+
+		$this->assertSame( 'store_stock', $captured->notification->get_type() );
+		$this->assertSame( $product->get_id(), $captured->notification->get_resource_id() );
+
+		$this->reset_container_replacements();
+	}
+
+	/**
+	 * Replaces the container's processor with one whose dispatcher reports
+	 * success, so a retry runs end to end and the notification it was handed
+	 * can be inspected.
+	 *
+	 * @return stdClass Holder whose `notification` property receives the dispatched notification.
+	 */
+	private function stub_processor_with_successful_dispatch(): stdClass {
+		$captured               = new stdClass();
+		$captured->notification = null;
+
+		$dispatcher          = $this->createMock( WpcomNotificationDispatcher::class );
+		$data_store          = $this->createMock( PushTokensDataStore::class );
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+
+		$preferences_service->method( 'get_preferences' )->willReturn( array() );
+
+		$dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->with(
+				$this->callback(
+					function ( $notification ) use ( $captured ) {
+						$captured->notification = $notification;
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				array(
+					'success'     => true,
+					'retry_after' => null,
+				)
+			);
+
+		$data_store->method( 'get_tokens_for_roles' )->willReturn(
+			array(
+				new PushToken(
+					array(
+						'user_id'       => 1,
+						'token'         => 'test-token',
+						'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+						'platform'      => PushToken::PLATFORM_APPLE,
+						'device_locale' => 'en_US',
+						'device_uuid'   => 'test-uuid',
+					)
+				),
+			)
+		);
+
+		$processor = new NotificationProcessor();
+		$processor->init( $dispatcher, $data_store, $preferences_service, $this->createMock( NotificationRetryHandler::class ) );
+		wc_get_container()->replace( NotificationProcessor::class, $processor );
+
+		return $captured;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
@@ -53,6 +53,9 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
+		// Container first: a throw in the unschedule would otherwise leak the
+		// replacement into every later test in the process.
+		$this->reset_container_replacements();
 		as_unschedule_all_actions( NotificationRetryHandler::RETRY_HOOK );
 		parent::tearDown();
 	}
@@ -239,8 +242,6 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 
 		$order = wc_get_order( $this->order_id );
 		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
-
-		$this->reset_container_replacements();
 	}
 
 	/**
@@ -349,8 +350,6 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 		$refreshed = wc_get_product( $product->get_id() );
 		$this->assertNotEmpty( $refreshed->get_meta( NotificationProcessor::SENT_META_KEY . '_out_of_stock' ) );
 		$this->assertEmpty( $refreshed->get_meta( NotificationProcessor::SENT_META_KEY . '_low_stock' ) );
-
-		$this->reset_container_replacements();
 	}
 
 	/**
@@ -373,8 +372,7 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'store_stock', $captured->notification->get_type() );
 		$this->assertSame( $product->get_id(), $captured->notification->get_resource_id() );
-
-		$this->reset_container_replacements();
+		$this->assertSame( StockNotification::EVENT_LOW_STOCK, $captured->notification->get_event_type() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes AINFRA-3116

A stock push notification records which event fired (low stock, out of stock, or backorder). That event decides the wording, names the delivery state stored on the product, and keeps the three events separate from one another.

When a send to WordPress.com fails, the notification is scheduled for a retry through Action Scheduler. The retry job stored only the notification type and the product ID, so the retry rebuilt the notification without knowing which stock event it was for and fell back to low stock.

Three things are different for a merchant.

-   A retried stock notification now describes the event that actually happened. An out of stock or backorder event that needed a retry previously arrived on the phone as "PRODUCT is running low (0 remaining)".
-   A product with more than one stock event waiting to retry now gets a notification for each one. Action Scheduler treats two jobs with identical arguments as the same job, and without the event type the arguments were identical, so only the first was scheduled.
-   A product no longer stops sending a stock notification for good. Retrying one event previously wrote and cleared another event's delivery state, which left a claim marker on the event that actually fired, and a product carrying that marker never sends that notification type again. This stops new cases; a product already in that state stays in it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Written following the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/).

#### Prerequisites

**Before testing, ensure:**

-   You have replaced the WooCommerce core files on a test site with the files from this PR
-   Jetpack is connected on that site. Push notifications are switched on by the connection, there is no separate setting
-   You have opened the site in the WooCommerce iOS or Android app, which registers a push token against it
-   Your store has at least one published product with **Stock management** enabled and a **Quantity** of `1`. Setting its price to `0` lets you check out without a payment gateway
-   You have WP-CLI access to the site

Leave the low stock threshold at its default. WooCommerce fires either the low stock event or the out of stock event for one stock reduction, never both, so taking the quantity from `1` to `0` fires only the out of stock event. That is what makes the wrong wording visible.

#### Forcing the first send to fail

A retry only happens after a failed send, so the test needs one. Save the following as `wp-content/mu-plugins/force-push-failure.php`. It fails the first send to WordPress.com and then stops interfering, so the retry that follows can succeed.

```php
<?php
/**
 * Plugin Name: Force one push notification send failure
 */

add_filter(
	'pre_http_request',
	function ( $preempt, $args, $url ) {
		// Both conditions are needed. The site's own loopback request also has
		// "push-notifications" in its path, and failing that one stops the
		// dispatch before any send happens, so no retry is ever scheduled.
		if ( false === strpos( $url, 'public-api.wordpress.com' ) || false === strpos( $url, 'push-notifications' ) ) {
			return $preempt;
		}

		if ( get_option( 'force_push_failure_used' ) ) {
			return $preempt;
		}

		update_option( 'force_push_failure_used', 1 );

		return new WP_Error( 'http_request_failed', 'Forced failure for testing.' );
	},
	10,
	3
);
```

Create `wp-content/mu-plugins/` first if it does not exist, which is common on a new site. WordPress reports nothing when a mu-plugin is missing or in the wrong place, so there is no error to tell you it did not load. The first send then succeeds, no retry is scheduled, and step 3 returns no rows.

#### Steps

1.  Note the product's ID from **Products > All Products**, by hovering over its name.
2.  As a shopper, add that product to the cart and complete checkout, which takes its stock to `0`. No notification reaches your phone yet, because the forced failure has swallowed the first send.
3.  Run the following.

    ```sh
    wp eval '
    global $wpdb;
    $rows = $wpdb->get_results(
        $wpdb->prepare(
            "SELECT status, scheduled_date_gmt, args FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s ORDER BY action_id DESC LIMIT 3",
            "wc_push_notification_retry"
        )
    );
    foreach ( $rows as $row ) {
        printf( "%s  %s  %s" . PHP_EOL, $row->status, $row->scheduled_date_gmt, $row->args );
    }'
    ```

    **Expected result:** one `pending` row whose `args` contain `"extra":{"event_type":"out_of_stock"}`. On trunk the `args` stop after `attempt` and carry no event type. An empty result means the forced failure did not apply, so check the mu-plugin is in place before going on.

4.  Wait three minutes. The first retry is scheduled 60 seconds ahead, and Action Scheduler needs a WP-Cron run to pick it up.
5.  Check your phone.

    **Expected result: a notification reading "Out of stock: PRODUCT NAME 🚨", with the body "PRODUCT NAME is out of stock on SITE NAME". On trunk the same notification reads "Low stock: PRODUCT NAME ⚠️" with the body "PRODUCT NAME is running low (0 remaining) on SITE NAME".**

6.  Run the following, replacing `PRODUCT_ID`.

    ```sh
    wp eval '
    $product = wc_get_product( PRODUCT_ID );
    foreach ( array( "sent", "claimed" ) as $key ) {
        foreach ( array( "out_of_stock", "low_stock" ) as $event ) {
            $value = $product->get_meta( "_wc_push_notification_" . $key . "_" . $event );
            printf( "_wc_push_notification_%s_%s : %s" . PHP_EOL, $key, $event, "" === $value ? "NOT SET" : $value );
        }
    }'
    ```

    **Expected result:** `_wc_push_notification_sent_out_of_stock` holds a Unix timestamp, and the other three are `NOT SET`.

    On trunk the two `sent` values are the other way round, because the retry wrote the low stock marker for a product that never had a low stock notification. `_wc_push_notification_claimed_out_of_stock` is also left behind there, and `NotificationProcessor::process()` returns early while a claimed marker is present, so that product can never send another out of stock notification.

#### Checking retries scheduled before this change

Those jobs carry no event type and still need to run. Run the following at any point, replacing `PRODUCT_ID`.

```sh
wp eval '
do_action( "wc_push_notification_retry", "store_stock", PRODUCT_ID, 1 );
echo "callback returned" . PHP_EOL;'
```

**Expected result:** `callback returned`, with no fatal error about a missing argument.

<!-- End testing instructions -->

### Testing that has already taken place:

I have run through the testing instructions above.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal only change - fixes a bug on the retry path, which only runs when a send to WordPress.com fails. Nothing changes for a store whose sends succeed.

</details>

### Use of AI Tools

Authored with Claude Code (Claude Opus 5). The change was specified, reviewed and verified by me.
