### PR TITLE
Associate the Shop page with the Product Catalog template

### DIFF
--- a/plugins/woocommerce/changelog/associate-shop-page-product-catalog
+++ b/plugins/woocommerce/changelog/associate-shop-page-product-catalog
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Associate the Shop page with the Product Catalog block template while keeping the template selector hidden.

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\Templates;
 
@@ -25,6 +26,31 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	public function init() {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'current_theme_supports-block-templates', array( $this, 'remove_block_template_support_for_shop_page' ) );
+		add_filter( 'get_post_metadata', array( $this, 'handle_get_post_metadata' ), 10, 4 );
+	}
+
+	/**
+	 * Associate the current Shop page with the catalog without overwriting its saved page template.
+	 *
+	 * @internal
+	 *
+	 * @param mixed  $value Short-circuited metadata value, or null.
+	 * @param int    $post_id Post ID.
+	 * @param string $meta_key Metadata key.
+	 * @param bool   $single Whether to return a single value.
+	 * @return mixed
+	 */
+	public function handle_get_post_metadata( $value, $post_id, $meta_key, $single ) {
+		if (
+			null === $value &&
+			'_wp_page_template' === $meta_key &&
+			wp_is_block_theme() &&
+			wc_get_page_id( 'shop' ) === $post_id
+		) {
+			return $single ? self::SLUG : array( self::SLUG );
+		}
+
+		return $value;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/ProductCatalogTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/ProductCatalogTemplateTest.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Templates;
+
+use Automattic\WooCommerce\Blocks\Templates\ProductCatalogTemplate;
+use WC_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * Tests for the Shop page's Product Catalog template relationship.
+ */
+class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ProductCatalogTemplate
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		switch_theme( 'twentytwentyfour' );
+		$this->sut = new ProductCatalogTemplate();
+		$this->sut->init();
+	}
+
+	/**
+	 * @testdox Should associate only the Shop page template and preserve unrelated metadata.
+	 */
+	public function test_shop_template_metadata(): void {
+		$shop_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		update_post_meta( $shop_id, '_thumbnail_id', 123 );
+		update_option( 'woocommerce_shop_page_id', $shop_id );
+
+		$this->assertSame( 'archive-product', get_page_template_slug( $shop_id ), 'The Shop page should be associated with the catalog.' );
+		$this->assertSame( array( 'archive-product' ), get_post_meta( $shop_id, '_wp_page_template', false ), 'Multiple-value reads should return an array.' );
+		$this->assertSame( '123', get_post_meta( $shop_id, '_thumbnail_id', true ), 'Featured image metadata must remain unchanged.' );
+		$this->assertArrayHasKey( '_thumbnail_id', get_post_meta( $shop_id ), 'Reading all metadata must return the stored fields.' );
+	}
+
+	/**
+	 * @testdox Should preserve template overrides supplied by earlier metadata filters.
+	 */
+	public function test_existing_metadata_override(): void {
+		$shop_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_id );
+		add_filter(
+			'get_post_metadata',
+			static function ( $value, $post_id, $meta_key ) use ( $shop_id ) {
+				return $shop_id === $post_id && '_wp_page_template' === $meta_key ? 'extension-template' : $value;
+			},
+			5,
+			3
+		);
+
+		$this->assertSame( 'extension-template', get_page_template_slug( $shop_id ), 'Earlier metadata overrides should retain their precedence.' );
+	}
+
+	/**
+	 * @testdox Should accept editor saves and move the relationship without overwriting the previous template.
+	 */
+	public function test_rest_save_and_shop_reassignment(): void {
+		$shop_id     = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$new_shop_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		update_post_meta( $shop_id, '_wp_page_template', 'custom-page' );
+		update_option( 'woocommerce_shop_page_id', $shop_id );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages/' . $shop_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status(), 'The editor should be able to load the Shop page.' );
+		$this->assertSame( 'archive-product', $response->get_data()['template'], 'The editor should receive the catalog relationship.' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . $shop_id );
+		$request->set_param( 'template', 'archive-product' );
+		$request->set_param( 'title', 'Updated shop' );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status(), 'Saving the existing template relationship should pass REST validation.' );
+		$this->assertSame( 'Updated shop', get_the_title( $shop_id ), 'The page changes should be saved.' );
+		$this->assertSame( '', get_page_template_slug( $new_shop_id ), 'Other pages should keep their default template.' );
+
+		update_option( 'woocommerce_shop_page_id', $new_shop_id );
+		$this->assertSame( 'custom-page', get_page_template_slug( $shop_id ), 'The former Shop page should retain its stored template.' );
+		$this->assertSame( 'archive-product', get_page_template_slug( $new_shop_id ), 'The relationship should follow the Shop page setting.' );
+
+		switch_theme( 'twentytwentyone' );
+		$this->assertSame( '', get_page_template_slug( $new_shop_id ), 'Classic themes should retain their existing behavior.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Shop page currently has no explicit template association in its metadata, even though its layout is controlled by the Product Catalog template. This makes the editing experience confusing, as shown in 

<video src="https://github.com/user-attachments/assets/cb2dcd5e-dd98-4b23-a260-d25755153079"></video>

This PR associates the Shop page with the Product Catalog template when a block theme is active, without overwriting its stored template metadata. The template selector remains hidden, preserving the behavior maintained in [[#46405](https://github.com/woocommerce/woocommerce/pull/46405)](https://github.com/woocommerce/woocommerce/pull/46405): merchants cannot assign a different template through the Shop page editor.

The main compatibility consideration is that `get_post_meta( wc_get_page_id( 'shop' ), '_wp_page_template', true )` now returns `archive-product` instead of the stored value, which is typically empty. Extensions relying on that value may be affected, so a developer advisory may be warranted.



<video src="https://github.com/user-attachments/assets/e9aaf45d-f92d-434a-afb6-6e83262d494b"></video>

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

No visible UI change is intended; the template selector remains hidden. Browser verification has not been performed.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Activate a block theme, such as Twenty Twenty-Four, and assign a published page as the Shop page in WooCommerce settings.
2. Run `wp eval 'echo get_page_template_slug( wc_get_page_id( "shop" ) );'`. Expect `archive-product`.
3. Open the Shop page in the page editor. Confirm the Template selector stays hidden, the existing featured image remains correct, and changes to the title save successfully. Confirm the editor's page REST response contains `template: "archive-product"`.
4. Set a different page as the Shop page. Confirm the new page reports `archive-product` and the former Shop page reports its previously stored template.
5. Switch to a classic theme. Confirm the Shop page returns its stored template rather than the inferred catalog slug.
6. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'ProductCatalogTemplateTest|SingleProductTemplateTests|BlockTemplatesControllerTest'`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Docker wp-env, PHP 8.1.34, PHPUnit 9.6.35, single-site test installation: 14 tests passed with 29 assertions.
- Regression coverage includes unrelated metadata, earlier filter overrides, REST load/save, Shop-page reassignment, and classic-theme behavior.
- Changed-file PHP lint, full-branch lint, direct PHPCS on both PHP files, PHPStan on the modified production class, and `git diff --check` passed.
- No manual browser or multisite testing performed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex assisted with implementation, regression tests, validation, and PR preparation. The author revised the implementation during development.
