### PR TITLE
[Mise en Place] Add early action and gate filter to the classic add to cart handler

### DIFF
--- a/plugins/woocommerce/changelog/add-wooplug-6638-early-add-to-cart-action-hooks
+++ b/plugins/woocommerce/changelog/add-wooplug-6638-early-add-to-cart-action-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_before_add_to_cart_action and woocommerce_add_to_cart_action_allowed hooks so external code can observe and gate classic add to cart requests before cart manipulation begins.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -1028,6 +1028,36 @@ class WC_Form_Handler {
 			return;
 		}
 
+		/**
+		 * Fires before an add to cart request from the cart form or an add to cart URL is handled.
+		 *
+		 * Runs after the requested product has been resolved but before any cart manipulation begins,
+		 * providing an early observation point for every such request, including ones later rejected.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param int        $product_id     ID of the product being added to the cart.
+		 * @param WC_Product $adding_to_cart Product object being added to the cart.
+		 */
+		do_action( 'woocommerce_before_add_to_cart_action', $product_id, $adding_to_cart );
+
+		/**
+		 * Filters whether an add to cart request from the cart form or an add to cart URL may proceed.
+		 *
+		 * Returning false aborts the request before any cart manipulation begins, giving external code
+		 * an enforcement point for rate limiting or abuse prevention. The request ends silently;
+		 * callbacks can queue their own notice with wc_add_notice() when feedback is desired.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param bool       $allowed        Whether the add to cart request may proceed. Default true.
+		 * @param int        $product_id     ID of the product being added to the cart.
+		 * @param WC_Product $adding_to_cart Product object being added to the cart.
+		 */
+		if ( ! apply_filters( 'woocommerce_add_to_cart_action_allowed', true, $product_id, $adding_to_cart ) ) {
+			return;
+		}
+
 		$add_to_cart_handler = apply_filters( 'woocommerce_add_to_cart_handler', $adding_to_cart->get_type(), $adding_to_cart );
 
 		if ( ProductType::VARIABLE === $add_to_cart_handler || ProductType::VARIATION === $add_to_cart_handler ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -668,4 +668,75 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 
 		$this->fail( 'Expected save_account_details() to redirect after a successful save.' );
 	}
+
+	/**
+	 * @testdox An add to cart request rejected by the allowed filter fires the before action but leaves the cart untouched.
+	 */
+	public function test_add_to_cart_action_can_be_aborted_by_the_allowed_filter(): void {
+		$product                 = WC_Helper_Product::create_simple_product();
+		$_REQUEST['add-to-cart'] = (string) $product->get_id();
+
+		$action_args = array();
+		add_action(
+			'woocommerce_before_add_to_cart_action',
+			function ( $product_id, $adding_to_cart ) use ( &$action_args ) {
+				$action_args[] = array( $product_id, $adding_to_cart );
+			},
+			10,
+			2
+		);
+		add_filter( 'woocommerce_add_to_cart_action_allowed', '__return_false' );
+
+		WC_Form_Handler::add_to_cart_action();
+
+		$this->assertCount( 0, WC()->cart->get_cart_contents(), 'A rejected request must not modify the cart.' );
+		$this->assertCount( 1, $action_args, 'The before action must fire once per request, including rejected ones.' );
+		$this->assertSame( $product->get_id(), $action_args[0][0], 'The action must receive the resolved product ID.' );
+		$this->assertInstanceOf( WC_Product::class, $action_args[0][1], 'The action must receive the product object.' );
+		$this->assertSame( $product->get_id(), $action_args[0][1]->get_id(), 'The product object must match the requested product.' );
+	}
+
+	/**
+	 * @testdox An add to cart request proceeds normally when the allowed filter returns true.
+	 */
+	public function test_add_to_cart_action_proceeds_when_the_allowed_filter_returns_true(): void {
+		$product                 = WC_Helper_Product::create_simple_product();
+		$_REQUEST['add-to-cart'] = (string) $product->get_id();
+
+		$filter_args = array();
+		add_filter(
+			'woocommerce_add_to_cart_action_allowed',
+			function ( $allowed, $product_id, $adding_to_cart ) use ( &$filter_args ) {
+				$filter_args[] = array( $allowed, $product_id, $adding_to_cart->get_id() );
+
+				return $allowed;
+			},
+			10,
+			3
+		);
+
+		WC_Form_Handler::add_to_cart_action();
+
+		$this->assertCount( 1, WC()->cart->get_cart_contents(), 'An allowed request must add the product to the cart.' );
+		$this->assertSame( array( array( true, $product->get_id(), $product->get_id() ) ), $filter_args, 'The filter must receive the default, the product ID, and the product object.' );
+	}
+
+	/**
+	 * @testdox The early add to cart hooks do not fire when the requested product cannot be resolved.
+	 */
+	public function test_add_to_cart_action_skips_early_hooks_for_an_unresolvable_product(): void {
+		$_REQUEST['add-to-cart'] = '99999999';
+
+		$fired = 0;
+		add_action(
+			'woocommerce_before_add_to_cart_action',
+			function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		WC_Form_Handler::add_to_cart_action();
+
+		$this->assertSame( 0, $fired, 'The before action must not fire when the product cannot be resolved.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The classic `?add-to-cart=` GET flow (`WC_Form_Handler::add_to_cart_action()`) has no early exit point that external plugins or hosting environments can hook into before cart manipulation begins, so there is no plugin-layer mechanism to gate abusive traffic against it (the AJAX path has `woocommerce_add_to_cart_validation`; this path had nothing equivalent at request level). This adds the two hooks proposed in the issue, firing after the product is resolved but before any cart work:

- `woocommerce_before_add_to_cart_action` (action): observation point for every such request, including ones later rejected, receiving the resolved product ID and product object.
- `woocommerce_add_to_cart_action_allowed` (filter): returning false aborts the request silently before any cart manipulation; callbacks can queue their own notice via `wc_add_notice()`.

Per the discussion on the issue: this deliberately delegates enforcement (rate limiting, IP reputation, session checks) to external code that has the context to do it safely, rather than shipping a native rate limiter with unavoidable false-positive tradeoffs. It does not preclude wiring the Store API rate limiter into this path later; it unblocks merchants bringing their own solutions today, which matters while the majority of stores remain on classic cart.

**Backward compatibility impact:** purely additive. Two new hooks; no existing hook, signature, or behavior changes. The new hooks become public contracts from this release onward.

Closes #64545.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. With a plain install, visit `?add-to-cart=<simple product id>` and confirm the product is added to the cart as before (no behavior change).
2. Add a snippet: `add_filter( 'woocommerce_add_to_cart_action_allowed', '__return_false' );` and repeat step 1: nothing is added to the cart and no error is shown.
3. Add a snippet logging `woocommerce_before_add_to_cart_action` arguments and confirm it fires with the resolved product ID and `WC_Product` object, both with and without the blocking filter.
4. Confirm neither hook fires for an invalid product, e.g. `?add-to-cart=99999999`.

<!-- End testing instructions -->

### Testing that has already taken place:

Three new unit tests in `WC_Form_Handler_Test` cover: filter abort leaves the cart untouched while the action still fires with the right arguments; an allowing filter passes the request through and receives the documented arguments; neither hook fires for an unresolvable product. Full `WC_Form_Handler_Test` (20 tests) passes. `phpcs-changed` (per-file and branch) and PHPStan are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

This PR was written with the help of Claude Code; the hook design follows the issue discussion and was reviewed by the author.