### PR TITLE
Add a query args filter to the Product Categories List block

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-873-product-categories-query-args-filter
+++ b/plugins/woocommerce/changelog/wooplug-873-product-categories-query-args-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `woocommerce_blocks_product_categories_query_args` filter to the Product Categories List block so the arguments passed to `get_terms()` can be adjusted, e.g. to exclude categories.

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -633,7 +633,7 @@ apply_filters( 'woocommerce_blocks_product_categories_query_args', array $args, 
 
 ### Description
 
-Use `exclude_tree` rather than `exclude` to hide a category and its children in hierarchical output.
+Use `exclude_tree` rather than `exclude` to hide a category and its children in hierarchical output. The `taxonomy` and `fields` arguments are reset after filtering, and a non-array return value is ignored.
 
 ### Parameters
 

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -25,6 +25,7 @@
 - [woocommerce_apply_with_individual_use_coupon](#woocommerce_apply_with_individual_use_coupon)
 - [woocommerce_blocks_hook_compatibility_additional_data](#woocommerce_blocks_hook_compatibility_additional_data)
 - [woocommerce_blocks_pre_get_routes_from_namespace](#woocommerce_blocks_pre_get_routes_from_namespace)
+- [woocommerce_blocks_product_categories_query_args](#woocommerce_blocks_product_categories_query_args)
 - [woocommerce_blocks_product_filters_selected_items](#woocommerce_blocks_product_filters_selected_items)
 - [woocommerce_blocks_product_grid_add_to_cart_attributes](#woocommerce_blocks_product_grid_add_to_cart_attributes)
 - [woocommerce_blocks_product_grid_is_cacheable](#woocommerce_blocks_product_grid_is_cacheable)
@@ -618,6 +619,32 @@ apply_filters( 'woocommerce_blocks_pre_get_routes_from_namespace', array $routes
 ### Source
 
 - [Blocks/BlockTypes/AbstractBlock.php](../../../../../../src/Blocks/BlockTypes/AbstractBlock.php)
+
+---
+
+## woocommerce_blocks_product_categories_query_args
+
+
+Filters the `get_terms()` arguments used by the Product Categories List block.
+
+```php
+apply_filters( 'woocommerce_blocks_product_categories_query_args', array $args, array $attributes )
+```
+
+### Description
+
+Use `exclude_tree` rather than `exclude` to hide a category and its children in hierarchical output.
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $args | array | Arguments passed to `get_terms()`. |
+| $attributes | array | Block attributes. |
+
+### Source
+
+- [Blocks/BlockTypes/ProductCategories.php](../../../../../../src/Blocks/BlockTypes/ProductCategories.php)
 
 ---
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -50692,12 +50692,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductCategories.php
 
 		-
-			message: '#^Parameter \#1 \$args of function get_terms expects array\{taxonomy\?\: array\<string\>\|string, object_ids\?\: array\<int\>\|int, orderby\?\: string, order\?\: string, hide_empty\?\: bool\|int, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, exclude_tree\?\: array\<int\>\|string, \.\.\.\}, ''product_cat'' given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Blocks/BlockTypes/ProductCategories.php
-
-		-
 			message: '#^Parameter \#1 \$default of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AbstractDynamicBlock\:\:get_schema_boolean\(\) expects string, false given\.$#'
 			identifier: argument.type
 			count: 4

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
@@ -161,8 +161,9 @@ class ProductCategories extends AbstractDynamicBlock {
 			$args = $filtered_args;
 		}
 
-		// The block always links to product categories, so the taxonomy is not overridable.
+		// The renderer builds product_cat links and reads term objects, so neither is overridable.
 		$args['taxonomy'] = 'product_cat';
+		$args['fields']   = 'all';
 
 		$categories = get_terms( $args );
 
@@ -199,17 +200,18 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return array
 	 */
 	protected function build_category_tree( $categories, $children_only ) {
-		$categories_by_parent = [];
+		$parent_id = $children_only ? get_queried_object_id() : 0;
+		$term_ids  = array_flip( array_column( $categories, 'term_id' ) );
 
+		$categories_by_parent = [];
 		foreach ( $categories as $category ) {
-			if ( ! isset( $categories_by_parent[ 'cat-' . $category->parent ] ) ) {
-				$categories_by_parent[ 'cat-' . $category->parent ] = [];
-			}
-			$categories_by_parent[ 'cat-' . $category->parent ][] = $category;
+			// A filter can drop a parent but keep its children. Like core's Walker, show those orphans at the top level.
+			$parent = isset( $term_ids[ $category->parent ] ) ? $category->parent : $parent_id;
+
+			$categories_by_parent[ 'cat-' . $parent ][] = $category;
 		}
 
-		$parent_id = $children_only ? get_queried_object_id() : 0;
-		$tree      = $categories_by_parent[ 'cat-' . $parent_id ]; // these are top level categories. So all parents.
+		$tree = $categories_by_parent[ 'cat-' . $parent_id ] ?? [];
 		unset( $categories_by_parent[ 'cat-' . $parent_id ] );
 
 		foreach ( $tree as $category ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
@@ -149,6 +149,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		/**
 		 * Filters the `get_terms()` arguments used by the Product Categories List block.
 		 * Use `exclude_tree` rather than `exclude` to hide a category and its children in hierarchical output.
+		 * The `taxonomy` and `fields` arguments are reset after filtering, and a non-array return value is ignored.
 		 *
 		 * @since 11.2.0
 		 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
@@ -135,27 +135,36 @@ class ProductCategories extends AbstractDynamicBlock {
 		$hierarchical  = wc_string_to_bool( $attributes['isHierarchical'] );
 		$children_only = wc_string_to_bool( $attributes['showChildrenOnly'] ) && is_product_category();
 
+		$args = [
+			'taxonomy'     => 'product_cat',
+			'hide_empty'   => ! $attributes['hasEmpty'],
+			'pad_counts'   => true,
+			'hierarchical' => true,
+		];
+
 		if ( $children_only ) {
-			$term_id    = get_queried_object_id();
-			$categories = get_terms(
-				'product_cat',
-				[
-					'hide_empty'   => ! $attributes['hasEmpty'],
-					'pad_counts'   => true,
-					'hierarchical' => true,
-					'child_of'     => $term_id,
-				]
-			);
-		} else {
-			$categories = get_terms(
-				'product_cat',
-				[
-					'hide_empty'   => ! $attributes['hasEmpty'],
-					'pad_counts'   => true,
-					'hierarchical' => true,
-				]
-			);
+			$args['child_of'] = get_queried_object_id();
 		}
+
+		/**
+		 * Filters the `get_terms()` arguments used by the Product Categories List block.
+		 * Use `exclude_tree` rather than `exclude` to hide a category and its children in hierarchical output.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param array $args       Arguments passed to `get_terms()`.
+		 * @param array $attributes Block attributes.
+		 */
+		$filtered_args = apply_filters( 'woocommerce_blocks_product_categories_query_args', $args, $attributes );
+
+		if ( is_array( $filtered_args ) ) {
+			$args = $filtered_args;
+		}
+
+		// The block always links to product categories, so the taxonomy is not overridable.
+		$args['taxonomy'] = 'product_cat';
+
+		$categories = get_terms( $args );
 
 		if ( ! is_array( $categories ) || empty( $categories ) ) {
 			return [];

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCategoriesTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCategoriesTest.php
@@ -1,0 +1,148 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Product Categories List block type.
+ */
+class ProductCategoriesTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Category term IDs created for the tests, keyed by name.
+	 *
+	 * @var array<string, int>
+	 */
+	private $categories = array();
+
+	/**
+	 * Set up a small category tree with one product per leaf category.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->categories['Apparel']     = $this->create_category( 'Apparel' );
+		$this->categories['Hats']        = $this->create_category( 'Hats', $this->categories['Apparel'] );
+		$this->categories['Memberships'] = $this->create_category( 'Memberships' );
+		$this->categories['Events']      = $this->create_category( 'Events' );
+
+		foreach ( array( 'Hats', 'Memberships', 'Events' ) as $name ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_category_ids( array( $this->categories[ $name ] ) );
+			$product->save();
+		}
+
+		wc_recount_all_terms();
+		delete_transient( 'wc_term_counts' );
+	}
+
+	/**
+	 * @testdox Should let the query args filter exclude a category and its descendants.
+	 */
+	public function test_query_args_filter_can_exclude_a_category_tree(): void {
+		$excluded = array( $this->categories['Apparel'], $this->categories['Memberships'] );
+		add_filter(
+			'woocommerce_blocks_product_categories_query_args',
+			function ( $args ) use ( $excluded ) {
+				$args['exclude_tree'] = $excluded;
+				return $args;
+			}
+		);
+
+		$output = $this->render_block();
+
+		$this->assertStringContainsString( $this->item_name_markup( 'Events' ), $output, 'Events should still be rendered.' );
+		foreach ( array( 'Apparel', 'Hats', 'Memberships' ) as $name ) {
+			$this->assertStringNotContainsString( $this->item_name_markup( $name ), $output, "$name should be excluded." );
+		}
+	}
+
+	/**
+	 * @testdox Should pass the block attributes to the query args filter.
+	 */
+	public function test_query_args_filter_receives_block_attributes(): void {
+		$received = null;
+		add_filter(
+			'woocommerce_blocks_product_categories_query_args',
+			function ( $args, $attributes ) use ( &$received ) {
+				$received = $attributes;
+				return $args;
+			},
+			10,
+			2
+		);
+
+		$this->render_block( '{"hasCount":false,"isDropdown":true}' );
+
+		$this->assertIsArray( $received, 'The filter should receive the block attributes.' );
+		$this->assertFalse( $received['hasCount'], 'hasCount should reflect the block markup.' );
+		$this->assertTrue( $received['isDropdown'], 'isDropdown should reflect the block markup.' );
+	}
+
+	/**
+	 * @testdox Should ignore a non-array filter return value and keep the default query.
+	 */
+	public function test_non_array_filter_return_falls_back_to_defaults(): void {
+		add_filter( 'woocommerce_blocks_product_categories_query_args', '__return_false' );
+
+		$output = $this->render_block();
+
+		foreach ( array( 'Apparel', 'Hats', 'Memberships', 'Events' ) as $name ) {
+			$this->assertStringContainsString( $this->item_name_markup( $name ), $output, "$name should be rendered." );
+		}
+	}
+
+	/**
+	 * @testdox Should keep querying product categories even if the filter changes the taxonomy.
+	 */
+	public function test_filter_cannot_change_the_taxonomy(): void {
+		add_filter(
+			'woocommerce_blocks_product_categories_query_args',
+			function ( $args ) {
+				$args['taxonomy'] = 'category';
+				return $args;
+			}
+		);
+
+		$output = $this->render_block();
+
+		$this->assertStringContainsString( $this->item_name_markup( 'Events' ), $output, 'Product categories should still be rendered.' );
+	}
+
+	/**
+	 * Render the block via do_blocks().
+	 *
+	 * @param string $attrs_json JSON object string for block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render_block( string $attrs_json = '' ): string {
+		$attrs = '' !== $attrs_json ? ' ' . $attrs_json : '';
+		return do_blocks( "<!-- wp:woocommerce/product-categories{$attrs} /-->" );
+	}
+
+	/**
+	 * Markup fragment that identifies a rendered list item by category name.
+	 *
+	 * @param string $name Category name.
+	 * @return string
+	 */
+	private function item_name_markup( string $name ): string {
+		return 'list-item__name">' . $name . '</span>';
+	}
+
+	/**
+	 * Create a product category term.
+	 *
+	 * @param string $name      Term name.
+	 * @param int    $parent_id Parent term ID.
+	 * @return int Term ID.
+	 */
+	private function create_category( string $name, int $parent_id = 0 ): int {
+		$term = wp_insert_term( $name, 'product_cat', array( 'parent' => $parent_id ) );
+		$this->assertIsArray( $term, "Category $name should be created." );
+		return (int) $term['term_id'];
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCategoriesTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCategoriesTest.php
@@ -61,14 +61,16 @@ class ProductCategoriesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should pass the block attributes to the query args filter.
+	 * @testdox Should pass the default query args and the block attributes to the filter.
 	 */
-	public function test_query_args_filter_receives_block_attributes(): void {
-		$received = null;
+	public function test_query_args_filter_receives_query_args_and_block_attributes(): void {
+		$received_args       = null;
+		$received_attributes = null;
 		add_filter(
 			'woocommerce_blocks_product_categories_query_args',
-			function ( $args, $attributes ) use ( &$received ) {
-				$received = $attributes;
+			function ( $args, $attributes ) use ( &$received_args, &$received_attributes ) {
+				$received_args       = $args;
+				$received_attributes = $attributes;
 				return $args;
 			},
 			10,
@@ -77,9 +79,16 @@ class ProductCategoriesTest extends WC_Unit_Test_Case {
 
 		$this->render_block( '{"hasCount":false,"isDropdown":true}' );
 
-		$this->assertIsArray( $received, 'The filter should receive the block attributes.' );
-		$this->assertFalse( $received['hasCount'], 'hasCount should reflect the block markup.' );
-		$this->assertTrue( $received['isDropdown'], 'isDropdown should reflect the block markup.' );
+		$this->assertIsArray( $received_args, 'The filter should receive the query args.' );
+		$this->assertSame( 'product_cat', $received_args['taxonomy'], 'The taxonomy should be product_cat.' );
+		$this->assertTrue( $received_args['hide_empty'], 'Empty categories should be hidden by default.' );
+		$this->assertTrue( $received_args['pad_counts'], 'Counts should be padded.' );
+		$this->assertTrue( $received_args['hierarchical'], 'The query should be hierarchical.' );
+		$this->assertArrayNotHasKey( 'child_of', $received_args, 'child_of should only be set on category archives.' );
+
+		$this->assertIsArray( $received_attributes, 'The filter should receive the block attributes.' );
+		$this->assertFalse( $received_attributes['hasCount'], 'hasCount should reflect the block markup.' );
+		$this->assertTrue( $received_attributes['isDropdown'], 'isDropdown should reflect the block markup.' );
 	}
 
 	/**
@@ -96,13 +105,14 @@ class ProductCategoriesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should keep querying product categories even if the filter changes the taxonomy.
+	 * @testdox Should keep querying full product category objects even if the filter changes the taxonomy or fields.
 	 */
-	public function test_filter_cannot_change_the_taxonomy(): void {
+	public function test_filter_cannot_change_the_taxonomy_or_fields(): void {
 		add_filter(
 			'woocommerce_blocks_product_categories_query_args',
 			function ( $args ) {
 				$args['taxonomy'] = 'category';
+				$args['fields']   = 'ids';
 				return $args;
 			}
 		);
@@ -110,6 +120,47 @@ class ProductCategoriesTest extends WC_Unit_Test_Case {
 		$output = $this->render_block();
 
 		$this->assertStringContainsString( $this->item_name_markup( 'Events' ), $output, 'Product categories should still be rendered.' );
+	}
+
+	/**
+	 * @testdox Should show the children of an excluded parent at the top level.
+	 */
+	public function test_excluding_a_parent_keeps_its_children_at_the_top_level(): void {
+		$excluded = array( $this->categories['Apparel'] );
+		add_filter(
+			'woocommerce_blocks_product_categories_query_args',
+			function ( $args ) use ( $excluded ) {
+				$args['exclude'] = $excluded;
+				return $args;
+			}
+		);
+
+		$output = $this->render_block();
+
+		$this->assertStringNotContainsString( $this->item_name_markup( 'Apparel' ), $output, 'Apparel should be excluded.' );
+		$this->assertStringContainsString( $this->item_name_markup( 'Hats' ), $output, 'Hats should still be rendered.' );
+		$this->assertStringNotContainsString( 'wc-block-product-categories-list--depth-1', $output, 'Hats should be rendered at the top level.' );
+	}
+
+	/**
+	 * @testdox Should render an included child category without its parent.
+	 */
+	public function test_including_only_a_child_renders_it(): void {
+		$included = array( $this->categories['Hats'] );
+		add_filter(
+			'woocommerce_blocks_product_categories_query_args',
+			function ( $args ) use ( $included ) {
+				$args['include'] = $included;
+				return $args;
+			}
+		);
+
+		$output = $this->render_block();
+
+		$this->assertStringContainsString( $this->item_name_markup( 'Hats' ), $output, 'Hats should be rendered.' );
+		foreach ( array( 'Apparel', 'Memberships', 'Events' ) as $name ) {
+			$this->assertStringNotContainsString( $this->item_name_markup( $name ), $output, "$name should not be rendered." );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The legacy Product Categories widget lets developers adjust its category query through `woocommerce_product_categories_widget_args`. The Product Categories List block has no equivalent, so hiding a category from the block today means filtering `get_terms` for every product category query on the site.

This adds a `woocommerce_blocks_product_categories_query_args` filter around the block's `get_terms()` call. Callbacks receive the query arguments and the block attributes, so a store can, for example, use `exclude_tree` to drop a category and its children from the block only.

**Backward compatibility:** the new filter is additive. The tree-building change can alter rendered output even when no callback is attached if a parent is missing from the query result. This can happen when `product_count_product_cat` meta is stale or absent after a category is reparented, or when another plugin hides the parent through a site-wide terms filter. In those cases, the children now appear at the top level instead of disappearing. This matches how core's Walker renders orphans for `wp_list_categories`. The same handling prevents PHP warnings in children-only mode when a missing direct parent leaves a grandchild in the result. The `taxonomy` and `fields` arguments are reset after the filter runs because the block always links to product category archives and reads full term objects.

Closes #42555.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a few product categories with products, including at least one parent with a child category (for example Apparel > Hats, plus Memberships and Events).
2. Add the **Product Categories List** block to a page and confirm every category shows on the frontend.
3. Add this snippet as a mu-plugin or through a code snippets plugin, using your own category slugs:

    ```php
    add_filter( 'woocommerce_blocks_product_categories_query_args', function ( $args ) {
        $ids = array();
        foreach ( array( 'apparel', 'memberships' ) as $slug ) {
            $term = get_term_by( 'slug', $slug, 'product_cat' );
            if ( $term ) {
                $ids[] = $term->term_id;
            }
        }
        $args['exclude_tree'] = $ids;
        return $args;
    } );
    ```

4. Reload the page. The excluded categories, including the child categories of the excluded parent, are gone from the block. Toggle the block's **Dropdown** and **Hierarchical** options in the editor and confirm the same categories stay hidden in each layout.
5. Check that the categories are still present elsewhere, for example in the Product Filters block or the category admin screen. Only this block is affected.
6. Remove the snippet and confirm the block lists all categories again.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

**Automated:** new PHPUnit coverage for the filter passes, lint is clean, and PHPStan passes with the obsolete baseline entry for the old `get_terms()` call removed.

**Manual:** on a local wp-env site with a block theme, the rendered block markup was compared before and after the change across the list, dropdown, flat, hierarchical and children-only variants. Normal populated hierarchies remained unchanged with no callback. A missing parent count fixture confirmed that its child now appears at the top level instead of disappearing, and a children-only fixture confirmed that an orphaned grandchild renders without PHP warnings. With the snippet above, the excluded categories disappeared from the block while the Store API categories endpoint still returned them.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually. The single entry covers the filter and the rendering fix.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to investigate the issue, draft the change and its tests, and write this description. I reviewed and tested the result.
