### PR TITLE
Add per-taxonomy descendant control to Store API product queries

### DIFF
--- a/docs/apis/store-api/resources-endpoints/products.md
+++ b/docs/apis/store-api/resources-endpoints/products.md
@@ -36,6 +36,7 @@ GET /products?type=simple
 GET /products?sku=sku-1,sku-2
 GET /products?featured=true
 GET /products?category=22
+GET /products?category=22&taxonomy_include_children[product_cat]=false
 GET /products?brand=adidas
 GET /products?_unstable_tax_my-taxonomy=my-taxonomy-term-id
 GET /products?tag=special-items
@@ -70,6 +71,7 @@ GET /products?return_rating_counts=true
 | `sku`                                       | string  |    no    | Limit result set to products with specific SKU(s). Use commas to separate.                                                                                                                                                            |
 | `featured`                                  | boolean |    no    | Limit result set to featured products.                                                                                                                                                                                                |
 | `category`                                  | string  |    no    | Limit result set to products assigned to categories IDs or slugs, separated by commas.                                                                                                                                                |
+| `taxonomy_include_children`                 | object  |    no    | Whether to include descendants for each taxonomy filter, keyed by taxonomy name (for example, `product_cat`, `product_brand`, or `pa_color`). Values are booleans; omitted taxonomies include descendants. Applies to category, tag, brand, custom taxonomy, and attribute filters. |
 | `category_operator`                         | string  |    no    | Operator to compare product category terms. Allowed values: `in`, `not_in`, `and`                                                                                                                                                     |
 | `brand`                                     | string  |    no    | Limit result set to products assigned to brands IDs or slugs, separated by commas.                                                                                                                                                    |
 | `brand_operator`                            | string  |    no    | Operator to compare product brand terms. Allowed values: `in`, `not_in`, `and`                                                                                                                                                        |
@@ -86,6 +88,8 @@ GET /products?return_rating_counts=true
 | `catalog_visibility`                        | string  |    no    | Determines if hidden or visible catalog products are shown. Allowed values: `any`, `visible`, `catalog`, `search`, `hidden`                                                                                                           |
 | `rating`                                    | array   |    no    | Limit result set to products with a certain average rating. Allowed values: `1`, `2`, `3`, `4`, `5`.                                                                                                                                  |
 | `related`                                   | integer |    no    | Limit result set to products related to a specific product ID.                                                                                                                                                                        |
+
+Set `taxonomy_include_children[product_cat]=false` with `category=22` to match products assigned directly to category 22. Products assigned only to descendants are excluded; products assigned to both category 22 and a descendant still match. This option also applies to `/products/collection-data`.
 
 ```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products"

--- a/plugins/woocommerce/changelog/add-store-api-taxonomy-descendant-control
+++ b/plugins/woocommerce/changelog/add-store-api-taxonomy-descendant-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add optional per-taxonomy descendant control to Store API product queries.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
@@ -266,6 +266,16 @@ class Products extends AbstractRoute {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
+		$params['taxonomy_include_children'] = array(
+			'description'          => __( 'Whether to include descendants for each taxonomy filter, keyed by taxonomy name. Omitted taxonomies include descendants.', 'woocommerce' ),
+			'type'                 => 'object',
+			'additionalProperties' => array(
+				'type' => 'boolean',
+			),
+			'validate_callback'    => 'rest_validate_request_arg',
+			'sanitize_callback'    => 'rest_sanitize_request_arg',
+		);
+
 		$params['category'] = array(
 			'description'       => __( 'Limit result set to products assigned a set of category IDs or slugs, separated by commas.', 'woocommerce' ),
 			'type'              => 'string',

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -123,7 +123,8 @@ class ProductQuery implements QueryClausesGenerator {
 			'product_brand' => 'brand',
 		);
 
-		$taxonomies = array_merge( $all_product_taxonomies, $default_taxonomies );
+		$taxonomies                = array_merge( $all_product_taxonomies, $default_taxonomies );
+		$taxonomy_include_children = $request['taxonomy_include_children'] ?? array();
 
 		// Set tax_query for each passed arg.
 		foreach ( $taxonomies as $taxonomy => $key ) {
@@ -131,10 +132,11 @@ class ProductQuery implements QueryClausesGenerator {
 				$type        = is_numeric( $request[ $key ][0] ) ? 'term_id' : 'slug';
 				$operator    = $request->get_param( $key . '_operator' ) && isset( $operator_mapping[ $request->get_param( $key . '_operator' ) ] ) ? $operator_mapping[ $request->get_param( $key . '_operator' ) ] : 'IN';
 				$tax_query[] = array(
-					'taxonomy' => $taxonomy,
-					'field'    => $type,
-					'terms'    => $request[ $key ],
-					'operator' => $operator,
+					'taxonomy'         => $taxonomy,
+					'field'            => $type,
+					'terms'            => $request[ $key ],
+					'operator'         => $operator,
+					'include_children' => $taxonomy_include_children[ $taxonomy ] ?? true,
 				);
 			}
 		}
@@ -150,10 +152,11 @@ class ProductQuery implements QueryClausesGenerator {
 				if ( in_array( $attribute['attribute'], wc_get_attribute_taxonomy_names(), true ) ) {
 					$operator      = isset( $attribute['operator'], $operator_mapping[ $attribute['operator'] ] ) ? $operator_mapping[ $attribute['operator'] ] : 'IN';
 					$att_queries[] = array(
-						'taxonomy' => $attribute['attribute'],
-						'field'    => ! empty( $attribute['term_id'] ) ? 'term_id' : 'slug',
-						'terms'    => ! empty( $attribute['term_id'] ) ? $attribute['term_id'] : $attribute['slug'],
-						'operator' => $operator,
+						'taxonomy'         => $attribute['attribute'],
+						'field'            => ! empty( $attribute['term_id'] ) ? 'term_id' : 'slug',
+						'terms'            => ! empty( $attribute['term_id'] ) ? $attribute['term_id'] : $attribute['slug'],
+						'operator'         => $operator,
+						'include_children' => $taxonomy_include_children[ $attribute['attribute'] ] ?? true,
 					);
 				}
 			}

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -124,7 +124,7 @@ class ProductQuery implements QueryClausesGenerator {
 		);
 
 		$taxonomies                = array_merge( $all_product_taxonomies, $default_taxonomies );
-		$taxonomy_include_children = $request['taxonomy_include_children'] ?? array();
+		$taxonomy_include_children = is_array( $request['taxonomy_include_children'] ) ? $request['taxonomy_include_children'] : array();
 
 		// Set tax_query for each passed arg.
 		foreach ( $taxonomies as $taxonomy => $key ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -941,4 +941,201 @@ class Products extends ControllerTestCase {
 		$this->assertEquals( 404, $response->get_status() );
 		$this->assertFalse( get_transient( 'wc_related_' . $nonexistent_id ), 'No transient should be created for a non-existent product.' );
 	}
+
+	/**
+	 * @testdox Taxonomy descendant options control product membership and collection aggregates.
+	 * @dataProvider taxonomy_include_children_provider
+	 * @param string     $taxonomy Taxonomy to filter.
+	 * @param string     $parameter Request parameter for the taxonomy.
+	 * @param array|null $options Descendant options, or null to omit the parameter.
+	 * @param bool       $include_child Whether the child-only product should match.
+	 */
+	public function test_taxonomy_include_children( string $taxonomy, string $parameter, ?array $options, bool $include_child ): void {
+		$fixtures  = new FixtureData();
+		$products  = array( $this->products[0], $this->products[1], $fixtures->get_simple_product( array() ) );
+		$parent_id = self::factory()->term->create( array( 'taxonomy' => $taxonomy ) );
+		$child_id  = self::factory()->term->create(
+			array(
+				'taxonomy' => $taxonomy,
+				'parent'   => $parent_id,
+			)
+		);
+		$terms     = array( array( $parent_id ), array( $child_id ), array( $parent_id, $child_id ) );
+		$prices    = array( '17', '93', '29' );
+
+		foreach ( $products as $index => $product ) {
+			wp_set_object_terms( $product->get_id(), $terms[ $index ], $taxonomy );
+			$product->set_regular_price( $prices[ $index ] );
+			$product->set_price( $prices[ $index ] );
+			$product->save();
+		}
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( $parameter, (string) $parent_id );
+		$request->set_param( 'orderby', 'id' );
+		$request->set_param( 'order', 'asc' );
+		if ( null !== $options ) {
+			$request->set_param( 'taxonomy_include_children', $options );
+		}
+		$response = rest_get_server()->dispatch( $request );
+		$expected = array( $products[0]->get_id(), $products[2]->get_id() );
+		if ( $include_child ) {
+			$expected[] = $products[1]->get_id();
+		}
+		sort( $expected );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $expected, wp_list_pluck( $response->get_data(), 'id' ) );
+		$this->assertSame( count( $expected ), $response->get_headers()['X-WP-Total'] );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/collection-data' );
+		$request->set_param( $parameter, (string) $parent_id );
+		$request->set_param( 'calculate_price_range', true );
+		if ( null !== $options ) {
+			$request->set_param( 'taxonomy_include_children', $options );
+		}
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '1700', $data['price_range']->min_price );
+		$this->assertSame( $include_child ? '9300' : '2900', $data['price_range']->max_price );
+	}
+
+	/**
+	 * Descendant options for built-in hierarchical product taxonomies.
+	 *
+	 * @return array
+	 */
+	public function taxonomy_include_children_provider(): array {
+		$cases = array();
+		foreach ( array(
+			'product_cat'   => 'category',
+			'product_brand' => 'brand',
+		) as $taxonomy => $parameter ) {
+			$cases[ $taxonomy . ' omitted' ]       = array( $taxonomy, $parameter, null, true );
+			$cases[ $taxonomy . ' unrelated key' ] = array( $taxonomy, $parameter, array( 'product_tag' => false ), true );
+			$cases[ $taxonomy . ' false' ]         = array( $taxonomy, $parameter, array( $taxonomy => false ), false );
+			$cases[ $taxonomy . ' true' ]          = array( $taxonomy, $parameter, array( $taxonomy => true ), true );
+			$cases[ $taxonomy . ' string false' ]  = array( $taxonomy, $parameter, array( $taxonomy => 'false' ), false );
+			$cases[ $taxonomy . ' string true' ]   = array( $taxonomy, $parameter, array( $taxonomy => 'true' ), true );
+		}
+		return $cases;
+	}
+
+	/**
+	 * @testdox Both product routes reject malformed taxonomy descendant options.
+	 * @dataProvider invalid_taxonomy_include_children_provider
+	 * @param string $route Route under test.
+	 * @param mixed  $options Invalid descendant options.
+	 */
+	public function test_invalid_taxonomy_include_children( string $route, $options ): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' . $route );
+		$request->set_param( 'taxonomy_include_children', $options );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $data['code'] );
+		$this->assertArrayHasKey( 'taxonomy_include_children', $data['data']['params'] );
+	}
+
+	/**
+	 * Malformed descendant maps and values for both product routes.
+	 *
+	 * @return array
+	 */
+	public function invalid_taxonomy_include_children_provider(): array {
+		$cases = array();
+		foreach ( array( '', '/collection-data' ) as $route ) {
+			foreach ( array( 'false', array( 'product_cat' => 'invalid' ), array( 'product_cat' => array( false ) ), array( 'product_cat' => 2 ) ) as $index => $options ) {
+				$cases[ $route . ' invalid ' . $index ] = array( $route, $options );
+			}
+		}
+		return $cases;
+	}
+
+	/**
+	 * @testdox Custom taxonomy and attribute filters honor taxonomy descendant options.
+	 * @dataProvider custom_taxonomy_include_children_provider
+	 * @param bool      $is_attribute Whether to use the attribute filter.
+	 * @param bool|null $include_children Descendant option, or null to omit it.
+	 */
+	public function test_custom_taxonomy_include_children( bool $is_attribute, ?bool $include_children ): void {
+		$taxonomy     = $is_attribute ? 'pa_region' : 'region_include_children';
+		$attribute_id = $is_attribute ? wc_create_attribute(
+			array(
+				'name' => 'Region',
+				'slug' => 'region',
+			)
+		) : null;
+		register_taxonomy( $taxonomy, array( 'product' ), array( 'hierarchical' => true ) );
+
+		try {
+			$parent_id = self::factory()->term->create( array( 'taxonomy' => $taxonomy ) );
+			$child_id  = self::factory()->term->create(
+				array(
+					'taxonomy' => $taxonomy,
+					'parent'   => $parent_id,
+				)
+			);
+			wp_set_object_terms( $this->products[0]->get_id(), array( $parent_id ), $taxonomy );
+			wp_set_object_terms( $this->products[1]->get_id(), array( $child_id ), $taxonomy );
+
+			$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+			if ( $is_attribute ) {
+				$request->set_param(
+					'attributes',
+					array(
+						array(
+							'attribute' => $taxonomy,
+							'term_id'   => $parent_id,
+						),
+					)
+				);
+			} else {
+				$parameter              = '_unstable_tax_' . $taxonomy;
+				$_REQUEST[ $parameter ] = (string) $parent_id;
+				$this->initialize_store_api_server();
+				$request->set_param( $parameter, (string) $parent_id );
+			}
+			if ( null !== $include_children ) {
+				$request->set_param( 'taxonomy_include_children', array( $taxonomy => $include_children ) );
+			}
+			$request->set_param( 'orderby', 'id' );
+			$request->set_param( 'order', 'asc' );
+			$response = rest_get_server()->dispatch( $request );
+			$expected = array( $this->products[0]->get_id() );
+			if ( false !== $include_children ) {
+				$expected[] = $this->products[1]->get_id();
+			}
+			sort( $expected );
+
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertSame( $expected, wp_list_pluck( $response->get_data(), 'id' ) );
+		} finally {
+			unset( $_REQUEST[ '_unstable_tax_' . $taxonomy ] );
+			unregister_taxonomy( $taxonomy );
+			if ( $is_attribute ) {
+				wc_delete_attribute( $attribute_id );
+			}
+		}
+	}
+
+	/**
+	 * Custom taxonomy and attribute descendant options.
+	 *
+	 * @return array
+	 */
+	public function custom_taxonomy_include_children_provider(): array {
+		return array(
+			'custom omitted'    => array( false, null ),
+			'custom false'      => array( false, false ),
+			'custom true'       => array( false, true ),
+			'attribute omitted' => array( true, null ),
+			'attribute false'   => array( true, false ),
+			'attribute true'    => array( true, true ),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -1116,9 +1116,10 @@ class Products extends ControllerTestCase {
 			$this->assertSame( $expected, wp_list_pluck( $response->get_data(), 'id' ) );
 		} finally {
 			unset( $_REQUEST[ '_unstable_tax_' . $taxonomy ] );
-			unregister_taxonomy( $taxonomy );
 			if ( $is_attribute ) {
 				wc_delete_attribute( $attribute_id );
+			} else {
+				unregister_taxonomy( $taxonomy );
 			}
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ProductQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ProductQueryTest.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 
 /**
- * Unit tests for the ProductQuery::get_last_modified() caching behavior.
+ * Unit tests for ProductQuery.
  */
 class ProductQueryTest extends \WC_Unit_Test_Case {
 
@@ -213,5 +213,19 @@ class ProductQueryTest extends \WC_Unit_Test_Case {
 
 		$this->assertNotNull( $second_result );
 		$this->assertNotFalse( wp_cache_get( 'last_modified', 'wc_products' ) );
+	}
+
+	/**
+	 * @testdox prepare_objects_query ignores taxonomy descendant options that are not an array.
+	 */
+	public function test_prepare_objects_query_ignores_non_array_taxonomy_include_children(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'category', '15' );
+		$request->set_param( 'taxonomy_include_children', (object) array( 'product_cat' => false ) );
+
+		$query_args       = $this->product_query->prepare_objects_query( $request );
+		$category_clauses = wp_list_filter( $query_args['tax_query'], array( 'taxonomy' => 'product_cat' ) );
+
+		$this->assertSame( array( true ), array_column( $category_clauses, 'include_children' ), 'Descendants should stay included when the options are not an array.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->

<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->

<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR is one of three that came out of trying to handle #45370. It adds the Store API option that the editor fix in #68511 needs, and changes nothing for existing requests.

**Where this fits**

#45370 reports that Product Filters inside a Product Collection with its own query ignore the collection's saved restrictions. The fix spans three layers, so it's split into three PRs:

| PR | What it fixes | Depends on |
| --- | --- | --- |
| #68507 | Frontend filter counts ignore the collection's saved restrictions. | Nothing |
| **#68510 (this PR)** | The Store API can't match products the way the collection does. | Nothing |
| #68511 | Editor filter previews ignore the collection's saved restrictions. | This PR |

Merge this PR before #68511. #68507 is independent. #45370 stays open after all three, and #68511 lists the restrictions that remain unsupported.

**Why this PR**

- A collection with its own query matches only products assigned directly to its saved terms. WordPress core's `build_query_vars_from_query_block()` turns descendant terms off.
- Store API taxonomy filters always include descendants. A collection restricted to "Clothing" hides a product that is only in "Clothing > Shirts", but the Store API returns it.
- Editor filter previews read from the Store API, so they count products the published collection never shows. #68511 needs this option to request the collection's matching rule.

**What changed**

- Add optional `taxonomy_include_children` to Products and collection-data requests. It maps taxonomy names to booleans, so a client turns off descendants only where it needs to.
- False matches direct assignments only, for category, tag, brand, custom taxonomy and attribute filters. Attributes aren't hierarchical by default, so their keys matter only on sites that make one hierarchical.

**Compatibility**

- Omitted maps or keys keep descendants included. Response shapes, endpoints and PHP signatures stay the same.
- Invalid values return HTTP 400. Queries stay scoped to the current site, and no migration or install-path change is needed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a parent category and a child category. Assign a $17 product directly to the parent, a $93 product only to the child, and a $29 product to both.
2. Request `/wp-json/wc/store/v1/products?category=<parent-id>`. Confirm all three products are returned.
3. Add `taxonomy_include_children[product_cat]=false`. Confirm only the parent-only and both-assigned products are returned. Set it to true or omit it to restore all three.
4. Repeat with `/wp-json/wc/store/v1/products/collection-data` and `calculate_price_range=true`. For a two-decimal currency, false gives 1700–2900. True or an omitted flag gives 1700–9300.
5. Repeat with a hierarchical brand or custom taxonomy, and with an `attributes[]` clause. Use the taxonomy name as the map key.
6. Send `taxonomy_include_children[product_cat]=invalid` to both endpoints. Confirm HTTP 400.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->

<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Local API tests and real HTTP requests pass. Tested on single-site WordPress. Multisite and third-party integrations were not tested.

<details>
<summary>Tests confirm direct assignments and unchanged defaults</summary>

- The 26 new cases pass with 108 assertions. The full Products and collection-data selection passes 86 tests with 417 assertions.
- Real requests confirm product IDs and price ranges for omitted, true and false values, including products assigned to both parent and child.
- Invalid booleans return HTTP 400 on both endpoints.
- PHPStan, security scanning, PHP lint, API-document lint and changelog validation pass.
- Tests catch every generated mutation of the new filtering behavior. Two changed-line survivors alter description text only.

</details>

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->

<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->

<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

<!-- Choose only one -->

<!-- Choose only one -->

<!-- Add a changelog message here -->

<!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

The changelog entry is already committed in this branch.

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex authored the implementation, tests and description, and assisted with local review and verification.

**Review handoff**

Please review the new public request parameter and its default behavior. Independent human review is required before merging.

