### PR TITLE
Scope Product Filter editor data to local collection taxonomies

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-filter-local-collection-context
+++ b/plugins/woocommerce/changelog/fix-product-filter-local-collection-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Scope Product Filter editor data to local Product Collection taxonomy constraints.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -35,6 +35,7 @@ import { FilterOptionItem, FilterItemFields } from '../../types';
 import { InitialDisabled } from '../../components/initial-disabled';
 import { Notice } from '../../components/notice';
 import { sortFilterOptions } from '../../utils/sort-filter-options';
+import { getProductCollectionQueryState } from '../../utils/get-product-collection-query-state';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
@@ -71,6 +72,9 @@ const Edit = ( props: EditProps ) => {
 				__experimental_visual: true,
 			},
 		} );
+	const localQueryState = getProductCollectionQueryState(
+		props.context.query
+	);
 
 	const { data: filteredCounts, isLoading: isFilterCountsLoading } =
 		useCollectionData( {
@@ -78,7 +82,7 @@ const Edit = ( props: EditProps ) => {
 				taxonomy: attributeObject?.taxonomy || '',
 				queryType,
 			},
-			queryState: {},
+			queryState: localQueryState ?? {},
 			isEditor: true,
 		} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/block-editor';
 import { useCollectionData } from '@woocommerce/base-context/hooks';
 import { __ } from '@wordpress/i18n';
+import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,13 +16,17 @@ import { __ } from '@wordpress/i18n';
 import { getAllowedBlocks } from '../../utils/get-allowed-blocks';
 import { getPriceFilterData } from './utils';
 import { InitialDisabled } from '../../components/initial-disabled';
+import { getProductCollectionQueryState } from '../../utils/get-product-collection-query-state';
 
-const Edit = () => {
+const Edit = ( props: BlockEditProps< Record< string, never > > ) => {
 	const blockProps = useBlockProps();
+	const localQueryState = getProductCollectionQueryState(
+		props.context.query
+	);
 
 	const { data, isLoading } = useCollectionData( {
 		queryPrices: true,
-		queryState: {},
+		queryState: localQueryState ?? {},
 		isEditor: true,
 	} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -33,6 +33,7 @@ import type { Attributes } from './types';
 import type { FilterItemFields } from '../../types';
 import { InitialDisabled } from '../../components/initial-disabled';
 import RatingStars from './components/rating-stars';
+import { getProductCollectionQueryState } from '../../utils/get-product-collection-query-state';
 
 const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { attributes, setAttributes, clientId } = props;
@@ -64,12 +65,15 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 		}
 	);
 
-	const [ queryState ] = useQueryStateByContext();
+	const [ globalQueryState ] = useQueryStateByContext();
+	const localQueryState = getProductCollectionQueryState(
+		props.context.query
+	);
 
 	const { data: collectionFilters, isLoading: filteredCountsLoading } =
 		useCollectionData( {
 			queryRating: true,
-			queryState,
+			queryState: localQueryState ?? globalQueryState,
 			isEditor: true,
 		} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -19,6 +19,7 @@ import { InitialDisabled } from '../../components/initial-disabled';
 import { Inspector } from './inspector';
 import type { EditProps } from './types';
 import type { FilterItemFields } from '../../types';
+import { getProductCollectionQueryState } from '../../utils/get-product-collection-query-state';
 
 const Edit = ( props: EditProps ) => {
 	const { showCounts, hideEmpty } = props.attributes;
@@ -50,10 +51,13 @@ const Edit = ( props: EditProps ) => {
 		'stockStatusOptions',
 		{}
 	);
+	const localQueryState = getProductCollectionQueryState(
+		props.context.query
+	);
 
 	const { data: filteredCounts, isLoading } = useCollectionData( {
 		queryStock: true,
-		queryState: {},
+		queryState: localQueryState ?? {},
 		isEditor: true,
 	} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -28,6 +28,8 @@ import { InitialDisabled } from '../../components/initial-disabled';
 import { Notice } from '../../components/notice';
 import { getTaxonomyLabel } from './utils';
 import { sortFilterOptions } from '../../utils/sort-filter-options';
+import { createHierarchicalList } from '../../utils/create-hierarchical-list';
+import { getProductCollectionQueryState } from '../../utils/get-product-collection-query-state';
 
 type WPTaxonomyTerm = {
 	id: number;
@@ -49,57 +51,6 @@ const EMPTY_TAXONOMY_TERMS_RESULT = Object.freeze( {
 	isTermsLoading: false,
 } );
 
-// Create hierarchical structure: parents followed by their children
-function createHierarchicalList(
-	terms: FilterOptionItem[],
-	sortOrder: string
-) {
-	const children = new Map();
-
-	// First: categorize terms by parent (numeric WP term ID)
-	terms.forEach( ( term ) => {
-		const parentId = term.parent ?? 0;
-		if ( ! children.has( parentId ) ) {
-			children.set( parentId, [] );
-		}
-		children.get( parentId ).push( term );
-	} );
-
-	// Next: sort them
-	children.keys().forEach( ( key ) => {
-		children.set(
-			key,
-			sortFilterOptions( children.get( key ), sortOrder )
-		);
-	} );
-
-	// Last: build hierarchical list
-	const result: FilterOptionItem[] = [];
-	function addTermsRecursively(
-		termList: FilterOptionItem[],
-		depth = 0,
-		visited = new Set< number >()
-	) {
-		if ( depth > 10 ) {
-			return;
-		}
-		termList.forEach( ( term ) => {
-			if ( ! term.termId || visited.has( term.termId ) ) {
-				return;
-			}
-			visited.add( term.termId );
-			result.push( { ...term, depth } );
-			const termChildren = children.get( term.termId ) || [];
-			if ( termChildren.length > 0 ) {
-				addTermsRecursively( termChildren, depth + 1, visited );
-			}
-		} );
-	}
-
-	addTermsRecursively( children.get( 0 ) );
-	return result;
-}
-
 const Edit = ( props: EditProps ) => {
 	const { attributes: blockAttributes } = props;
 
@@ -120,11 +71,36 @@ const Edit = ( props: EditProps ) => {
 	const [ isOptionsLoading, setIsOptionsLoading ] = useState< boolean >(
 		! isPreview
 	);
+	const localQueryState = getProductCollectionQueryState(
+		props.context.query
+	);
+	const { data: filteredCounts, isLoading: isFilterCountsLoading } =
+		useCollectionData( {
+			queryTaxonomy: isPreview ? undefined : taxonomy,
+			queryState: localQueryState ?? {},
+			isEditor: true,
+		} );
+	const shouldScopeTerms = localQueryState !== null && hideEmpty;
+	const includedTermIds =
+		shouldScopeTerms &&
+		objectHasProp( filteredCounts, 'taxonomy_counts' ) &&
+		Array.isArray( filteredCounts.taxonomy_counts )
+			? filteredCounts.taxonomy_counts
+					.filter( ( { count } ) => count > 0 )
+					.map( ( { term } ) => term )
+					.sort( ( a, b ) => a - b )
+					.join( ',' )
+			: '';
 
 	// Fetch taxonomy terms using WordPress core data
 	const { taxonomyTerms, isTermsLoading } = useSelect(
 		( select ) => {
-			if ( isPreview || ! taxonomy ) {
+			if (
+				isPreview ||
+				! taxonomy ||
+				( shouldScopeTerms &&
+					( isFilterCountsLoading || ! includedTermIds ) )
+			) {
 				return EMPTY_TAXONOMY_TERMS_RESULT;
 			}
 
@@ -132,7 +108,8 @@ const Edit = ( props: EditProps ) => {
 				select( coreStore );
 
 			const selectArgs = {
-				per_page: 15,
+				per_page: shouldScopeTerms ? -1 : 15,
+				...( shouldScopeTerms && { include: includedTermIds } ),
 				hide_empty: hideEmpty,
 				orderby: 'name',
 				order: 'asc',
@@ -149,16 +126,15 @@ const Edit = ( props: EditProps ) => {
 				] ),
 			};
 		},
-		[ taxonomy, hideEmpty, isPreview ]
+		[
+			taxonomy,
+			hideEmpty,
+			isPreview,
+			shouldScopeTerms,
+			isFilterCountsLoading,
+			includedTermIds,
+		]
 	);
-
-	// Fetch taxonomy counts using the updated useCollectionData hook
-	const { data: filteredCounts, isLoading: isFilterCountsLoading } =
-		useCollectionData( {
-			queryTaxonomy: isPreview ? undefined : taxonomy,
-			queryState: {},
-			isEditor: true,
-		} );
 
 	useEffect( () => {
 		if ( isPreview ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/create-hierarchical-list.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/create-hierarchical-list.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import type { FilterOptionItem } from '../types';
+import { sortFilterOptions } from './sort-filter-options';
+
+/**
+ * Sorts taxonomy options with parents followed by their matching descendants.
+ */
+export function createHierarchicalList(
+	terms: FilterOptionItem[],
+	sortOrder: string
+) {
+	const children = new Map();
+	const termIds = new Set( terms.map( ( term ) => term.termId ) );
+
+	// First: categorize terms by parent (numeric WP term ID)
+	terms.forEach( ( term ) => {
+		const parentId =
+			term.parent && termIds.has( term.parent ) ? term.parent : 0;
+		if ( ! children.has( parentId ) ) {
+			children.set( parentId, [] );
+		}
+		children.get( parentId ).push( term );
+	} );
+
+	// Next: sort them
+	children.keys().forEach( ( key ) => {
+		children.set(
+			key,
+			sortFilterOptions( children.get( key ), sortOrder )
+		);
+	} );
+
+	// Last: build hierarchical list
+	const result: FilterOptionItem[] = [];
+	function addTermsRecursively(
+		termList: FilterOptionItem[],
+		depth = 0,
+		visited = new Set< number >()
+	) {
+		if ( depth > 10 ) {
+			return;
+		}
+		termList.forEach( ( term ) => {
+			if ( ! term.termId || visited.has( term.termId ) ) {
+				return;
+			}
+			visited.add( term.termId );
+			result.push( { ...term, depth } );
+			const termChildren = children.get( term.termId ) || [];
+			if ( termChildren.length > 0 ) {
+				addTermsRecursively( termChildren, depth + 1, visited );
+			}
+		} );
+	}
+
+	addTermsRecursively( children.get( 0 ) ?? [] );
+	return result;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/get-product-collection-query-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/get-product-collection-query-state.ts
@@ -1,0 +1,156 @@
+type ProductCollectionQueryState = Record< string, string >;
+
+const isRecord = ( value: unknown ): value is Record< string, unknown > =>
+	typeof value === 'object' && value !== null && ! Array.isArray( value );
+
+const isValidTaxonomySlug = ( value: unknown ): value is string =>
+	typeof value === 'string' && /^[a-z0-9_-]+$/.test( value );
+
+const productCollectionTaxQueryExclusions = new Set( [
+	'product_shipping_class',
+	'product_visibility',
+] );
+
+const getValidIds = ( value: unknown ): number[] => {
+	if ( ! Array.isArray( value ) ) {
+		return [];
+	}
+
+	return [
+		...new Set(
+			value.filter(
+				( termId ): termId is number =>
+					typeof termId === 'number' &&
+					Number.isInteger( termId ) &&
+					termId > 0
+			)
+		),
+	].sort( ( a, b ) => a - b );
+};
+
+const getTaxQueryTerms = ( value: unknown ): Map< string, number[] > => {
+	const terms = new Map< string, number[] >();
+
+	if ( ! isRecord( value ) ) {
+		return terms;
+	}
+
+	Object.entries( value ).forEach( ( [ taxonomy, termIds ] ) => {
+		const validTermIds = getValidIds( termIds );
+
+		if (
+			isValidTaxonomySlug( taxonomy ) &&
+			! productCollectionTaxQueryExclusions.has( taxonomy ) &&
+			validTermIds.length
+		) {
+			terms.set( taxonomy, validTermIds );
+		}
+	} );
+
+	return terms;
+};
+
+const getAttributeTerms = ( value: unknown ): Map< string, number[] > => {
+	const groupedTerms = new Map< string, Set< number > >();
+
+	if ( ! Array.isArray( value ) ) {
+		return new Map();
+	}
+
+	value.forEach( ( attribute ) => {
+		if ( ! isRecord( attribute ) ) {
+			return;
+		}
+
+		const { taxonomy, termId } = attribute;
+		if (
+			! isValidTaxonomySlug( taxonomy ) ||
+			typeof termId !== 'number' ||
+			! Number.isInteger( termId ) ||
+			termId <= 0
+		) {
+			return;
+		}
+
+		if ( ! groupedTerms.has( taxonomy ) ) {
+			groupedTerms.set( taxonomy, new Set() );
+		}
+		groupedTerms.get( taxonomy )?.add( termId );
+	} );
+
+	return new Map(
+		[ ...groupedTerms.entries() ].map( ( [ taxonomy, termIds ] ) => [
+			taxonomy,
+			[ ...termIds ].sort( ( a, b ) => a - b ),
+		] )
+	);
+};
+
+const getTaxQueryParam = ( taxonomy: string ): string => {
+	switch ( taxonomy ) {
+		case 'product_cat':
+			return 'category';
+		case 'product_tag':
+			return 'tag';
+		case 'product_brand':
+			return 'brand';
+		default:
+			return `_unstable_tax_${ taxonomy }`;
+	}
+};
+
+/**
+ * Adapts representable local Product Collection constraints to Store API query state.
+ *
+ * @param query Inherited query context.
+ * @return Query state, or null for an unrecognized query context.
+ */
+export const getProductCollectionQueryState = (
+	query: unknown
+): ProductCollectionQueryState | null => {
+	if (
+		! isRecord( query ) ||
+		query.isProductCollectionBlock !== true ||
+		query.inherit !== false
+	) {
+		return null;
+	}
+
+	const taxQueryTerms = getTaxQueryTerms( query.taxQuery );
+	const attributeTerms = getAttributeTerms( query.woocommerceAttributes );
+	const taxonomies = [
+		...new Set( [ ...taxQueryTerms.keys(), ...attributeTerms.keys() ] ),
+	].sort();
+	const queryState: ProductCollectionQueryState = {};
+
+	taxonomies.forEach( ( taxonomy ) => {
+		const hasTaxQueryTerms = taxQueryTerms.has( taxonomy );
+		const hasAttributeTerms = attributeTerms.has( taxonomy );
+
+		if (
+			hasTaxQueryTerms &&
+			hasAttributeTerms &&
+			taxQueryTerms.get( taxonomy )?.join( ',' ) !==
+				attributeTerms.get( taxonomy )?.join( ',' )
+		) {
+			// Independent IN groups cannot generally be flattened into one clause.
+			return;
+		}
+
+		const termIds = hasTaxQueryTerms
+			? taxQueryTerms.get( taxonomy )
+			: attributeTerms.get( taxonomy );
+		const param = getTaxQueryParam( taxonomy );
+		if ( param.endsWith( '_operator' ) ) {
+			// Store API reserves this suffix for operator enum parameters.
+			return;
+		}
+
+		queryState[ param ] = termIds?.join( ',' ) ?? '';
+		if ( hasTaxQueryTerms ) {
+			queryState[ `taxonomy_include_children[${ taxonomy }]` ] = 'false';
+		}
+	} );
+
+	return queryState;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/test/create-hierarchical-list.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/test/create-hierarchical-list.ts
@@ -1,0 +1,67 @@
+/**
+ * Internal dependencies
+ */
+import { createHierarchicalList } from '../create-hierarchical-list';
+import type { FilterOptionItem } from '../../types';
+
+const createTerm = (
+	termId: number,
+	label: string,
+	parent = 0
+): FilterOptionItem => ( {
+	id: String( termId ),
+	termId,
+	label,
+	value: label,
+	selected: false,
+	parent,
+} );
+
+describe( 'createHierarchicalList', () => {
+	it( 'returns an empty list when no terms match', () => {
+		expect( createHierarchicalList( [], 'name-asc' ) ).toEqual( [] );
+	} );
+
+	it( 'retains a matching child when its parent is absent', () => {
+		const root = createTerm( 1, 'Clothing' );
+		const orphan = createTerm( 3, 'Hoodies', 2 );
+		const grandchild = createTerm( 4, 'Zip hoodies', 3 );
+
+		expect(
+			createHierarchicalList( [ grandchild, orphan, root ], 'name-asc' )
+		).toEqual( [
+			{ ...root, depth: 0 },
+			{ ...orphan, depth: 0 },
+			{ ...grandchild, depth: 1 },
+		] );
+	} );
+
+	it( 'retains matching terms when every parent is absent', () => {
+		const orphan = createTerm( 3, 'Hoodies', 2 );
+
+		expect( createHierarchicalList( [ orphan ], 'name-asc' ) ).toEqual( [
+			{ ...orphan, depth: 0 },
+		] );
+	} );
+
+	it( 'sorts siblings while keeping descendants after their parent', () => {
+		const root = createTerm( 1, 'Clothing' );
+		const otherRoot = createTerm( 2, 'Accessories' );
+		const child = createTerm( 3, 'Hoodies', 1 );
+		const otherChild = createTerm( 4, 'T-shirts', 1 );
+		const grandchild = createTerm( 5, 'Zip hoodies', 3 );
+
+		expect(
+			createHierarchicalList(
+				[ otherChild, grandchild, root, child, otherRoot ],
+				'name-desc'
+			)
+		).toEqual( [
+			{ ...root, depth: 0 },
+			{ ...otherChild, depth: 1 },
+			{ ...child, depth: 1 },
+			{ ...grandchild, depth: 2 },
+			{ ...otherRoot, depth: 0 },
+		] );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/test/get-product-collection-query-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/test/get-product-collection-query-state.ts
@@ -1,0 +1,303 @@
+/**
+ * Internal dependencies
+ */
+import { getProductCollectionQueryState } from '../get-product-collection-query-state';
+
+const localProductCollectionQuery = {
+	isProductCollectionBlock: true,
+	inherit: false,
+};
+
+describe( 'getProductCollectionQueryState', () => {
+	it.each( [
+		undefined,
+		null,
+		'query',
+		[],
+		{},
+		{ inherit: false },
+		{ isProductCollectionBlock: true },
+		{ isProductCollectionBlock: false, inherit: false },
+		{ isProductCollectionBlock: true, inherit: true },
+		{ postType: 'product', inherit: false },
+	] )( 'returns null for an unrecognized query context', ( query ) => {
+		expect( getProductCollectionQueryState( query ) ).toBeNull();
+	} );
+
+	it.each( [
+		localProductCollectionQuery,
+		{
+			...localProductCollectionQuery,
+			search: 'example',
+			featured: false,
+			orderBy: 'date',
+		},
+		{
+			...localProductCollectionQuery,
+			taxQuery: [],
+			woocommerceAttributes: {},
+		},
+	] )(
+		'returns an empty query state when no taxonomy boundary is safely representable',
+		( query ) => {
+			expect( getProductCollectionQueryState( query ) ).toStrictEqual(
+				{}
+			);
+		}
+	);
+
+	it( 'maps built-in product taxonomies to their Store API parameters', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				product_cat: [ 8, 2, 8 ],
+				product_tag: [ 5 ],
+				product_brand: [ 13 ],
+			},
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			brand: '13',
+			category: '2,8',
+			tag: '5',
+			'taxonomy_include_children[product_brand]': 'false',
+			'taxonomy_include_children[product_cat]': 'false',
+			'taxonomy_include_children[product_tag]': 'false',
+		} );
+	} );
+
+	it( 'maps custom taxonomies to unstable Store API taxonomy parameters', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				product_material: [ 21, 3 ],
+			},
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_product_material: '3,21',
+			'taxonomy_include_children[product_material]': 'false',
+		} );
+	} );
+
+	it( 'ignores Product Collection taxQuery exclusions while retaining unrelated taxonomies', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				product_visibility: [ 2 ],
+				product_shipping_class: [ 3 ],
+				product_material: [ 4 ],
+			},
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_product_material: '4',
+			'taxonomy_include_children[product_material]': 'false',
+		} );
+	} );
+
+	it( 'retains Product Collection taxQuery exclusions when supplied as attributes', () => {
+		const query = {
+			...localProductCollectionQuery,
+			woocommerceAttributes: [
+				{ taxonomy: 'product_visibility', termId: 2 },
+				{ taxonomy: 'product_shipping_class', termId: 3 },
+			],
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_product_shipping_class: '3',
+			_unstable_tax_product_visibility: '2',
+		} );
+	} );
+
+	it( 'ignores empty taxonomies, malformed sources, and invalid term IDs', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				'': [ 4 ],
+				product_cat: [ -1, 0, 1.5, '2', null, 7 ],
+				product_tag: '8',
+			},
+			woocommerceAttributes: [
+				null,
+				{ termId: 2 },
+				{ taxonomy: '', termId: 3 },
+				{ taxonomy: 'pa_color', termId: -5 },
+				{ taxonomy: 'pa_color', termId: 2.5 },
+				{ taxonomy: 'pa_color', termId: '6' },
+				{ taxonomy: 'pa_color', termId: 9 },
+			],
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_pa_color: '9',
+			category: '7',
+			'taxonomy_include_children[product_cat]': 'false',
+		} );
+	} );
+
+	it( 'ignores invalid taxQuery taxonomy slugs while retaining valid lowercase slugs', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				'   ': [ 2 ],
+				'product material': [ 3 ],
+				'product/material': [ 4 ],
+				Product_Material: [ 5 ],
+				'product-material_2': [ 6 ],
+			},
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			'_unstable_tax_product-material_2': '6',
+			'taxonomy_include_children[product-material_2]': 'false',
+		} );
+	} );
+
+	it( 'ignores invalid attribute taxonomy slugs while retaining valid lowercase slugs', () => {
+		const query = {
+			...localProductCollectionQuery,
+			woocommerceAttributes: [
+				{ taxonomy: '   ', termId: 7 },
+				{ taxonomy: 'pa color', termId: 8 },
+				{ taxonomy: 'pa/color', termId: 9 },
+				{ taxonomy: 'Pa_Color', termId: 10 },
+				{ taxonomy: 'pa_color-2', termId: 11 },
+			],
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			'_unstable_tax_pa_color-2': '11',
+		} );
+	} );
+
+	it( 'groups repeated attribute entries and sorts unique term IDs', () => {
+		const query = {
+			...localProductCollectionQuery,
+			woocommerceAttributes: [
+				{ taxonomy: 'pa_size', termId: 12 },
+				{ taxonomy: 'pa_color', termId: 8 },
+				{ taxonomy: 'pa_size', termId: 3 },
+				{ taxonomy: 'pa_color', termId: 8 },
+				{ taxonomy: 'pa_size', termId: 12 },
+			],
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_pa_color: '8',
+			_unstable_tax_pa_size: '3,12',
+		} );
+	} );
+
+	it( 'keeps non-colliding taxonomies from both sources', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				product_cat: [ 4 ],
+			},
+			woocommerceAttributes: [
+				{ taxonomy: 'pa_color', termId: 6 },
+				{ taxonomy: 'pa_size', termId: 9 },
+			],
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_pa_color: '6',
+			_unstable_tax_pa_size: '9',
+			category: '4',
+			'taxonomy_include_children[product_cat]': 'false',
+		} );
+	} );
+
+	it( 'omits a taxonomy with valid terms in both sources while retaining unrelated taxonomies', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				pa_color: [ 3 ],
+				product_tag: [ 7 ],
+				product_material: [ 11 ],
+			},
+			woocommerceAttributes: [
+				{ taxonomy: 'pa_color', termId: 5 },
+				{ taxonomy: 'pa_size', termId: 13 },
+			],
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			_unstable_tax_pa_size: '13',
+			_unstable_tax_product_material: '11',
+			tag: '7',
+			'taxonomy_include_children[product_material]': 'false',
+			'taxonomy_include_children[product_tag]': 'false',
+		} );
+	} );
+
+	it( 'does not emit unsupported Product Collection query fields', () => {
+		const query = {
+			...localProductCollectionQuery,
+			taxQuery: {
+				product_cat: [ 2 ],
+			},
+			search: 'example',
+			featured: true,
+			woocommerceOnSale: true,
+			woocommerceStockStatus: [ 'instock' ],
+			woocommerceHandPickedProducts: [ 10 ],
+			priceRange: { min: 10, max: 20 },
+		};
+
+		expect( getProductCollectionQueryState( query ) ).toStrictEqual( {
+			category: '2',
+			'taxonomy_include_children[product_cat]': 'false',
+		} );
+	} );
+
+	it.each( [
+		{ taxQuery: { pa_operator: [ 9 ] } },
+		{ woocommerceAttributes: [ { taxonomy: 'pa_operator', termId: 9 } ] },
+	] )(
+		'omits taxonomy parameters reserved for Store API operators',
+		( source ) => {
+			expect(
+				getProductCollectionQueryState( {
+					...localProductCollectionQuery,
+					...source,
+					taxQuery: { ...source.taxQuery, product_cat: [ 2 ] },
+				} )
+			).toStrictEqual( {
+				category: '2',
+				'taxonomy_include_children[product_cat]': 'false',
+			} );
+		}
+	);
+
+	it( 'uses built-in taxonomy parameters for attribute-sourced constraints', () => {
+		expect(
+			getProductCollectionQueryState( {
+				...localProductCollectionQuery,
+				woocommerceAttributes: [
+					{ taxonomy: 'product_cat', termId: 2 },
+					{ taxonomy: 'product_tag', termId: 3 },
+					{ taxonomy: 'product_brand', termId: 4 },
+				],
+			} )
+		).toStrictEqual( { category: '2', tag: '3', brand: '4' } );
+	} );
+
+	it( 'preserves identical constraints from both sources', () => {
+		expect(
+			getProductCollectionQueryState( {
+				...localProductCollectionQuery,
+				taxQuery: { pa_color: [ 5, 3, 5 ] },
+				woocommerceAttributes: [
+					{ taxonomy: 'pa_color', termId: 3 },
+					{ taxonomy: 'pa_color', termId: 5 },
+				],
+			} )
+		).toStrictEqual( {
+			_unstable_tax_pa_color: '3,5',
+			'taxonomy_include_children[pa_color]': 'false',
+		} );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/inspector-controls.block_theme.spec.ts
@@ -1,12 +1,63 @@
 /**
  * External dependencies
  */
+import type { Request } from '@playwright/test';
 import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
  */
 import ProductCollectionPage, { SELECTORS } from './product-collection.page';
+
+const COLLECTION_DATA_PATH = '/wc/store/v1/products/collection-data';
+const COLLECTION_DATA_CALCULATION_FAMILIES = [
+	'calculate_attribute_counts',
+	'calculate_price_range',
+	'calculate_stock_status_counts',
+	'calculate_rating_counts',
+	'calculate_taxonomy_counts',
+] as const;
+
+const isCollectionDataRequest = ( request: Request ) =>
+	new URL( request.url() ).pathname.endsWith( COLLECTION_DATA_PATH );
+
+const hasQueryParameterFamily = (
+	searchParams: URLSearchParams,
+	parameter: string
+) => {
+	let hasParameter = false;
+	searchParams.forEach( ( _value, key ) => {
+		if ( key === parameter || key.startsWith( `${ parameter }[` ) ) {
+			hasParameter = true;
+		}
+	} );
+	return hasParameter;
+};
+
+const isColorAggregateCollectionDataRequest = ( request: Request ) => {
+	if ( ! isCollectionDataRequest( request ) ) {
+		return false;
+	}
+
+	const searchParams = new URL( request.url() ).searchParams;
+	let calculatesColorAttributeCounts = false;
+	searchParams.forEach( ( value, key ) => {
+		if (
+			key.startsWith( 'calculate_attribute_counts' ) &&
+			key.endsWith( '[taxonomy]' ) &&
+			value === 'pa_color'
+		) {
+			calculatesColorAttributeCounts = true;
+		}
+	} );
+
+	return (
+		calculatesColorAttributeCounts &&
+		COLLECTION_DATA_CALCULATION_FAMILIES.every( ( calculation ) =>
+			hasQueryParameterFamily( searchParams, calculation )
+		)
+	);
+};
 
 const test = base.extend< { pageObject: ProductCollectionPage } >( {
 	pageObject: async ( { page, admin, editor }, use ) => {
@@ -662,7 +713,12 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 			await expect( pageObject.products ).toHaveCount( 9 );
 
 			await pageObject.addFilter( 'Show product categories' );
-			await pageObject.checkTaxonomyTerm( 'categories', 'Music' );
+			await pageObject
+				.locateSidebarSettings()
+				.getByRole( 'treeitem', { name: /Clothing/ } )
+				.press( 'Enter' );
+			await pageObject.checkTaxonomyTerm( 'categories', 'Hoodies' );
+			await expect( pageObject.products ).toHaveCount( 3 );
 
 			const productCollectionBlock = await editor.getBlockByName(
 				'woocommerce/product-collection'
@@ -671,25 +727,93 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 				( await productCollectionBlock
 					.last()
 					.getAttribute( 'data-block' ) ) ?? '';
-			await editor.insertBlock(
-				{ name: 'woocommerce/product-filters' },
-				{ clientId: productCollectionClientId }
+			const selectedCategoryIds = await page.evaluate(
+				( clientId ) =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.getBlock( clientId ).attributes.query.taxQuery
+						.product_cat,
+				productCollectionClientId
 			);
+			expect( selectedCategoryIds ).toHaveLength( 1 );
+			const selectedCategoryId = selectedCategoryIds[ 0 ];
+			expect( selectedCategoryId ).toEqual( expect.any( Number ) );
 
-			await expect( pageObject.products ).toHaveCount( 2 );
+			const observedRequests: Request[] = [];
+			const captureRequest = ( request: Request ) =>
+				observedRequests.push( request );
+			page.on( 'request', captureRequest );
+
+			try {
+				await editor.insertBlock(
+					{ name: 'woocommerce/product-filters' },
+					{ clientId: productCollectionClientId }
+				);
+
+				const colorFilter = await editor.getBlockByName(
+					'woocommerce/product-filter-attribute'
+				);
+				const colorFilterOptions = colorFilter.locator(
+					'.wc-block-product-filter-checkbox-list'
+				);
+				await expect( colorFilterOptions ).not.toHaveClass(
+					/is-loading/
+				);
+				await expect(
+					colorFilterOptions.getByText( 'Blue', { exact: true } )
+				).toBeVisible();
+				await expect(
+					colorFilterOptions.getByText( 'Yellow', { exact: true } )
+				).toHaveCount( 0 );
+				const categoryFilter = await editor.getBlockByName(
+					'woocommerce/product-filter-taxonomy'
+				);
+				await expect(
+					categoryFilter.getByText( 'Hoodies', { exact: true } )
+				).toBeVisible();
+				await expect(
+					categoryFilter.getByText( 'Music', { exact: true } )
+				).toHaveCount( 0 );
+
+				await expect
+					.poll( () =>
+						observedRequests.some(
+							isColorAggregateCollectionDataRequest
+						)
+					)
+					.toBe( true );
+
+				const collectionDataRequests = observedRequests.filter(
+					isCollectionDataRequest
+				);
+				for ( const request of collectionDataRequests ) {
+					expect(
+						new URL( request.url() ).searchParams.get( 'category' )
+					).toBe( selectedCategoryId.toString() );
+					expect(
+						new URL( request.url() ).searchParams.get(
+							'taxonomy_include_children[product_cat]'
+						)
+					).toBe( 'false' );
+				}
+			} finally {
+				page.off( 'request', captureRequest );
+			}
+
+			await expect( pageObject.products ).toHaveCount( 3 );
 
 			const postId = await editor.publishPost();
 			await page.goto( `/?p=${ postId }` );
 			await pageObject.refreshLocators( 'frontend' );
 
-			await expect( pageObject.products ).toHaveCount( 2 );
+			await expect( pageObject.products ).toHaveCount( 3 );
 
 			await page
 				.getByRole( 'textbox', {
 					name: 'Filter products by maximum price',
 				} )
 				.dblclick();
-			await page.keyboard.type( '5' );
+			await page.keyboard.type( '44' );
 			await page.keyboard.press( 'Tab' );
 
 			await expect( pageObject.products ).toHaveCount( 1 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->

<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->

<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR is one of three that came out of fixing #45370. It fixes the editor filter previews.

**Where this fits**

#45370 reports that Product Filters inside a Product Collection with its own query ignore the collection's saved restrictions. The fix spans three layers, so it's split into three PRs:

| PR | What it fixes | Depends on |
| --- | --- | --- |
| #68507 | Frontend filter counts ignore the collection's saved restrictions. | Nothing |
| #68510 | The Store API can't match products the way the collection does. | Nothing |
| **#68511 (this PR)** | Editor filter previews ignore the collection's saved restrictions. | #68510 |

Merge #68510 first, then rebase this branch onto trunk and retarget this PR. #68507 is independent. This PR doesn't close #45370 (see What's deferred).

**Why this PR**

- In the editor, every Product Filter asked the Store API for data without the collection's query. Price, rating, stock, attribute and taxonomy previews ignored the collection's restrictions.
- Bug introduced in [Blocks PR #12022](https://github.com/woocommerce/woocommerce-blocks/pull/12022), which removed the scoped editor requests. PR #59609 added taxonomy previews the same way.

**What changed**

- Add a query adapter that turns the collection's saved categories, tags, brands, custom taxonomies and attributes into Store API parameters. All five filter previews use it.
- Saved taxonomy terms go out with `taxonomy_include_children[<taxonomy>]=false` from #68510, so child-only products stay out, as on the published page.
- With empty terms hidden, taxonomy previews fetch the terms that have products in the scoped counts. The old first-15-by-name fetch could miss the collection's terms. Empty results and orphaned child terms no longer break the preview.
- Inherited collections and standalone filters send the same requests as before. No public signatures, migrations or install-path changes.

**What's deferred**

- Featured and hand-picked products, visibility, search, price, sale, stock, exclusions, timeframe and collection-specific query rules aren't sent as restrictions yet.
- If the collection restricts one taxonomy two different ways, through its taxonomy and attribute settings, the adapter skips that taxonomy.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Build Blocks assets and open the post editor on a store with products in several categories.
2. Insert a Product Collection, disable query inheritance and restrict it to one category. Add Product Filters inside it.
3. Confirm price, rating, stock, attribute and taxonomy previews use only products matching that saved restriction. Each collection-data request should include the selected category and `taxonomy_include_children[product_cat]=false`.
4. Add a product only to a child category. Confirm selecting the parent does not include that product in the previews.
5. Select a populated category beyond the first 15 alphabetic terms, then an empty category. Confirm the populated option appears and the empty result does not crash.
6. Add nested and sibling local collections with different categories. Confirm each filter uses its nearest collection. Check inherited collections and standalone filters for unchanged behavior.
7. Publish and confirm product filtering still works.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->

<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Local JavaScript tests, the editor browser scenario and the Blocks build pass. Tested on single-site WordPress with a block theme. Multisite and third-party integrations were not tested.

Full-project TypeScript still fails on existing errors, with no new diagnostic locations, codes or summaries. Advisory sort warnings and existing lint warnings remain.

<details>
<summary>Editor checks pass with the API dependency alone</summary>

- All 74 Product Filters tests pass, including 28 query-adapter tests.
- Disabling the adapter causes 25 test failures. Restoring it makes the focused suite pass.
- The browser scenario passes with #68510 and this PR, without the frontend repair in #68507.
- Actual requests respect saved category and attribute restrictions and omit deferred featured and hand-picked parameters.
- Published product and price filtering still work. Formatting, browser-test discovery, scoped lint and changelog validation pass.

</details>

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->

<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->

<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

<!-- Choose only one -->

<!-- Choose only one -->

<!-- Add a changelog message here -->

<!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

The changelog entry is already committed in this branch.

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex authored the implementation, tests and description, and assisted with local review and verification.

**Review handoff**

Please review the taxonomy-only scope and remaining gaps. Independent human review is required before merging, after #68510 lands.

