### PR TITLE
Fix product attribute Term ID sorting

### DIFF
--- a/plugins/woocommerce/changelog/fix-45521-attribute-term-id-order
+++ b/plugins/woocommerce/changelog/fix-45521-attribute-term-id-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor the Term ID sort order for product attribute terms and variation dropdowns.

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -37,6 +37,9 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 	// Change defaults. Invalid values will be changed later @see wc_change_pre_get_terms.
 	// These are in place so we know if a specific order was requested.
 	switch ( $orderby ) {
+		case 'id':
+			$defaults['orderby'] = 'term_id';
+			break;
 		case 'menu_order':
 		case 'name_num':
 		case 'parent':

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -87,6 +87,35 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should honor the attribute's Term ID default without overriding explicit query ordering.
+	 */
+	public function test_attribute_term_id_ordering(): void {
+		global $wc_product_attributes;
+
+		$original_attributes = $wc_product_attributes;
+		$attribute           = WC_Helper_Product::create_attribute( 'id_sort_test', array( 'Zebra', 'Apple', 'Mango' ) );
+		$taxonomy            = $attribute['attribute_taxonomy'];
+		try {
+			wc_update_attribute( $attribute['attribute_id'], array( 'order_by' => 'id' ) );
+			$product_id = $this->products['product1']->get_id();
+			wp_set_object_terms( $product_id, $attribute['term_ids'], $taxonomy );
+
+			$args = array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+				'fields'     => 'names',
+			);
+			$this->assertSame( array( 'Zebra', 'Apple', 'Mango' ), get_terms( $args ), 'Default queries should honor the saved Term ID setting.' );
+			$this->assertSame( array( 'Zebra', 'Apple', 'Mango' ), wc_get_product_terms( $product_id, $taxonomy, array( 'fields' => 'names' ) ), 'Product term queries should use the same default ordering.' );
+			$this->assertSame( array( 'Apple', 'Mango', 'Zebra' ), get_terms( array_merge( $args, array( 'orderby' => 'name' ) ) ), 'An explicit ordering should override the attribute default.' );
+			$this->assertSame( array( 'Mango', 'Apple', 'Zebra' ), get_terms( array_merge( $args, array( 'order' => 'DESC' ) ) ), 'Descending order should use term IDs too.' );
+		} finally {
+			unregister_taxonomy( $taxonomy );
+			$wc_product_attributes = $original_attributes;
+		}
+	}
+
+	/**
 	 * @testdox Term product counts with default settings.
 	 */
 	public function test_term_count_baseline(): void {


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Attributes configured with **Term ID** sorting still fall back to alphabetical order in default term queries and variation dropdowns. Map the saved `id` setting to WordPress's `term_id` query value, and cover default ordering, product term queries, explicit alphabetical ordering and descending ID order.

Closes #45521. Also addresses the duplicate #30052 and follows the fix direction in the closed #65064.

**Compatibility:** Default term queries now honour the existing Term ID setting. Stores already using this setting may see variation dropdowns and attribute tables change from alphabetical order to term ID order after updating. With a persistent object cache, previously cached product term results can retain alphabetical ordering until the cache is cleared. Saving the attribute does not clear those cached results. This is an existing cache-invalidation limitation; this PR does not change it. Explicit query ordering still takes precedence. Signatures, hook timing and arguments, stored settings, and other sorting modes are unchanged. Multisite was not separately tested.

Bug introduced in PR #22570.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. In **Products > Attributes**, create an attribute with **Default sort order = Term ID**.
2. Add terms in this order: **Zebra**, **Apple**, **Mango**. Their IDs should increase in that order.
3. Create a published variable product using this attribute, enable it for variations, and add a priced, in-stock variation for each term.
4. Open the product on the storefront. The dropdown should list **Zebra, Apple, Mango**, rather than **Apple, Mango, Zebra**.
5. Change the attribute's default sort order to **Name** and reload. Confirm the options are alphabetical again.
6. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'WC_Term_Functions_Tests|WC_Test_Taxonomies'`.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The new regression test failed before the fix and passed afterwards.
- The term-function and legacy taxonomy suites passed: **10 tests, 39 assertions** in total, using PHP 8.1 and PHPUnit 9.6.
- Browser smoke test passed on a local single-site installation with Storefront and a three-variation product: the rendered dropdown followed term ID order. Cart submission was not tested.
- PHP changed-line and branch lint, plus PHPStan on the modified production file, passed. No baseline changes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-45521-attribute-term-id-order`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex authored the fix, regression test, changelog and PR description, and ran the reported checks. Oleksandr reviewed and approved the change.
