### PR TITLE
Fix fetch_patterns failing on cron and rescheduling on each page load

### DIFF
--- a/plugins/woocommerce/changelog/fix-fetch-patterns-cron-callback
+++ b/plugins/woocommerce/changelog/fix-fetch-patterns-cron-callback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the daily patterns fetch failing under WP-Cron since 11.1.0, and stop it from being rescheduled on every page load while it keeps failing.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53148,7 +53148,7 @@ parameters:
 		-
 			message: '#^Callback expects 0 parameters, \$accepted_args is set to 2\.$#'
 			identifier: arguments.count
-			count: 3
+			count: 2
 			path: src/Blocks/Patterns/PTKPatternsStore.php
 
 		-

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -125,6 +125,10 @@ class Bootstrap {
 		$this->container->get( AssetsController::class );
 		$this->container->get( DependencyDetection::class );
 
+		// Created on every request, cron included, so the fetch_patterns callback it registers is in place
+		// when WP-Cron runs the scheduled action.
+		$this->container->get( PTKPatternsStore::class );
+
 		// Load assets in admin and on the frontend.
 		if ( ! $is_rest ) {
 			$this->add_build_notice();
@@ -146,10 +150,6 @@ class Bootstrap {
 			}
 			$this->container->get( ClassicTemplatesCompatibility::class );
 			$this->container->get( Notices::class )->init();
-
-			if ( is_admin() || $is_rest ) {
-				$this->container->get( PTKPatternsStore::class );
-			}
 
 			if ( is_admin() ) {
 				$this->container->get( TemplateOptions::class )->init();

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -17,6 +17,20 @@ class PTKPatternsStore {
 	 */
 	const FETCH_PATTERNS_ACTION = 'fetch_patterns';
 
+	/**
+	 * Transient set when a fetch is scheduled. While it exists, no further fetch is scheduled.
+	 *
+	 * @since 11.2.0
+	 */
+	const SCHEDULE_COOLDOWN_TRANSIENT = 'wc_ptk_fetch_patterns_cooldown';
+
+	/**
+	 * Minimum time between two scheduled fetches, in seconds.
+	 *
+	 * @since 11.2.0
+	 */
+	const SCHEDULE_COOLDOWN = DAY_IN_SECONDS;
+
 	const CATEGORY_MAPPING = array(
 		'testimonials' => 'reviews',
 	);
@@ -103,16 +117,27 @@ class PTKPatternsStore {
 	}
 
 	/**
-	 * Schedule an action if it's not already pending.
+	 * Schedule an action if it's not already pending and no fetch was scheduled within the cooldown.
+	 *
+	 * The cooldown guards against a failing fetch being rescheduled on every page load: a failed
+	 * action is not pending, so without it each request that finds the cache empty would queue a
+	 * new one. The first fetch is still scheduled immediately.
+	 *
+	 * @since 11.2.0 Scheduling is skipped while the cooldown transient exists.
 	 *
 	 * @param string $action The action name to schedule.
 	 * @return void
 	 */
 	private function schedule_action_if_not_pending( $action ) {
+		if ( get_transient( self::SCHEDULE_COOLDOWN_TRANSIENT ) ) {
+			return;
+		}
+
 		if ( as_has_scheduled_action( $action, array(), 'woocommerce' ) ) {
 			return;
 		}
 
+		set_transient( self::SCHEDULE_COOLDOWN_TRANSIENT, time(), self::SCHEDULE_COOLDOWN );
 		as_schedule_recurring_action( time(), DAY_IN_SECONDS, $action, array(), 'woocommerce' );
 	}
 

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -209,10 +209,12 @@ class PTKPatternsStore {
 	 * Reset the cached patterns to fetch them again from the PTK.
 	 *
 	 * @since 10.4.1 Unscheduling is deferred if Action Scheduler hasn't initialized yet.
+	 * @since 11.2.0 The scheduling cooldown is cleared so a fetch requested after the flush is not held back.
 	 * @return void
 	 */
 	public function flush_cached_patterns() {
 		delete_option( self::OPTION_NAME );
+		delete_transient( self::SCHEDULE_COOLDOWN_TRANSIENT );
 
 		if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
 			return;

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -60,7 +60,9 @@ class PTKPatternsStore {
 		// - The WooCommerce plugin is updated.
 		add_action( 'woocommerce_activated_plugin', array( $this, 'flush_or_fetch_patterns' ), 10, 2 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'flush_or_fetch_patterns' ), 10, 2 );
-		add_action( 'deactivated_plugin', array( $this, 'flush_cached_patterns' ), 10, 2 );
+		if ( defined( 'WC_PLUGIN_BASENAME' ) ) {
+			add_action( 'deactivate_' . WC_PLUGIN_BASENAME, array( $this, 'flush_cached_patterns' ) );
+		}
 		add_action( 'upgrader_process_complete', array( $this, 'fetch_patterns_on_plugin_update' ), 10, 2 );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'ensure_recurring_fetch_patterns_if_enabled' ) );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/BootstrapTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/BootstrapTest.php
@@ -3,7 +3,12 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\Domain;
 
+use Automattic\WooCommerce\Blocks\BlockPatterns;
 use Automattic\WooCommerce\Blocks\BlockTypesController;
+use Automattic\WooCommerce\Blocks\Domain\Bootstrap;
+use Automattic\WooCommerce\Blocks\Domain\Package as BlocksPackage;
+use Automattic\WooCommerce\Blocks\Patterns\PTKPatternsStore;
+use Automattic\WooCommerce\Blocks\Registry\Container;
 use WC_Unit_Test_Case;
 use WP_Block_Type_Registry;
 
@@ -367,5 +372,57 @@ HTML;
 			$registry->is_registered( self::SAMPLE_BLOCK ),
 			'Block types should remain registered and must not be re-registered on demand.'
 		);
+	}
+
+	/**
+	 * @testdox Bootstrap registers the fetch_patterns callback on cron requests while still skipping pattern registration.
+	 */
+	public function test_fetch_patterns_callback_is_registered_on_cron_requests(): void {
+		$store_callbacks_before   = $this->count_hooked_callbacks( PTKPatternsStore::FETCH_PATTERNS_ACTION, PTKPatternsStore::class );
+		$pattern_callbacks_before = $this->count_hooked_callbacks( 'init', BlockPatterns::class );
+
+		add_filter( 'wp_doing_cron', '__return_true' );
+
+		$container = new Container();
+		$container->register(
+			BlocksPackage::class,
+			function () {
+				return new BlocksPackage( 'test', dirname( WC_PLUGIN_FILE ) );
+			}
+		);
+		new Bootstrap( $container );
+
+		$this->assertSame(
+			$store_callbacks_before + 1,
+			$this->count_hooked_callbacks( PTKPatternsStore::FETCH_PATTERNS_ACTION, PTKPatternsStore::class ),
+			'The fetch_patterns callback must be registered on cron requests, or Action Scheduler fails the action with "no callbacks are registered".'
+		);
+		$this->assertSame(
+			$pattern_callbacks_before,
+			$this->count_hooked_callbacks( 'init', BlockPatterns::class ),
+			'Pattern registration should still be skipped on cron requests.'
+		);
+	}
+
+	/**
+	 * Count the callbacks on a hook whose bound object is an instance of the given class.
+	 *
+	 * @param string $hook       Hook name.
+	 * @param string $class_name Fully qualified class name of the bound object.
+	 * @return int
+	 */
+	private function count_hooked_callbacks( string $hook, string $class_name ): int {
+		global $wp_filter;
+
+		$count = 0;
+		foreach ( ( $wp_filter[ $hook ]->callbacks ?? array() ) as $callbacks_at_priority ) {
+			foreach ( $callbacks_at_priority as $callback ) {
+				if ( is_array( $callback['function'] ) && ( $callback['function'][0] ?? null ) instanceof $class_name ) {
+					++$count;
+				}
+			}
+		}
+
+		return $count;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -554,4 +554,21 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 		$this->pattern_store->get_patterns();
 		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'A fetch should be scheduled again after the cooldown expires' );
 	}
+
+	/**
+	 * @testdox flush_cached_patterns should clear the cooldown so the next fetch is scheduled immediately.
+	 */
+	public function test_flush_cached_patterns_clears_the_cooldown() {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		delete_option( PTKPatternsStore::OPTION_NAME );
+
+		$this->pattern_store->get_patterns();
+		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'The first call should schedule a fetch' );
+
+		$this->pattern_store->flush_cached_patterns();
+		$this->assertFalse( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'Flushing should unschedule the pending fetch' );
+
+		$this->pattern_store->flush_or_fetch_patterns();
+		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'A fetch requested right after a flush should not be held back by the cooldown' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -35,6 +35,7 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 
 		// Clean up any existing actions before each test.
 		as_unschedule_all_actions( 'fetch_patterns', array(), 'woocommerce' );
+		delete_transient( PTKPatternsStore::SCHEDULE_COOLDOWN_TRANSIENT );
 
 		$this->ptk_client    = $this->createMock( PTKClient::class );
 		$this->pattern_store = new PTKPatternsStore( $this->ptk_client );
@@ -519,5 +520,38 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 
 		// Restore the original action count.
 		$wp_actions['action_scheduler_init'] = $original_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
+	 * @testdox get_patterns should schedule the first fetch immediately but not another one within the cooldown.
+	 */
+	public function test_get_patterns_does_not_reschedule_within_cooldown() {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		delete_option( PTKPatternsStore::OPTION_NAME );
+
+		$this->pattern_store->get_patterns();
+		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'The first call should schedule a fetch immediately' );
+
+		// A failed run leaves no pending action behind; before the cooldown this let every page load schedule a new one.
+		as_unschedule_all_actions( 'fetch_patterns', array(), 'woocommerce' );
+
+		$this->pattern_store->get_patterns();
+		$this->assertFalse( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'A second call within the cooldown should not schedule another fetch' );
+	}
+
+	/**
+	 * @testdox get_patterns should schedule a fetch again once the cooldown has expired.
+	 */
+	public function test_get_patterns_schedules_again_after_cooldown_expires() {
+		delete_option( PTKPatternsStore::OPTION_NAME );
+
+		$this->pattern_store->get_patterns();
+		as_unschedule_all_actions( 'fetch_patterns', array(), 'woocommerce' );
+
+		// Simulate the transient timing out.
+		delete_transient( PTKPatternsStore::SCHEDULE_COOLDOWN_TRANSIENT );
+
+		$this->pattern_store->get_patterns();
+		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'A fetch should be scheduled again after the cooldown expires' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -571,4 +571,27 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 		$this->pattern_store->flush_or_fetch_patterns();
 		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'A fetch requested right after a flush should not be held back by the cooldown' );
 	}
+
+	/**
+	 * @testdox Deactivating a plugin other than WooCommerce should keep the cached patterns.
+	 */
+	public function test_deactivating_another_plugin_keeps_the_cached_patterns() {
+		$patterns = array( array( 'ID' => 1 ) );
+		update_option( PTKPatternsStore::OPTION_NAME, $patterns, false );
+
+		do_action( 'deactivated_plugin', 'some-other-plugin/some-other-plugin.php', false );
+
+		$this->assertSame( $patterns, get_option( PTKPatternsStore::OPTION_NAME ), 'Another plugin being deactivated should not flush the WooCommerce patterns cache' );
+	}
+
+	/**
+	 * @testdox Deactivating WooCommerce should flush the cached patterns.
+	 */
+	public function test_deactivating_woocommerce_flushes_the_cached_patterns() {
+		update_option( PTKPatternsStore::OPTION_NAME, array( array( 'ID' => 1 ) ), false );
+
+		do_action( 'deactivate_' . WC_PLUGIN_BASENAME, false );
+
+		$this->assertFalse( get_option( PTKPatternsStore::OPTION_NAME ), 'Deactivating WooCommerce should flush the patterns cache' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`fetch_patterns` is the daily job that downloads the remote WooCommerce patterns from the Patterns Toolkit and caches them in the `ptk_patterns` option. It was built for Customize Your Store; the CYS flow was removed in 10.5, but the patterns are still registered in the editor under the Intro, About, Featured Selling, Services, Reviews, Social Media, and Shop categories, so the job is still needed.

Since 11.1.0 the job fails under WP-Cron with "no callbacks are registered". `PTKPatternsStore`, whose constructor registers the callback, was only instantiated as a dependency of `BlockPatterns` (skipped on non-rendering requests since #65781) or on admin and REST requests. On its own that is one failed action a day. Combined with `get_patterns()` rescheduling whenever the cache is empty, guarded only by "is one pending?", every page load queued a new action once the fetch failed; woocommerce.com accumulated 1.5M failed rows this way.

One commit per change:
- Instantiate `PTKPatternsStore` with the other services Bootstrap creates on every request. Block and pattern registration stays skipped on cron.
- Add a one-day cooldown transient at the shared scheduling method, checked before the Action Scheduler query. The first fetch is still scheduled immediately; retries are bounded to one per day.
- Clear the cooldown when the cache is flushed, so tracking off then on gets an immediate fetch.
- Flush the cache only on WooCommerce's own deactivation (`deactivate_{WC_PLUGIN_BASENAME}`, as DraftOrders does) instead of on any plugin's. This shrinks one baselined PHPStan entry.

Existing failed rows are not removed; `wp action-scheduler clean --status=failed` takes care of those.

Backward compatibility: no signatures or fired hooks change. `PTKPatternsStore` is now also created on Store API requests (its constructor only adds hooks), and deactivating a plugin other than WooCommerce no longer clears the patterns cache.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #68409.
Closes WOOPLUG-7684

Bug introduced in PR #65781.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Setup**
- Usage tracking on: WooCommerce > Settings > Advanced > WooCommerce.com, tick "Allow usage of WooCommerce to be tracked". Any store works, no fresh install needed.
- Make Action Scheduler use WP-Cron only. In wp-admin it otherwise runs due actions through an admin-ajax request, a path that never had this bug, so on trunk the action would complete too and prove nothing. Add this as an mu-plugin or Code Snippet for the duration of the test:

  ```php
  add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );
  ```

Scheduled Actions is under WooCommerce > Status > Scheduled Actions. It opens on the "All" view; use the **Pending** and **Complete** links above the table, and search for `fetch_patterns`. A yellow "Action Scheduler migration in progress" notice appears for about a minute after any plugin deactivation; it is unrelated and goes away on its own.

**Cron runs the fetch**
1. In Plugins, deactivate WooCommerce, then activate it again. This clears the patterns cache and schedules a fetch that is due immediately.
2. Open Scheduled Actions, **Pending** view, search `fetch_patterns`. WP-Cron picks the action up within about a minute of any page view, so you may already find it gone from Pending. If it is still there, open `https://your-site/wp-cron.php` in a new tab (the page stays blank, that is normal), wait a few seconds, and reload.
3. Switch to the **Complete** view, search `fetch_patterns`. The newest row's log should read "action started via WP Cron ; action complete via WP Cron", and the Pending view now shows one `fetch_patterns` for tomorrow. On trunk the row is under **Failed** instead, with "Scheduled action for fetch_patterns will not be executed as no callbacks are registered."
4. Edit any page, open the inserter, Patterns tab: the About, Intro, Services and Reviews categories are listed. They only exist once the patterns are downloaded.

**Deactivating another plugin keeps the cache**
5. Deactivate any other plugin. Reopen the inserter: the categories from step 4 are still there, and the Pending view still shows only tomorrow's `fetch_patterns`.

**No rescheduling on every page load**
6. In the Pending view, hover the `fetch_patterns` row and click **Cancel**.
7. Reload a few shop pages on the front end.
8. Back in the Pending view, search `fetch_patterns`: nothing. On trunk, every page load added a new one, which then moved to Failed.

Remove the snippet when done.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Reproduced both bugs on trunk on a WordPress Studio site (SQLite, PHP 8.4, WooCommerce only, Twenty Twenty-Five): the action failed via WP Cron with the reported message, and each page load plus cron cycle added one failed row once Action Scheduler stopped rescheduling. With this branch I ran the steps above on the same site: the cron run completes and caches 97 patterns, deactivating another plugin keeps them, and three page loads after cancelling the pending action add nothing. Verified with the async runner disabled that the reactivation fetch stays pending until wp-cron.php runs it. All 1155 Blocks PHP tests pass in wp-env; phpcs-changed and PHPStan are clean. Not tested on multisite; the transient and the option are both site-scoped, so I expect no difference.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

I used Claude Code for the triage, the reproduction on Studio, the implementation, and the tests. I reviewed the diff and the commit messages myself.