### PR TITLE
Fix double block registration when a description renders before init

### DIFF
--- a/plugins/woocommerce/changelog/fix-register-blocks-double-run
+++ b/plugins/woocommerce/changelog/fix-register-blocks-double-run
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WooCommerce block types from being registered twice when a product description is rendered before init.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -131,8 +131,11 @@ final class BlockTypesController {
 	 * Register blocks, hooking up assets and render functions as needed.
 	 */
 	public function register_blocks() {
-		// Set before registering rather than after: it guards against re-entry through the on-demand
-		// registration in Bootstrap, and a registration failure must not be retried on later filter fires.
+		if ( self::$register_blocks_has_run ) {
+			return;
+		}
+
+		// Set before registering rather than after, so a registration failure is not retried on a later call.
 		self::$register_blocks_has_run = true;
 		$this->register_block_metadata();
 		$block_types = $this->get_block_types();

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/BootstrapTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/BootstrapTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\Domain;
 
 use Automattic\WooCommerce\Blocks\BlockTypesController;
+use Automattic\WooCommerce\Blocks\Package;
 use WC_Unit_Test_Case;
 use WP_Block_Type_Registry;
 
@@ -367,5 +368,52 @@ HTML;
 			$registry->is_registered( self::SAMPLE_BLOCK ),
 			'Block types should remain registered and must not be re-registered on demand.'
 		);
+	}
+
+	/**
+	 * @testdox The init registration is a no-op after a description registered the block types on demand before init.
+	 */
+	public function test_register_blocks_is_a_no_op_after_on_demand_registration(): void {
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$controller = Package::container()->get( BlockTypesController::class );
+		$this->assertFalse( $registry->is_registered( self::SAMPLE_BLOCK ), 'Blocks should start unregistered.' );
+
+		// An extension renders a description before init on a request where register_blocks() is queued on init.
+		apply_filters( 'woocommerce_short_description', 'Intro <!-- wp:woocommerce/product-price /--> outro' );
+		$this->assertTrue( $controller->register_blocks_has_run(), 'The filter should have run register_blocks() on demand.' );
+		$this->assertTrue( $registry->is_registered( self::SAMPLE_BLOCK ), 'The filter should register block types on demand.' );
+		$hooked_block_instances = $this->count_block_editor_asset_callbacks();
+		$this->assertGreaterThan( 0, $hooked_block_instances, 'Each registered block instance should have hooked its editor assets.' );
+
+		// Then the queued init callback fires. The registry rejects duplicate block types with a doing_it_wrong
+		// notice (a test failure), but a second run would still construct every block class again and hook each
+		// new instance a second time.
+		$controller->register_blocks();
+
+		$this->assertSame(
+			$hooked_block_instances,
+			$this->count_block_editor_asset_callbacks(),
+			'A second register_blocks() call must not construct the block types again and hook duplicate callbacks.'
+		);
+		$this->assertTrue( $registry->is_registered( self::SAMPLE_BLOCK ), 'Block types should remain registered.' );
+	}
+
+	/**
+	 * Count the callbacks hooked to enqueue_block_editor_assets.
+	 *
+	 * Every block instance that register_blocks() constructs hooks its enqueue_editor_assets method there, so
+	 * the count grows by one per block type each time the registration runs.
+	 *
+	 * @return int Number of hooked callbacks.
+	 */
+	private function count_block_editor_asset_callbacks(): int {
+		global $wp_filter;
+
+		$count = 0;
+		foreach ( $wp_filter['enqueue_block_editor_assets']->callbacks ?? array() as $callbacks_at_priority ) {
+			$count += count( $callbacks_at_priority );
+		}
+
+		return $count;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetectorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetectorTest.php
@@ -533,12 +533,11 @@ class WCEmailTemplateDivergenceDetectorTest extends \WC_Unit_Test_Case {
 	 * `init`-time hooks (notably `WCEmailTemplateDivergenceDetector::register_meta`)
 	 * register on the global hook table, the `woo_email` post type is registered, and
 	 * `init` fires so the meta-registration callback runs. Swallows the doing-it-wrong
-	 * notices that the full chain triggers when re-registering already-registered
-	 * blocks / integrations during a unit-test process; those notices are unrelated
+	 * notice that the full chain triggers when re-registering already-registered
+	 * integrations during a unit-test process; that notice is unrelated
 	 * to the meta-registration wiring under test.
 	 */
 	private function initialize_email_editor_integration(): void {
-		$this->setExpectedIncorrectUsage( 'WP_Block_Type_Registry::register' );
 		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry::register' );
 
 		add_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

`register_blocks()` sets `$register_blocks_has_run` but never reads it — only `Bootstrap::maybe_register_blocks_from_content()` checks the flag. If an extension renders a product description before init, blocks register on demand, then init re-runs full registration: every block class is constructed and hooked again, and the registry emits a `_doing_it_wrong` per block.

It's highly unlikely that anyone renders a description before `init`, but the fix is small and puts the guard where the flag lives.

Closes WOOAIRR-47

Bug introduced in PR #66672.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'BootstrapTest|WCEmailTemplateDivergenceDetectorTest'`; all tests pass.
2. Manual check: with `WP_DEBUG` and `WP_DEBUG_LOG` enabled, add an mu-plugin that renders a description before `init`:
   ```php
   add_action( 'after_setup_theme', function () {
   	apply_filters( 'woocommerce_short_description', '<!-- wp:woocommerce/product-price /-->' );
   } );
   ```
   Load any front-end page. On trunk `debug.log` gets one `Block type "woocommerce/..." is already registered` notice per block (176 on my site); with this PR it stays clean. Hooking on `init` at priority 1 or on `woocommerce_init` gives the same result, since the block registration runs on `init` at priority 10.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `BootstrapTest`, `WCEmailTemplateDivergenceDetectorTest`, and the `WC_AJAX_Test` on-demand registration test pass in wp-env (PHP 8.1).
- The new regression test fails on trunk: a second `register_blocks()` call adds 166 callbacks to `enqueue_block_editor_assets` (340 → 506).
- Manual check above on a wp-env site (WP 7.1, PHP 8.1, Twenty Twenty-Five): 176 notices per page load on trunk for each of `after_setup_theme`, `init@1`, and `woocommerce_init`; 0 with this PR. The trunk page is also ~1 KB larger, from the duplicated hook callbacks.
- phpcs and PHPStan are clean on the changed files.

**Backward compatibility:** no signature, hook, or public getter changes. `register_blocks()` is public; calling it a second time in one request is now a no-op instead of a burst of `_doing_it_wrong` notices with the registry keeping the first registration anyway, so no working behaviour is lost.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

I used Claude Code to write the fix, the tests, and this description; I reviewed and take responsibility for all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
