### PR TITLE
Guard bare as_has_scheduled_action() calls behind a version-tolerant helper

### DIFF
--- a/plugins/woocommerce/changelog/fix-52745-guard-as-has-scheduled-action
+++ b/plugins/woocommerce/changelog/fix-52745-guard-as-has-scheduled-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard every `as_has_scheduled_action()` call behind a helper that falls back to `as_next_scheduled_action()`, preventing a fatal error when another plugin loads a pre-3.3.0 copy of Action Scheduler.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
@@ -10,6 +10,8 @@
  * @version     2.0.0
  */
 
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -58,7 +60,7 @@ class WC_Admin_Reports {
 			static $skip_consequent;
 
 			// Schedule the deletion, cap the execution to single pending event at any given time.
-			$schedule = ! $skip_consequent && ! as_has_scheduled_action( 'woocommerce_delete_legacy_report_transients', null, 'woocommerce' );
+			$schedule = ! $skip_consequent && ! ActionSchedulerUtil::has_scheduled_action( 'woocommerce_delete_legacy_report_transients', null, 'woocommerce' );
 			if ( $schedule ) {
 				as_schedule_single_action( time() + MINUTE_IN_SECONDS, 'woocommerce_delete_legacy_report_transients', array( $order_id, false ), 'woocommerce' );
 			}

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Blocks;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Patterns\PatternRegistry;
 use Automattic\WooCommerce\Blocks\Patterns\PTKPatternsStore;
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 
 /**
  * Registers patterns under the `./patterns/` directory and from the PTK API and updates their content.
@@ -206,10 +207,6 @@ class BlockPatterns {
 			return;
 		}
 
-		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
-		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
-		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-
 		$patterns = $this->ptk_patterns_store->get_patterns();
 		if ( empty( $patterns ) || ! is_array( $patterns ) ) {
 			// Only log once per day by using a transient.
@@ -217,7 +214,7 @@ class BlockPatterns {
 			// By only logging when patterns are empty and no fetch is scheduled,
 			// we ensure that warnings are only generated in genuinely problematic situations,
 			// such as when the pattern fetching mechanism has failed entirely.
-			if ( ! get_transient( $transient_key ) && ! call_user_func( $has_scheduled_action, 'fetch_patterns' ) ) {
+			if ( ! get_transient( $transient_key ) && ! ActionSchedulerUtil::has_scheduled_action( 'fetch_patterns' ) ) {
 				wc_get_logger()->warning(
 					__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),
 				);

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 use Exception;
 use WC_Order;
 
@@ -77,8 +78,7 @@ class DraftOrders {
 	 * Maybe create cron events.
 	 */
 	protected function maybe_create_cronjobs() {
-		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-		if ( false === call_user_func( $has_scheduled_action, self::DRAFT_CLEANUP_EVENT_HOOK ) ) {
+		if ( ! ActionSchedulerUtil::has_scheduled_action( self::DRAFT_CLEANUP_EVENT_HOOK ) ) {
 			$midnight_tonight = strtotime( 'midnight tonight' );
 			if ( false !== $midnight_tonight ) {
 				as_schedule_recurring_action( $midnight_tonight, DAY_IN_SECONDS, self::DRAFT_CLEANUP_EVENT_HOOK );

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Patterns;
 
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 use WP_Upgrader;
 
 /**
@@ -109,7 +110,7 @@ class PTKPatternsStore {
 	 * @return void
 	 */
 	private function schedule_action_if_not_pending( $action ) {
-		if ( as_has_scheduled_action( $action, array(), 'woocommerce' ) ) {
+		if ( ActionSchedulerUtil::has_scheduled_action( $action, array(), 'woocommerce' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataS
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\DataStore as TaxesDataStore;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
@@ -529,10 +530,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 		if ( null === $action_hook ) {
 			return;
 		}
-		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
-		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
-		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-		if ( call_user_func( $has_scheduled_action, $action_hook ) ) {
+		if ( ActionSchedulerUtil::has_scheduled_action( $action_hook ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -851,7 +851,7 @@ class BatchProcessingController {
 		// Everything below reads "not scheduled" as grounds for recording a failure against a processor
 		// and eventually dropping it from the queue. Action Scheduler being unloaded also reads as
 		// "not scheduled", so bail rather than dismantle the queue over a missing dependency.
-		if ( ! ActionSchedulerUtil::is_available() ) {
+		if ( ! ActionSchedulerUtil::can_check_scheduled_actions() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -21,6 +21,8 @@
 
 namespace Automattic\WooCommerce\Internal\BatchProcessing;
 
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
+
 /**
  * Class BatchProcessingController
  *
@@ -380,7 +382,7 @@ class BatchProcessingController {
 			$time += apply_filters( 'woocommerce_batch_processor_watchdog_delay_seconds', HOUR_IN_SECONDS );
 		}
 
-		if ( ! as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
+		if ( ! ActionSchedulerUtil::has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
 			as_schedule_single_action(
 				$time,
 				self::WATCHDOG_ACTION_NAME,
@@ -559,14 +561,14 @@ class BatchProcessingController {
 
 	/**
 	 * Check if a batch processing action is already scheduled for a given processor.
-	 * Differs from `as_has_scheduled_action` in that this excludes actions in progress.
+	 * Pending and in-progress actions both count as scheduled.
 	 *
 	 * @param string $processor_class_name Fully qualified class name of the batch processor.
 	 *
 	 * @return bool True if a batch processing action is already scheduled for the processor.
 	 */
 	public function is_scheduled( string $processor_class_name ): bool {
-		return as_has_scheduled_action( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+		return ActionSchedulerUtil::has_scheduled_action( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
 	}
 
 	/**
@@ -846,11 +848,14 @@ class BatchProcessingController {
 			return;
 		}
 
-		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
-		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
-		$has_scheduled_action = function_exists( 'as_has_scheduled_action') ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+		// Everything below reads "not scheduled" as grounds for recording a failure against a processor
+		// and eventually dropping it from the queue. Action Scheduler being unloaded also reads as
+		// "not scheduled", so bail rather than dismantle the queue over a missing dependency.
+		if ( ! ActionSchedulerUtil::is_available() ) {
+			return;
+		}
 
-		if ( call_user_func( $has_scheduled_action, self::WATCHDOG_ACTION_NAME ) ) {
+		if ( ActionSchedulerUtil::has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger_Interface;
 use Automattic\WooCommerce\Internal\EmailEditor\Logger;
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 
 /**
  * Auto-applies the current core block template to `woo_email` posts that have
@@ -227,14 +228,14 @@ class WCEmailTemplateAutoApplier {
 	 * Enqueue the batched auto-apply runner as an Action Scheduler async action.
 	 *
 	 * Hooked to {@see 'woocommerce_email_template_divergence_sweep_complete'}. The
-	 * `as_has_scheduled_action()` short-circuit guards against double-enqueueing
+	 * already-scheduled short-circuit guards against double-enqueueing
 	 * when the detector sweep runs twice in one request — once on
 	 * `woocommerce_updated`, once on `BACKFILL_COMPLETE_ACTION`.
 	 *
 	 * @since 10.8.0
 	 */
 	public static function schedule(): void {
-		if ( as_has_scheduled_action( self::AUTO_APPLY_AS_HOOK, array(), self::AUTO_APPLY_AS_GROUP ) ) {
+		if ( ActionSchedulerUtil::has_scheduled_action( self::AUTO_APPLY_AS_HOOK, array(), self::AUTO_APPLY_AS_GROUP ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 
 /**
  * Store that collects notifications during a request and dispatches them all on
@@ -125,7 +126,7 @@ class PendingNotificationStore {
 		// them from the same place; see Notification::get_safety_net_args().
 		$args = $notification->get_safety_net_args();
 
-		if ( as_has_scheduled_action( NotificationProcessor::SAFETY_NET_HOOK, $args, NotificationProcessor::ACTION_SCHEDULER_GROUP ) ) {
+		if ( ActionSchedulerUtil::has_scheduled_action( NotificationProcessor::SAFETY_NET_HOOK, $args, NotificationProcessor::ACTION_SCHEDULER_GROUP ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Internal\TransientFiles;
 
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
 use \DateTime;
 use \Exception;
 use \InvalidArgumentException;
@@ -370,7 +371,7 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 * @return bool True if the expired files cleanup action is currently scheduled, false otherwise.
 	 */
 	public function expired_files_cleanup_is_scheduled(): bool {
-		return as_has_scheduled_action( self::CLEANUP_ACTION_NAME, array(), self::CLEANUP_ACTION_GROUP );
+		return ActionSchedulerUtil::has_scheduled_action( self::CLEANUP_ACTION_NAME, array(), self::CLEANUP_ACTION_GROUP );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/ActionSchedulerUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/ActionSchedulerUtil.php
@@ -11,15 +11,14 @@ class ActionSchedulerUtil {
 	/**
 	 * Is a matching action currently scheduled (pending or in-progress)?
 	 *
-	 * `as_has_scheduled_action` is the cheapest way to answer this, but it only exists since Action
-	 * Scheduler 3.3.0. Another plugin can register an older copy of Action Scheduler early enough to
-	 * win the version race against the copy bundled with WooCommerce, so calling it directly risks a
-	 * `Call to undefined function` fatal. `as_next_scheduled_action` has been part of the API for far
-	 * longer, so it is the fallback - the same one WooCommerce already used at the call sites that
-	 * were guarded before this helper existed. On a copy old enough to lack `as_has_scheduled_action`
-	 * the fallback may only report pending actions rather than pending and in-progress ones, which
-	 * can mean a duplicate scheduling attempt on an already-degraded install. That is the accepted
-	 * trade for not fataling.
+	 * Prefers `as_has_scheduled_action`, which only exists since Action Scheduler 3.3.0: another plugin
+	 * can load an older copy early enough to win the version race against the one bundled with
+	 * WooCommerce, and a bare call is then a fatal. Falls back to the much older `as_next_scheduled_action`,
+	 * which on such a copy may report only pending actions, not in-progress ones - an accepted trade.
+	 *
+	 * Reports false when Action Scheduler is not loaded at all, indistinguishable from "nothing is
+	 * scheduled". A caller that treats a negative answer as licence to discard state should check
+	 * {@see self::can_check_scheduled_actions()} first.
 	 *
 	 * @since 11.2.0
 	 *
@@ -27,13 +26,7 @@ class ActionSchedulerUtil {
 	 * @param array|null $args  Args that have been passed to the action. Null matches any args.
 	 * @param string     $group The group the action is assigned to.
 	 *
-	 * When Action Scheduler is not loaded at all this reports false, which a caller cannot tell apart
-	 * from a genuine "nothing is scheduled". That is fine for the usual shape of caller, which
-	 * schedules the action immediately afterwards and would fail on that call anyway. A caller that
-	 * instead treats a negative answer as licence to discard state should check {@see self::is_available()}
-	 * first.
-	 *
-	 * @return bool True if a matching action is scheduled, false otherwise (including when Action Scheduler isn't loaded at all).
+	 * @return bool True if a matching action is scheduled, false otherwise.
 	 */
 	public static function has_scheduled_action( string $hook, ?array $args = null, string $group = '' ): bool {
 		foreach ( array( 'as_has_scheduled_action', 'as_next_scheduled_action' ) as $function ) {
@@ -50,16 +43,14 @@ class ActionSchedulerUtil {
 	}
 
 	/**
-	 * Is Action Scheduler loaded well enough to answer a scheduled-action question?
-	 *
-	 * Lets a caller distinguish "no matching action" from "no answer available" before acting
-	 * destructively on a false from {@see self::has_scheduled_action()}.
+	 * Can {@see self::has_scheduled_action()} actually query Action Scheduler, or would it report false
+	 * only because neither function it relies on is loaded?
 	 *
 	 * @since 11.2.0
 	 *
-	 * @return bool True if Action Scheduler is available, false otherwise.
+	 * @return bool True if a scheduled-action check can be answered, false otherwise.
 	 */
-	public static function is_available(): bool {
+	public static function can_check_scheduled_actions(): bool {
 		return function_exists( 'as_has_scheduled_action' ) || function_exists( 'as_next_scheduled_action' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Utilities/ActionSchedulerUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/ActionSchedulerUtil.php
@@ -1,0 +1,65 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+/**
+ * A class of utilities for dealing with Action Scheduler across the versions of it that may be loaded.
+ */
+class ActionSchedulerUtil {
+
+	/**
+	 * Is a matching action currently scheduled (pending or in-progress)?
+	 *
+	 * `as_has_scheduled_action` is the cheapest way to answer this, but it only exists since Action
+	 * Scheduler 3.3.0. Another plugin can register an older copy of Action Scheduler early enough to
+	 * win the version race against the copy bundled with WooCommerce, so calling it directly risks a
+	 * `Call to undefined function` fatal. `as_next_scheduled_action` has been part of the API for far
+	 * longer, so it is the fallback - the same one WooCommerce already used at the call sites that
+	 * were guarded before this helper existed. On a copy old enough to lack `as_has_scheduled_action`
+	 * the fallback may only report pending actions rather than pending and in-progress ones, which
+	 * can mean a duplicate scheduling attempt on an already-degraded install. That is the accepted
+	 * trade for not fataling.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param string     $hook  The hook of the action.
+	 * @param array|null $args  Args that have been passed to the action. Null matches any args.
+	 * @param string     $group The group the action is assigned to.
+	 *
+	 * When Action Scheduler is not loaded at all this reports false, which a caller cannot tell apart
+	 * from a genuine "nothing is scheduled". That is fine for the usual shape of caller, which
+	 * schedules the action immediately afterwards and would fail on that call anyway. A caller that
+	 * instead treats a negative answer as licence to discard state should check {@see self::is_available()}
+	 * first.
+	 *
+	 * @return bool True if a matching action is scheduled, false otherwise (including when Action Scheduler isn't loaded at all).
+	 */
+	public static function has_scheduled_action( string $hook, ?array $args = null, string $group = '' ): bool {
+		foreach ( array( 'as_has_scheduled_action', 'as_next_scheduled_action' ) as $function ) {
+			// PHPStan sees the Action Scheduler copy bundled with WooCommerce and concludes both functions
+			// always exist. The runtime case this guard exists for is precisely the one it cannot see.
+			// @phpstan-ignore-next-line function.alreadyNarrowedType -- see comment above.
+			if ( function_exists( $function ) ) {
+				// `as_next_scheduled_action` returns the timestamp of the next pending action, hence the cast.
+				return (bool) $function( $hook, $args, $group );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Is Action Scheduler loaded well enough to answer a scheduled-action question?
+	 *
+	 * Lets a caller distinguish "no matching action" from "no answer available" before acting
+	 * destructively on a false from {@see self::has_scheduled_action()}.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @return bool True if Action Scheduler is available, false otherwise.
+	 */
+	public static function is_available(): bool {
+		return function_exists( 'as_has_scheduled_action' ) || function_exists( 'as_next_scheduled_action' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/ActionSchedulerUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/ActionSchedulerUtilTest.php
@@ -107,21 +107,22 @@ class ActionSchedulerUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox `is_available` should report Action Scheduler as available when it is loaded.
+	 * @testdox `can_check_scheduled_actions` should be true when Action Scheduler is loaded.
 	 */
-	public function test_reports_action_scheduler_as_available(): void {
+	public function test_can_check_scheduled_actions_when_action_scheduler_is_loaded(): void {
 		$this->assertTrue(
-			ActionSchedulerUtil::is_available(),
-			'Action Scheduler is loaded in the test suite, so it should be reported as available'
+			ActionSchedulerUtil::can_check_scheduled_actions(),
+			'Action Scheduler is loaded in the test suite, so scheduled-action checks should be possible'
 		);
 	}
 
 	/**
 	 * The helper falls back to `as_next_scheduled_action` when `as_has_scheduled_action` is missing.
-	 * That branch cannot be exercised directly here - Action Scheduler is always fully loaded in the
-	 * test suite - so pin the property it relies on instead: with the bundled Action Scheduler the
-	 * two functions answer identically, so routing a call site through the fallback is a no-op for
-	 * every store that is not running an ancient copy.
+	 * Neither that branch nor the false branch of `can_check_scheduled_actions` can be exercised here:
+	 * Action Scheduler is always fully loaded in the test suite, and the function-mocking seam
+	 * (CodeHacker) only rewrites files under `includes/`, not `src/`. So pin the property the fallback
+	 * relies on instead: with the bundled Action Scheduler the two functions answer identically, so
+	 * routing a call site through the fallback is a no-op for every store not running an ancient copy.
 	 *
 	 * @testdox The `as_next_scheduled_action` fallback agrees with `as_has_scheduled_action`.
 	 * @dataProvider provider_fallback_equivalence

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/ActionSchedulerUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/ActionSchedulerUtilTest.php
@@ -1,0 +1,163 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Internal\Utilities\ActionSchedulerUtil class.
+ */
+class ActionSchedulerUtilTest extends WC_Unit_Test_Case {
+
+	private const HOOK  = 'woocommerce_action_scheduler_util_test';
+	private const GROUP = 'woocommerce_action_scheduler_util_test_group';
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		as_unschedule_all_actions( self::HOOK );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should return false when no matching action exists.
+	 */
+	public function test_returns_false_when_nothing_is_scheduled(): void {
+		$this->assertFalse(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK ),
+			'An unscheduled hook should not be reported as scheduled'
+		);
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should return true for a pending action.
+	 */
+	public function test_returns_true_for_a_pending_action(): void {
+		as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, array(), self::GROUP );
+
+		$this->assertTrue(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK, array(), self::GROUP ),
+			'A pending action should be reported as scheduled'
+		);
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should return true for an in-progress action.
+	 */
+	public function test_returns_true_for_an_in_progress_action(): void {
+		$action_id = as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, array(), self::GROUP );
+		\ActionScheduler::store()->log_execution( $action_id );
+
+		$this->assertTrue(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK, array(), self::GROUP ),
+			'An in-progress action should be reported as scheduled'
+		);
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should return false when only the group differs.
+	 */
+	public function test_returns_false_when_the_group_does_not_match(): void {
+		as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, array(), self::GROUP );
+
+		$this->assertFalse(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK, array(), 'some_other_group' ),
+			'An action in a different group should not match'
+		);
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should return false when only the args differ.
+	 */
+	public function test_returns_false_when_the_args_do_not_match(): void {
+		as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, array( 'a' ), self::GROUP );
+
+		$this->assertFalse(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK, array( 'b' ), self::GROUP ),
+			'An action scheduled with different args should not match'
+		);
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should treat null args as a wildcard.
+	 */
+	public function test_null_args_match_any_args(): void {
+		as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, array( 'a' ), self::GROUP );
+
+		$this->assertTrue(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK, null, self::GROUP ),
+			'Null args should match an action scheduled with any args'
+		);
+	}
+
+	/**
+	 * @testdox `has_scheduled_action` should return false once the action has been unscheduled.
+	 */
+	public function test_returns_false_after_the_action_is_unscheduled(): void {
+		as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, array(), self::GROUP );
+		as_unschedule_all_actions( self::HOOK, array(), self::GROUP );
+
+		$this->assertFalse(
+			ActionSchedulerUtil::has_scheduled_action( self::HOOK, array(), self::GROUP ),
+			'An unscheduled action should no longer be reported as scheduled'
+		);
+	}
+
+	/**
+	 * @testdox `is_available` should report Action Scheduler as available when it is loaded.
+	 */
+	public function test_reports_action_scheduler_as_available(): void {
+		$this->assertTrue(
+			ActionSchedulerUtil::is_available(),
+			'Action Scheduler is loaded in the test suite, so it should be reported as available'
+		);
+	}
+
+	/**
+	 * The helper falls back to `as_next_scheduled_action` when `as_has_scheduled_action` is missing.
+	 * That branch cannot be exercised directly here - Action Scheduler is always fully loaded in the
+	 * test suite - so pin the property it relies on instead: with the bundled Action Scheduler the
+	 * two functions answer identically, so routing a call site through the fallback is a no-op for
+	 * every store that is not running an ancient copy.
+	 *
+	 * @testdox The `as_next_scheduled_action` fallback agrees with `as_has_scheduled_action`.
+	 * @dataProvider provider_fallback_equivalence
+	 *
+	 * @param array|null $scheduled_args Args to schedule the action with, or null to schedule nothing.
+	 * @param array|null $queried_args   Args to query with.
+	 * @param bool       $expected       Expected result.
+	 */
+	public function test_fallback_is_equivalent_to_the_preferred_function( ?array $scheduled_args, ?array $queried_args, bool $expected ): void {
+		if ( null !== $scheduled_args ) {
+			as_schedule_single_action( time() + HOUR_IN_SECONDS, self::HOOK, $scheduled_args, self::GROUP );
+		}
+
+		$this->assertSame(
+			$expected,
+			(bool) as_has_scheduled_action( self::HOOK, $queried_args, self::GROUP ),
+			'as_has_scheduled_action should report the expected result'
+		);
+		$this->assertSame(
+			$expected,
+			(bool) as_next_scheduled_action( self::HOOK, $queried_args, self::GROUP ),
+			'The as_next_scheduled_action fallback should report the same result'
+		);
+	}
+
+	/**
+	 * Data provider for test_fallback_is_equivalent_to_the_preferred_function.
+	 *
+	 * @return array
+	 */
+	public function provider_fallback_equivalence(): array {
+		return array(
+			'nothing scheduled'     => array( null, array(), false ),
+			'exact args match'      => array( array( 'a' ), array( 'a' ), true ),
+			'args mismatch'         => array( array( 'a' ), array( 'b' ), false ),
+			'null args as wildcard' => array( array( 'a' ), null, true ),
+		);
+	}
+}


### PR DESCRIPTION
### Task

> Guard the bare `as_has_scheduled_action()` call sites. Closes https://github.com/woocommerce/woocommerce/issues/52745 and https://github.com/woocommerce/woocommerce/issues/46632 - these are one task and a single PR closes both. The codebase already carries the fallback pattern in four places, but seven call sites still call the function bare: PTKPatternsStore, WCEmailTemplateAutoApplier, TransientFilesEngine, BatchProcessingController (twice), PendingNotificationStore, and the legacy reports class. A real fatal was reported on 10.4.2. Add one small helper and route the seven sites through it rather than copying the ternary seven times.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`as_has_scheduled_action()` only exists since Action Scheduler 3.3.0. Another plugin can register an older copy of Action Scheduler early enough to win the load race against the copy bundled with WooCommerce (the historical example is WP Mail SMTP 2.8.0), and then any bare call is `Call to undefined function as_has_scheduled_action`. A fatal from this was reported on WooCommerce 10.4.2.

This adds one helper:

```php
Automattic\WooCommerce\Internal\Utilities\ActionSchedulerUtil::has_scheduled_action( string $hook, ?array $args = null, string $group = '' ): bool
```

It prefers `as_has_scheduled_action()`, falls back to `as_next_scheduled_action()` (the same fallback WooCommerce already used at the sites that were guarded before), and returns `false` if neither exists.

**The seven previously-bare call sites, now routed through it:**

| File | What it guards |
| --- | --- |
| `src/Blocks/Patterns/PTKPatternsStore.php` | recurring `fetch_patterns` scheduling |
| `src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php` | auto-apply runner double-enqueue |
| `src/Internal/TransientFiles/TransientFilesEngine.php` | `expired_files_cleanup_is_scheduled()` |
| `src/Internal/BatchProcessing/BatchProcessingController.php` (x2) | watchdog scheduling, `is_scheduled()` |
| `src/Internal/PushNotifications/Services/PendingNotificationStore.php` | safety-net job |
| `includes/admin/class-wc-admin-reports.php` | legacy report transient deletion |

**Also folded in (behavior-preserving):** the four sites that already carried an inline `function_exists()` ternary + `call_user_func()` (`BlockPatterns`, `DraftOrders`, `OrdersScheduler`, and the second `BatchProcessingController` watchdog path) now call the same helper, so the version-tolerance logic lives in exactly one place instead of five.

After this, no bare `as_has_scheduled_action()` call remains anywhere in `plugins/woocommerce/src` or `plugins/woocommerce/includes`.

**One caller needed more than the guard.** `BatchProcessingController::remove_or_retry_failed_processors()` is the only site that treats a negative answer as licence to discard state: it records a failure against every enqueued processor and, past the threshold, calls `remove_processor()`. Because "Action Scheduler is unloaded" reports the same `false` as "nothing is scheduled", the plain guard would have converted an old fatal into a silent teardown of the batch queue (HPOS order sync, the product attributes lookup regeneration). It now bails through a second small method, `ActionSchedulerUtil::can_check_scheduled_actions()`, which lets a caller tell "no matching action" apart from "no answer available". The other ten sites schedule the action immediately afterwards, so `false` is harmless there - the failure just moves down one line.

Closes #52745.
Closes #46632.
Closes WOOPLUG-2732
Closes WOOPLUG-2140

(For Bug Fixes) Bug introduced in PR: not attributable to a single PR. The bare calls were added by several PRs over time as new Action Scheduler consumers landed; the pattern was first reported against WooCommerce 8.8.1 in #46632, and #52725 added the fallback at some sites without covering the rest.

### Backward compatibility

No public signature, hook, script/style handle, or option is changed. `ActionSchedulerUtil` is new and internal. `BatchProcessingController::is_scheduled()` is public and keeps its exact signature and semantics; its body swaps a bare Action Scheduler call for the guarded equivalent, so subclasses that override or call it are unaffected. Nothing is renamed or removed.

One behavioral note worth stating explicitly: on an Action Scheduler copy old enough to lack `as_has_scheduled_action()`, `as_next_scheduled_action()` may report only pending actions rather than pending *and* in-progress ones. On such an install a check could therefore miss an in-progress action and attempt a duplicate schedule. That is the same trade the four pre-existing guards already made, and it is strictly better than the fatal it replaces. With the bundled Action Scheduler the two functions answer identically - a test pins that.

If Action Scheduler is absent entirely, the helper reports "not scheduled". That is not a full fix for that scenario (several of these sites call `as_schedule_*()` immediately afterwards, which would still fatal), but it is no worse than today, where the check itself fataled one line earlier.

### How to test the changes in this Pull Request:

Reproducing the original fatal needs a plugin that loads a pre-3.3.0 Action Scheduler first, so the practical checks are:

1. On a normal install, confirm no behavior change: visit **WooCommerce → Status → Scheduled Actions** and check that `fetch_patterns` (group `woocommerce`), the batch-processor watchdog, and the transient-files cleanup still schedule and de-duplicate as before.
2. Trash an order on a store without an external object cache and confirm exactly one pending `woocommerce_delete_legacy_report_transients` action is created, not one per order.
3. `grep -rn "as_has_scheduled_action" plugins/woocommerce/src plugins/woocommerce/includes` returns no bare call - only the helper itself.

### Testing that has already taken place:

- New `ActionSchedulerUtilTest` (12 tests): nothing-scheduled, pending, in-progress, group mismatch, args mismatch, null-args wildcard, post-unschedule, `can_check_scheduled_actions()`, plus a data-provider test pinning that the fallback agrees with the preferred function on the bundled Action Scheduler.
- Existing suites for every touched class pass: `ActionSchedulerUtilTest`, `BatchProcessingControllerTests`, `PTKPatternsStoreTest`, `TransientFilesEngineTest`, `WCEmailTemplateAutoApplierTest`, `PendingNotificationStoreTest`, `DraftOrdersTest`, `OrdersSchedulerTest`, `BlockPatternsTest`, `WC_Admin_Reports_Test` - 178 tests, 491 assertions, 2 pre-existing skips (`OrdersSchedulerTest`, requires the CPT store).
- `bin/lint-branch.sh` (phpcs-changed vs trunk + `check-new-functions.php`) exits 0.
- PHPStan clean on all 10 changed `src/` and `includes/` files. The baseline is unchanged - the one new finding (`function_exists()` on these names is "always true" because PHPStan sees the bundled Action Scheduler) is suppressed inline with a justification rather than baselined.

Not tested under multisite; nothing here reads or writes site-scoped state, so no multisite-specific behavior is expected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

The entry was created manually and is already in the branch: `plugins/woocommerce/changelog/fix-52745-guard-as-has-scheduled-action` (significance `patch`, type `fix`).

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Use of AI Tools

This PR was authored with Claude Code (Anthropic Claude models Opus 5 and Fable 5.1), including the code, tests, changelog entry, and this description, under my direction and review. It was then run through a multi-agent AI code review (pirategoat-tools, 16 specialist reviewers plus reconciliation and a decision critic); its findings were triaged by me, and the follow-up commit reflects the ones I accepted. I have reviewed all of the generated code and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eRbLcJ3rJqVz4UFdtkrWU
