### PR TITLE
Add policies for malformed legacy query recovery

### DIFF
--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -357,6 +357,8 @@ class WC_Data_Store_WP {
 		// Validate here so overrides can normalize custom date formats before calling the parent parser.
 		if ( ! is_scalar( $query_var ) && ! ( is_object( $query_var ) && method_exists( $query_var, '__toString' ) ) ) {
 			$wp_query_args['errors'][] = new WP_Error( 'woocommerce_data_store_invalid_date', __( 'Invalid date query.', 'woocommerce' ) );
+			$wp_query_args['post__in'] = array( 0 );
+			unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
 
 			return $wp_query_args;
 		} elseif ( is_object( $query_var ) && ! ( $query_var instanceof WC_DateTime ) ) {
@@ -364,6 +366,8 @@ class WC_Data_Store_WP {
 				$query_var = (string) $query_var;
 			} catch ( Throwable $e ) { // @phpstan-ignore catch.neverThrown (Stringable conversion can throw at runtime.)
 				$wp_query_args['errors'][] = new WP_Error( 'woocommerce_data_store_invalid_date', __( 'Invalid date query.', 'woocommerce' ) );
+				$wp_query_args['post__in'] = array( 0 );
+				unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
 
 				return $wp_query_args;
 			}

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -942,6 +942,26 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
+	 * Checks whether a status value would actually narrow the query.
+	 *
+	 * WP_Query builds its status clause by intersecting the requested list with get_post_stati(),
+	 * so a value naming no registered status contributes nothing and the clause disappears.
+	 * Truthiness is not the test: 'not-a-status' is truthy and still filters nothing. 'any' is the
+	 * exception, since WP_Query turns it into exclusion clauses instead.
+	 *
+	 * @since 11.2.0
+	 * @param mixed $status The status value to check.
+	 * @return bool True if the value narrows the query, false otherwise.
+	 */
+	private function status_narrows_query( $status ) {
+		if ( 'any' === $status ) {
+			return true;
+		}
+
+		return in_array( sanitize_key( $status ), get_post_stati(), true );
+	}
+
+	/**
 	 * Normalizes the leaves of a customer query value.
 	 *
 	 * Nested arrays are supported grouping constructs. Stringable leaves are converted once so the
@@ -1036,23 +1056,25 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		if ( ! empty( $query_vars['post_status'] ) ) {
 			if ( is_array( $query_vars['post_status'] ) ) {
-				$normalized_statuses = array();
+				$usable_statuses = array();
 
 				foreach ( $query_vars['post_status'] as $status ) {
 					$normalized_status = null;
 
 					if ( ! $this->normalize_status_value( $status, $normalized_status ) ) {
 						$has_unusable_status = true;
-						break;
+						continue;
 					}
 
-					$normalized_statuses[] = wc_is_order_status( 'wc-' . $normalized_status ) ? 'wc-' . $normalized_status : $normalized_status;
+					$usable_statuses[] = wc_is_order_status( 'wc-' . $normalized_status ) ? 'wc-' . $normalized_status : $normalized_status;
 				}
+
+				$query_vars['post_status'] = $usable_statuses;
+				$has_unusable_status       = $has_unusable_status
+					&& ! array_filter( $usable_statuses, array( $this, 'status_narrows_query' ) );
 
 				if ( $has_unusable_status ) {
 					unset( $query_vars['post_status'] );
-				} else {
-					$query_vars['post_status'] = $normalized_statuses;
 				}
 			} else {
 				$normalized_status = null;

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -911,6 +911,13 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
+	 * Query failures already logged during this PHP execution, keyed by site and error code.
+	 *
+	 * @var array
+	 */
+	private static $logged_query_failures = array();
+
+	/**
 	 * Normalizes an order status value before it is prefixed.
 	 *
 	 * Arrays and null keep their pre-existing behavior. Stringable objects are converted once so
@@ -1019,6 +1026,22 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 */
 	private function fail_query_closed( &$wp_query_args, $code, $message ) {
 		$wp_query_args['errors'][] = new WP_Error( $code, $message );
+		$dedupe_key                = get_current_blog_id() . '|' . $code;
+
+		if ( isset( self::$logged_query_failures[ $dedupe_key ] ) ) {
+			return;
+		}
+
+		self::$logged_query_failures[ $dedupe_key ] = true;
+
+		wc_get_logger()->warning(
+			__( 'Malformed order query args. Returning no orders.', 'woocommerce' ),
+			array(
+				'code'   => $code,
+				'origin' => __METHOD__,
+				'source' => 'legacy-order-query',
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1015,8 +1015,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
-	 * Marks a query as invalid, so it returns no orders rather than running without the filter the
-	 * caller asked for.
+	 * Marks a query as unsatisfiable for both the data store short-circuit and WP_Query. The
+	 * markers are reasserted after the public query filter runs.
 	 *
 	 * @since 11.2.0
 	 * @param array  $wp_query_args WP_Query args, passed by reference.
@@ -1026,7 +1026,10 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 */
 	private function fail_query_closed( &$wp_query_args, $code, $message ) {
 		$wp_query_args['errors'][] = new WP_Error( $code, $message );
-		$dedupe_key                = get_current_blog_id() . '|' . $code;
+		$wp_query_args['post__in'] = array( 0 );
+		unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
+
+		$dedupe_key = get_current_blog_id() . '|' . $code;
 
 		if ( isset( self::$logged_query_failures[ $dedupe_key ] ) ) {
 			return;
@@ -1235,6 +1238,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$wp_query_args['no_found_rows'] = true;
 		}
 
+		$query_errors = $wp_query_args['errors'] ?? array();
+
 		/**
 		 * Filters the WP_Query arguments used for a legacy order query.
 		 *
@@ -1245,6 +1250,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		 * @param WC_Order_Data_Store_CPT $data_store   Current order data store.
 		 */
 		$wp_query_args = apply_filters( 'woocommerce_order_data_store_cpt_get_orders_query', $wp_query_args, $query_vars, $this );
+
+		if ( ! empty( $query_errors ) ) {
+			if ( empty( $wp_query_args['errors'] ) ) {
+				$wp_query_args['errors'] = $query_errors;
+			}
+			$wp_query_args['post__in'] = array( 0 );
+			unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
+		}
 
 		return $wp_query_args;
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2523,6 +2523,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$wp_query_args['orderby'] = 'post__in';
 		}
 
+		$query_errors = $wp_query_args['errors'] ?? array();
+
 		/**
 		 * Filters the WP_Query arguments used for a legacy product query.
 		 *
@@ -2533,6 +2535,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		 * @param WC_Product_Data_Store_CPT $data_store   Current product data store.
 		 */
 		$wp_query_args = apply_filters( 'woocommerce_product_data_store_cpt_get_products_query', $wp_query_args, $query_vars, $this );
+
+		if ( ! empty( $query_errors ) ) {
+			if ( empty( $wp_query_args['errors'] ) ) {
+				$wp_query_args['errors'] = $query_errors;
+			}
+			$wp_query_args['post__in'] = array( 0 );
+			unset( $wp_query_args['p'], $wp_query_args['page_id'], $wp_query_args['attachment_id'], $wp_query_args['subpost_id'] );
+		}
 
 		return $wp_query_args;
 	}

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -350,9 +350,11 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 			}
 		};
 
-		$result = $this->sut->parse_date_for_wp_query( $query_var, 'post_date', array() );
+		$result = $this->sut->parse_date_for_wp_query( $query_var, 'post_date', array( 'p' => 123 ) );
 
 		$this->assertNotEmpty( $result['errors'] ?? array(), 'A failed conversion must mark the query as invalid.' );
+		$this->assertSame( array( 0 ), $result['post__in'] ?? null, 'A failed conversion must make WP_Query unsatisfiable.' );
+		$this->assertArrayNotHasKey( 'p', $result, 'A single-post alias must not override the fail-closed marker.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1669,6 +1669,59 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Query failure warnings are deduplicated independently for each site.
+	 */
+	public function test_query_failure_logging_is_deduped_per_site(): void {
+		$warning_count = 0;
+		$logger        = $this->createMock( WC_Logger_Interface::class );
+		$logger->method( 'warning' )->willReturnCallback(
+			static function ( $message, $context ) use ( &$warning_count ) {
+				unset( $message, $context );
+				++$warning_count;
+			}
+		);
+
+		$inject_logger = static function () use ( $logger ) {
+			return $logger;
+		};
+
+		$logged_query_failures = new ReflectionProperty( WC_Order_Data_Store_CPT::class, 'logged_query_failures' );
+		$logged_query_failures->setAccessible( true );
+		$previous_failures = $logged_query_failures->getValue();
+		$previous_blog_id  = $GLOBALS['blog_id'] ?? 1;
+
+		$logged_query_failures->setValue( null, array() );
+		add_filter( 'woocommerce_logging_class', $inject_logger );
+
+		try {
+			$args = array(
+				'status' => new stdClass(),
+				'return' => 'ids',
+				'limit'  => -1,
+			);
+
+			$first_result  = wc_get_orders( $args );
+			$second_result = wc_get_orders( $args );
+
+			$this->assertSame( array(), $first_result, 'The first malformed query must fail closed.' );
+			$this->assertSame( array(), $second_result, 'A deduplicated query must still fail closed.' );
+			$this->assertSame( 1, $warning_count, 'The same failure should be logged once per site.' );
+
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test-only: simulate another site without changing database tables.
+			$GLOBALS['blog_id'] = $previous_blog_id + 1;
+			$third_result       = wc_get_orders( $args );
+
+			$this->assertSame( array(), $third_result, 'The malformed query on another site must fail closed.' );
+			$this->assertSame( 2, $warning_count, 'The same failure should be logged again for another site.' );
+		} finally {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the test's original site context.
+			$GLOBALS['blog_id'] = $previous_blog_id;
+			remove_filter( 'woocommerce_logging_class', $inject_logger );
+			$logged_query_failures->setValue( null, $previous_failures );
+		}
+	}
+
+	/**
 	 * @testdox Malformed date args match no orders rather than returning every order.
 	 *
 	 * @dataProvider provider_malformed_date_keys

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1847,6 +1847,67 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A status list keeps a valid sibling when another Stringable conversion throws.
+	 */
+	public function test_status_list_keeps_valid_sibling_of_throwing_stringable(): void {
+		$completed = OrderHelper::create_order();
+		$completed->set_status( OrderStatus::COMPLETED );
+		$completed->save();
+
+		$pending = OrderHelper::create_order();
+		$pending->set_status( OrderStatus::PENDING );
+		$pending->save();
+
+		$status = self::create_throwing_stringable();
+		$sut    = new WC_Order_Data_Store_CPT();
+
+		$result = $sut->query(
+			array(
+				'status'   => array( OrderStatus::COMPLETED, $status ),
+				'return'   => 'ids',
+				'limit'    => -1,
+				'paginate' => false,
+				'type'     => 'shop_order',
+			)
+		);
+
+		$this->assertContains( $completed->get_id(), $result, 'The valid status must remain active.' );
+		$this->assertNotContains( $pending->get_id(), $result, 'The valid status must still narrow the query.' );
+	}
+
+	/**
+	 * @testdox A throwing status Stringable with no narrowing sibling fails closed.
+	 */
+	public function test_throwing_stringable_status_with_inert_sibling_fails_closed(): void {
+		$status   = self::create_throwing_stringable();
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+		$sut      = new WC_Order_Data_Store_CPT();
+
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		try {
+			$result = $sut->query(
+				array(
+					'status'   => array( $status, 'bogus-not-a-status' ),
+					'return'   => 'ids',
+					'limit'    => -1,
+					'paginate' => false,
+					'type'     => 'shop_order',
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+		}
+
+		$this->assertSame( array(), $result, 'A failed status conversion without a narrowing sibling must return no orders.' );
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'A non-narrowing survivor must not reopen the failed query.' );
+	}
+
+	/**
 	 * @testdox Status normalization does not swallow errors from the public status filter.
 	 */
 	public function test_status_filter_error_still_propagates(): void {
@@ -2111,12 +2172,73 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox A status list fails closed when any entry is unusable.
+	 * Status lists whose only surviving entry filters nothing.
+	 *
+	 * @return array<string, array{0: array}>
 	 */
-	public function test_partially_usable_status_list_fails_closed(): void {
+	public function provider_unusable_status_with_inert_sibling(): array {
+		return array(
+			'object and empty string' => array( array( new stdClass(), '' ) ),
+			'object and null'         => array( array( new stdClass(), null ) ),
+			'object and array'        => array( array( new stdClass(), array() ) ),
+		);
+	}
+
+	/**
+	 * @testdox An unusable status fails closed even when an inert entry sits beside it.
+	 *
+	 * The inert entry survives normalization but filters no status, so treating it as a
+	 * usable sibling would drop the clause and return every order, including trashed ones.
+	 *
+	 * @dataProvider provider_unusable_status_with_inert_sibling
+	 *
+	 * @param array $status Status list mixing an unusable entry with an inert one.
+	 */
+	public function test_unusable_status_with_inert_sibling_fails_closed( array $status ): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = $args;
+			return $args;
+		};
+
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+
+		// Array entries keep their pre-existing warning behavior.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test-only: reproduces production error semantics.
+		set_error_handler( static fn() => true );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'status' => $status,
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			restore_error_handler();
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $capture, 1 );
+		}
+
+		$this->assertSame( array(), $result, 'The query must match no orders.' );
+		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked invalid.' );
+	}
+
+	/**
+	 * @testdox A status list keeps its usable entries and drops only unusable ones.
+	 */
+	public function test_partially_usable_status_list_keeps_working(): void {
 		$completed = OrderHelper::create_order();
 		$completed->set_status( OrderStatus::COMPLETED );
 		$completed->save();
+
+		$pending = OrderHelper::create_order();
+		$pending->set_status( OrderStatus::PENDING );
+		$pending->save();
 
 		$result = wc_get_orders(
 			array(
@@ -2126,7 +2248,8 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertSame( array(), $result, 'An unusable status must fail the whole query closed.' );
+		$this->assertContains( $completed->get_id(), $result, 'The usable status must still be applied.' );
+		$this->assertNotContains( $pending->get_id(), $result, 'Dropping an unusable entry must not drop the whole status filter.' );
 	}
 
 	/**
@@ -2164,6 +2287,60 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			"array('all')" => array( array( 'all' ) ),
 			"array('any')" => array( array( 'any' ) ),
 		);
+	}
+
+	/**
+	 * Status lists pairing an unusable entry with a truthy sibling that names no status.
+	 *
+	 * Truthiness alone does not make a survivor useful: WP_Query keeps only entries that match a
+	 * registered status, so these narrow nothing and the clause would vanish.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provider_unusable_status_with_non_filtering_sibling(): array {
+		return array(
+			'unregistered string sibling' => array( array( new stdClass(), 'bogus-not-a-status' ) ),
+			'non-empty array sibling'     => array( array( new stdClass(), array( 'x' ) ) ),
+			'zero string sibling'         => array( array( new stdClass(), '0' ) ),
+		);
+	}
+
+	/**
+	 * @testdox An unusable status whose only siblings filter nothing fails the query closed.
+	 *
+	 * @dataProvider provider_unusable_status_with_non_filtering_sibling
+	 *
+	 * @param array $status Status list mixing an unusable entry with a non-filtering one.
+	 */
+	public function test_unusable_status_with_non_filtering_sibling_fails_closed( array $status ): void {
+		$completed = OrderHelper::create_order();
+		$completed->set_status( OrderStatus::COMPLETED );
+		$completed->save();
+
+		$trashed = OrderHelper::create_order();
+		$trashed->set_status( OrderStatus::COMPLETED );
+		$trashed->save();
+		wp_trash_post( $trashed->get_id() );
+
+		// A non-empty array entry warns on the 'wc-' concatenation. Swallow it and continue, as
+		// production does, rather than let phpunit convert it.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test-only: reproduces production error semantics.
+		set_error_handler( static fn() => true, E_WARNING | E_NOTICE );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'status' => $status,
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $result, 'The query must match no orders.' );
+		$this->assertNotContains( $trashed->get_id(), $result, 'A trashed order must never leak through a failed-closed status query.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1634,17 +1634,62 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The public order query filter can replace a failed query with valid arguments.
+	 * WP_Query vars that resolve to 'p', which takes precedence over post__in.
+	 *
+	 * @return array<string, array{0: string}>
 	 */
-	public function test_order_filter_can_replace_failed_query(): void {
-		$order    = OrderHelper::create_order();
-		$order_id = $order->get_id();
+	public function provider_post_id_query_vars(): array {
+		return array(
+			'p'             => array( 'p' ),
+			'page_id'       => array( 'page_id' ),
+			'attachment_id' => array( 'attachment_id' ),
+			'subpost_id'    => array( 'subpost_id' ),
+		);
+	}
 
-		$replace_query_args = static function () use ( $order_id ) {
+	/**
+	 * @testdox A failed-closed query stays closed even if a filter drops the errors key.
+	 *
+	 * @dataProvider provider_post_id_query_vars
+	 *
+	 * @param string $id_var The WP_Query var carrying the order ID.
+	 */
+	public function test_fail_closed_query_survives_a_filter_dropping_errors( string $id_var ): void {
+		$order = OrderHelper::create_order();
+
+		$drop_errors = static function ( $args ) {
+			unset( $args['errors'] );
+			return $args;
+		};
+
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $drop_errors, 99 );
+
+		try {
+			$result = wc_get_orders(
+				array(
+					'status' => new stdClass(),
+					$id_var  => $order->get_id(),
+					'return' => 'ids',
+					'limit'  => -1,
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $drop_errors, 99 );
+		}
+
+		$this->assertSame( array(), $result, 'post__in must not be bypassed by a caller-supplied p.' );
+	}
+
+	/**
+	 * @testdox A failed-closed query stays closed when a filter replaces the query args.
+	 */
+	public function test_fail_closed_query_survives_a_filter_rebuilding_args(): void {
+		OrderHelper::create_order();
+
+		$replace_query_args = static function () {
 			return array(
 				'post_type'      => 'shop_order',
 				'post_status'    => 'any',
-				'post__in'       => array( $order_id ),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 			);
@@ -1665,7 +1710,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $replace_query_args, 99 );
 		}
 
-		$this->assertSame( array( $order_id ), array_values( $result ), 'The public filter must remain authoritative.' );
+		$this->assertSame( array(), $result, 'A malformed query must not be reopened by a filter.' );
 	}
 
 	/**
@@ -1757,6 +1802,44 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			'An unusable date filter must fail closed rather than dropping the filter and returning every order.'
 		);
 		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed in case a filter drops the errors key.' );
+	}
+
+	/**
+	 * @testdox A throwing order date Stringable stays closed when a filter replaces the query args.
+	 */
+	public function test_throwing_stringable_order_date_stays_closed_after_filter_rebuild(): void {
+		OrderHelper::create_order();
+
+		$date_value         = self::create_throwing_stringable();
+		$replace_query_args = static function () {
+			return array(
+				'post_type'      => 'shop_order',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			);
+		};
+
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $replace_query_args, 99 );
+
+		try {
+			$sut    = new WC_Order_Data_Store_CPT();
+			$result = $sut->query(
+				array(
+					'date_paid' => $date_value,
+					'return'    => 'ids',
+					'limit'     => -1,
+					'paginate'  => false,
+					'status'    => 'any',
+					'type'      => 'shop_order',
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $replace_query_args, 99 );
+		}
+
+		$this->assertSame( array(), $result, 'A failed date conversion must not be reopened by a filter.' );
 	}
 
 	/**
@@ -1785,6 +1868,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( array(), $result, 'An unusable customer must not return orders.' );
 		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed.' );
 	}
 
 	/**
@@ -1897,6 +1981,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( array(), $result, 'A failed status conversion must return no orders.' );
 		$this->assertNotEmpty( $captured['errors'] ?? array(), 'A failed conversion must mark the query as invalid.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'A failed conversion must make WP_Query unsatisfiable.' );
 	}
 
 	/**
@@ -1958,6 +2043,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( array(), $result, 'A failed status conversion without a narrowing sibling must return no orders.' );
 		$this->assertNotEmpty( $captured['errors'] ?? array(), 'A non-narrowing survivor must not reopen the failed query.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'A failed conversion must make WP_Query unsatisfiable.' );
 	}
 
 	/**
@@ -2168,6 +2254,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			'A status that cannot be used as a string must not fall back to querying every order.'
 		);
 		$this->assertNotEmpty( $captured['errors'] ?? array(), 'The query must be marked unsatisfiable via the errors mechanism.' );
+		$this->assertSame( array( 0 ), $captured['post__in'] ?? null, 'post__in must pin the query closed in case a filter drops the errors key.' );
 	}
 
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -785,17 +785,15 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The public product query filter can replace a failed query with valid arguments.
+	 * @testdox A malformed product date stays closed when a filter replaces the query args.
 	 */
-	public function test_product_filter_can_replace_failed_query(): void {
-		$product    = WC_Helper_Product::create_simple_product();
-		$product_id = $product->get_id();
+	public function test_malformed_product_date_stays_closed_after_filter_rebuild(): void {
+		WC_Helper_Product::create_simple_product();
 
-		$replace_query_args = static function () use ( $product_id ) {
+		$replace_query_args = static function () {
 			return array(
 				'post_type'      => 'product',
 				'post_status'    => 'publish',
-				'post__in'       => array( $product_id ),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 			);
@@ -815,6 +813,49 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			remove_filter( 'woocommerce_product_data_store_cpt_get_products_query', $replace_query_args, 99 );
 		}
 
-		$this->assertSame( array( $product_id ), array_values( $result ), 'The public filter must remain authoritative.' );
+		$this->assertSame( array(), $result, 'A malformed date query must not be reopened by a filter.' );
+	}
+
+	/**
+	 * @testdox A throwing product date Stringable stays closed when a filter replaces the query args.
+	 */
+	public function test_throwing_stringable_product_date_stays_closed_after_filter_rebuild(): void {
+		WC_Helper_Product::create_simple_product();
+
+		$date_value         = new class() {
+			/**
+			 * Simulate a failed string conversion.
+			 */
+			public function __toString(): string {
+				throw new TypeError( 'String conversion failed.' );
+			}
+		};
+		$replace_query_args = static function () {
+			return array(
+				'post_type'      => 'product',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			);
+		};
+
+		add_filter( 'woocommerce_product_data_store_cpt_get_products_query', $replace_query_args, 99 );
+
+		try {
+			$sut    = new WC_Product_Data_Store_CPT();
+			$result = $sut->query(
+				array(
+					'date_on_sale_from' => $date_value,
+					'return'            => 'ids',
+					'limit'             => -1,
+					'paginate'          => false,
+					'type'              => ProductType::SIMPLE,
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_product_data_store_cpt_get_products_query', $replace_query_args, 99 );
+		}
+
+		$this->assertSame( array(), $result, 'A failed date conversion must not be reopened by a filter.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked for related open pull requests; #68032 partially overlaps the diagnostics policy and is called out below.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PR #67971 now contains only the malformed-input fatal prevention. This stacked follow-up separates three broader policies for independent review:

- Recover registered status values from a partially malformed status list, but fail closed unless a survivor still narrows the query.
- Log malformed order queries once per site and error code.
- Preserve failure markers after the public order and product query filters, preventing callbacks from reopening a rejected query.

Date validation remains inside the shared parent parser, so extension overrides can still normalize custom raw values before core validation.

The logging change partially overlaps #68032, which proposes richer order and product diagnostics. The two implementations should not both be merged.

Refs #58259. This PR uses head branch `fix/58259-legacy-query-recovery-hardening` targeting `fix/58259-legacy-order-query-fatal-guard`; review and merge #67971 first.

The final stacked diff against the updated #67971 branch is 6 files with 457 insertions and 25 deletions.

### Backward compatibility

No public method signatures or filter arguments change. However, this intentionally restricts existing public query filters: once core rejects malformed input, `woocommerce_order_data_store_cpt_get_orders_query` and `woocommerce_product_data_store_cpt_get_products_query` can no longer replace it with a valid query. Extensions relying on that recovery behavior will observe a change.

Because this alters public filter behavior, it is high-impact and requires independent human review.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run the affected legacy data-store suites:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env:hpos-off -- --filter '/(WC_Data_Store_WP_Test|WC_Order_Data_Store_CPT_Test|WC_Product_Data_Store_CPT_Test)/'
   ```

2. Verify all 133 tests and 486 assertions pass.
3. Confirm the focused regressions cover partial status recovery, per-site warning deduplication, rebuilt query-filter arguments, single-ID aliases, and order/product malformed dates.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Verified in wp-env using PHP 8.1.34:

- 133 affected tests and 486 assertions passed on port 8186.
- TDD regressions failed before each policy was restored and passed afterward.
- A self-cleaning Chrome probe on port 8888 confirmed partial status recovery, custom date-parser compatibility, post-filter enforcement for orders and products, and warning deduplication.
- Changed-file lint, full branch lint, PHPStan, and diff checks passed.

The deduplication test covers separate blog IDs, but the complete flow was not run under multisite. No options, paths, capabilities, or database migrations change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs created from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Covered by the existing changelog entry in stacked base PR #67971.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used substantially for investigation, implementation, regression tests, and drafting this description. I reviewed the resulting changes and verification evidence.
