### PR TITLE
Bootstrap Action Scheduler during uninstall so scheduled actions are removed

### DIFF
--- a/plugins/woocommerce/changelog/fix-60415-uninstall-unschedule-actions
+++ b/plugins/woocommerce/changelog/fix-60415-uninstall-unschedule-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure WooCommerce scheduled actions are removed on uninstall by bootstrapping Action Scheduler when no other plugin has loaded it.

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -46,14 +46,20 @@ if ( ! class_exists( 'ActionScheduler', false ) ) {
 	if ( is_readable( $wc_action_scheduler_bootstrap ) ) {
 		try {
 			require_once $wc_action_scheduler_bootstrap;
-
-			// WordPress deletes this plugin's files later in the same request, so the queue runner's
-			// shutdown hook would autoload Action Scheduler classes that no longer exist and fatal.
-			ActionScheduler::runner()->unhook_dispatch_async_request();
 		} catch ( Throwable $e ) {
-			// Nothing to recover, but leave a trace: the guard below silently skips the cleanup otherwise.
+			// Leave a trace; whether the cleanup below still runs depends on how far initialization got.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- No WooCommerce logger during uninstall.
-			error_log( 'WooCommerce: could not load Action Scheduler during uninstall, scheduled actions were not removed. ' . $e->getMessage() );
+			error_log( 'WooCommerce: Action Scheduler threw while loading during uninstall: ' . $e->getMessage() );
+		} finally {
+			/*
+			 * WordPress deletes this plugin's files later in the same request, so the queue runner's
+			 * shutdown hook would autoload Action Scheduler classes that no longer exist and fatal.
+			 * The hook is registered before `action_scheduler_init` fires, so a throw from a callback on
+			 * that action still leaves it attached; is_initialized() is set at the same point.
+			 */
+			if ( class_exists( 'ActionScheduler', false ) && ActionScheduler::is_initialized() ) {
+				ActionScheduler::runner()->unhook_dispatch_async_request();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -27,6 +27,37 @@ wp_clear_scheduled_hook( 'wc_admin_daily' );
 wp_clear_scheduled_hook( 'generate_category_lookup_table' );
 wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
 
+/*
+ * WordPress deactivates a plugin before running its uninstall.php, so `plugins_loaded` has already
+ * fired without WooCommerce. When WooCommerce is the only plugin bundling Action Scheduler, nothing
+ * has loaded the library and the cleanup below would be skipped, leaving every pending action behind.
+ *
+ * Requiring the bundled bootstrap is enough to fully initialize it: the file self-initializes once
+ * `plugins_loaded` has fired (the same path it uses when loaded from a theme).
+ *
+ * That initialization fires `action_scheduler_init`, and WordPress does not deactivate WooCommerce
+ * extensions before deleting WooCommerce, so a still-active extension's callback runs here without
+ * WooCommerce loaded. Anything it throws is caught: leaving actions behind is the bug we are fixing,
+ * but aborting uninstall_plugin() would also stop WordPress from deleting the plugin's files.
+ */
+$wc_bootstrapped_action_scheduler = false;
+
+if ( ! class_exists( 'ActionScheduler', false ) ) {
+	$wc_action_scheduler_bootstrap = __DIR__ . '/packages/action-scheduler/action-scheduler.php';
+
+	if ( is_readable( $wc_action_scheduler_bootstrap ) ) {
+		try {
+			require_once $wc_action_scheduler_bootstrap;
+			$wc_bootstrapped_action_scheduler = class_exists( 'ActionScheduler', false );
+		} catch ( Throwable $e ) {
+			// Leave the flag false; the guards below skip the cleanup rather than aborting uninstall.
+			$wc_bootstrapped_action_scheduler = false;
+		}
+	}
+
+	unset( $wc_action_scheduler_bootstrap );
+}
+
 if ( class_exists( ActionScheduler::class ) && ActionScheduler::is_initialized() && function_exists( 'as_unschedule_all_actions' ) ) {
 	as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
 	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
@@ -39,7 +70,22 @@ if ( class_exists( ActionScheduler::class ) && ActionScheduler::is_initialized()
 	as_unschedule_all_actions( 'wc_admin_daily' );
 	as_unschedule_all_actions( 'generate_category_lookup_table' );
 	as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
+
+	/*
+	 * Initializing Action Scheduler above makes it schedule its own daily housekeeping action. Nothing
+	 * else on this site had loaded it, so it is going away with WooCommerce and that action would be
+	 * left behind by the very cleanup we just ran.
+	 */
+	if ( $wc_bootstrapped_action_scheduler ) {
+		as_unschedule_all_actions( 'action_scheduler_run_recurring_actions_schedule_hook' );
+
+		// Also drop the queue runner's shutdown hook, which would otherwise write a lock option row
+		// (and, when the Action Scheduler tables have been dropped below, query missing tables).
+		ActionScheduler::runner()->unhook_dispatch_async_request();
+	}
 }
+
+unset( $wc_bootstrapped_action_scheduler );
 
 /*
  * Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -40,18 +40,20 @@ wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
  * WooCommerce loaded. Anything it throws is caught: leaving actions behind is the bug we are fixing,
  * but aborting uninstall_plugin() would also stop WordPress from deleting the plugin's files.
  */
-$wc_bootstrapped_action_scheduler = false;
-
 if ( ! class_exists( 'ActionScheduler', false ) ) {
 	$wc_action_scheduler_bootstrap = __DIR__ . '/packages/action-scheduler/action-scheduler.php';
 
 	if ( is_readable( $wc_action_scheduler_bootstrap ) ) {
 		try {
 			require_once $wc_action_scheduler_bootstrap;
-			$wc_bootstrapped_action_scheduler = class_exists( 'ActionScheduler', false );
+
+			// WordPress deletes this plugin's files later in the same request, so the queue runner's
+			// shutdown hook would autoload Action Scheduler classes that no longer exist and fatal.
+			ActionScheduler::runner()->unhook_dispatch_async_request();
 		} catch ( Throwable $e ) {
-			// Leave the flag false; the guards below skip the cleanup rather than aborting uninstall.
-			$wc_bootstrapped_action_scheduler = false;
+			// Nothing to recover, but leave a trace: the guard below silently skips the cleanup otherwise.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- No WooCommerce logger during uninstall.
+			error_log( 'WooCommerce: could not load Action Scheduler during uninstall, scheduled actions were not removed. ' . $e->getMessage() );
 		}
 	}
 
@@ -71,21 +73,12 @@ if ( class_exists( ActionScheduler::class ) && ActionScheduler::is_initialized()
 	as_unschedule_all_actions( 'generate_category_lookup_table' );
 	as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
 
-	/*
-	 * Initializing Action Scheduler above makes it schedule its own daily housekeeping action. Nothing
-	 * else on this site had loaded it, so it is going away with WooCommerce and that action would be
-	 * left behind by the very cleanup we just ran.
-	 */
-	if ( $wc_bootstrapped_action_scheduler ) {
-		as_unschedule_all_actions( 'action_scheduler_run_recurring_actions_schedule_hook' );
-
-		// Also drop the queue runner's shutdown hook, which would otherwise write a lock option row
-		// (and, when the Action Scheduler tables have been dropped below, query missing tables).
-		ActionScheduler::runner()->unhook_dispatch_async_request();
-	}
+	// WooCommerce::register_recurring_actions() schedules these four under wrapper hooks.
+	as_unschedule_all_actions( 'woocommerce_tracker_send_event_wrapper' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits_wrapper' );
+	as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
+	as_unschedule_all_actions( 'generate_category_lookup_table_wrapper' );
 }
-
-unset( $wc_bootstrapped_action_scheduler );
 
 /*
  * Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #60415.
Closes WOOPLUG-5342

WordPress deactivates a plugin before running its `uninstall.php`, so when WooCommerce is the only plugin bundling Action Scheduler nothing has loaded it by then. The `class_exists( ActionScheduler::class ) && ActionScheduler::is_initialized()` guard is false and the `as_unschedule_all_actions()` block is skipped, leaving WooCommerce's pending actions behind after the plugin is deleted.

This PR requires the bundled `packages/action-scheduler/action-scheduler.php` before that block when the class is not loaded. The bootstrap self-initializes once `plugins_loaded` has fired, so nothing else is needed.

Three details:

- In a `finally` after the require, `ActionScheduler::runner()->unhook_dispatch_async_request()` removes the queue runner's `shutdown` hook. WordPress deletes the plugin files later in the same request, and without this the runner autoloads classes whose files are gone (`Class "ActionScheduler_Lock" not found` on every uninstall, reproduced on a test site). This is the same fatal that made #58498 remove a full `woocommerce.php` require from this file; this PR re-applies the idea narrowly, for Action Scheduler only, with that hook removed. It lives in `finally` because `ActionScheduler::init()` registers the hook before it fires `action_scheduler_init`, so a throw from an extension callback there must not skip it.
- The require is wrapped in `try/catch ( Throwable )` with an `error_log()`. WordPress does not deactivate WooCommerce extensions before deleting WooCommerce, so a still-active extension's `action_scheduler_init` callback runs here without WooCommerce loaded and can throw; a fatal would stop WordPress from deleting the files. `error_log()` rather than a warning because deletion from the Plugins screen is an AJAX request. Firing those hooks during uninstall is a new situation for extensions and is accepted as the cost of the fix.
- The four `*_wrapper` hooks are added to the cancel list. `WooCommerce::register_recurring_actions()` has scheduled them under wrapper names since #60360, so the existing list missed them.

Action Scheduler's own housekeeping action, which the bootstrap schedules as a side effect, is intentionally left alone. It is Action Scheduler's concern and is tracked as ACTSCH-109.

No public signatures, hooks, or options change.

### How to test the changes in this Pull Request:

The bug only reproduces when WooCommerce is the only plugin using Action Scheduler, and on a fresh site WooCommerce's recurring actions are not in Action Scheduler until its daily check runs, so step 2 forces that.

1. On a fresh site with only WooCommerce active (Jetpack and Akismet are fine, they do not bundle Action Scheduler), run `wp eval 'WC()->register_recurring_actions();'`.
2. Confirm pending rows with `SELECT hook, status FROM wp_actionscheduler_actions WHERE status = 'pending';`. Expect `woocommerce_cleanup_sessions`, `woocommerce_scheduled_sales`, `wc_admin_daily_wrapper` and similar.
3. Deactivate, then Delete WooCommerce from Plugins > Installed Plugins.
4. Re-run the query. Before this change the WooCommerce rows are still `pending`; after, they are `canceled`. `debug.log` should contain no fatal from `ActionScheduler_QueueRunner`.
5. Regression check: repeat with another Action Scheduler user active and not deleted. Its actions and Action Scheduler's own housekeeping action must be untouched.
6. Failure path: drop a mu-plugin that throws from an `action_scheduler_init` callback when `WP_UNINSTALL_PLUGIN` is defined, then repeat steps 1 to 4. Deletion must still succeed, the actions must still be `canceled`, `debug.log` must contain the `WooCommerce: Action Scheduler threw while loading during uninstall` line and no fatal.

### Testing that has already taken place:

Manually on a Jurassic Ninja site (WP 7.1, Akismet and Jetpack active): reproduced the bug on WooCommerce 11.1.0 (all 9 WooCommerce actions still pending after delete), then verified a build of this branch cancels every WooCommerce action including the wrapper ones, leaves another plugin's action untouched, and logs no fatal. The failure path in step 6 was verified the same way with a throwaway mu-plugin.

Automated: `lint:php:changes` and `lint:changes:branch` clean; full PHP suite matches the trunk baseline (14702 tests, 0 errors, 0 failures). No unit test is included because Action Scheduler is always loaded under PHPUnit, which makes the new code path unreachable there.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entry added manually at `plugins/woocommerce/changelog/fix-60415-uninstall-unschedule-actions`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Ensure WooCommerce scheduled actions are removed on uninstall by bootstrapping Action Scheduler when no other plugin has loaded it.

</details>

### Use of AI Tools

Implemented, reviewed with a multi-agent review pipeline, and manually verified with Claude Code (Claude). All code and testing reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd8TDoZpazshqTULr4JDSq
