### PR TITLE
Fix fatal by ignoring non-string `remove_coupon` in `update_cart_action`

### DIFF
--- a/plugins/woocommerce/changelog/fix-68376-remove-coupon-array-fatal
+++ b/plugins/woocommerce/changelog/fix-68376-remove-coupon-array-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error when the remove_coupon cart parameter is given an array value instead of a string.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -776,7 +776,8 @@ class WC_Form_Handler {
 			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		} elseif ( isset( $_GET['remove_coupon'] ) ) {
-			WC()->cart->remove_coupon( wc_format_coupon_code( urldecode( wp_unslash( $_GET['remove_coupon'] ) ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$coupon_code = is_string( $_GET['remove_coupon'] ) ? wp_unslash( $_GET['remove_coupon'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			WC()->cart->remove_coupon( wc_format_coupon_code( urldecode( $coupon_code ) ) );
 
 		} elseif ( ! empty( $_GET['remove_item'] ) && wp_verify_nonce( $nonce_value, 'woocommerce-cart' ) ) {
 			$cart_item_key = sanitize_text_field( wp_unslash( $_GET['remove_item'] ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -414,6 +414,44 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox update_cart_action() removes a string-valued coupon and ignores an array-valued one instead of fataling.
+	 * @dataProvider remove_coupon_value_provider
+	 *
+	 * @covers WC_Form_Handler::update_cart_action()
+	 *
+	 * @param string|array $remove_coupon_value  Value of the remove_coupon request parameter.
+	 * @param bool         $expect_still_applied Whether the coupon should remain applied afterwards.
+	 */
+	public function test_update_cart_action_remove_coupon_value_handling( $remove_coupon_value, bool $expect_still_applied ): void {
+		$coupon  = WC_Helper_Coupon::create_coupon( 'save10' );
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->apply_coupon( $coupon->get_code() );
+
+		$this->assertTrue( WC()->cart->has_discount( $coupon->get_code() ), 'The coupon should be applied before the request is handled.' );
+
+		$_GET['remove_coupon']     = $remove_coupon_value;
+		$_REQUEST['remove_coupon'] = $remove_coupon_value;
+
+		WC_Form_Handler::update_cart_action();
+
+		$this->assertSame( $expect_still_applied, WC()->cart->has_discount( $coupon->get_code() ), 'A string value should remove the coupon; a non-string value should leave it untouched.' );
+	}
+
+	/**
+	 * Provides remove_coupon request values and whether the coupon should survive the request.
+	 *
+	 * @return array<string,array{string|array,bool}>
+	 */
+	public function remove_coupon_value_provider(): array {
+		return array(
+			'string coupon code' => array( 'save10', false ),
+			'array-wrapped code' => array( array( 'save10' ), true ),
+			'nested array'       => array( array( array( 'save10' ) ), true ),
+		);
+	}
+
+	/**
 	 * @testdox save_account_details() saves other account fields when an email-like display name is unchanged.
 	 *
 	 * @covers WC_Form_Handler::save_account_details()


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

On PHP 8+, `GET ?remove_coupon[]=SAVE10` (array value, unauthenticated, works appended to any front-end URL) fatals with `TypeError: urldecode(): Argument #1 ($string) must be of type string, array given`, because `WC_Form_Handler::update_cart_action()` passes `$_GET['remove_coupon']` straight into `urldecode()`. This PR adds the same `is_string( ... ) ? wp_unslash( ... ) : ''` guard that #68307 applied to the order pay/cancel/PayPal paths, so a non-string value degrades to a no-op instead of a 500. A regression test covers the string, array, and nested-array shapes.

**Backward compatibility impact**: none — no hook, signature, or template changes. Behavior only changes for non-string `remove_coupon` values, which previously fataled.

Closes #68376.

(For Bug Fixes) The unguarded `urldecode()` call predates the monorepo restructure and the PR workflow (it traces back to 2014-era refactors), so no introducing PR can be referenced; the fatal surfaced when PHP 8 turned this argument-type warning into a `TypeError`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a site running PHP 8.0+ with WooCommerce active but **without** this branch, visit any front-end URL with `?remove_coupon[]=SAVE10` appended (e.g. `https://your-site.test/?remove_coupon[]=SAVE10`). Observe the request fails with HTTP 500 ("There has been a critical error on this website").
2. Switch to this branch and repeat step 1. The page now loads normally (HTTP 200); the array value is treated as an empty coupon code and ignored.
3. Verify normal coupon removal still works: create a coupon, add a product to the cart, apply the coupon on the classic cart page (`[woocommerce_cart]` shortcode), then click the `[Remove]` link next to the applied coupon in the cart totals. The coupon is removed as before.

<!-- End testing instructions -->

### Testing that has already taken place:

- New PHPUnit regression test (`WC_Form_Handler_Test::test_update_cart_action_remove_coupon_value_handling`) with three data sets: string code (coupon removed), array-wrapped code, and nested array (coupon untouched, no fatal). Verified the two array cases fail with the original `TypeError` when the guard is removed, and all three pass with it.
- End-to-end HTTP verification against wp-env (PHP 8.1): pre-fix, `?remove_coupon[]=SAVE10` returns HTTP 500 on both the homepage and cart page; with the fix, string, array, and nested-array shapes all return HTTP 200, and clicking a coupon's `[Remove]` link still removes it.
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified source file are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Use of AI Tools

This PR was authored with the assistance of Claude Code (Anthropic); all changes and testing were reviewed and verified by the contributor.