### PR TITLE
Fix the checkout order summary collapsible bar being inert before its width is measured

### DIFF
--- a/plugins/woocommerce/changelog/68530-order-summary-collapsible-bar-keyboard-defaults
+++ b/plugins/woocommerce/changelog/68530-order-summary-collapsible-bar-keyboard-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Checkout block: stop Space scrolling the page and Enter submitting the form when toggling the collapsible order summary.

--- a/plugins/woocommerce/changelog/68530-order-summary-collapsible-bar-operable
+++ b/plugins/woocommerce/changelog/68530-order-summary-collapsible-bar-operable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Checkout block: keep the collapsible order summary expandable by mouse and keyboard before the container width has been measured.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx
@@ -8,12 +8,10 @@ import { TotalsFooterItem } from '@woocommerce/base-components/cart-checkout';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { __ } from '@wordpress/i18n';
-import { useId, useState } from '@wordpress/element';
 import { Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import clsx from 'clsx';
 import { FormattedMonetaryAmount } from '@woocommerce/blocks-components';
-import { useContainerWidthContext } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -23,6 +21,7 @@ import {
 	getAllowedBlocks,
 } from '../../../cart-checkout-shared';
 import { OrderMetaSlotFill } from './slotfills';
+import { useOrderSummaryToggle } from './use-order-summary-toggle';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
@@ -32,24 +31,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const allowedBlocks = getAllowedBlocks(
 		innerBlockAreas.CHECKOUT_ORDER_SUMMARY
 	);
-	const { isLarge } = useContainerWidthContext();
-	const [ isOpen, setIsOpen ] = useState( false );
-	const ariaControlsId = useId();
-
-	const orderSummaryProps = ! isLarge
-		? {
-				role: 'button',
-				onClick: () => setIsOpen( ! isOpen ),
-				'aria-expanded': isOpen,
-				'aria-controls': ariaControlsId,
-				tabIndex: 0,
-				onKeyDown: ( event: React.KeyboardEvent ) => {
-					if ( event.key === 'Enter' || event.key === ' ' ) {
-						setIsOpen( ! isOpen );
-					}
-				},
-		  }
-		: {};
+	const { isOpen, ariaControlsId, toggleProps } = useOrderSummaryToggle();
 
 	const defaultTemplate = [
 		[ 'woocommerce/checkout-order-summary-cart-items-block', {}, [] ],
@@ -67,7 +49,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		<div { ...blockProps }>
 			<div
 				className="wc-block-components-checkout-order-summary__title"
-				{ ...orderSummaryProps }
+				{ ...toggleProps }
 			>
 				<p
 					className="wc-block-components-checkout-order-summary__title-text"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx
@@ -24,28 +24,32 @@ const FrontendBlock = ( {
 	className?: string;
 } ): JSX.Element | null => {
 	const { cartTotals } = useStoreCart();
-	const { isMedium, isSmall, isMobile } = useContainerWidthContext();
+	const { isLarge } = useContainerWidthContext();
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
 	const totalPrice = parseInt( cartTotals.total_price, 10 );
 	const ariaControlsId = useId();
 
-	const orderSummaryProps =
-		isMedium || isSmall || isMobile
-			? {
-					role: 'button',
-					onClick: () => setIsOpen( ! isOpen ),
-					'aria-expanded': isOpen,
-					'aria-controls': ariaControlsId,
-					tabIndex: 0,
-					onKeyDown: ( event: React.KeyboardEvent ) => {
-						if ( event.key === 'Enter' || event.key === ' ' ) {
-							setIsOpen( ! isOpen );
-						}
-					},
-			  }
-			: {};
+	// Checked as `! isLarge` rather than by listing the smaller sizes: the
+	// container width is unknown until the resize observer first reports, and
+	// the CSS has already collapsed the summary by then. Assuming the collapsed
+	// presentation while unsure keeps the bar operable; the reverse leaves it
+	// inert with no other way to see the totals.
+	const orderSummaryProps = ! isLarge
+		? {
+				role: 'button',
+				onClick: () => setIsOpen( ! isOpen ),
+				'aria-expanded': isOpen,
+				'aria-controls': ariaControlsId,
+				tabIndex: 0,
+				onKeyDown: ( event: React.KeyboardEvent ) => {
+					if ( event.key === 'Enter' || event.key === ' ' ) {
+						setIsOpen( ! isOpen );
+					}
+				},
+		  }
+		: {};
 
 	// Render the summary once here in the block and once in the fill. The fill can be slotted once elsewhere. The fill is only
 	// rendered on small and mobile screens.
@@ -96,9 +100,10 @@ const FrontendBlock = ( {
 					<OrderMetaSlotFill />
 				</div>
 			</div>
-			{ /* Render a second instance of the order summary in a different location for smaller screens
-			This prevents the fill from appearing on desktop before width data is available */ }
-			{ ( isMedium || isSmall || isMobile ) && (
+			{ /* Render a second instance of the order summary in a different location for smaller screens.
+			On large containers the CSS hides this fill, so rendering it while the
+			width is still unknown is safe. */ }
+			{ ! isLarge && (
 				<CheckoutOrderSummaryFill>
 					<div
 						className={ `${ className } checkout-order-summary-block-fill-wrapper` }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx
@@ -6,15 +6,14 @@ import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
-import { useId, useState } from '@wordpress/element';
 import clsx from 'clsx';
 import { FormattedMonetaryAmount } from '@woocommerce/blocks-components';
 /**
  * Internal dependencies
  */
 import { OrderMetaSlotFill, CheckoutOrderSummaryFill } from './slotfills';
-import { useContainerWidthContext } from '../../../../base/context';
 import { FormStepHeading } from '../../form-step';
+import { useOrderSummaryToggle } from './use-order-summary-toggle';
 
 const FrontendBlock = ( {
 	children,
@@ -24,35 +23,15 @@ const FrontendBlock = ( {
 	className?: string;
 } ): JSX.Element | null => {
 	const { cartTotals } = useStoreCart();
-	const { isLarge } = useContainerWidthContext();
-	const [ isOpen, setIsOpen ] = useState( false );
+	const { isOpen, isLarge, ariaControlsId, toggleProps } =
+		useOrderSummaryToggle();
 
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
 	const totalPrice = parseInt( cartTotals.total_price, 10 );
-	const ariaControlsId = useId();
 
-	// Checked as `! isLarge` rather than by listing the smaller sizes: the
-	// container width is unknown until the resize observer first reports, and
-	// the CSS has already collapsed the summary by then. Assuming the collapsed
-	// presentation while unsure keeps the bar operable; the reverse leaves it
-	// inert with no other way to see the totals.
-	const orderSummaryProps = ! isLarge
-		? {
-				role: 'button',
-				onClick: () => setIsOpen( ! isOpen ),
-				'aria-expanded': isOpen,
-				'aria-controls': ariaControlsId,
-				tabIndex: 0,
-				onKeyDown: ( event: React.KeyboardEvent ) => {
-					if ( event.key === 'Enter' || event.key === ' ' ) {
-						setIsOpen( ! isOpen );
-					}
-				},
-		  }
-		: {};
-
-	// Render the summary once here in the block and once in the fill. The fill can be slotted once elsewhere. The fill is only
-	// rendered on small and mobile screens.
+	// Render the summary once here in the block and once in the fill, so the
+	// fill can be slotted elsewhere. Below the large breakpoint both render and
+	// the CSS decides which one is visible.
 	return (
 		<>
 			<div className={ className }>
@@ -63,7 +42,7 @@ const FrontendBlock = ( {
 							'is-open': isOpen,
 						}
 					) }
-					{ ...orderSummaryProps }
+					{ ...toggleProps }
 				>
 					<p
 						className="wc-block-components-checkout-order-summary__title-text"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/collapsible-bar.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/collapsible-bar.js
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { previewCart as mockPreviewCart } from '../../../../../previews/cart';
+import SummaryBlock from '../frontend';
+
+const baseContext = jest.requireMock( '@woocommerce/base-context' );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	SITE_CURRENCY: {
+		code: 'USD',
+		symbol: '$',
+		thousandSeparator: ',',
+		decimalSeparator: '.',
+		minorUnit: 2,
+		prefix: '$',
+		suffix: '',
+	},
+} ) );
+
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	...jest.requireActual( '@woocommerce/base-context/hooks' ),
+	useStoreCart: jest.fn().mockReturnValue( {
+		cartItems: [],
+		cartTotals: {
+			total_price: '4000',
+			currency_code: 'USD',
+			currency_symbol: '$',
+			currency_minor_unit: 2,
+			currency_decimal_separator: '.',
+			currency_thousand_separator: ',',
+			currency_prefix: '$',
+			currency_suffix: '',
+		},
+		cartCoupons: [],
+		cartFees: [],
+		cartNeedsShipping: false,
+		shippingRates: [],
+		shippingAddress: mockPreviewCart.shipping_address,
+		billingAddress: mockPreviewCart.billing_address,
+		cartHasCalculatedShipping: true,
+	} ),
+} ) );
+
+jest.mock( '@woocommerce/base-context', () => ( {
+	...jest.requireActual( '@woocommerce/base-context' ),
+	useContainerWidthContext: jest.fn(),
+} ) );
+
+/**
+ * The values ContainerWidthContext produces for a given container class name.
+ * An empty class name is what it reports until the resize observer first fires.
+ *
+ * @param {string} containerClassName Class name for the measured width.
+ * @return {Object} The context value.
+ */
+const containerWidthOf = ( containerClassName ) => ( {
+	hasContainerWidth: containerClassName !== '',
+	containerClassName,
+	isMobile: containerClassName === 'is-mobile',
+	isSmall: containerClassName === 'is-small',
+	isMedium: containerClassName === 'is-medium',
+	isLarge: containerClassName === 'is-large',
+} );
+
+const renderAt = ( containerClassName ) => {
+	baseContext.useContainerWidthContext.mockReturnValue(
+		containerWidthOf( containerClassName )
+	);
+	return render(
+		<SummaryBlock>
+			<div />
+		</SummaryBlock>
+	);
+};
+
+describe( 'Checkout Order Summary collapsible bar', () => {
+	describe.each( [ '', 'is-mobile', 'is-small', 'is-medium' ] )(
+		'when the container reports %p',
+		( containerClassName ) => {
+			it( 'exposes the summary as an expandable button', () => {
+				renderAt( containerClassName );
+
+				const bar = screen.getByRole( 'button', {
+					name: /Order summary/,
+				} );
+				expect( bar ).toHaveAttribute( 'aria-expanded', 'false' );
+				expect( bar ).toHaveAttribute( 'aria-controls' );
+				expect( bar ).toHaveAttribute( 'tabindex', '0' );
+			} );
+
+			it( 'toggles on click', () => {
+				renderAt( containerClassName );
+
+				const bar = screen.getByRole( 'button', {
+					name: /Order summary/,
+				} );
+				fireEvent.click( bar );
+				expect( bar ).toHaveAttribute( 'aria-expanded', 'true' );
+			} );
+
+			it.each( [ 'Enter', ' ' ] )( 'toggles on %p', ( key ) => {
+				renderAt( containerClassName );
+
+				const bar = screen.getByRole( 'button', {
+					name: /Order summary/,
+				} );
+				fireEvent.keyDown( bar, { key } );
+				expect( bar ).toHaveAttribute( 'aria-expanded', 'true' );
+			} );
+		}
+	);
+
+	it( 'is not a button once the container is large enough for two columns', () => {
+		const { container } = renderAt( 'is-large' );
+
+		const bar = container.querySelector(
+			'.wc-block-components-checkout-order-summary__title'
+		);
+		expect( bar ).not.toHaveAttribute( 'role' );
+		expect( bar ).not.toHaveAttribute( 'tabindex' );
+		expect( bar ).not.toHaveAttribute( 'aria-expanded' );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/collapsible-bar.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/collapsible-bar.js
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
  */
 import { previewCart as mockPreviewCart } from '../../../../../previews/cart';
 import SummaryBlock from '../frontend';
+import { CheckoutOrderSummarySlot } from '../slotfills';
 
 const baseContext = jest.requireMock( '@woocommerce/base-context' );
 
@@ -69,6 +71,10 @@ const containerWidthOf = ( containerClassName ) => ( {
 	isLarge: containerClassName === 'is-large',
 } );
 
+/**
+ * @param {string} containerClassName Class name for the measured width.
+ * @return {import('@testing-library/react').RenderResult} The render result.
+ */
 const renderAt = ( containerClassName ) => {
 	baseContext.useContainerWidthContext.mockReturnValue(
 		containerWidthOf( containerClassName )
@@ -114,6 +120,37 @@ describe( 'Checkout Order Summary collapsible bar', () => {
 				fireEvent.keyDown( bar, { key } );
 				expect( bar ).toHaveAttribute( 'aria-expanded', 'true' );
 			} );
+
+			// Without this the browser still acts on the key: Space scrolls the
+			// page out from under the summary that just opened, and Enter
+			// submits the checkout form the bar sits inside.
+			it.each( [ 'Enter', ' ' ] )(
+				'suppresses the browser default for %p',
+				( key ) => {
+					renderAt( containerClassName );
+
+					const bar = screen.getByRole( 'button', {
+						name: /Order summary/,
+					} );
+					const event = createEvent.keyDown( bar, { key } );
+					fireEvent( bar, event );
+
+					expect( event.defaultPrevented ).toBe( true );
+				}
+			);
+
+			it( 'collapses again when activated a second time', () => {
+				renderAt( containerClassName );
+
+				const bar = screen.getByRole( 'button', {
+					name: /Order summary/,
+				} );
+				fireEvent.click( bar );
+				expect( bar ).toHaveAttribute( 'aria-expanded', 'true' );
+
+				fireEvent.click( bar );
+				expect( bar ).toHaveAttribute( 'aria-expanded', 'false' );
+			} );
 		}
 	);
 
@@ -126,5 +163,54 @@ describe( 'Checkout Order Summary collapsible bar', () => {
 		expect( bar ).not.toHaveAttribute( 'role' );
 		expect( bar ).not.toHaveAttribute( 'tabindex' );
 		expect( bar ).not.toHaveAttribute( 'aria-expanded' );
+	} );
+} );
+
+describe( 'Checkout Order Summary fill', () => {
+	/**
+	 * Renders the block together with the slot the fill targets, so the second
+	 * summary instance actually appears in the tree.
+	 *
+	 * @param {string} containerClassName Class name for the measured width.
+	 * @return {import('@testing-library/react').RenderResult} The render result.
+	 */
+	const renderWithSlot = ( containerClassName ) => {
+		baseContext.useContainerWidthContext.mockReturnValue(
+			containerWidthOf( containerClassName )
+		);
+		return render(
+			<SlotFillProvider>
+				<SummaryBlock>
+					<div />
+				</SummaryBlock>
+				<CheckoutOrderSummarySlot />
+			</SlotFillProvider>
+		);
+	};
+
+	/**
+	 * @param {HTMLElement} container Render container.
+	 * @return {NodeList} The rendered fill wrappers.
+	 */
+	const fillsIn = ( container ) =>
+		container.querySelectorAll(
+			'.checkout-order-summary-block-fill-wrapper'
+		);
+
+	describe.each( [ '', 'is-mobile', 'is-small', 'is-medium' ] )(
+		'when the container reports %p',
+		( containerClassName ) => {
+			it( 'renders the second summary into the slot', () => {
+				const { container } = renderWithSlot( containerClassName );
+
+				expect( fillsIn( container ) ).toHaveLength( 1 );
+			} );
+		}
+	);
+
+	it( 'renders no fill once the container is large enough for two columns', () => {
+		const { container } = renderWithSlot( 'is-large' );
+
+		expect( fillsIn( container ) ).toHaveLength( 0 );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/use-order-summary-toggle.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/use-order-summary-toggle.ts
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { useContainerWidthContext } from '@woocommerce/base-context';
+import { useId, useState } from '@wordpress/element';
+import type { HTMLAttributes, KeyboardEvent } from 'react';
+
+export type OrderSummaryToggle = {
+	isOpen: boolean;
+	isLarge: boolean;
+	ariaControlsId: string;
+	toggleProps: HTMLAttributes< HTMLDivElement >;
+};
+
+/**
+ * State and props for the collapsible "Order summary" bar, shared by the
+ * frontend block and the editor preview so the two can't drift apart.
+ *
+ * The interactive props are attached when the container is not large, rather
+ * than by listing the smaller sizes: the width is unknown until the resize
+ * observer first reports, and the CSS has already collapsed the summary by
+ * then. Assuming the collapsed presentation while unsure keeps the bar
+ * operable; the reverse leaves it inert with no other way to see the totals.
+ *
+ * @return {OrderSummaryToggle} Open state, the measured size, the id the bar
+ *                              controls, and the props to spread on the bar.
+ */
+export const useOrderSummaryToggle = (): OrderSummaryToggle => {
+	const { isLarge } = useContainerWidthContext();
+	const [ isOpen, setIsOpen ] = useState( false );
+	const ariaControlsId = useId();
+
+	const toggleProps = ! isLarge
+		? {
+				role: 'button',
+				onClick: () => setIsOpen( ! isOpen ),
+				'aria-expanded': isOpen,
+				'aria-controls': ariaControlsId,
+				tabIndex: 0,
+				onKeyDown: ( event: KeyboardEvent ) => {
+					if ( event.key === 'Enter' || event.key === ' ' ) {
+						// Space scrolls the page and Enter submits the
+						// surrounding checkout form. A real button would
+						// suppress both for us.
+						event.preventDefault();
+						setIsOpen( ! isOpen );
+					}
+				},
+		  }
+		: {};
+
+	return { isOpen, isLarge, ariaControlsId, toggleProps };
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

Below the collapse breakpoint the block Checkout shows the order summary as a collapsible "Order summary $40.00" bar. That bar could render **inert** — no `role`, `tabindex`, `aria-expanded` or handlers — while the CSS had already collapsed the panel behind it, leaving no way to see the totals before paying.

The handlers were attached on the positive form of the container-width flags:

```js
const orderSummaryProps =
    isMedium || isSmall || isMobile ? { role: 'button', onClick, … } : {};
```

`useContainerQueries` returns an empty class name whenever the observed width is falsy, and then all four flags are false — so the positive form resolves to "not interactive" while the CSS, which doesn't wait for JS, has already collapsed the panel. The same condition gated `CheckoutOrderSummaryFill`, so the expanded summary near "Place order" wasn't rendered either. A falsy width covers a measured `0` as well as "not yet measured", so wherever the width stays `0` the bar is inert permanently, not for one frame.

The fix checks `! isLarge`, which is what [#52253](https://github.com/woocommerce/woocommerce/pull/52253) shipped originally and what `edit.tsx` still does — [#58476](https://github.com/woocommerce/woocommerce/pull/58476) flipped only `frontend.tsx` to the positive form. An unknown width now assumes the collapsed presentation and keeps the bar operable.

Two things came out of reviewing that. The handler never called `preventDefault()`, so on a `div[role="button"]` the browser still acted on the key: Space scrolled the page out from under the summary that had just opened, and Enter submitted the checkout form the bar sits inside. And the gate, open state, generated id and props were duplicated across `frontend.tsx` and `edit.tsx` — the drift that caused this bug in the first place — so they now live in one `useOrderSummaryToggle` hook that both consumers spread.

Closes #68530.

(For Bug Fixes) Bug introduced in PR #58476.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store using the **block-based** Checkout, add two or three products to the cart.
2. Open Checkout and narrow the browser until the layout collapses to one column and the order summary becomes the collapsible "Order summary &lt;total&gt;" bar.
3. Click the bar — it should expand and collapse. Tab to it and press <kbd>Enter</kbd>, then <kbd>Space</kbd> — each should toggle it.
4. Confirm `.wc-block-components-checkout-order-summary__title` carries `role="button"`, `tabindex="0"` and an `aria-expanded` that tracks the panel.
5. **Hard-reload with the network throttled** and try the bar as soon as it appears, before the layout settles. This is the case that was broken. Resizing an already-loaded page won't reproduce it.
6. Widen past the two-column breakpoint. The bar should stop being a button entirely, and the summary should sit in the sidebar, always visible.

<!-- End testing instructions -->

### Testing that has already taken place:

**Unit tests:** 34 tests across the four collapsed states (including unmeasured) plus `is-large`, covering attributes, click / <kbd>Enter</kbd> / <kbd>Space</kbd> toggling, collapse-back, the suppressed key defaults, and the fill render gate. Every assertion was mutation-checked: removing `preventDefault()` fails 8, forcing the fill gate false fails 4, forcing it true fails 1, and reverting the gate to trunk's form fails exactly the 7 unmeasured-state tests. Full cart + checkout suite: 29 suites, 231 passed, 3 skipped.

**In a real browser** (Chrome, block Checkout, 3 items) At a 786px container the bar exposes `role="button"`, `tabindex="0"`, `aria-expanded` tracking the panel, and `aria-controls` resolving to the panel element; click and <kbd>Enter</kbd>/<kbd>Space</kbd> both toggle it open and closed. <kbd>Enter</kbd> did not submit or navigate. Space left `scrollY` at 0 on a 4000px page — and as a control, focusing an element with no handler and pressing Space scrolled 876px, so the bar's 0px is genuinely the `preventDefault`. At a 1100px container the bar carries no `role`, `tabindex` or `aria-expanded`, the panel is always visible, and the fill is absent from the DOM.

**The bug itself, end to end.** Rather than race a throttled reload, the permanent variant was reproduced directly: zeroing the element the `ResizeObserver` measures while leaving the CSS container at 786px puts the page in exactly the reported state — panel collapsed by CSS, no `is-*` class, all four flags false. On this branch the bar stays operable there and the panel opens. Rebuilding with trunk's gate and recreating the identical state gives `role`, `tabindex` and `aria-expanded` all `null` and a click that does nothing.

**Backward compatibility:** nothing changes in the settled render. Only the unmeasured window differs, where the title now carries `role`/`tabindex`/`aria-expanded` and the fill wrapper mounts (hidden by CSS) — that difference is the fix.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Two changelog entries are **already committed in this branch**, so neither checkbox below is ticked:

```
Significance: patch
Type: fix

Checkout block: keep the collapsible order summary expandable by mouse and keyboard before the container width has been measured.
```

```
Significance: patch
Type: fix

Checkout block: stop Space scrolling the page and Enter submitting the form when toggling the collapsible order summary.
```

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Use of AI Tools

This pull request was authored with Claude Code (Claude Opus 5). The root cause was traced with `git log -L` on the gate, and the fix was verified both with unit tests and by driving the real checkout in a browser. I reviewed and take responsibility for the change.
