### PR TITLE
Total Customer History per currency instead of summing across them

### DIFF
--- a/plugins/woocommerce/changelog/fix-43781-customer-history-currencies
+++ b/plugins/woocommerce/changelog/fix-43781-customer-history-currencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Customer history template overrides now receive per-currency totals, counts and averages. Overrides supplying only the original single-total arguments continue to render.
+
+Total the Customer History metabox separately per currency instead of adding amounts from different currencies together.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -46,27 +46,31 @@ class CustomerHistory {
 	 *
 	 * @param WC_Order $order The order object.
 	 *
-	 * @return array{orders_count: int, total_spend: float, avg_order_value: float, tooltip: string} Order count, total spend, average order value, and tooltip text.
+	 * @return array{orders_count: int, currency_totals: array<string, float>, currency_counts: array<string, int>, currency_averages: array<string, float>, tooltip: string} Order count, plus spend, order count and average order value per currency.
 	 */
 	private function get_customer_history( WC_Order $order ): array {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$customer_id   = $order->get_customer_id();
-			$billing_email = $order->get_billing_email();
-			$result        = $this->query_hpos( $customer_id, $billing_email );
+			$rows = $this->query_hpos( $order->get_customer_id(), $order->get_billing_email() );
 		} else {
 			$customer_report_id = $this->get_cpt_report_customer_id( $order );
-			if ( $customer_report_id > 0 ) {
-				$result = $this->query_cpt( $customer_report_id );
-			} else {
-				$result = (object) array(
-					'orders_count' => 0,
-					'total_spend'  => 0,
-				);
-			}
+			$rows               = $customer_report_id > 0 ? $this->query_cpt( $customer_report_id ) : array();
 		}
 
-		$orders_count = (int) ( $result->orders_count ?? 0 );
-		$total_spend  = (float) ( $result->total_spend ?? 0 );
+		$orders_count = 0;
+		$totals       = array();
+		$counts       = array();
+		foreach ( $rows as $row ) {
+			$currency = strtoupper( (string) ( $row->currency ?? '' ) );
+			$count    = (int) ( $row->orders_count ?? 0 );
+			if ( ! preg_match( '/^[A-Z]{3}$/D', $currency ) || $count < 1 ) {
+				continue;
+			}
+			$orders_count       += $count;
+			$counts[ $currency ] = $count;
+			$totals[ $currency ] = (float) ( $row->total_spend ?? 0 );
+		}
+		// Largest first, so the currency a merchant cares about leads.
+		arsort( $totals );
 
 		// Build a dynamic tooltip listing the excluded statuses by their translated labels.
 		// Internal statuses (auto-draft, trash) are naturally filtered out because they
@@ -95,29 +99,33 @@ class CustomerHistory {
 			$tooltip = __( 'Total number of orders for this customer, including the current one.', 'woocommerce' );
 		}
 
+		$averages = array();
+		foreach ( $totals as $currency => $total ) {
+			$averages[ $currency ] = $total / $counts[ $currency ];
+		}
+
 		return array(
-			'orders_count'    => $orders_count,
-			'total_spend'     => $total_spend,
-			'avg_order_value' => $orders_count > 0 ? $total_spend / $orders_count : 0,
-			'tooltip'         => $tooltip,
+			'orders_count'      => $orders_count,
+			'currency_totals'   => $totals,
+			'currency_counts'   => $counts,
+			'currency_averages' => $averages,
+			'tooltip'           => $tooltip,
 		);
 	}
 
 	/**
 	 * Query customer order stats from HPOS tables.
 	 *
+	 * Amounts are grouped by the order's own currency and never added across them:
+	 * a customer with a EUR order and a GBP order has two totals, not one.
+	 *
 	 * @param int    $customer_id   The customer user ID.
 	 * @param string $billing_email The billing email address.
 	 *
-	 * @return object Object with orders_count and total_spend properties.
+	 * @return array One row per currency, each with currency, orders_count and total_spend.
 	 */
-	private function query_hpos( int $customer_id, string $billing_email ): object {
+	private function query_hpos( int $customer_id, string $billing_email ): array {
 		global $wpdb;
-
-		$default = (object) array(
-			'orders_count' => 0,
-			'total_spend'  => 0,
-		);
 
 		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
 		$orders_table          = OrdersTableDataStore::get_orders_table_name();
@@ -130,10 +138,11 @@ class CustomerHistory {
 			$co_status_filter = $excluded_statuses_sql ? "AND co.status NOT IN $excluded_statuses_sql" : '';
 
 			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count,
+				"SELECT filtered.currency AS currency,
+					COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
 				FROM (
-					SELECT id, total_amount
+					SELECT id, total_amount, currency
 					FROM {$orders_table}
 					WHERE customer_id = %d AND type = 'shop_order' $status_filter
 				) AS filtered
@@ -144,7 +153,8 @@ class CustomerHistory {
 					WHERE rp.type = 'shop_order_refund'
 						AND co.customer_id = %d AND co.type = 'shop_order' $co_status_filter
 					GROUP BY rp.parent_order_id
-				) AS r ON filtered.id = r.parent_order_id",
+				) AS r ON filtered.id = r.parent_order_id
+				GROUP BY filtered.currency",
 				$customer_id,
 				$customer_id
 			);
@@ -154,10 +164,11 @@ class CustomerHistory {
 			$co_status_filter = $excluded_statuses_sql ? "AND co.status NOT IN $excluded_statuses_sql" : '';
 
 			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count,
+				"SELECT filtered.currency AS currency,
+					COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
 				FROM (
-					SELECT o.id, o.total_amount
+					SELECT o.id, o.total_amount, o.currency
 					FROM {$orders_table} AS o
 					INNER JOIN {$addresses_table} AS a ON o.id = a.order_id AND a.address_type = 'billing'
 					WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' $o_status_filter
@@ -170,7 +181,8 @@ class CustomerHistory {
 					WHERE rp.type = 'shop_order_refund'
 						AND co.customer_id = 0 AND ca.email = %s AND co.type = 'shop_order' $co_status_filter
 					GROUP BY rp.parent_order_id
-				) AS r ON filtered.id = r.parent_order_id",
+				) AS r ON filtered.id = r.parent_order_id
+				GROUP BY filtered.currency",
 				$billing_email,
 				$billing_email
 			);
@@ -178,11 +190,11 @@ class CustomerHistory {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		if ( null === $sql ) {
-			return $default;
+			return array();
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-		$row = $wpdb->get_row( $sql );
+		$rows = $wpdb->get_results( $sql );
 
 		if ( $wpdb->last_error ) {
 			wc_get_logger()->error(
@@ -191,7 +203,7 @@ class CustomerHistory {
 			);
 		}
 
-		return $row ?? $default;
+		return is_array( $rows ) ? $rows : array();
 	}
 
 	/**
@@ -199,9 +211,9 @@ class CustomerHistory {
 	 *
 	 * @param int $customer_report_id The reports customer ID.
 	 *
-	 * @return object Object with orders_count and total_spend properties.
+	 * @return array Zero or one row, shaped like query_hpos.
 	 */
-	private function query_cpt( int $customer_report_id ): object {
+	private function query_cpt( int $customer_report_id ): array {
 		$args = array(
 			'customers'    => array( $customer_report_id ),
 			// If unset, these params have default values that affect the results.
@@ -213,9 +225,19 @@ class CustomerHistory {
 		$customer_data   = $customers_query->get_data();
 		$customer_row    = $customer_data->data[0] ?? null;
 
-		return (object) array(
-			'orders_count' => $customer_row['orders_count'] ?? 0,
-			'total_spend'  => $customer_row['total_spend'] ?? 0,
+		$orders_count = (int) ( $customer_row['orders_count'] ?? 0 );
+		if ( $orders_count < 1 ) {
+			return array();
+		}
+
+		// The Analytics report already reports in the store's currency, so legacy
+		// storage yields a single converted row rather than a per-currency split.
+		return array(
+			(object) array(
+				'currency'     => get_woocommerce_currency(),
+				'orders_count' => $orders_count,
+				'total_spend'  => $customer_row['total_spend'] ?? 0,
+			),
 		);
 	}
 

--- a/plugins/woocommerce/templates/order/customer-history.php
+++ b/plugins/woocommerce/templates/order/customer-history.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory
  * @package WooCommerce\Templates
- * @version 10.8.0
+ * @version 11.2.0
  */
 
 declare( strict_types=1 );
@@ -16,11 +16,20 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Variables used in this file.
  *
- * @var int    $orders_count    The number of paid orders placed by the current customer.
- * @var float  $total_spend     The total money spent by the current customer.
- * @var float  $avg_order_value The average money spent by the current customer.
- * @var string $tooltip         The tooltip text for the "Total orders" heading.
+ * @var int    $orders_count The number of paid orders placed by the current customer.
+ * @var array  $currency_totals   Money spent by this customer, keyed by the currency they paid in.
+ * @var array  $currency_counts   Order count per currency, keyed the same way.
+ * @var array  $currency_averages Average order value per currency, keyed the same way.
+ * @var string $tooltip      The tooltip text for the "Total orders" heading.
  */
+// Preserve callers that still supply only the original single-total arguments.
+if ( ! isset( $currency_totals ) ) {
+	$store             = get_woocommerce_currency();
+	$currency_totals   = isset( $total_spend ) ? array( $store => (float) $total_spend ) : array();
+	$currency_counts   = array( $store => (int) ( $orders_count ?? 0 ) );
+	$currency_averages = isset( $avg_order_value ) ? array( $store => (float) $avg_order_value ) : array();
+}
+$multi_currency = count( $currency_totals ) > 1;
 ?>
 
 <div class="customer-history order-attribution-metabox">
@@ -32,25 +41,56 @@ defined( 'ABSPATH' ) || exit;
 	</h4>
 
 	<span class="order-attribution-total-orders">
-		<?php echo esc_html( $orders_count ); ?>
+		<?php echo esc_html( (string) $orders_count ); ?>
 	</span>
 
 	<h4>
 		<?php
-		esc_html_e( 'Total revenue', 'woocommerce' );
+		esc_html_e( 'Total order value', 'woocommerce' );
 		echo wp_kses_post(
 			wc_help_tip(
-				__( "This is the Customer Lifetime Value, or the total amount you have earned from this customer's orders.", 'woocommerce' )
+				$multi_currency
+					? __( 'Total order value after refunds, including tax and shipping, before payment processing fees. This customer paid in more than one currency, so each is totalled separately rather than added together.', 'woocommerce' )
+					: __( 'Total order value after refunds, including tax and shipping, before payment processing fees.', 'woocommerce' )
 			)
 		);
 		?>
 	</h4>
-	<span class="order-attribution-total-spend">
-		<?php echo wp_kses_post( wc_price( $total_spend ) ); ?>
-	</span>
+	<?php if ( ! $currency_totals ) : ?>
+		<span class="order-attribution-total-spend"><?php echo wp_kses_post( wc_price( 0 ) ); ?></span>
+	<?php else : ?>
+		<?php foreach ( $currency_totals as $currency => $total ) : ?>
+			<div class="order-attribution-currency-row">
+				<span data-currency="<?php echo esc_attr( $currency ); ?>" class="order-attribution-total-spend">
+					<?php echo wp_kses_post( wc_price( $total, array( 'currency' => $currency ) ) ); ?>
+				</span>
+				<?php if ( $multi_currency ) : ?>
+					<small>
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: %s: number of orders placed in this currency. */
+								_n( '%s order', '%s orders', $currency_counts[ $currency ], 'woocommerce' ),
+								number_format_i18n( $currency_counts[ $currency ] )
+							)
+						);
+						?>
+					</small>
+				<?php endif; ?>
+			</div>
+		<?php endforeach; ?>
+	<?php endif; ?>
 
 	<h4><?php esc_html_e( 'Average order value', 'woocommerce' ); ?></h4>
-	<span class="order-attribution-average-order-value">
-		<?php echo wp_kses_post( wc_price( $avg_order_value ) ); ?>
-	</span>
+	<?php if ( ! $currency_averages ) : ?>
+		<span class="order-attribution-average-order-value"><?php echo wp_kses_post( wc_price( 0 ) ); ?></span>
+	<?php else : ?>
+		<?php foreach ( $currency_averages as $currency => $average ) : ?>
+			<div class="order-attribution-currency-row">
+				<span data-currency="<?php echo esc_attr( $currency ); ?>" class="order-attribution-average-order-value">
+					<?php echo wp_kses_post( wc_price( $average, array( 'currency' => $currency ) ) ); ?>
+				</span>
+			</div>
+		<?php endforeach; ?>
+	<?php endif; ?>
 </div>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -132,6 +132,106 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Orders in different currencies are totalled separately, never added together.
+	 */
+	public function test_mixed_currency_orders_are_totalled_separately(): void {
+		$previous_currency = get_option( 'woocommerce_currency' );
+		update_option( 'woocommerce_currency', 'EUR' );
+		$customer_id = $this->factory->user->create();
+		try {
+			$native = WC_Helper_Order::create_order( $customer_id );
+			$native->set_status( 'completed' );
+			$native->set_currency( 'EUR' );
+			$native->set_total( 41.90 );
+			$native->save();
+
+			$foreign = WC_Helper_Order::create_order( $customer_id );
+			$foreign->set_status( 'completed' );
+			$foreign->set_currency( 'GBP' );
+			$foreign->set_total( 36.00 );
+			$foreign->save();
+
+			ob_start();
+			$this->sut->output( $native );
+			$output = ob_get_clean();
+
+			// Both orders count, but 41.90 and 36.00 are never added into 77.90.
+			$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output );
+			$this->assertStringNotContainsString( '77.90', $output, 'Amounts in different currencies must not be summed' );
+			$this->assertMatchesRegularExpression( '/data-currency="EUR"[^>]*>[\s\S]{0,200}?41\.90/', $output );
+			$this->assertMatchesRegularExpression( '/data-currency="GBP"[^>]*>[\s\S]{0,200}?36\.00/', $output );
+			// Each currency reports how many of the orders it covers.
+			$this->assertStringContainsString( '1 order', $output );
+		} finally {
+			update_option( 'woocommerce_currency', $previous_currency );
+		}
+	}
+
+	/**
+	 * @testdox A refund reduces only the total for the currency its order was placed in.
+	 */
+	public function test_refund_applies_only_to_its_own_currency(): void {
+		$previous_currency = get_option( 'woocommerce_currency' );
+		update_option( 'woocommerce_currency', 'EUR' );
+		$customer_id = $this->factory->user->create();
+		try {
+			$native = WC_Helper_Order::create_order( $customer_id );
+			$native->set_status( 'completed' );
+			$native->set_currency( 'EUR' );
+			$native->set_total( 100.00 );
+			$native->save();
+
+			$foreign = WC_Helper_Order::create_order( $customer_id );
+			$foreign->set_status( 'completed' );
+			$foreign->set_currency( 'GBP' );
+			$foreign->set_total( 50.00 );
+			$foreign->save();
+
+			wc_create_refund(
+				array(
+					'order_id' => $foreign->get_id(),
+					'amount'   => 20.00,
+				)
+			);
+
+			ob_start();
+			$this->sut->output( $native );
+			$output = ob_get_clean();
+
+			$this->assertMatchesRegularExpression( '/data-currency="EUR"[^>]*>[\s\S]{0,200}?100\.00/', $output, 'EUR total is untouched by a GBP refund' );
+			$this->assertMatchesRegularExpression( '/data-currency="GBP"[^>]*>[\s\S]{0,200}?30\.00/', $output, 'GBP total drops by the GBP refund' );
+		} finally {
+			update_option( 'woocommerce_currency', $previous_currency );
+		}
+	}
+
+	/**
+	 * @testdox A single-currency customer renders exactly as before, with no per-currency chrome.
+	 */
+	public function test_single_currency_customer_is_unchanged(): void {
+		$previous_currency = get_option( 'woocommerce_currency' );
+		update_option( 'woocommerce_currency', 'EUR' );
+		$customer_id = $this->factory->user->create();
+		try {
+			$order = WC_Helper_Order::create_order( $customer_id );
+			$order->set_status( 'completed' );
+			$order->set_currency( 'EUR' );
+			$order->set_total( 25.00 );
+			$order->save();
+
+			ob_start();
+			$this->sut->output( $order );
+			$output = ob_get_clean();
+
+			$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*25\.00/', $output );
+			// The order-count suffix belongs to the mixed-currency case only.
+			$this->assertStringNotContainsString( '1 order<', $output );
+		} finally {
+			update_option( 'woocommerce_currency', $previous_currency );
+		}
+	}
+
+	/**
 	 * @testdox Should fetch data correctly for a guest customer matched by billing email (HPOS).
 	 */
 	public function test_guest_customer_by_email(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Customer History adds up a customer's order totals without reading each order's `currency`. On a EUR store, a customer with a €41.90 order and a £36.00 order sees **€77.90** — two different units added together and labelled with the store's symbol. No exchange rate makes that number correct.

The HPOS query now groups by the order's own currency, so those orders report as €41.90 and £36.00 side by side.

Nothing is converted, deliberately. Today's rate gives a lifetime value that moves with the market and disagrees with the merchant's books; the order's saved rate only exists where one was stored. This panel sits beside the refund controls, where a plausible wrong number is worse than two separate right ones.

Refunds are already denominated in their order's currency, so each now reduces only its own total. Legacy CPT storage keeps its Analytics Customers report, which reports in store currency and so yields a single converted row.

Closes #43781. Tracked as [WOOPLUG-1822](https://linear.app/a8c/issue/WOOPLUG-1822/customer-history-meta-box-not-working-correctly-for-multi-currency), where the reproduction, the regression trace and the reasoning against converting are recorded in full.

(For Bug Fixes) Bug introduced in PR #63715.

This panel has been here before. #44318 moved the calculation onto the Analytics Customers report in 8.6, which read converted amounts. #63715 moved it back to direct SQL for a real reason — Analytics is stale when regeneration is delayed or scheduled, so operators could not tell a new customer from a returning one — but raw `total_amount` carries no conversion. This keeps #63715's real-time reads and fixes the currency handling on top of them.

### Screenshots or screen recordings:

EUR store, one customer, a €41.90 order and a £36.00 order.

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/d3ae8c36-6751-4aae-b774-ab5b877601c7) | ![after](https://github.com/user-attachments/assets/1c7fd0cd-37b4-41e3-9dd5-67438ccd5a2e) |

"Total revenue" is also corrected to "Total order value" — it was never revenue.

### How to test the changes in this Pull Request:

1. Set the store currency to EUR.
2. Create two orders for one customer or guest email: EUR 41.90 and GBP 36.00, both Completed.
3. Open either and find **Customer history**.
4. `trunk` reads **€77.90**, average €38.95. This branch reads **€41.90 · 1 order** and **£36.00 · 1 order**, with per-currency averages.
5. Refund 10.00 on the GBP order. Only the GBP line drops, to £26.00.
6. Delete the GBP order. The panel renders as on trunk — one total, no per-currency markup.

### Testing that has already taken place:

wp-env, WooCommerce 11.2.0-dev, PHP 8.1.34, HPOS, EUR store.

- `CustomerHistoryTest`: 25 tests, 73 assertions. **The 22 pre-existing tests pass unchanged** — single-currency stores render exactly as before. Three added: mixed-currency totals, per-currency refund attribution, and single-currency output staying free of per-currency markup.
- PHPStan and WordPress Coding Standards clean.
- Verified through a real gateway checkout: WooPayments test mode, GBP at a fixed 0.85 rate against a EUR store, a €50.00 product bought at £42.50 through the block checkout. The order joined the customer's GBP total and left the EUR figure untouched — **3 orders, £78.50 across 2, €41.90 across 1**.

![Customer history after a real WooPayments checkout](https://github.com/user-attachments/assets/348387f1-1ad2-4133-95fd-d60efa302ac1)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

The entry is committed in this branch.

### Use of AI Tools

Written with Claude Code and reviewed by me before submission. I take responsibility for the contents.

🤖 Written by Claude, on behalf of Daniel Kam. Generated with [Claude Code](https://claude.com/claude-code)
