### PR TITLE
Fix missing space between parts in the Mini-Cart header when seen in the editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOAIRR-283-missing-spacing-mini-cart-header-editor
+++ b/plugins/woocommerce/changelog/fix-WOOAIRR-283-missing-spacing-mini-cart-header-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix missing spacing between parts in the Mini-Cart header when seen in the editor
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -52,11 +52,11 @@
 		// Simulate the space taken by notifications in the frontend.
 		margin-top: $gap;
 
-		// Because this block contains a rich editor div inside, its displayed
-		// as block. We reset it to inline-block to avoid a line break.
+		// Because this block contains a rich editor div inside, it's displayed
+		// as a block. We reset it to inline-block to avoid a line break.
 		.wp-block-woocommerce-mini-cart-title-label-block {
 			display: inline-block;
-			margin-inline-end: .5rem;
+			margin-inline-end: .5em;
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -56,7 +56,7 @@
 		// as block. We reset it to inline-block to avoid a line break.
 		.wp-block-woocommerce-mini-cart-title-label-block {
 			display: inline-block;
-			margin-right: .5rem;
+			margin-inline-end: .5rem;
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -56,7 +56,7 @@
 		// as a block. We reset it to inline-block to avoid a line break.
 		.wp-block-woocommerce-mini-cart-title-label-block {
 			display: inline-block;
-			margin-inline-end: .5em;
+			margin-inline-end: 0.25em;
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -49,13 +49,14 @@
 	h2.wc-block-mini-cart__title {
 		font-size: 1.5rem;
 		mask-image: none;
+		// Simulate the space taken by notifications in the frontend.
+		margin-top: $gap;
 
-		.block-editor-block-list__layout {
-			display: flex;
-			align-items: baseline;
-
-			// Simulate the space taken by notifications in the frontend.
-			margin-top: $gap;
+		// Because this block contains a rich editor div inside, its displayed
+		// as block. We reset it to inline-block to avoid a line break.
+		.wp-block-woocommerce-mini-cart-title-label-block {
+			display: inline-block;
+			margin-right: .5rem;
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOAIRR-283.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/68432.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Patterns > Mini-Cart.
2. Verify there is space between 'Your cart' and '(3 items)'.

Before | After
--- | ---
<img width="1014" height="670" alt="imatge" src="https://github.com/user-attachments/assets/6563959d-4044-4a8d-9d25-6297432751ce" /> | <img width="1014" height="670" alt="imatge" src="https://github.com/user-attachments/assets/3e95cb74-c741-447c-a7cf-241927f73a5f" />