### PR TITLE
Update mobile app QR login session handling

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-146-qr-login-session-handling
+++ b/plugins/woocommerce/changelog/fix-woo6-146-qr-login-session-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update mobile app QR login session handling.

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -1842,6 +1842,11 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 			return $this->rest_ensure_nocache_response( array( 'state' => self::STATE_EXPIRED ) );
 		}
 
+		$canonical_session = isset( $record['challenge']['session_id'] ) ? (string) $record['challenge']['session_id'] : '';
+		if ( '' === $canonical_session || ! hash_equals( $canonical_session, $session_id ) ) {
+			return $this->rest_ensure_nocache_response( array( 'state' => self::STATE_EXPIRED ) );
+		}
+
 		$state    = isset( $record['state'] ) ? (string) $record['state'] : self::STATE_PENDING;
 		$response = array( 'state' => $state );
 

--- a/plugins/woocommerce/tests/php/src/Admin/API/MobileAppQRLoginTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/MobileAppQRLoginTest.php
@@ -2392,6 +2392,50 @@ class MobileAppQRLoginTest extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( $post->get_data()['exchange_grant'] );
 	}
 
+	/**
+	 * @testdox Session-status is scoped to the session recorded on the token.
+	 */
+	public function test_session_status_is_scoped_to_the_recorded_session(): void {
+		$plaintext = $this->generate_token_as_admin();
+
+		wp_set_current_user( 0 );
+		$scan_data        = $this->dispatch_scan( $plaintext )->get_data();
+		$recorded_session = $scan_data['session_id'];
+
+		// A second session id can also resolve to the same token record, while
+		// the record itself still names the scanned session above.
+		$other_session = wp_generate_uuid4();
+		set_transient(
+			MobileAppQRLogin::SESSION_TRANSIENT_PREFIX . hash( 'sha256', $other_session ),
+			$this->token_hash( $plaintext ),
+			MobileAppQRLogin::TOKEN_TTL
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertSame( 200, $this->dispatch_approve( $plaintext, $scan_data['real_number'] )->get_status() );
+		wp_set_current_user( 0 );
+
+		$other = $this->dispatch_session_status( $other_session, $plaintext );
+		$this->assertSame( 200, $other->get_status() );
+		$this->assertSame(
+			MobileAppQRLogin::STATE_EXPIRED,
+			$other->get_data()['state'],
+			'State is only returned for the session recorded on the token.'
+		);
+		$this->assertArrayNotHasKey(
+			'exchange_grant',
+			$other->get_data(),
+			'The exchange grant is only returned for the session recorded on the token.'
+		);
+
+		$recorded = $this->dispatch_session_status( $recorded_session, $plaintext );
+		$this->assertSame( MobileAppQRLogin::STATE_APPROVED, $recorded->get_data()['state'] );
+		$this->assertNotEmpty(
+			$recorded->get_data()['exchange_grant'],
+			'The recorded session receives its grant.'
+		);
+	}
+
 	// -----------------------------------------------------------------------
 	// Availability endpoint (`/qr-login-availability`).
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).

### Changes proposed in this Pull Request:

The mobile app QR login *session-status* endpoint returns the login state, and once approved the exchange grant, to the calling session. This change scopes that response to the session recorded on the token: the endpoint now confirms the caller's session id matches the canonical `session_id` stored on the challenge record, using a timing-safe `hash_equals()` comparison, and otherwise responds with `STATE_EXPIRED`.

Adds test coverage for the scoping behavior.

### How to test the changes in this Pull Request:

1. Generate a QR login token in wp-admin and scan it from the WooCommerce mobile app.
2. Approve the login from wp-admin and confirm the app completes login as before — no regression in the normal flow.

### Testing that has already taken place:

Added automated coverage for the endpoint's session scoping (a non-recorded session receives `STATE_EXPIRED` and no exchange grant; the recorded session still receives its state and grant).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry is already included in this branch (`Significance: patch`, `Type: fix`).