### PR TITLE
Add REST-path regression test for stock notifications endpoint slug sanitization

### DIFF
--- a/plugins/woocommerce/changelog/wooairr-278-rest-endpoint-slug-sanitize-test
+++ b/plugins/woocommerce/changelog/wooairr-278-rest-endpoint-slug-sanitize-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a regression test covering that the stock notifications My Account endpoint slug is sanitized when saved through the REST settings API.

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Admin\SettingsController;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
 use WC_Settings_Advanced;
 use WC_Settings_Products;
+use WP_REST_Request;
 
 /**
  * SettingsControllerTests data tests.
@@ -144,5 +145,23 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 		$this->assertSame( 10, has_filter( $hook, 'wc_sanitize_endpoint_slug' ) );
 		$this->assertSame( 'restock-alerts', apply_filters( $hook, 'Restock Alerts' ) );
 		$this->assertSame( 'stock-notifications', apply_filters( $hook, 'stock-notifications' ) );
+	}
+
+	/**
+	 * @testdox The My Account endpoint setting is sanitized the same way when saved through the REST settings API.
+	 */
+	public function test_my_account_endpoint_setting_is_sanitized_via_rest() {
+		new StockNotificationsSettings();
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/advanced/' . MyAccountEndpoint::ENDPOINT_OPTION );
+		$request->set_body_params( array( 'value' => 'Restock Alerts' ) );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Saving the endpoint setting via REST should succeed.' );
+		$this->assertSame( 'restock-alerts', get_option( MyAccountEndpoint::ENDPOINT_OPTION ), 'The value saved via the REST settings API should be sanitized as an endpoint slug, matching the classic admin settings save path.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -151,8 +151,6 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 	 * @testdox The My Account endpoint setting is sanitized the same way when saved through the REST settings API.
 	 */
 	public function test_my_account_endpoint_setting_is_sanitized_via_rest() {
-		new StockNotificationsSettings();
-
 		// Routes must register on rest_api_init; firing it explicitly makes the test's outcome
 		// independent of whatever REST server state an earlier test in the process left behind.
 		do_action( 'rest_api_init' );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Admin/SettingsControllerTests.php
@@ -153,6 +153,10 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 	public function test_my_account_endpoint_setting_is_sanitized_via_rest() {
 		new StockNotificationsSettings();
 
+		// Routes must register on rest_api_init; firing it explicitly makes the test's outcome
+		// independent of whatever REST server state an earlier test in the process left behind.
+		do_action( 'rest_api_init' );
+
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
 
@@ -163,5 +167,13 @@ class SettingsControllerTests extends \WC_Settings_Unit_Test_Case {
 
 		$this->assertSame( 200, $response->get_status(), 'Saving the endpoint setting via REST should succeed.' );
 		$this->assertSame( 'restock-alerts', get_option( MyAccountEndpoint::ENDPOINT_OPTION ), 'The value saved via the REST settings API should be sanitized as an endpoint slug, matching the classic admin settings save path.' );
+	}
+
+	/**
+	 * Reset the REST server so this test does not leak it into tests that run after it.
+	 */
+	public function tearDown(): void {
+		$this->clear_rest_server();
+		parent::tearDown();
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds regression coverage for the stock notifications My Account endpoint slug sanitization fix (#68475), verifying the slug is sanitized the same way when saved through the REST settings API as through the classic admin settings save path. The new test also fires `rest_api_init` explicitly and clears the REST server in `tearDown()`, so its outcome doesn't depend on ambient `$wp_rest_server` state left behind by other tests in the same PHPUnit process — verified by running it directly after `TaxSettingsRecommendationsTest`, which otherwise leaves that global populated.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm test:php:env -- --filter SettingsControllerTests` — all 4 tests should pass.
2. Run `pnpm test:php:env -- --filter 'TaxSettingsRecommendationsTest|SettingsControllerTests'` — all 9 tests should pass, confirming the new test is independent of run order.

### Testing that has already taken place:

Ran both commands above locally via `wp-env`; all tests pass. Also confirmed via `git stash` that reverting the `rest_api_init` fix causes the new test to fail with a 404 when run after `TaxSettingsRecommendationsTest` in the same process.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

This PR was drafted by Claude Code (Claude), reviewed and approved by the author before submission.