### PR TITLE
Fix product category queries discarding a caller's term meta filter

### DIFF
--- a/plugins/woocommerce/changelog/34042-fix-get-terms-meta-key-clobber
+++ b/plugins/woocommerce/changelog/34042-fix-get-terms-meta-key-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop get_terms() from discarding a caller's own term meta filter on product categories.

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -52,6 +52,7 @@ add_filter( 'get_terms_defaults', 'wc_change_get_terms_defaults', 10, 2 );
  * Adds support to get_terms for menu_order argument.
  *
  * @since 3.6.0
+ * @since 11.2.0 A term meta filter supplied by the caller is kept instead of being overwritten by the 'order' sorting key.
  * @param WP_Term_Query $terms_query Instance of WP_Term_Query.
  */
 function wc_change_pre_get_terms( $terms_query ) {

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -80,6 +80,39 @@ function wc_change_pre_get_terms( $terms_query ) {
 	}
 
 	if ( ! empty( $args['force_menu_order_sort'] ) ) {
+		// Sorting by menu order claims the primary meta clause for the 'order' meta key, so move any meta
+		// filter the caller asked for into meta_query, where it still applies as an additional clause.
+		$caller_meta_clause = array();
+
+		foreach ( array(
+			'key'         => 'meta_key',
+			'compare'     => 'meta_compare',
+			'type'        => 'meta_type',
+			'compare_key' => 'meta_compare_key',
+			'type_key'    => 'meta_type_key',
+		) as $clause_key => $query_var ) {
+			if ( ! empty( $args[ $query_var ] ) ) {
+				$caller_meta_clause[ $clause_key ] = $args[ $query_var ];
+				$args[ $query_var ]                = '';
+			}
+		}
+
+		// Matches how WP_Meta_Query::parse_query_vars() decides that a meta value was supplied.
+		if ( isset( $args['meta_value'] ) && '' !== $args['meta_value'] && ( ! is_array( $args['meta_value'] ) || $args['meta_value'] ) ) {
+			$caller_meta_clause['value'] = $args['meta_value'];
+			$args['meta_value']          = ''; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		}
+
+		if ( ! empty( $caller_meta_clause ) ) {
+			$args['meta_query'] = empty( $args['meta_query'] ) // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				? array( $caller_meta_clause )
+				: array(
+					'relation' => 'AND',
+					$caller_meta_clause,
+					$args['meta_query'],
+				);
+		}
+
 		$args['orderby']  = 'meta_value_num';
 		$args['meta_key'] = 'order'; // phpcs:ignore
 		$terms_query->meta_query->parse_query_vars( $args );

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -346,6 +346,19 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 					),
 				),
 			),
+			'both forms combined'     => array(
+				array(
+					'meta_key'   => 'wc_test_flag', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_value' => 'yes', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+					'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'     => 'order',
+							'value'   => 2,
+							'compare' => '<=',
+						),
+					),
+				),
+			),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -256,4 +256,96 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$featured_product->delete();
 		$regular_product->delete();
 	}
+
+	/**
+	 * @testdox Product categories are sorted by their order term meta when no orderby is requested.
+	 */
+	public function test_product_cat_default_sort_uses_order_term_meta(): void {
+		$unordered = wp_insert_term( 'Category A', 'product_cat' );
+		$third     = wp_insert_term( 'Category B', 'product_cat' );
+		$first     = wp_insert_term( 'Category C', 'product_cat' );
+		$second    = wp_insert_term( 'Category D', 'product_cat' );
+
+		delete_term_meta( $unordered['term_id'], 'order' );
+		update_term_meta( $first['term_id'], 'order', 1 );
+		update_term_meta( $second['term_id'], 'order', 2 );
+		update_term_meta( $third['term_id'], 'order', 3 );
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'product_cat',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+				'include'    => array( $unordered['term_id'], $third['term_id'], $first['term_id'], $second['term_id'] ),
+			)
+		);
+
+		$this->assertSame(
+			array( (int) $unordered['term_id'], (int) $first['term_id'], (int) $second['term_id'], (int) $third['term_id'] ),
+			array_map( 'intval', $terms ),
+			'Categories should come back in order meta sequence, and categories without order meta should still be returned.'
+		);
+	}
+
+	/**
+	 * @testdox A term meta filter passed to get_terms is honored on product categories, without losing the default sorting.
+	 * @dataProvider provider_term_meta_filter_args
+	 *
+	 * @param array $filter_args The meta filter arguments to pass to get_terms().
+	 */
+	public function test_product_cat_honors_caller_term_meta_filter( array $filter_args ): void {
+		$second    = wp_insert_term( 'Category A', 'product_cat' );
+		$first     = wp_insert_term( 'Category B', 'product_cat' );
+		$unmatched = wp_insert_term( 'Category C', 'product_cat' );
+
+		add_term_meta( $first['term_id'], 'wc_test_flag', 'yes' );
+		add_term_meta( $second['term_id'], 'wc_test_flag', 'yes' );
+		add_term_meta( $unmatched['term_id'], 'wc_test_flag', 'no' );
+		update_term_meta( $first['term_id'], 'order', 1 );
+		update_term_meta( $second['term_id'], 'order', 2 );
+
+		$terms = get_terms(
+			array_merge(
+				array(
+					'taxonomy'   => 'product_cat',
+					'hide_empty' => false,
+					'fields'     => 'ids',
+					'include'    => array( $second['term_id'], $first['term_id'], $unmatched['term_id'] ),
+				),
+				$filter_args
+			)
+		);
+
+		$this->assertSame(
+			array( (int) $first['term_id'], (int) $second['term_id'] ),
+			array_map( 'intval', $terms ),
+			'Only the categories matching the meta filter should be returned, in order meta sequence.'
+		);
+	}
+
+	/**
+	 * Both forms WordPress accepts for a term meta filter.
+	 *
+	 * @return array
+	 */
+	public function provider_term_meta_filter_args(): array {
+		return array(
+			'meta_key and meta_value' => array(
+				array(
+					'meta_key'   => 'wc_test_flag', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_value' => 'yes', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				),
+			),
+			'nested meta_query'       => array(
+				array(
+					'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'   => 'wc_test_flag',
+							'value' => 'yes',
+						),
+					),
+				),
+			),
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Asking for product categories with a `meta_key`/`meta_value` filter returns an empty array. Nothing errors, nothing warns, and the same filter works on every other taxonomy.

The cause is category ordering. Product categories are sorted by an `order` term meta value by default, and to sort by it WooCommerce overwrites the caller's `meta_key` with its own `order`, then rebuilds the meta query from the changed arguments. The caller's filter is gone before the query runs, so the query ends up looking for a category whose `order` equals the value they asked for. There never is one.

`wc_change_pre_get_terms()` now moves the caller's filter into `meta_query` first, so it survives as a separate condition next to the `order` one and both apply. Callers keep their filter and the store keeps its category order.

Backward compatibility: no signature, hook, or hook-timing changes, and a query that passes no term meta filter generates byte-identical SQL. A query that does pass one now behaves the way WordPress documents rather than being silently retargeted at the internal `order` key.

One case can return fewer categories than it used to. Passing `meta_key` without a `meta_value` returned every category before, because the key was replaced before it could filter anything; it now returns only the categories that have that key, which is what the same query already does on any other taxonomy.

The nested `meta_query` workaround suggested in the issue was never affected, and behaves exactly as it did before.

Closes #34042.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. On a store with a few product categories, go to **Products → Categories** and drag them into a custom order that is not alphabetical. Note the order.
2. Run this in `wp shell` (or any snippet runner):

    ```php
    $term = wp_insert_term( 'Meta filter demo', 'product_cat' );
    add_term_meta( $term['term_id'], 'some_key', 'some_value' );
    get_terms( array(
        'hide_empty' => false,
        'taxonomy'   => 'product_cat',
        'meta_key'   => 'some_key',
        'meta_value' => 'some_value',
    ) );
    ```

    On `trunk` this returns an empty array. On this branch it returns the "Meta filter demo" category.

3. Confirm nothing else moved: reload **Products → Categories**, the product category widget or block, and `get_terms( array( 'taxonomy' => 'product_cat', 'hide_empty' => false ) )`. The custom order from step 1 is still in effect everywhere.
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- The two new tests that cover the reported behavior fail on `trunk` and pass here. The other two pin behavior that must not change, and pass on both.
- Compared the SQL WooCommerce generates for a range of category and term queries on `trunk` and on this branch. Only the query from the issue comes out different; every other one is character-for-character identical, so no other query can behave differently.
- Tested locally on `trunk` and on this PR: the reproducer returns nothing before and the category after, with category order unchanged.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Investigation, implementation, tests, and the verification described above were done with Claude Code. I reviewed the result and take responsibility for it.
