### PR TITLE
Fix emailed Analytics report exports never arriving

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-3315-emailed-report-export-never-arrives
+++ b/plugins/woocommerce/changelog/fix-wooplug-3315-emailed-report-export-never-arrives
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Emailed Analytics report exports now cover the orders that existed when the export was requested, complete even when orders change while it runs or when batches run concurrently, and email the requester when a batch fails instead of silently sending nothing.

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -125,6 +125,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 *
 	 * @since 3.1.0
 	 * @param string $data Data.
+	 * @return void|false False when the data could not be written, so a caller can tell a written page from a lost one.
 	 */
 	protected function write_csv_data( $data ) {
 
@@ -171,6 +172,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 					),
 					$log_context
 				);
+				return false;
 			}
 		} else {
 			// fopen() raises a warning when it fails, so the last PHP error usually explains why (permissions, an
@@ -187,6 +189,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 				),
 				$log_context
 			);
+			return false;
 		}
 
 		// Add all columns when finished.

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -30,6 +30,16 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	protected $page = 1;
 
 	/**
+	 * Whether to write the headers row file, which marks the export complete, once the row count reaches 100%.
+	 *
+	 * An exporter whose pages can run in any order decides completion itself and sets this to false.
+	 *
+	 * @since 11.2.0
+	 * @var bool
+	 */
+	protected $completes_by_row_count = true;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -193,7 +203,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		}
 
 		// Add all columns when finished.
-		if ( 100 === $this->get_percent_complete() ) {
+		if ( $this->completes_by_row_count && 100 === $this->get_percent_complete() ) {
 			$header = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
 
 			// We need to use a temporary file to store headers, this will make our life so much easier.

--- a/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-failed.php
+++ b/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-failed.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Admin report export failed
+ *
+ * @package WooCommerce\Admin\Templates\Emails\HTML
+ *
+ * @var string    $email_heading Email heading.
+ * @var string    $report_name   Name of the report that could not be exported.
+ * @var string    $date_range    Date range the report covers. Empty for reports without one.
+ * @var \WC_Email $email         Email object.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Output the email header.
+ *
+ * @since 11.2.0
+ * @hooked WC_Emails::email_header()
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email );
+
+?>
+<p>
+	<?php
+		/* translators: %s: report name */
+		echo esc_html( sprintf( __( 'Your %s Report could not be exported, so there is no file to download.', 'woocommerce' ), $report_name ) );
+	?>
+</p>
+<?php if ( ! empty( $date_range ) ) : ?>
+<p>
+	<?php
+		/* translators: %s: the date range the report covers, e.g. "June 1, 2025 - June 30, 2025" */
+		echo esc_html( sprintf( __( 'Date range: %s', 'woocommerce' ), $date_range ) );
+	?>
+</p>
+<?php endif; ?>
+<p>
+	<?php esc_html_e( 'Please request the report again from Analytics. If this keeps happening, the WooCommerce logs (source: report-csv-exporter) say which part of the export failed.', 'woocommerce' ); ?>
+</p>
+<?php
+/**
+ * Output the email footer.
+ *
+ * @since 11.2.0
+ * @hooked WC_Emails::email_footer()
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-failed.php
+++ b/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-failed.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Admin report export failed email (plain text)
+ *
+ * @package WooCommerce\Admin\Templates\Emails\Plain
+ *
+ * @var string    $email_heading Email heading.
+ * @var string    $report_name   Name of the report that could not be exported.
+ * @var string    $date_range    Date range the report covers. Empty for reports without one.
+ * @var \WC_Email $email         Email object.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %s: report name */
+echo esc_html( sprintf( __( 'Your %s Report could not be exported, so there is no file to download.', 'woocommerce' ), $report_name ) );
+
+echo "\n\n";
+
+if ( ! empty( $date_range ) ) {
+	/* translators: %s: the date range the report covers, e.g. "June 1, 2025 - June 30, 2025" */
+	echo esc_html( sprintf( __( 'Date range: %s', 'woocommerce' ), $date_range ) );
+
+	echo "\n\n";
+}
+
+echo esc_html__( 'Please request the report again from Analytics. If this keeps happening, the WooCommerce logs (source: report-csv-exporter) say which part of the export failed.', 'woocommerce' );
+
+echo "\n\n----------------------------------------\n\n";
+
+/**
+ * Filter the footer text of the plain text email.
+ *
+ * @since 11.2.0
+ * @param string $footer_text Footer text.
+ */
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/src/Admin/API/Reports/Export/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Export/Controller.php
@@ -249,6 +249,10 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			);
 		}
 
+		if ( 100 !== $percentage && ReportExporter::finalize_if_complete( $report_type, $export_id ) ) {
+			$percentage = 100;
+		}
+
 		$result = array(
 			'percent_complete' => $percentage,
 		);

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -50,6 +50,14 @@ class ReportCSVEmail extends \WC_Email {
 	protected $report_date_range = '';
 
 	/**
+	 * Whether this email reports an export that could not be completed instead of a download link.
+	 *
+	 * @since 11.2.0
+	 * @var bool
+	 */
+	protected $failed = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -114,6 +122,10 @@ class ReportCSVEmail extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_heading() {
+		if ( $this->failed ) {
+			return __( 'Your report export did not complete', 'woocommerce' );
+		}
+
 		return __( 'Your Report Download', 'woocommerce' );
 	}
 
@@ -126,6 +138,14 @@ class ReportCSVEmail extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject() {
+		if ( $this->failed ) {
+			if ( '' !== $this->report_date_range ) {
+				return __( '[{site_title}]: Your {report_name} Report export for {report_date_range} did not complete', 'woocommerce' );
+			}
+
+			return __( '[{site_title}]: Your {report_name} Report export did not complete', 'woocommerce' );
+		}
+
 		if ( '' !== $this->report_date_range ) {
 			return __( '[{site_title}]: Your {report_name} Report for {report_date_range} is ready', 'woocommerce' );
 		}
@@ -140,7 +160,7 @@ class ReportCSVEmail extends \WC_Email {
 	 */
 	public function get_content_html() {
 		return wc_get_template_html(
-			$this->template_html,
+			$this->failed ? 'html-admin-report-export-failed.php' : $this->template_html,
 			array(
 				'report_name'   => $this->report_type,
 				'date_range'    => $this->report_date_range,
@@ -163,7 +183,7 @@ class ReportCSVEmail extends \WC_Email {
 	 */
 	public function get_content_plain() {
 		return wc_get_template_html(
-			$this->template_plain,
+			$this->failed ? 'plain-admin-report-export-failed.php' : $this->template_plain,
 			array(
 				'report_name'   => $this->report_type,
 				'date_range'    => $this->report_date_range,
@@ -212,9 +232,36 @@ class ReportCSVEmail extends \WC_Email {
 	 * @param string $download_url The URL for downloading the report.
 	 */
 	public function trigger( $user_id, $report_type, $download_url ) {
-		$user               = new \WP_User( $user_id );
-		$this->recipient    = $user->user_email;
 		$this->download_url = $download_url;
+
+		$this->send_to( $user_id, $report_type );
+	}
+
+	/**
+	 * Tell the user who asked for an export that it could not be completed, so they can request it again.
+	 *
+	 * @since 11.2.0
+	 * @param int    $user_id User ID to email.
+	 * @param string $report_type The type of report export that failed.
+	 * @return void
+	 */
+	public function trigger_failed( $user_id, $report_type ) {
+		$this->failed = true;
+
+		$this->send_to( $user_id, $report_type );
+	}
+
+	/**
+	 * Address and send the email.
+	 *
+	 * @since 11.2.0
+	 * @param int    $user_id User ID to email.
+	 * @param string $report_type The type of report export.
+	 * @return void
+	 */
+	protected function send_to( $user_id, $report_type ) {
+		$user            = new \WP_User( $user_id );
+		$this->recipient = $user->user_email;
 
 		if ( isset( $this->report_labels[ $report_type ] ) ) {
 			$this->report_type                   = $this->report_labels[ $report_type ];

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -207,12 +207,12 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	/**
 	 * Append this page to the export body, or throw.
 	 *
-	 * The parent would recreate the body on page 1, throwing away pages that ran before it, and write
-	 * nothing for a page that ran earlier. Here a lost page fails the queued action, which is how the
-	 * export learns it is incomplete.
+	 * The parent would recreate the body on page 1, throwing away pages that ran before it, and log a
+	 * page it could not write while reporting nothing. Here a lost page fails the queued action, which
+	 * is how the export learns it is incomplete.
 	 *
 	 * @since 11.2.0
-	 * @throws \RuntimeException When the body is missing.
+	 * @throws \RuntimeException When the body is missing or the page could not be written to it.
 	 * @return void
 	 */
 	public function generate_file() {
@@ -221,7 +221,10 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 		}
 
 		$this->prepare_data_to_export();
-		$this->write_csv_data( $this->get_csv_data() );
+
+		if ( false === $this->write_csv_data( $this->get_csv_data() ) ) {
+			throw new \RuntimeException( sprintf( 'Page %2$d of export %1$s could not be written.', esc_html( $this->get_filename() ), (int) $this->get_page() ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -187,6 +187,25 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	}
 
 	/**
+	 * Write the `.headers` companion that marks the export as complete, unless it is already there.
+	 *
+	 * The parent writes it only when its own row count reaches 100%, which an export whose row total
+	 * changed while it ran never does. The exporter that confirms every page was written calls this.
+	 *
+	 * @since 11.2.0
+	 * @return void
+	 */
+	public function write_headers_row_file() {
+		if ( file_exists( $this->get_headers_row_file_path() ) ) {
+			return;
+		}
+
+		$header = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
+
+		@file_put_contents( $this->get_headers_row_file_path(), $header ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	}
+
+	/**
 	 * Write the export to the output, leaving the file in place. Send the download headers first.
 	 *
 	 * @since 11.2.0

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -187,6 +187,44 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	}
 
 	/**
+	 * Create the empty export body, unless it is already there.
+	 *
+	 * Called once when the export is queued, so the pages can append in whatever order the queue
+	 * runs them. The parent creates the body on page 1 only, and a page that ran earlier wrote nothing.
+	 *
+	 * @since 11.2.0
+	 * @return bool Whether the body exists.
+	 */
+	public function create_export_file() {
+		if ( ! file_exists( $this->get_file_path() ) ) {
+			@file_put_contents( $this->get_file_path(), '' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			@chmod( $this->get_file_path(), 0664 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+		}
+
+		return file_exists( $this->get_file_path() );
+	}
+
+	/**
+	 * Append this page to the export body, or throw.
+	 *
+	 * The parent would recreate the body on page 1, throwing away pages that ran before it, and write
+	 * nothing for a page that ran earlier. Here a lost page fails the queued action, which is how the
+	 * export learns it is incomplete.
+	 *
+	 * @since 11.2.0
+	 * @throws \RuntimeException When the body is missing.
+	 * @return void
+	 */
+	public function generate_file() {
+		if ( ! file_exists( $this->get_file_path() ) ) {
+			throw new \RuntimeException( sprintf( 'Export file %1$s is missing, so page %2$d could not be written.', esc_html( $this->get_filename() ), (int) $this->get_page() ) );
+		}
+
+		$this->prepare_data_to_export();
+		$this->write_csv_data( $this->get_csv_data() );
+	}
+
+	/**
 	 * Write the `.headers` companion that marks the export as complete, unless it is already there.
 	 *
 	 * The parent writes it only when its own row count reaches 100%, which an export whose row total

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -51,6 +51,14 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	protected $download_suffix = '';
 
 	/**
+	 * Pages run in any order, and the row total moves under them, so the last page to run is not the
+	 * end of the export. ReportExporter::finalize_export() marks it complete once every page is in.
+	 *
+	 * @var bool
+	 */
+	protected $completes_by_row_count = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $type Report type. E.g. 'customers'.

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -195,19 +195,21 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	}
 
 	/**
-	 * Create the empty export body, unless it is already there.
+	 * Start the export from a clean, empty body with no completion mark.
 	 *
 	 * Called once when the export is queued, so the pages can append in whatever order the queue
 	 * runs them. The parent creates the body on page 1 only, and a page that ran earlier wrote nothing.
+	 * An export ID can be reused through the `woocommerce_admin_export_id` filter, so a previous
+	 * export's rows and its `.headers` mark must not carry over.
 	 *
 	 * @since 11.2.0
 	 * @return bool Whether the body exists.
 	 */
 	public function create_export_file() {
-		if ( ! file_exists( $this->get_file_path() ) ) {
-			@file_put_contents( $this->get_file_path(), '' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			@chmod( $this->get_file_path(), 0664 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-		}
+		wp_delete_file( $this->get_headers_row_file_path() );
+
+		@file_put_contents( $this->get_file_path(), '' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		@chmod( $this->get_file_path(), 0664 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_chmod
 
 		return file_exists( $this->get_file_path() );
 	}

--- a/plugins/woocommerce/src/Admin/ReportCSVExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVExporter.php
@@ -191,7 +191,7 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	 * @return bool
 	 */
 	public function export_file_exists() {
-		return file_exists( $this->get_file_path() ) && file_exists( $this->get_headers_row_file_path() );
+		return is_file( $this->get_file_path() ) && is_file( $this->get_headers_row_file_path() );
 	}
 
 	/**
@@ -244,16 +244,18 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	 * changed while it ran never does. The exporter that confirms every page was written calls this.
 	 *
 	 * @since 11.2.0
-	 * @return void
+	 * @return bool Whether the companion is on disk after the call.
 	 */
 	public function write_headers_row_file() {
-		if ( file_exists( $this->get_headers_row_file_path() ) ) {
-			return;
+		if ( is_file( $this->get_headers_row_file_path() ) ) {
+			return true;
 		}
 
 		$header = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
 
 		@file_put_contents( $this->get_headers_row_file_path(), $header ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		return is_file( $this->get_headers_row_file_path() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -236,7 +236,7 @@ class ReportExporter {
 			// The pages ran inline, in order, in this one process, so the row count reaching 100 on a page means
 			// every later page is empty. Nothing else marks an inline export complete, so it is done here.
 			if ( 100 === $exporter->get_percent_complete() ) {
-				self::finalize_export( $report_type, $export_id );
+				self::finalize_or_fail( $report_type, $export_id );
 			} else {
 				self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
 			}
@@ -246,7 +246,7 @@ class ReportExporter {
 		// This page is still "in progress" in the queue while it runs, so count it as done here.
 		$pages_done = $progress['complete'] + 1;
 		if ( $pages_done >= $progress['pages'] && 0 === $progress['failed'] ) {
-			self::finalize_export( $report_type, $export_id );
+			self::finalize_or_fail( $report_type, $export_id );
 			return;
 		}
 
@@ -336,18 +336,43 @@ class ReportExporter {
 	/**
 	 * Mark an export as complete once every queued page has been written.
 	 *
+	 * The mark is a file. Reporting 100 without it would email a link the download route refuses.
+	 *
 	 * @internal
 	 * @since 11.2.0
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param string $export_id Unique ID for report (timestamp expected).
-	 * @return void
+	 * @return bool Whether the export is marked complete.
 	 */
 	public static function finalize_export( $report_type, $export_id ) {
 		$exporter = new ReportCSVExporter( $report_type );
 		$exporter->set_filename( self::get_export_filename( $report_type, $export_id ) );
-		$exporter->write_headers_row_file();
+
+		if ( ! $exporter->write_headers_row_file() ) {
+			wc_get_logger()->error(
+				sprintf( '%1$s report export %2$s could not be marked complete: %3$s could not be written.', $report_type, $export_id, $exporter->get_filename() . '.headers' ),
+				array( 'source' => 'report-csv-exporter' )
+			);
+			return false;
+		}
 
 		self::update_export_percentage_complete( $report_type, $export_id, 100 );
+
+		return true;
+	}
+
+	/**
+	 * Mark an export as complete from within a page action, failing the action when the mark cannot be written.
+	 *
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @throws \RuntimeException When the completion mark could not be written, so the page fails like a page that was lost.
+	 * @return void
+	 */
+	private static function finalize_or_fail( $report_type, $export_id ) {
+		if ( ! self::finalize_export( $report_type, $export_id ) ) {
+			throw new \RuntimeException( sprintf( 'Export %s could not be marked complete.', esc_html( $export_id ) ) );
+		}
 	}
 
 	/**
@@ -370,9 +395,7 @@ class ReportExporter {
 			return false;
 		}
 
-		self::finalize_export( $report_type, $export_id );
-
-		return true;
+		return self::finalize_export( $report_type, $export_id );
 	}
 
 	/**
@@ -684,7 +707,10 @@ class ReportExporter {
 		}
 
 		if ( null !== $progress ) {
-			self::finalize_export( $report_type, $export_id );
+			if ( ! self::finalize_export( $report_type, $export_id ) ) {
+				$email->trigger_failed( $user_id, $report_type );
+				return;
+			}
 		} elseif ( 100 !== self::get_export_percentage_complete( $report_type, $export_id ) ) {
 			// Batches ran synchronously, so the only record is the percentage they left behind.
 			wc_get_logger()->error(

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -160,17 +160,22 @@ class ReportExporter {
 	/**
 	 * Cap the report period at the time of the request, so orders placed while the export runs are not in it.
 	 *
-	 * Each batch queries live data. With an open-ended period, new orders would shift the pages under the
-	 * export, duplicating some rows, dropping others, and moving the row count the batches paginate by.
+	 * Each batch queries live data. With a period running into the future, new orders would shift the
+	 * pages under the export, duplicating some rows, dropping others, and moving the row count the
+	 * batches paginate by.
+	 *
+	 * Only an end the request sent is capped. Each report gives `before` its own meaning, and one it
+	 * did not ask for is a new filter: Customers turns it into an order date, which drops every
+	 * customer who never ordered.
 	 *
 	 * @internal
 	 * @since 11.2.0
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param array  $report_args Report parameters, passed to data query.
-	 * @return array Report parameters with `before` no later than now, for reports that take one.
+	 * @return array Report parameters with a `before` that was sent lowered to now, for reports that take one.
 	 */
 	public static function freeze_report_period( $report_type, $report_args ) {
-		if ( ! is_array( $report_args ) ) {
+		if ( ! is_array( $report_args ) || empty( $report_args['before'] ) || ! is_string( $report_args['before'] ) ) {
 			return $report_args;
 		}
 
@@ -181,18 +186,16 @@ class ReportExporter {
 
 		$now = time();
 
-		if ( ! empty( $report_args['before'] ) && is_string( $report_args['before'] ) ) {
-			try {
-				// Unspecified timezone means the local one, as the report data store reads it.
-				$before = new \DateTime( $report_args['before'], new \DateTimeZone( wc_timezone_string() ) );
-			} catch ( \Exception $e ) {
-				// Leave an unreadable value for the report's own validation to reject.
-				return $report_args;
-			}
+		try {
+			// Unspecified timezone means the local one, as the report data store reads it.
+			$before = new \DateTime( $report_args['before'], new \DateTimeZone( wc_timezone_string() ) );
+		} catch ( \Exception $e ) {
+			// Leave an unreadable value for the report's own validation to reject.
+			return $report_args;
+		}
 
-			if ( $before->getTimestamp() <= $now ) {
-				return $report_args;
-			}
+		if ( $before->getTimestamp() <= $now ) {
+			return $report_args;
 		}
 
 		// Local wall time with its offset spelled out. The data store reads a bare time as local, and on a

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -142,7 +142,7 @@ class ReportExporter {
 	public static function queue_report_export( $export_id, $report_type, $report_args = array(), $send_email = false ) {
 		// Progress is read back from the queue by the JSON-quoted ID, which an int would not match.
 		$export_id   = (string) $export_id;
-		$report_args = self::freeze_report_period( $report_type, $report_args );
+		$report_args = self::freeze_report_period( $report_args );
 
 		$exporter = new ReportCSVExporter( $report_type, $report_args );
 		$exporter->prepare_data_to_export();
@@ -183,17 +183,11 @@ class ReportExporter {
 	 *
 	 * @internal
 	 * @since 11.2.0
-	 * @param string $report_type Report type. E.g. 'customers'.
-	 * @param array  $report_args Report parameters, passed to data query.
-	 * @return array Report parameters with a `before` that was sent lowered to now, for reports that take one.
+	 * @param array $report_args Report parameters, passed to data query.
+	 * @return array Report parameters with a `before` that was sent lowered to now.
 	 */
-	public static function freeze_report_period( $report_type, $report_args ) {
+	public static function freeze_report_period( $report_args ) {
 		if ( ! is_array( $report_args ) || empty( $report_args['before'] ) || ! is_string( $report_args['before'] ) ) {
-			return $report_args;
-		}
-
-		$controller = ReportCSVExporter::get_report_controller( $report_type );
-		if ( ! $controller || ! isset( $controller->get_collection_params()['before'] ) ) {
 			return $report_args;
 		}
 

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -146,6 +146,10 @@ class ReportExporter {
 		$report_batch_args = array( $export_id, $report_type, $report_args );
 
 		if ( 0 < $num_batches ) {
+			// The body exists before any page runs, so the queue may run the pages in any order.
+			$exporter->set_filename( self::get_export_filename( $report_type, $export_id ) );
+			$exporter->create_export_file();
+
 			self::queue_batches( 1, $num_batches, 'export_report', $report_batch_args );
 
 			if ( $send_email ) {

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -140,6 +140,8 @@ class ReportExporter {
 	 * @return int Number of items to export.
 	 */
 	public static function queue_report_export( $export_id, $report_type, $report_args = array(), $send_email = false ) {
+		// Progress is read back from the queue by the JSON-quoted ID, which an int would not match.
+		$export_id   = (string) $export_id;
 		$report_args = self::freeze_report_period( $report_type, $report_args );
 
 		$exporter = new ReportCSVExporter( $report_type, $report_args );

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -237,7 +237,13 @@ class ReportExporter {
 		// batch, so an order changing status mid-export would otherwise leave the export short of 100.
 		$progress = self::get_export_progress( $export_id );
 		if ( null === $progress ) {
-			self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
+			// The pages ran inline, in order, in this one process, so the row count reaching 100 on a page means
+			// every later page is empty. Nothing else marks an inline export complete, so it is done here.
+			if ( 100 === $exporter->get_percent_complete() ) {
+				self::finalize_export( $report_type, $export_id );
+			} else {
+				self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
+			}
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 use Automattic\WooCommerce\Admin\Schedulers\SchedulerTraits;
 use Automattic\WooCommerce\Utilities\TimeUtil;
 
@@ -133,6 +134,8 @@ class ReportExporter {
 	 * @return int Number of items to export.
 	 */
 	public static function queue_report_export( $export_id, $report_type, $report_args = array(), $send_email = false ) {
+		$report_args = self::freeze_report_period( $report_type, $report_args );
+
 		$exporter = new ReportCSVExporter( $report_type, $report_args );
 		$exporter->prepare_data_to_export();
 
@@ -156,6 +159,54 @@ class ReportExporter {
 	}
 
 	/**
+	 * Cap the report period at the time of the request, so orders placed while the export runs are not in it.
+	 *
+	 * Each batch queries live data. With an open-ended period, new orders would shift the pages under the
+	 * export, duplicating some rows, dropping others, and moving the row count the batches paginate by.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param array  $report_args Report parameters, passed to data query.
+	 * @return array Report parameters with `before` no later than now, for reports that take one.
+	 */
+	public static function freeze_report_period( $report_type, $report_args ) {
+		if ( ! is_array( $report_args ) ) {
+			return $report_args;
+		}
+
+		$controller = ReportCSVExporter::get_report_controller( $report_type );
+		if ( ! $controller || ! isset( $controller->get_collection_params()['before'] ) ) {
+			return $report_args;
+		}
+
+		/**
+		 * The request time, in the store timezone.
+		 *
+		 * @var \WC_DateTime $now
+		 */
+		$now = TimeInterval::default_before();
+
+		if ( ! empty( $report_args['before'] ) && is_string( $report_args['before'] ) ) {
+			try {
+				// Unspecified timezone means the local one, as the report data store reads it.
+				$before = new \DateTime( $report_args['before'], new \DateTimeZone( wc_timezone_string() ) );
+			} catch ( \Exception $e ) {
+				// Leave an unreadable value for the report's own validation to reject.
+				return $report_args;
+			}
+
+			if ( $before->getTimestamp() <= $now->getTimestamp() ) {
+				return $report_args;
+			}
+		}
+
+		$report_args['before'] = $now->format( 'Y-m-d\TH:i:s' );
+
+		return $report_args;
+	}
+
+	/**
 	 * Process a report export action.
 	 *
 	 * @param int    $page_number Page number for this action.
@@ -171,7 +222,100 @@ class ReportExporter {
 		$exporter->set_filename( self::get_export_filename( $report_type, $export_id ) );
 		$exporter->generate_file();
 
-		self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
+		// Progress is counted in queued pages, not rows. The row total is re-read from live data on every
+		// batch, so an order changing status mid-export would otherwise leave the export short of 100.
+		$progress = self::get_export_progress( $export_id );
+		if ( null === $progress ) {
+			self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
+			return;
+		}
+
+		// This page is still "in progress" in the queue while it runs, so count it as done here.
+		$pages_done = $progress['complete'] + 1;
+		if ( $pages_done >= $progress['pages'] && 0 === $progress['failed'] ) {
+			self::finalize_export( $report_type, $export_id );
+			return;
+		}
+
+		self::update_export_percentage_complete( $report_type, $export_id, (int) floor( $pages_done / $progress['pages'] * 100 ) );
+	}
+
+	/**
+	 * Count this export's batch actions in the queue by outcome.
+	 *
+	 * The queue is the only record of how many pages were scheduled and which of them actually ran,
+	 * so completion is read from it rather than from a percentage each batch computes for itself.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @return array|null Counts keyed by `pages`, `complete`, `unfinished`, `failed`, plus the queue
+	 *                    log messages of failed batches under `errors`. Null when the queue holds
+	 *                    no batches for this export, e.g. when batches ran synchronously.
+	 */
+	public static function get_export_progress( $export_id ) {
+		$outcomes = array(
+			'complete'   => array( \ActionScheduler_Store::STATUS_COMPLETE ),
+			'unfinished' => array( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::STATUS_RUNNING ),
+			'failed'     => array( \ActionScheduler_Store::STATUS_FAILED, \ActionScheduler_Store::STATUS_CANCELED ),
+		);
+		$progress = array(
+			'pages'  => 0,
+			'errors' => array(),
+		);
+
+		/**
+		 * The queue.
+		 *
+		 * @var \WC_Queue_Interface $queue
+		 */
+		$queue = self::queue();
+
+		foreach ( $outcomes as $outcome => $statuses ) {
+			$actions = $queue->search(
+				array(
+					'hook'     => self::get_action( 'export_report' ),
+					'group'    => self::$group,
+					'status'   => $statuses,
+					// The quoted JSON form, so a longer export ID or an action ID cannot match.
+					'search'   => '"' . $export_id . '"',
+					'per_page' => -1,
+				)
+			);
+
+			$progress[ $outcome ] = count( $actions );
+			$progress['pages']   += count( $actions );
+
+			if ( 'failed' === $outcome ) {
+				foreach ( array_keys( $actions ) as $action_id ) {
+					// The failure is the last thing the queue logs for an action.
+					$log_entries = \ActionScheduler::logger()->get_logs( $action_id );
+					$log_entry   = end( $log_entries );
+					if ( $log_entry ) {
+						$progress['errors'][] = $log_entry->get_message();
+					}
+				}
+			}
+		}
+
+		return 0 === $progress['pages'] ? null : $progress;
+	}
+
+	/**
+	 * Mark an export as complete once every queued page has been written.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @return void
+	 */
+	public static function finalize_export( $report_type, $export_id ) {
+		$exporter = new ReportCSVExporter( $report_type );
+		$exporter->set_filename( self::get_export_filename( $report_type, $export_id ) );
+		$exporter->write_headers_row_file();
+
+		self::update_export_percentage_complete( $report_type, $export_id, 100 );
 	}
 
 	/**
@@ -416,15 +560,58 @@ class ReportExporter {
 	 * @return void
 	 */
 	public static function email_report_download_link( $user_id, $export_id, $report_type, $report_args = array() ) {
-		$percent_complete = self::get_export_percentage_complete( $report_type, $export_id );
+		$progress = self::get_export_progress( $export_id );
 
-		if ( 100 === $percent_complete ) {
-			$download_url = self::get_download_url( $report_type, $export_id, $report_args );
-
-			\WC_Emails::instance();
-			$email = new ReportCSVEmail();
-			$email->set_report_date_range( self::get_export_date_range_label( $report_args ) );
-			$email->trigger( $user_id, $report_type, $download_url );
+		// A page can be claimed by another runner between the dependency check and this call, so
+		// check again here rather than reporting on a file that is still being written.
+		if ( null !== $progress && $progress['unfinished'] > 0 ) {
+			/**
+			 * The queue.
+			 *
+			 * @var \WC_Queue_Interface $queue
+			 */
+			$queue = self::queue();
+			$queue->schedule_single(
+				time() + 5,
+				(string) self::get_action( 'email_report_download_link' ),
+				array( $user_id, $export_id, $report_type, $report_args ),
+				(string) self::$group
+			);
+			return;
 		}
+
+		\WC_Emails::instance();
+		$email = new ReportCSVEmail();
+		$email->set_report_date_range( self::get_export_date_range_label( $report_args ) );
+
+		if ( null !== $progress && $progress['failed'] > 0 ) {
+			wc_get_logger()->error(
+				sprintf(
+					'%1$s report export %2$s failed: %3$d of %4$d batches did not complete. %5$s',
+					$report_type,
+					$export_id,
+					$progress['failed'],
+					$progress['pages'],
+					implode( ' | ', $progress['errors'] )
+				),
+				array( 'source' => 'report-csv-exporter' )
+			);
+			$email->trigger_failed( $user_id, $report_type );
+			return;
+		}
+
+		if ( null !== $progress ) {
+			self::finalize_export( $report_type, $export_id );
+		} elseif ( 100 !== self::get_export_percentage_complete( $report_type, $export_id ) ) {
+			// Batches ran synchronously, so the only record is the percentage they left behind.
+			wc_get_logger()->error(
+				sprintf( '%1$s report export %2$s stopped at %3$s%%.', $report_type, $export_id, self::get_export_percentage_complete( $report_type, $export_id ) ),
+				array( 'source' => 'report-csv-exporter' )
+			);
+			$email->trigger_failed( $user_id, $report_type );
+			return;
+		}
+
+		$email->trigger( $user_id, $report_type, self::get_download_url( $report_type, $export_id, $report_args ) );
 	}
 }

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -198,10 +198,10 @@ class ReportExporter {
 			return $report_args;
 		}
 
-		// Local wall time with its offset spelled out. The data store reads a bare time as local, and on a
-		// store set to a manual UTC offset the only local clock available is wp_date(): WC_DateTime keeps
-		// that offset out of format(). The offset also pins down the repeated hour when DST ends.
-		$report_args['before'] = wp_date( 'Y-m-d\TH:i:sP', $now );
+		// Local wall time with its offset spelled out, so the data store reads it back as this instant
+		// and the repeated hour when DST ends is not ambiguous. Not wp_date(): calendar plugins filter
+		// it into dates the report then rejects. wp_timezone() also covers stores set to a manual offset.
+		$report_args['before'] = ( new \DateTimeImmutable( '@' . $now ) )->setTimezone( wp_timezone() )->format( 'Y-m-d\TH:i:sP' );
 
 		return $report_args;
 	}

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -243,6 +243,11 @@ class ReportExporter {
 	 * The queue is the only record of how many pages were scheduled and which of them actually ran,
 	 * so completion is read from it rather than from a percentage each batch computes for itself.
 	 *
+	 * A large export is queued through chunk actions that each schedule a range of pages. A chunk that
+	 * has not run yet stands for pages the queue does not hold, so it counts as an unfinished page, and
+	 * a chunk that failed as a failed one. Otherwise the pages queued so far could all be complete
+	 * while whole ranges were still missing.
+	 *
 	 * @internal
 	 * @since 11.2.0
 	 * @param string $export_id Unique ID for report (timestamp expected).
@@ -255,6 +260,10 @@ class ReportExporter {
 			'complete'   => array( \ActionScheduler_Store::STATUS_COMPLETE ),
 			'unfinished' => array( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::STATUS_RUNNING ),
 			'failed'     => array( \ActionScheduler_Store::STATUS_FAILED, \ActionScheduler_Store::STATUS_CANCELED ),
+		);
+		$hooks    = array(
+			self::get_action( 'export_report' ) => array_keys( $outcomes ),
+			self::get_action( 'queue_batches' ) => array( 'unfinished', 'failed' ),
 		);
 		$progress = array(
 			'pages'  => 0,
@@ -269,29 +278,37 @@ class ReportExporter {
 		$queue = self::queue();
 
 		foreach ( $outcomes as $outcome => $statuses ) {
-			// IDs only: an export can run to thousands of pages, and every page counts them again.
-			$action_ids = $queue->search(
-				array(
-					'hook'     => self::get_action( 'export_report' ),
-					'group'    => self::$group,
-					'status'   => $statuses,
-					// The quoted JSON form, so a longer export ID or an action ID cannot match.
-					'search'   => '"' . $export_id . '"',
-					'per_page' => -1,
-				),
-				'ids'
-			);
+			$progress[ $outcome ] = 0;
 
-			$progress[ $outcome ] = count( $action_ids );
-			$progress['pages']   += count( $action_ids );
+			foreach ( $hooks as $hook => $counted_outcomes ) {
+				if ( ! in_array( $outcome, $counted_outcomes, true ) ) {
+					continue;
+				}
 
-			if ( 'failed' === $outcome ) {
-				foreach ( $action_ids as $action_id ) {
-					// The failure is the last thing the queue logs for an action.
-					$log_entries = \ActionScheduler::logger()->get_logs( $action_id );
-					$log_entry   = end( $log_entries );
-					if ( $log_entry ) {
-						$progress['errors'][] = $log_entry->get_message();
+				// IDs only: an export can run to thousands of pages, and every page counts them again.
+				$action_ids = $queue->search(
+					array(
+						'hook'     => $hook,
+						'group'    => self::$group,
+						'status'   => $statuses,
+						// The quoted JSON form, so a longer export ID or an action ID cannot match.
+						'search'   => '"' . $export_id . '"',
+						'per_page' => -1,
+					),
+					'ids'
+				);
+
+				$progress[ $outcome ] += count( $action_ids );
+				$progress['pages']    += count( $action_ids );
+
+				if ( 'failed' === $outcome ) {
+					foreach ( $action_ids as $action_id ) {
+						// The failure is the last thing the queue logs for an action.
+						$log_entries = \ActionScheduler::logger()->get_logs( $action_id );
+						$log_entry   = end( $log_entries );
+						if ( $log_entry ) {
+							$progress['errors'][] = $log_entry->get_message();
+						}
 					}
 				}
 			}

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -286,12 +286,10 @@ class ReportExporter {
 			'errors' => array(),
 		);
 
-		/**
-		 * The queue.
-		 *
-		 * @var \WC_Queue_Interface $queue
-		 */
-		$queue = self::queue();
+		// Straight to the Action Scheduler store rather than through the queue interface: the statuses,
+		// the log lookup and the JSON-quoted search are all its own, and counting is cheaper than
+		// materializing IDs when an export runs to thousands of pages and every page counts them again.
+		$store = \ActionScheduler::store();
 
 		foreach ( $outcomes as $outcome => $statuses ) {
 			$progress[ $outcome ] = 0;
@@ -301,23 +299,20 @@ class ReportExporter {
 					continue;
 				}
 
-				// IDs only: an export can run to thousands of pages, and every page counts them again.
-				$action_ids = $queue->search(
-					array(
-						'hook'     => $hook,
-						'group'    => self::$group,
-						'status'   => $statuses,
-						// The quoted JSON form, so a longer export ID or an action ID cannot match.
-						'search'   => '"' . $export_id . '"',
-						'per_page' => -1,
-					),
-					'ids'
+				$query = array(
+					'hook'     => $hook,
+					'group'    => self::$group,
+					'status'   => $statuses,
+					// The quoted JSON form, so a longer export ID or an action ID cannot match.
+					'search'   => '"' . $export_id . '"',
+					'per_page' => -1,
 				);
 
-				$progress[ $outcome ] += count( $action_ids );
-				$progress['pages']    += count( $action_ids );
-
+				// Failed actions are fetched by ID because the failure is read from their logs.
 				if ( 'failed' === $outcome ) {
+					$action_ids = $store->query_actions( $query );
+					$count      = count( $action_ids );
+
 					foreach ( $action_ids as $action_id ) {
 						// The failure is the last thing the queue logs for an action.
 						$log_entries = \ActionScheduler::logger()->get_logs( $action_id );
@@ -326,7 +321,12 @@ class ReportExporter {
 							$progress['errors'][] = $log_entry->get_message();
 						}
 					}
+				} else {
+					$count = (int) $store->query_actions( $query, 'count' );
 				}
+
+				$progress[ $outcome ] += $count;
+				$progress['pages']    += $count;
 			}
 		}
 

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -46,6 +46,13 @@ class ReportExporter {
 	const EXPORT_RETENTION_PERIOD = WEEK_IN_SECONDS;
 
 	/**
+	 * How long the email waits for pages that are still running before reporting the export as failed.
+	 *
+	 * @since 11.2.0
+	 */
+	const EXPORT_WAIT_LIMIT = HOUR_IN_SECONDS;
+
+	/**
 	 * Get all available scheduling actions.
 	 * Used to determine action hook names and clear events.
 	 *
@@ -580,14 +587,44 @@ class ReportExporter {
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param array  $report_args Optional. Report parameters the export was queued with. Exports queued
 	 *                            before WooCommerce 11.2.0 run without them.
+	 * @param int    $wait_until  Optional. Time to stop waiting for pages that are still running. Set on the
+	 *                            first re-queue, so an export the queue never finishes is reported instead
+	 *                            of waited on forever.
 	 * @return void
 	 */
-	public static function email_report_download_link( $user_id, $export_id, $report_type, $report_args = array() ) {
+	public static function email_report_download_link( $user_id, $export_id, $report_type, $report_args = array(), $wait_until = 0 ) {
 		$progress = self::get_export_progress( $export_id );
+
+		\WC_Emails::instance();
+		$email = new ReportCSVEmail();
+		$email->set_report_date_range( self::get_export_date_range_label( $report_args ) );
 
 		// A page can be claimed by another runner between the dependency check and this call, so
 		// check again here rather than reporting on a file that is still being written.
 		if ( null !== $progress && $progress['unfinished'] > 0 ) {
+			$wait_until = (int) $wait_until;
+
+			if ( 0 === $wait_until ) {
+				$wait_until = time() + self::EXPORT_WAIT_LIMIT;
+			}
+
+			// A page can sit "in progress" for good when its runner died and the queue's cleanup is turned off.
+			if ( time() > $wait_until ) {
+				wc_get_logger()->error(
+					sprintf(
+						'%1$s report export %2$s gave up: %3$d of %4$d batches still had not finished after %5$s.',
+						$report_type,
+						$export_id,
+						$progress['unfinished'],
+						$progress['pages'],
+						human_time_diff( 0, self::EXPORT_WAIT_LIMIT )
+					),
+					array( 'source' => 'report-csv-exporter' )
+				);
+				$email->trigger_failed( $user_id, $report_type );
+				return;
+			}
+
 			/**
 			 * The queue.
 			 *
@@ -597,15 +634,11 @@ class ReportExporter {
 			$queue->schedule_single(
 				time() + 5,
 				(string) self::get_action( 'email_report_download_link' ),
-				array( $user_id, $export_id, $report_type, $report_args ),
+				array( $user_id, $export_id, $report_type, $report_args, $wait_until ),
 				(string) self::$group
 			);
 			return;
 		}
-
-		\WC_Emails::instance();
-		$email = new ReportCSVEmail();
-		$email->set_report_date_range( self::get_export_date_range_label( $report_args ) );
 
 		if ( null !== $progress && $progress['failed'] > 0 ) {
 			wc_get_logger()->error(

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -349,6 +349,31 @@ class ReportExporter {
 	}
 
 	/**
+	 * Mark the export complete if every queued page has been written, and say whether it is.
+	 *
+	 * Two pages that run at the same time each see the other as unfinished, so neither finalizes.
+	 * The email action does that for emailed exports. A caller polling the status endpoint has no
+	 * such action, so the status endpoint finalizes here.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @return bool Whether every queued page has been written.
+	 */
+	public static function finalize_if_complete( $report_type, $export_id ) {
+		$progress = self::get_export_progress( $export_id );
+
+		if ( null === $progress || $progress['unfinished'] > 0 || $progress['failed'] > 0 ) {
+			return false;
+		}
+
+		self::finalize_export( $report_type, $export_id );
+
+		return true;
+	}
+
+	/**
 	 * Generate a key to reference an export status.
 	 *
 	 * @param string $report_type Report type. E.g. 'customers'.

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 use Automattic\WooCommerce\Admin\Schedulers\SchedulerTraits;
 use Automattic\WooCommerce\Utilities\TimeUtil;
 
@@ -180,12 +179,7 @@ class ReportExporter {
 			return $report_args;
 		}
 
-		/**
-		 * The request time, in the store timezone.
-		 *
-		 * @var \WC_DateTime $now
-		 */
-		$now = TimeInterval::default_before();
+		$now = time();
 
 		if ( ! empty( $report_args['before'] ) && is_string( $report_args['before'] ) ) {
 			try {
@@ -196,12 +190,15 @@ class ReportExporter {
 				return $report_args;
 			}
 
-			if ( $before->getTimestamp() <= $now->getTimestamp() ) {
+			if ( $before->getTimestamp() <= $now ) {
 				return $report_args;
 			}
 		}
 
-		$report_args['before'] = $now->format( 'Y-m-d\TH:i:s' );
+		// Local wall time with its offset spelled out. The data store reads a bare time as local, and on a
+		// store set to a manual UTC offset the only local clock available is wp_date(): WC_DateTime keeps
+		// that offset out of format(). The offset also pins down the repeated hour when DST ends.
+		$report_args['before'] = wp_date( 'Y-m-d\TH:i:sP', $now );
 
 		return $report_args;
 	}

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -269,7 +269,8 @@ class ReportExporter {
 		$queue = self::queue();
 
 		foreach ( $outcomes as $outcome => $statuses ) {
-			$actions = $queue->search(
+			// IDs only: an export can run to thousands of pages, and every page counts them again.
+			$action_ids = $queue->search(
 				array(
 					'hook'     => self::get_action( 'export_report' ),
 					'group'    => self::$group,
@@ -277,14 +278,15 @@ class ReportExporter {
 					// The quoted JSON form, so a longer export ID or an action ID cannot match.
 					'search'   => '"' . $export_id . '"',
 					'per_page' => -1,
-				)
+				),
+				'ids'
 			);
 
-			$progress[ $outcome ] = count( $actions );
-			$progress['pages']   += count( $actions );
+			$progress[ $outcome ] = count( $action_ids );
+			$progress['pages']   += count( $action_ids );
 
 			if ( 'failed' === $outcome ) {
-				foreach ( array_keys( $actions ) as $action_id ) {
+				foreach ( $action_ids as $action_id ) {
 					// The failure is the last thing the queue logs for an action.
 					$log_entries = \ActionScheduler::logger()->get_logs( $action_id );
 					$log_entry   = end( $log_entries );

--- a/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
+++ b/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
@@ -219,7 +219,8 @@ trait SchedulerTraits {
 
 		$blocking_jobs = self::queue()->search(
 			array(
-				'status'   => 'pending',
+				// A dependency that another runner is executing right now blocks as much as a queued one.
+				'status'   => array( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::STATUS_RUNNING ),
 				'orderby'  => 'date',
 				'order'    => 'DESC',
 				'per_page' => 1,

--- a/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
+++ b/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
@@ -219,8 +219,7 @@ trait SchedulerTraits {
 
 		$blocking_jobs = self::queue()->search(
 			array(
-				// A dependency that another runner is executing right now blocks as much as a queued one.
-				'status'   => array( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::STATUS_RUNNING ),
+				'status'   => 'pending',
 				'orderby'  => 'date',
 				'order'    => 'DESC',
 				'per_page' => 1,

--- a/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportCSVEmailTest.php
@@ -163,4 +163,52 @@ class ReportCSVEmailTest extends WC_Unit_Test_Case {
 
 		return $sent ? $sent['subject'] : '';
 	}
+
+	/**
+	 * @testdox A failed export is emailed as a failure, with no download link, in HTML and plain text.
+	 */
+	public function test_failed_export_email_says_so(): void {
+		reset_phpmailer_instance();
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		( new ReportCSVEmail() )->trigger_failed( 1, 'orders' );
+
+		$this->assertCount( 1, $mailer->mock_sent, 'A failed export should send exactly one email.' );
+		$sent = $mailer->mock_sent[0];
+
+		$this->assertSame( get_userdata( 1 )->user_email, $sent['to'][0][0], 'The email should go to the user who requested the export.' );
+		$this->assertStringContainsString( 'Your Orders Report export did not complete', $sent['subject'], 'The subject should name the report and say it failed.' );
+		$this->assertStringContainsString( 'Your Orders Report could not be exported', $sent['body'], 'The HTML body should say the export failed.' );
+		$this->assertStringNotContainsString( 'Download your', $sent['body'], 'A failed export has no link to download.' );
+
+		$email = new ReportCSVEmail();
+		$email->trigger_failed( 1, 'orders' );
+		$plain = $email->get_content_plain();
+
+		$this->assertStringContainsString( 'Your Orders Report could not be exported', $plain, 'The plain text body should say the export failed.' );
+		$this->assertStringNotContainsString( 'Download your', $plain, 'A failed export has no link to download.' );
+	}
+
+	/**
+	 * @testdox A failed export email says which period the report covered, when it had one.
+	 */
+	public function test_failed_export_email_states_the_date_range(): void {
+		reset_phpmailer_instance();
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		$email = new ReportCSVEmail();
+		$email->set_report_date_range( 'June 1, 2025 - June 30, 2025' );
+		$email->trigger_failed( 1, 'orders' );
+
+		$sent = end( $mailer->mock_sent );
+
+		$this->assertIsArray( $sent, 'A failed export should be emailed.' );
+		$this->assertStringContainsString(
+			'Your Orders Report export for June 1, 2025 - June 30, 2025 did not complete',
+			$sent['subject'],
+			'The subject should name the period the failed export covered.'
+		);
+		$this->assertStringContainsString( 'Date range: June 1, 2025 - June 30, 2025', $sent['body'], 'The HTML body should name the period the failed export covered.' );
+		$this->assertStringContainsString( 'Date range: June 1, 2025 - June 30, 2025', $email->get_content_plain(), 'The plain text body should name the period the failed export covered.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -1066,6 +1066,63 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox An export queued under a reused ID starts from a clean file.
+	 */
+	public function test_reused_export_id_starts_from_a_clean_file(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		add_filter( 'woocommerce_admin_orders_report_export_batch_limit', array( $this, 'two_rows_per_batch' ) );
+		$this->create_reported_orders( 3 );
+		$export_id = (string) time();
+		$path      = ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv";
+
+		$this->paths[] = $path;
+		$this->paths[] = $path . '.headers';
+
+		ReportExporter::queue_report_export( $export_id, 'orders', array( 'after' => '2000-01-01T00:00:00' ), false );
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertTrue( $exporter->export_file_exists(), 'The first export completed.' );
+		$this->assertCount( 3, file( $path ), 'The first export holds its three rows.' );
+
+		// A filter that hands out a constant ID queues the next export under the same name.
+		$this->create_reported_orders( 1 );
+		ReportExporter::queue_report_export( $export_id, 'orders', array( 'after' => '2000-01-01T00:00:00' ), false );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'The previous export must not be served as the new one.' );
+		$this->assertSame( '', file_get_contents( $path ), 'The previous export\'s rows must not carry over.' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$this->assertTrue( $exporter->export_file_exists(), 'The new export completed.' );
+		$this->assertCount( 4, file( $path ), 'The new export holds its own rows and nothing else.' );
+	}
+
+	/**
+	 * @testdox An export ID given as a number is tracked in the queue like one given as a string.
+	 */
+	public function test_export_id_is_stored_as_a_string(): void {
+		wp_set_current_user( 1 );
+		add_filter( 'woocommerce_admin_orders_report_export_batch_limit', array( $this, 'two_rows_per_batch' ) );
+		$this->create_reported_orders( 3 );
+		$export_id = time();
+		$path      = ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv";
+
+		$this->paths[] = $path;
+		$this->paths[] = $path . '.headers';
+
+		ReportExporter::queue_report_export( $export_id, 'orders', array( 'after' => '2000-01-01T00:00:00' ), false );
+
+		$progress = ReportExporter::get_export_progress( (string) $export_id );
+
+		$this->assertNotNull( $progress, 'The queued pages should be found under the export ID.' );
+		$this->assertSame( 2, $progress['pages'], 'Three orders at two per batch should queue two pages.' );
+	}
+
+	/**
 	 * @testdox The email waits for pages that a queued chunk has not scheduled yet.
 	 */
 	public function test_email_waits_for_pages_a_chunk_has_yet_to_queue(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -816,13 +816,16 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 
 		$this->assertCount( 3, $batches, 'Five orders at two per batch should queue three pages.' );
 
-		// Another runner picked the last page first.
-		$this->run_action( array_key_last( $batches ) );
-		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
-
 		$exporter = new ReportCSVExporter();
 		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
 		$path = ReportCSVExporter::get_reports_directory() . $exporter->get_filename();
+
+		// Another runner picked the last page first.
+		$this->run_action( array_key_last( $batches ) );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'The last page by number is not the last page to run, so it must not mark the export complete.' );
+
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
 
 		$this->assertTrue( $exporter->export_file_exists(), 'Every page ran, so the export is complete.' );
 		$this->assertCount( 5, file( $path ), 'The page that ran first must be in the file.' );
@@ -996,6 +999,7 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 0, ReportExporter::get_export_progress( $export_id )['unfinished'], 'Both pages ran.' );
 		$this->assertNotSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'Neither page finalized, because each saw the other still running.' );
+		$this->assertFalse( $exporter->export_file_exists(), 'Nothing but finalize_export() may mark the export complete.' );
 
 		// The REST server outlives the test that built it, and the analytics routes load lazily through a
 		// filter that does not. Start a server here, with the namespace loaded up front.
@@ -1008,6 +1012,57 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 		$this->assertSame( 100, $response->get_data()['percent_complete'], 'The status endpoint should finish an export every page of which has been written.' );
 		$this->assertArrayHasKey( 'download_url', $response->get_data(), 'A finished export should offer its download.' );
 		$this->assertTrue( $exporter->export_file_exists(), 'The header row should be written once the status endpoint finished the export.' );
+	}
+
+	/**
+	 * @testdox An export whose pages run inline, with the queue turned off, is emailed a working link.
+	 */
+	public function test_export_run_without_the_queue_is_emailed(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		add_filter( 'woocommerce_analytics_disable_action_scheduling', '__return_true' );
+		add_filter( 'woocommerce_admin_orders_report_export_batch_limit', array( $this, 'two_rows_per_batch' ) );
+		$this->create_reported_orders( 3 );
+		$export_id = (string) time();
+		$path      = ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv";
+
+		$this->paths[] = $path;
+		$this->paths[] = $path . '.headers';
+
+		ReportExporter::queue_report_export( $export_id, 'orders', array( 'after' => '2000-01-01T00:00:00' ), true );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertNull( ReportExporter::get_export_progress( $export_id ), 'Nothing was queued.' );
+		$this->assertCount( 3, file( $path ), 'Every page ran inline.' );
+		$this->assertTrue( $exporter->export_file_exists(), 'The export should be marked complete before the link goes out.' );
+		$this->assertSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'The export should report complete.' );
+		$this->assertCount( 1, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'The download link should be emailed.' );
+	}
+
+	/**
+	 * @testdox An export whose pages run inline, with the queue turned off and no email, is marked complete.
+	 */
+	public function test_export_run_without_the_queue_is_marked_complete(): void {
+		wp_set_current_user( 1 );
+		add_filter( 'woocommerce_analytics_disable_action_scheduling', '__return_true' );
+		add_filter( 'woocommerce_admin_orders_report_export_batch_limit', array( $this, 'two_rows_per_batch' ) );
+		$this->create_reported_orders( 3 );
+		$export_id = (string) time();
+		$path      = ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv";
+
+		$this->paths[] = $path;
+		$this->paths[] = $path . '.headers';
+
+		ReportExporter::queue_report_export( $export_id, 'orders', array( 'after' => '2000-01-01T00:00:00' ), false );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertCount( 3, file( $path ), 'Every page ran inline.' );
+		$this->assertTrue( $exporter->export_file_exists(), 'The last page to run inline should mark the export complete.' );
+		$this->assertSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'The export should report complete.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -852,6 +852,41 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A page that could not be written to the export file fails instead of completing.
+	 */
+	public function test_page_that_cannot_be_written_fails(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger = $this->capture_log_errors();
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+
+		// A stream that opens but refuses to append, as a read-only wrapper would.
+		add_filter( 'woocommerce_csv_exporter_fopen_mode', array( $this, 'read_only_mode' ) );
+		// fwrite() raises a notice on such a stream, which the test runner would turn into an exception of its own.
+		set_error_handler( '__return_true', E_NOTICE ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+		restore_error_handler();
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'A page that was not written must not leave the export served as complete.' );
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertNotEmpty( preg_grep( '/could not be written/', $logger->errors ), 'The log should say the page was lost.' );
+	}
+
+	/**
+	 * Open the export file read-only, so writes fail.
+	 *
+	 * @return string
+	 */
+	public function read_only_mode(): string {
+		return 'r';
+	}
+
+	/**
 	 * @testdox The email waits for a batch that another runner is still executing.
 	 */
 	public function test_email_waits_for_a_running_batch(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -701,6 +701,24 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The cap is the store's local time on a store set to a manual UTC offset.
+	 */
+	public function test_report_period_cap_uses_the_store_utc_offset(): void {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 10 );
+
+		$capped = ReportExporter::freeze_report_period( 'orders', array( 'after' => '2020-01-01T00:00:00' ) );
+
+		$this->assertStringEndsWith( '+10:00', $capped['before'], 'The cap should spell out the store offset.' );
+		$this->assertEqualsWithDelta(
+			time(),
+			( new \DateTime( $capped['before'], new \DateTimeZone( wc_timezone_string() ) ) )->getTimestamp(),
+			5,
+			'Read as the report data store reads it, the cap should be the request time, not the UTC clock.'
+		);
+	}
+
+	/**
 	 * @testdox A failed batch is logged and emailed as a failure instead of being silently dropped.
 	 */
 	public function test_failed_batch_is_reported(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -899,12 +899,6 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 		$this->run_action( array_key_first( $batches ) );
 		\ActionScheduler::store()->log_execution( array_key_last( $batches ) );
 
-		$this->assertInstanceOf(
-			\ActionScheduler_Action::class,
-			ReportExporter::get_next_blocking_job( 'email_report_download_link' ),
-			'A batch that is in progress should block the email action like a pending one.'
-		);
-
 		$email_hook = ReportExporter::get_action( 'email_report_download_link' );
 		$pending    = count(
 			WC()->queue()->search(
@@ -932,6 +926,47 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 			),
 			'The email should be re-queued to check again later.'
 		);
+	}
+
+	/**
+	 * @testdox A page that never finishes is reported as a failed export once the wait runs out.
+	 */
+	public function test_export_with_a_page_that_never_finishes_is_reported(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger = $this->capture_log_errors();
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+		$batches   = $this->get_batch_actions( $export_id );
+
+		$this->run_action( array_key_first( $batches ) );
+		// Its runner died, and the queue's cleanup that would mark it failed is turned off.
+		\ActionScheduler::store()->log_execution( array_key_last( $batches ) );
+
+		ReportExporter::email_report_download_link( 1, $export_id, 'orders', array(), time() - 1 );
+
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed for an export that never finished.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertCount( 1, $logger->errors, 'Giving up should be logged.' );
+		$this->assertStringContainsString( '1 of 2 batches still had not finished', $logger->errors[0], 'The log should say which pages never ran.' );
+	}
+
+	/**
+	 * @testdox An export with no queued batches and a percentage short of 100 is reported as failed.
+	 */
+	public function test_export_that_stopped_short_is_reported(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger    = $this->capture_log_errors();
+		$export_id = (string) time();
+
+		// Batches ran synchronously and left only their percentage behind.
+		ReportExporter::update_export_percentage_complete( 'orders', $export_id, 50 );
+		ReportExporter::email_report_download_link( 1, $export_id, 'orders' );
+
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed for an export that stopped short.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertStringContainsString( 'stopped at 50%', $logger->errors[0], 'The log should carry the percentage it stopped at.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -11,6 +11,9 @@ namespace Automattic\WooCommerce\Tests\Admin;
 
 use Automattic\WooCommerce\Admin\ReportCSVExporter;
 use Automattic\WooCommerce\Admin\ReportExporter;
+use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
+use WC_Helper_Order;
+use WC_Helper_Queue;
 use WC_Unit_Test_Case;
 
 /**
@@ -173,6 +176,87 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 				)
 			),
 			'The range should be the dates the report was run for, as written.'
+		);
+	}
+
+	/**
+	 * Create orders and import them into the analytics tables.
+	 *
+	 * @param int      $count   Number of orders.
+	 * @param int|null $created Creation timestamp, defaults to now.
+	 * @return int[] Order IDs.
+	 */
+	private function create_reported_orders( int $count, ?int $created = null ): array {
+		$ids = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = WC_Helper_Order::create_order();
+			$order->set_status( 'completed' );
+			if ( null !== $created ) {
+				// Analytics may report by created, paid or completed date, so move all three.
+				$order->set_date_created( $created );
+				$order->set_date_paid( $created );
+				$order->set_date_completed( $created );
+			}
+			$order->save();
+
+			// The queue runner is not running during a test, so import directly rather than through it.
+			OrdersScheduler::import( $order->get_id() );
+			$ids[] = $order->get_id();
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Queue an emailed orders export, two orders per batch, and track its files for tear down.
+	 *
+	 * @return string Export ID.
+	 */
+	private function queue_orders_export(): string {
+		add_filter( 'woocommerce_admin_orders_report_export_batch_limit', array( $this, 'two_rows_per_batch' ) );
+
+		$export_id = (string) time();
+		$args      = array(
+			'after'  => '2000-01-01T00:00:00',
+			'before' => '2100-01-01T00:00:00',
+		);
+
+		ReportExporter::queue_report_export( $export_id, 'orders', $args, true );
+		ReportExporter::update_export_percentage_complete( 'orders', $export_id, 0 );
+
+		$path          = ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv";
+		$this->paths[] = $path;
+		$this->paths[] = $path . '.headers';
+
+		return $export_id;
+	}
+
+	/**
+	 * Batch limit filter callback.
+	 *
+	 * @return int
+	 */
+	public function two_rows_per_batch(): int {
+		return 2;
+	}
+
+	/**
+	 * Get this export's queued batch actions, keyed by action ID in page order.
+	 *
+	 * @param string $export_id Export ID.
+	 * @return \ActionScheduler_Action[]
+	 */
+	private function get_batch_actions( string $export_id ): array {
+		return WC()->queue()->search(
+			array(
+				'hook'     => ReportExporter::get_action( 'export_report' ),
+				'search'   => '"' . $export_id . '"',
+				'group'    => ReportExporter::$group,
+				'per_page' => -1,
+				'orderby'  => 'action_id',
+				'order'    => 'ASC',
+			)
 		);
 	}
 
@@ -472,6 +556,230 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Run one queued action.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 */
+	private function run_action( int $action_id ): void {
+		( new \ActionScheduler_QueueRunner() )->process_action( $action_id );
+	}
+
+	/**
+	 * Subjects of the emails sent so far.
+	 *
+	 * @return string[]
+	 */
+	private function get_sent_subjects(): array {
+		return array_column( tests_retrieve_phpmailer_instance()->mock_sent, 'subject' );
+	}
+
+	/**
+	 * Install a logger that records error calls.
+	 *
+	 * @return object Fake logger with a public `$errors` array.
+	 */
+	private function capture_log_errors(): object {
+		// phpcs:disable Squiz.Commenting, Squiz.Classes.ClassFileName.NoMatch
+		$logger = new class() implements \WC_Logger_Interface {
+			public array $errors = array();
+
+			public function add( $handle, $message, $level = \WC_Log_Levels::NOTICE ) {
+				unset( $handle, $message, $level );
+				return true;
+			}
+			public function log( $level, $message, $context = array() ) {
+				unset( $level, $message, $context );
+			}
+			public function emergency( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+			public function alert( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+			public function critical( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+			public function error( $message, $context = array() ) {
+				unset( $context );
+				$this->errors[] = $message;
+			}
+			public function warning( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+			public function notice( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+			public function info( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+			public function debug( $message, $context = array() ) {
+				unset( $message, $context );
+			}
+		};
+		// phpcs:enable
+
+		add_filter(
+			'woocommerce_logging_class',
+			static function () use ( $logger ) {
+				return $logger;
+			}
+		);
+
+		return $logger;
+	}
+
+	/**
+	 * @testdox An export covers the orders that existed when it was requested, not ones placed while it ran.
+	 */
+	public function test_export_is_a_snapshot_of_the_request_time(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$this->create_reported_orders( 3, time() - HOUR_IN_SECONDS );
+		$export_id = $this->queue_orders_export();
+		$batches   = $this->get_batch_actions( $export_id );
+
+		$this->assertCount( 2, $batches, 'Three orders at two per batch should queue two pages.' );
+		$this->assertLessThanOrEqual( time(), strtotime( reset( $batches )->get_args()[3]['before'] ), 'The queued period should end at the request time.' );
+
+		$this->run_action( array_key_first( $batches ) );
+		$this->create_reported_orders( 2, time() + HOUR_IN_SECONDS );
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+		$path = ReportCSVExporter::get_reports_directory() . $exporter->get_filename();
+
+		$this->assertSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'Every queued page ran, so the export is complete.' );
+		$this->assertTrue( $exporter->export_file_exists(), 'The header row should be written once every queued page ran.' );
+		$this->assertCount( 3, file( $path ), 'Orders placed after the request should not be in the export.' );
+		$this->assertCount( 1, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'The download link should be emailed.' );
+	}
+
+	/**
+	 * @testdox An export whose row count shrank while it ran is still finished and emailed.
+	 */
+	public function test_export_completes_when_orders_drop_out_mid_export(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$order_ids = $this->create_reported_orders( 4, time() - HOUR_IN_SECONDS );
+		$export_id = $this->queue_orders_export();
+		$batches   = $this->get_batch_actions( $export_id );
+
+		$this->assertCount( 2, $batches, 'Four orders at two per batch should queue two pages.' );
+
+		$this->run_action( array_key_first( $batches ) );
+		foreach ( array_slice( $order_ids, 0, 3 ) as $order_id ) {
+			$order = wc_get_order( $order_id );
+			$order->set_status( 'cancelled' );
+			$order->save();
+			OrdersScheduler::import( $order_id );
+		}
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'Every queued page ran, so the export is complete.' );
+		$this->assertTrue( $exporter->export_file_exists(), 'The header row should be written once every queued page ran.' );
+		$this->assertCount( 1, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'The download link should be emailed.' );
+	}
+
+	/**
+	 * @testdox The report period is capped at the request time only when it runs into the future.
+	 */
+	public function test_report_period_is_capped_at_the_request_time(): void {
+		$past   = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2020-01-01T00:00:00' ) );
+		$future = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
+		$open   = ReportExporter::freeze_report_period( 'orders', array( 'after' => '2020-01-01T00:00:00' ) );
+		$stock  = ReportExporter::freeze_report_period( 'stock', array( 'after' => '2020-01-01T00:00:00' ) );
+
+		$this->assertSame( '2020-01-01T00:00:00', $past['before'], 'A period that already ended is left alone.' );
+		$this->assertLessThanOrEqual( time(), strtotime( $future['before'] ), 'A period running into the future ends at the request time.' );
+		$this->assertLessThanOrEqual( time(), strtotime( $open['before'] ), 'A period with no end ends at the request time.' );
+		$this->assertArrayNotHasKey( 'before', $stock, 'A report without a period is left alone.' );
+	}
+
+	/**
+	 * @testdox A failed batch is logged and emailed as a failure instead of being silently dropped.
+	 */
+	public function test_failed_batch_is_reported(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger = $this->capture_log_errors();
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+
+		add_action(
+			ReportExporter::get_action( 'export_report' ),
+			static function ( $page ) {
+				if ( 2 === (int) $page ) {
+					throw new \RuntimeException( 'database went away' );
+				}
+			},
+			1
+		);
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'An export with a missing page must not be served as complete.' );
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed for a broken export.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertCount( 1, $logger->errors, 'The failure should be logged.' );
+		$this->assertStringContainsString( 'database went away', $logger->errors[0], 'The log should carry the batch error.' );
+	}
+
+	/**
+	 * @testdox The email waits for a batch that another runner is still executing.
+	 */
+	public function test_email_waits_for_a_running_batch(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+		$batches   = $this->get_batch_actions( $export_id );
+
+		$this->run_action( array_key_first( $batches ) );
+		\ActionScheduler::store()->log_execution( array_key_last( $batches ) );
+
+		$this->assertInstanceOf(
+			\ActionScheduler_Action::class,
+			ReportExporter::get_next_blocking_job( 'email_report_download_link' ),
+			'A batch that is in progress should block the email action like a pending one.'
+		);
+
+		$email_hook = ReportExporter::get_action( 'email_report_download_link' );
+		$pending    = count(
+			WC()->queue()->search(
+				array(
+					'hook'     => $email_hook,
+					'status'   => 'pending',
+					'per_page' => -1,
+				)
+			)
+		);
+
+		ReportExporter::email_report_download_link( 1, $export_id, 'orders' );
+
+		$this->assertCount( 0, preg_grep( '/Orders Report/', $this->get_sent_subjects() ), 'Nothing should be emailed while a page is still being written.' );
+		$this->assertSame(
+			$pending + 1,
+			count(
+				WC()->queue()->search(
+					array(
+						'hook'     => $email_hook,
+						'status'   => 'pending',
+						'per_page' => -1,
+					)
+				)
+			),
+			'The email should be re-queued to check again later.'
+		);
+	}
+
+	/**
 	 * @testdox An export queued before the date range was added still emails a working link.
 	 */
 	public function test_emailed_link_for_an_export_queued_without_report_args(): void {
@@ -521,6 +829,24 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 		$this->assertIsArray( $sent, 'A finished export should be emailed to the user who asked for it.' );
 
 		return $sent;
+	}
+
+	/**
+	 * @testdox Progress is counted in queued pages and is unknown when no pages were queued.
+	 */
+	public function test_progress_is_read_from_the_queue(): void {
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+
+		$this->run_action( array_key_first( $this->get_batch_actions( $export_id ) ) );
+		$progress = ReportExporter::get_export_progress( $export_id );
+
+		$this->assertSame( 2, $progress['pages'], 'Two pages were queued.' );
+		$this->assertSame( 1, $progress['complete'], 'One page has run.' );
+		$this->assertSame( 1, $progress['unfinished'], 'One page is still queued.' );
+		$this->assertSame( 0, $progress['failed'], 'No page failed.' );
+		$this->assertSame( 50, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'Half of the queued pages ran.' );
+		$this->assertNull( ReportExporter::get_export_progress( 'never-queued' ), 'An export without queued pages has no progress to read.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -242,6 +242,37 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Queue at most two pages per chunk, so a three page export goes through chunk actions.
+	 *
+	 * @param int    $batch_size Batch size.
+	 * @param string $name       Scheduler name.
+	 * @param string $action     Batch action name.
+	 * @return int
+	 */
+	public function two_pages_per_chunk( $batch_size, $name, $action ): int {
+		return 'queue_batches' === $action ? 2 : (int) $batch_size;
+	}
+
+	/**
+	 * Get the chunk actions queued for an export, oldest first.
+	 *
+	 * @param string $export_id Export ID.
+	 * @return \ActionScheduler_Action[] Keyed by action ID.
+	 */
+	private function get_chunk_actions( string $export_id ): array {
+		return WC()->queue()->search(
+			array(
+				'hook'     => ReportExporter::get_action( 'queue_batches' ),
+				'search'   => '"' . $export_id . '"',
+				'group'    => ReportExporter::$group,
+				'per_page' => -1,
+				'orderby'  => 'action_id',
+				'order'    => 'ASC',
+			)
+		);
+	}
+
+	/**
 	 * Get this export's queued batch actions, keyed by action ID in page order.
 	 *
 	 * @param string $export_id Export ID.
@@ -795,6 +826,82 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 			),
 			'The email should be re-queued to check again later.'
 		);
+	}
+
+	/**
+	 * @testdox The email waits for pages that a queued chunk has not scheduled yet.
+	 */
+	public function test_email_waits_for_pages_a_chunk_has_yet_to_queue(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		add_filter( 'woocommerce_analytics_regenerate_batch_size', array( $this, 'two_pages_per_chunk' ), 10, 3 );
+		$this->create_reported_orders( 5 );
+		$export_id = $this->queue_orders_export();
+		$chunks    = $this->get_chunk_actions( $export_id );
+
+		$this->assertCount( 2, $chunks, 'Three pages at two per chunk should queue two chunks.' );
+		$this->assertCount( 0, $this->get_batch_actions( $export_id ), 'No page is queued until a chunk runs.' );
+
+		$this->run_action( array_key_first( $chunks ) );
+		foreach ( array_keys( $this->get_batch_actions( $export_id ) ) as $action_id ) {
+			$this->run_action( $action_id );
+		}
+
+		$progress = ReportExporter::get_export_progress( $export_id );
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertSame( 2, $progress['complete'], 'The first chunk queued two pages, and both ran.' );
+		$this->assertSame( 1, $progress['unfinished'], 'The second chunk still has a page to queue.' );
+		$this->assertFalse( $exporter->export_file_exists(), 'Every queued page ran, but the export is not complete while a chunk is pending.' );
+
+		$email_hook = ReportExporter::get_action( 'email_report_download_link' );
+		$email_args = array(
+			'hook'     => $email_hook,
+			'search'   => '"' . $export_id . '"',
+			'status'   => 'pending',
+			'per_page' => -1,
+		);
+		$emails     = WC()->queue()->search( $email_args, 'ids' );
+
+		$this->assertCount( 1, $emails, 'The export should have queued one email action.' );
+
+		// No page is pending, so nothing blocks the email action. It has to see the chunk itself.
+		$this->run_action( (int) reset( $emails ) );
+
+		$this->assertCount( 0, preg_grep( '/Orders Report/', $this->get_sent_subjects() ), 'Nothing should be emailed while a chunk has pages to queue.' );
+		$this->assertCount( 1, WC()->queue()->search( $email_args, 'ids' ), 'The email should be re-queued to check again later.' );
+
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$this->assertTrue( $exporter->export_file_exists(), 'The export completes once the last chunk has queued its page and it ran.' );
+		$this->assertCount( 1, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'The download link should be emailed.' );
+	}
+
+	/**
+	 * @testdox A chunk that failed to queue its pages is reported as a failed export.
+	 */
+	public function test_failed_chunk_is_reported(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger = $this->capture_log_errors();
+		add_filter( 'woocommerce_analytics_regenerate_batch_size', array( $this, 'two_pages_per_chunk' ), 10, 3 );
+		$this->create_reported_orders( 5 );
+		$export_id = $this->queue_orders_export();
+		$chunks    = $this->get_chunk_actions( $export_id );
+
+		$this->run_action( array_key_first( $chunks ) );
+		\ActionScheduler::store()->mark_failure( array_key_last( $chunks ) );
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'An export missing a chunk of pages must not be served as complete.' );
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed for a broken export.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertCount( 1, $logger->errors, 'The failure should be logged.' );
+		$this->assertStringContainsString( '1 of 3 batches did not complete', $logger->errors[0], 'The failed chunk should count as a missing page.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Admin;
 
+use Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
 use Automattic\WooCommerce\Admin\ReportCSVExporter;
 use Automattic\WooCommerce\Admin\ReportExporter;
 use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
@@ -720,15 +721,17 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	 * @testdox The report period is capped at the request time only when it runs into the future.
 	 */
 	public function test_report_period_is_capped_at_the_request_time(): void {
-		$past   = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2020-01-01T00:00:00' ) );
-		$future = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
-		$open   = ReportExporter::freeze_report_period( 'orders', array( 'after' => '2020-01-01T00:00:00' ) );
-		$stock  = ReportExporter::freeze_report_period( 'stock', array( 'after' => '2020-01-01T00:00:00' ) );
+		$past      = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2020-01-01T00:00:00' ) );
+		$future    = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
+		$open      = ReportExporter::freeze_report_period( 'orders', array( 'after' => '2020-01-01T00:00:00' ) );
+		$customers = ReportExporter::freeze_report_period( 'customers', array() );
+		$stock     = ReportExporter::freeze_report_period( 'stock', array( 'before' => '2100-01-01T00:00:00' ) );
 
 		$this->assertSame( '2020-01-01T00:00:00', $past['before'], 'A period that already ended is left alone.' );
 		$this->assertLessThanOrEqual( time(), strtotime( $future['before'] ), 'A period running into the future ends at the request time.' );
-		$this->assertLessThanOrEqual( time(), strtotime( $open['before'] ), 'A period with no end ends at the request time.' );
-		$this->assertArrayNotHasKey( 'before', $stock, 'A report without a period is left alone.' );
+		$this->assertArrayNotHasKey( 'before', $open, 'A request that sent no end must not be given one.' );
+		$this->assertArrayNotHasKey( 'before', $customers, 'Customers reads before as an order date, so an export without one must not be given one.' );
+		$this->assertSame( '2100-01-01T00:00:00', $stock['before'], 'A report without a period is left alone.' );
 	}
 
 	/**
@@ -737,8 +740,7 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	public function test_report_period_cap_uses_the_store_utc_offset(): void {
 		update_option( 'timezone_string', '' );
 		update_option( 'gmt_offset', 10 );
-
-		$capped = ReportExporter::freeze_report_period( 'orders', array( 'after' => '2020-01-01T00:00:00' ) );
+		$capped = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
 
 		$this->assertStringEndsWith( '+10:00', $capped['before'], 'The cap should spell out the store offset.' );
 		$this->assertEqualsWithDelta(
@@ -747,6 +749,16 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 			5,
 			'Read as the report data store reads it, the cap should be the request time, not the UTC clock.'
 		);
+	}
+
+	/**
+	 * @testdox A Customers export with no dates keeps customers who never ordered.
+	 */
+	public function test_customers_export_keeps_customers_without_orders(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		CustomersDataStore::update_registered_customer( $user_id );
+
+		$this->assertSame( 1, ReportExporter::queue_report_export( (string) time(), 'customers', array(), false ), 'The customer with no orders should be the one row exported.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -1121,6 +1121,32 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox An export whose completion mark cannot be written is reported as failed, not as ready.
+	 */
+	public function test_export_whose_completion_mark_cannot_be_written_is_reported(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger = $this->capture_log_errors();
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+		$headers   = ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv.headers";
+
+		// Something else holds the path, so the mark cannot be written there.
+		mkdir( $headers ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+		rmdir( $headers ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'An export without its mark must not be served.' );
+		$this->assertNotSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'An export without its mark must not report complete.' );
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed for an export that could not be marked complete.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertNotEmpty( preg_grep( '/could not be marked complete/', $logger->errors ), 'The log should say the mark could not be written.' );
+	}
+
+	/**
 	 * @testdox The email waits for pages that a queued chunk has not scheduled yet.
 	 */
 	public function test_email_waits_for_pages_a_chunk_has_yet_to_queue(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -721,17 +721,15 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	 * @testdox The report period is capped at the request time only when it runs into the future.
 	 */
 	public function test_report_period_is_capped_at_the_request_time(): void {
-		$past      = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2020-01-01T00:00:00' ) );
-		$future    = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
-		$open      = ReportExporter::freeze_report_period( 'orders', array( 'after' => '2020-01-01T00:00:00' ) );
-		$customers = ReportExporter::freeze_report_period( 'customers', array() );
-		$stock     = ReportExporter::freeze_report_period( 'stock', array( 'before' => '2100-01-01T00:00:00' ) );
+		$past      = ReportExporter::freeze_report_period( array( 'before' => '2020-01-01T00:00:00' ) );
+		$future    = ReportExporter::freeze_report_period( array( 'before' => '2100-01-01T00:00:00' ) );
+		$open      = ReportExporter::freeze_report_period( array( 'after' => '2020-01-01T00:00:00' ) );
+		$customers = ReportExporter::freeze_report_period( array() );
 
 		$this->assertSame( '2020-01-01T00:00:00', $past['before'], 'A period that already ended is left alone.' );
 		$this->assertLessThanOrEqual( time(), strtotime( $future['before'] ), 'A period running into the future ends at the request time.' );
 		$this->assertArrayNotHasKey( 'before', $open, 'A request that sent no end must not be given one.' );
-		$this->assertArrayNotHasKey( 'before', $customers, 'Customers reads before as an order date, so an export without one must not be given one.' );
-		$this->assertSame( '2100-01-01T00:00:00', $stock['before'], 'A report without a period is left alone.' );
+		$this->assertArrayNotHasKey( 'before', $customers, 'A Customers export sends no dates, and its before is an order date, so it must not be given one.' );
 	}
 
 	/**
@@ -743,7 +741,7 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 		// Calendar plugins rewrite wp_date() output into dates the report cannot parse.
 		add_filter( 'wp_date', array( $this, 'not_a_date' ) );
 
-		$capped = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
+		$capped = ReportExporter::freeze_report_period( array( 'before' => '2100-01-01T00:00:00' ) );
 
 		$this->assertStringEndsWith( '+10:00', $capped['before'], 'The cap should spell out the store offset.' );
 		$this->assertEqualsWithDelta(

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -970,6 +970,47 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A polled export whose last two pages ran at the same time still reaches 100.
+	 */
+	public function test_status_completes_an_export_whose_last_pages_overlapped(): void {
+		wp_set_current_user( 1 );
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+		$batches   = $this->get_batch_actions( $export_id );
+		$last_page = array_key_last( $batches );
+
+		// Run the last page inside the first, after the first has counted progress, so each sees the other unfinished.
+		add_action(
+			ReportExporter::get_action( 'export_report' ),
+			function ( $page ) use ( $last_page ) {
+				if ( 1 === (int) $page ) {
+					$this->run_action( $last_page );
+				}
+			},
+			20
+		);
+		$this->run_action( array_key_first( $batches ) );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertSame( 0, ReportExporter::get_export_progress( $export_id )['unfinished'], 'Both pages ran.' );
+		$this->assertNotSame( 100, ReportExporter::get_export_percentage_complete( 'orders', $export_id ), 'Neither page finalized, because each saw the other still running.' );
+
+		// The REST server outlives the test that built it, and the analytics routes load lazily through a
+		// filter that does not. Start a server here, with the namespace loaded up front.
+		add_filter( 'woocommerce_rest_should_lazy_load_namespace', '__return_false' );
+		$GLOBALS['wp_rest_server'] = null;
+		$request                   = new \WP_REST_Request( 'GET', "/wc-analytics/reports/orders/export/{$export_id}/status" );
+		$response                  = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		$this->assertSame( 100, $response->get_data()['percent_complete'], 'The status endpoint should finish an export every page of which has been written.' );
+		$this->assertArrayHasKey( 'download_url', $response->get_data(), 'A finished export should offer its download.' );
+		$this->assertTrue( $exporter->export_file_exists(), 'The header row should be written once the status endpoint finished the export.' );
+	}
+
+	/**
 	 * @testdox The email waits for pages that a queued chunk has not scheduled yet.
 	 */
 	public function test_email_waits_for_pages_a_chunk_has_yet_to_queue(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -805,6 +805,53 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Pages that run out of order are all in the export.
+	 */
+	public function test_pages_run_out_of_order_are_all_exported(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$this->create_reported_orders( 5 );
+		$export_id = $this->queue_orders_export();
+		$batches   = $this->get_batch_actions( $export_id );
+
+		$this->assertCount( 3, $batches, 'Five orders at two per batch should queue three pages.' );
+
+		// Another runner picked the last page first.
+		$this->run_action( array_key_last( $batches ) );
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+		$path = ReportCSVExporter::get_reports_directory() . $exporter->get_filename();
+
+		$this->assertTrue( $exporter->export_file_exists(), 'Every page ran, so the export is complete.' );
+		$this->assertCount( 5, file( $path ), 'The page that ran first must be in the file.' );
+		$this->assertCount( 1, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'The download link should be emailed.' );
+	}
+
+	/**
+	 * @testdox A page whose export file is gone fails instead of completing with nothing written.
+	 */
+	public function test_page_without_an_export_file_fails(): void {
+		reset_phpmailer_instance();
+		wp_set_current_user( 1 );
+		$logger = $this->capture_log_errors();
+		$this->create_reported_orders( 3 );
+		$export_id = $this->queue_orders_export();
+
+		wp_delete_file( ReportCSVExporter::get_reports_directory() . "wc-orders-report-export-{$export_id}.csv" );
+		WC_Helper_Queue::run_all_pending( ReportExporter::$group );
+
+		$exporter = new ReportCSVExporter();
+		$exporter->set_filename( "wc-orders-report-export-{$export_id}" );
+
+		$this->assertFalse( $exporter->export_file_exists(), 'Nothing was written, so nothing must be served.' );
+		$this->assertCount( 0, preg_grep( '/is ready/', $this->get_sent_subjects() ), 'No download link should be emailed.' );
+		$this->assertCount( 1, preg_grep( '/did not complete/', $this->get_sent_subjects() ), 'The user should be told the export failed.' );
+		$this->assertStringContainsString( 'is missing', $logger->errors[0], 'The log should say the file was gone.' );
+	}
+
+	/**
 	 * @testdox The email waits for a batch that another runner is still executing.
 	 */
 	public function test_email_waits_for_a_running_batch(): void {

--- a/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ReportExporterTest.php
@@ -735,11 +735,14 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The cap is the store's local time on a store set to a manual UTC offset.
+	 * @testdox The cap is the store's local time on a store set to a manual UTC offset, and is not run through wp_date().
 	 */
 	public function test_report_period_cap_uses_the_store_utc_offset(): void {
 		update_option( 'timezone_string', '' );
 		update_option( 'gmt_offset', 10 );
+		// Calendar plugins rewrite wp_date() output into dates the report cannot parse.
+		add_filter( 'wp_date', array( $this, 'not_a_date' ) );
+
 		$capped = ReportExporter::freeze_report_period( 'orders', array( 'before' => '2100-01-01T00:00:00' ) );
 
 		$this->assertStringEndsWith( '+10:00', $capped['before'], 'The cap should spell out the store offset.' );
@@ -759,6 +762,15 @@ class ReportExporterTest extends WC_Unit_Test_Case {
 		CustomersDataStore::update_registered_customer( $user_id );
 
 		$this->assertSame( 1, ReportExporter::queue_report_export( (string) time(), 'customers', array(), false ), 'The customer with no orders should be the one row exported.' );
+	}
+
+	/**
+	 * Stand-in for a calendar plugin's wp_date filter.
+	 *
+	 * @return string
+	 */
+	public function not_a_date(): string {
+		return 'not a date';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The email action trusted a percentage stored in an option, which a persistent object cache, orders arriving mid-export, a failed batch or a concurrent runner all leave short of 100, so no email went out. Completion is now read from the export's own Action Scheduler batches, the CSV body exists from queue time so pages can run in any order, a page that cannot write fails its action, and the requester gets a "did not complete" email instead of silence. The export period is capped at the request time so orders placed during the export do not shift the pages.

**BC:** additive. `WC_CSV_Batch_Exporter` gains a protected `$completes_by_row_count` and `write_csv_data()` returns `false` on a failed write, `ReportCSVExporter::generate_file()` throws on a lost page, and new optional trailing parameters and methods land on `ReportExporter`, `ReportCSVExporter` and `ReportCSVEmail` (a subclass already declaring `trigger_failed()`, `create_export_file()` or `write_headers_row_file()` with another signature would fail to load, none known).

Closes #56018.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| No email on failure | <img width="1280" height="900" alt="email-export-failed" src="https://github.com/user-attachments/assets/017c441d-c99b-4ff6-a604-24e323dd4ec3" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. With Redis Object Cache, mail capture and `DISABLE_WP_CRON`, export Analytics > Orders with more than 50 orders in range, wait 6 s, start `wp eval 'for ( $i = 0; $i < 50000; $i++ ) { update_option( "ping", $i ); }'`, then 1 s later `wp action-scheduler run --group=wc-admin-data --hooks=woocommerce_admin_report_export`, then `wp action-scheduler run --group=wc-admin-data --hooks=woocommerce_admin_email_report_download_link`. Repeat a few times. Trunk: about half the runs send no email. Branch: every run emails the link.
2. Add `add_action( 'woocommerce_admin_report_export', function ( $page ) { if ( 2 === (int) $page ) { throw new Exception( 'boom' ); } }, 1 );` and export again. Branch: a "did not complete" email, and "boom" logged under `report-csv-exporter`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Local site, 201 orders, Redis via Predis, Mailpit: trunk lost 4 of 8 emails, branch delivered 8 of 8.
- Every fix has a test that fails on the commit before it. Report suites 69 tests, all exporter suites 121 tests, PHPCS and PHPStan clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code, directed and reviewed by the author.



