### PR TITLE
[Explore] Add initial Finance UI

### DIFF
--- a/packages/js/data/changelog/add-payments-finance-last-provider-preference
+++ b/packages/js/data/changelog/add-payments-finance-last-provider-preference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add the payments_finance_last_provider user preference type used by the Finance payouts page.

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -35,6 +35,7 @@ export type UserPreferences = {
 	launch_your_store_tour_hidden?: 'yes' | 'no' | '';
 	coming_soon_banner_dismissed?: 'yes' | 'no' | '';
 	scheduled_updates_promotion_notice_dismissed?: 'yes' | 'no' | '';
+	payments_finance_last_provider?: string;
 };
 
 export type WoocommerceMeta = {

--- a/plugins/woocommerce/changelog/add-payments-finance-admin-menu
+++ b/plugins/woocommerce/changelog/add-payments-finance-admin-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a Finance admin menu with Overview and Payouts pages, showing payment provider balances and payouts behind the payments_finance feature flag.

--- a/plugins/woocommerce/client/admin/client/finance/components/drawer/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/components/drawer/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { Modal } from '@wordpress/components';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+type FinanceDrawerProps = {
+	title: string;
+	onClose: () => void;
+	children: ReactNode;
+};
+
+/**
+ * Side panel built on the accessible Modal component and restyled as a right-anchored drawer.
+ */
+export const FinanceDrawer = ( {
+	title,
+	onClose,
+	children,
+}: FinanceDrawerProps ) => (
+	<Modal
+		title={ title }
+		onRequestClose={ onClose }
+		className="woocommerce-finance-drawer"
+		overlayClassName="woocommerce-finance-drawer__overlay"
+		shouldCloseOnClickOutside
+	>
+		{ children }
+	</Modal>
+);

--- a/plugins/woocommerce/client/admin/client/finance/components/drawer/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/components/drawer/style.scss
@@ -1,0 +1,36 @@
+.woocommerce-finance-drawer__overlay {
+	// Keep the page visible behind the drawer, as the design treats it as a side panel.
+	background-color: rgba(0, 0, 0, 0.35);
+	// Recent WordPress versions center the modal frame with flexbox; push it to the inline end.
+	justify-content: flex-end;
+	align-items: stretch;
+}
+
+.components-modal__frame.woocommerce-finance-drawer {
+	// The modal header is absolutely positioned, so the frame must be its containing block.
+	position: relative;
+	inset-block: 0;
+	inset-inline-end: 0;
+	inset-inline-start: auto;
+	transform: none;
+	margin: 0;
+	inline-size: min(480px, 100%);
+	max-inline-size: none;
+	block-size: 100%;
+	max-block-size: none;
+	border-radius: 0;
+	animation: woocommerce-finance-drawer-slide-in 0.2s ease-out;
+
+	.components-modal__content {
+		padding-inline: $gap-large;
+	}
+}
+
+@keyframes woocommerce-finance-drawer-slide-in {
+	from {
+		transform: translateX(100%);
+	}
+	to {
+		transform: none;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/finance/components/payout-status-badge/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/components/payout-status-badge/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { Pill } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getPayoutStatusLabel,
+	getPayoutStatusVariant,
+} from '../../utils/payout-status';
+import './style.scss';
+
+type PayoutStatusBadgeProps = {
+	status: string;
+};
+
+export const PayoutStatusBadge = ( { status }: PayoutStatusBadgeProps ) => (
+	<Pill
+		className={ `woocommerce-finance-status-badge woocommerce-finance-status-badge--${ getPayoutStatusVariant(
+			status
+		) }` }
+	>
+		{ getPayoutStatusLabel( status ) }
+	</Pill>
+);

--- a/plugins/woocommerce/client/admin/client/finance/components/payout-status-badge/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/components/payout-status-badge/style.scss
@@ -1,0 +1,23 @@
+.woocommerce-finance-status-badge {
+	display: inline-flex;
+	align-items: center;
+	border: none;
+	border-radius: var(--radius-primitive, 4px);
+	background: var(--Alias-bg-bg-surface-secondary, #f5f5f5);
+	color: var(--Alias-text-text, #070707);
+
+	&--success {
+		background: var(--Alias-bg-bg-surface-success, #daffe0);
+		color: var(--Alias-text-text-success, #144722);
+	}
+
+	&--warning {
+		background: var(--Alias-bg-bg-surface-warning, #fff2d7);
+		color: var(--Alias-text-text-warning, #4d3716);
+	}
+
+	&--error {
+		background: var(--Alias-bg-bg-surface-error, #ffe5e5);
+		color: var(--Alias-text-text-error, #8a2424);
+	}
+}

--- a/plugins/woocommerce/client/admin/client/finance/components/provider-cell/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/components/provider-cell/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import type { FinanceProvider } from '../../types';
+import './style.scss';
+
+type ProviderCellProps = {
+	provider?: FinanceProvider;
+	fallbackId: string;
+};
+
+/**
+ * Provider icon and title. Falls back to the raw provider id when the provider is unknown.
+ */
+export const ProviderCell = ( { provider, fallbackId }: ProviderCellProps ) => (
+	<span className="woocommerce-finance-provider-cell">
+		{ provider?.icon_url && (
+			<img
+				className="woocommerce-finance-provider-cell__icon"
+				src={ provider.icon_url }
+				alt=""
+				onError={ ( event ) => {
+					// A provider icon that fails to load should not leave a broken image behind.
+					event.currentTarget.hidden = true;
+				} }
+			/>
+		) }
+		<span className="woocommerce-finance-provider-cell__title">
+			{ provider?.title ?? fallbackId }
+		</span>
+	</span>
+);

--- a/plugins/woocommerce/client/admin/client/finance/components/provider-cell/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/components/provider-cell/style.scss
@@ -1,0 +1,12 @@
+.woocommerce-finance-provider-cell {
+	display: inline-flex;
+	align-items: center;
+	gap: $gap-smaller;
+
+	&__icon {
+		inline-size: 24px;
+		block-size: 24px;
+		object-fit: contain;
+		border-radius: 4px;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/finance/components/provider-select/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/components/provider-select/index.tsx
@@ -1,13 +1,17 @@
 /**
  * External dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { chevronDown } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { ProviderCell } from '../provider-cell';
 import type { FinanceProvider } from '../../types';
+import './style.scss';
 
 type ProviderSelectProps = {
 	providers: FinanceProvider[];
@@ -16,29 +20,76 @@ type ProviderSelectProps = {
 };
 
 /**
- * Single-select provider switcher. Hidden when there is nothing to switch between.
+ * Provider switcher showing the provider icon and name. Disabled when there is nothing to
+ * switch between, so the current provider stays visible.
  */
 export const ProviderSelect = ( {
 	providers,
 	value,
 	onChange,
 }: ProviderSelectProps ) => {
-	if ( providers.length <= 1 ) {
-		return null;
-	}
+	const instanceId = useInstanceId(
+		ProviderSelect,
+		'woocommerce-finance-provider-select'
+	);
+	const labelId = `${ instanceId }__label`;
+	const valueId = `${ instanceId }__value`;
+	const selected = providers.find(
+		( provider ) => provider.provider_id === value
+	);
+	const isDisabled = providers.length <= 1;
 
 	return (
-		<SelectControl
-			className="woocommerce-finance-provider-select"
-			label={ __( 'Payout provider', 'woocommerce' ) }
-			value={ value ?? '' }
-			options={ providers.map( ( provider ) => ( {
-				label: provider.title,
-				value: provider.provider_id,
-			} ) ) }
-			onChange={ onChange }
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-		/>
+		<div className="woocommerce-finance-provider-select">
+			<span
+				id={ labelId }
+				className="woocommerce-finance-provider-select__label"
+			>
+				{ __( 'Payout provider', 'woocommerce' ) }
+			</span>
+			<Dropdown
+				popoverProps={ { placement: 'bottom-start' } }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button
+						className="woocommerce-finance-provider-select__toggle"
+						variant="secondary"
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+						aria-haspopup="menu"
+						aria-labelledby={ `${ labelId } ${ valueId }` }
+						disabled={ isDisabled }
+						icon={ chevronDown }
+						iconPosition="right"
+					>
+						<span id={ valueId }>
+							<ProviderCell
+								provider={ selected }
+								fallbackId={ value ?? '' }
+							/>
+						</span>
+					</Button>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<MenuGroup className="woocommerce-finance-provider-select__menu">
+						{ providers.map( ( provider ) => (
+							<MenuItem
+								key={ provider.provider_id }
+								role="menuitemradio"
+								isSelected={ provider.provider_id === value }
+								onClick={ () => {
+									onChange( provider.provider_id );
+									onClose();
+								} }
+							>
+								<ProviderCell
+									provider={ provider }
+									fallbackId={ provider.provider_id }
+								/>
+							</MenuItem>
+						) ) }
+					</MenuGroup>
+				) }
+			/>
+		</div>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/finance/components/provider-select/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/components/provider-select/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { FinanceProvider } from '../../types';
+
+type ProviderSelectProps = {
+	providers: FinanceProvider[];
+	value: string | null;
+	onChange: ( providerId: string ) => void;
+};
+
+/**
+ * Single-select provider switcher. Hidden when there is nothing to switch between.
+ */
+export const ProviderSelect = ( {
+	providers,
+	value,
+	onChange,
+}: ProviderSelectProps ) => {
+	if ( providers.length <= 1 ) {
+		return null;
+	}
+
+	return (
+		<SelectControl
+			className="woocommerce-finance-provider-select"
+			label={ __( 'Payout provider', 'woocommerce' ) }
+			value={ value ?? '' }
+			options={ providers.map( ( provider ) => ( {
+				label: provider.title,
+				value: provider.provider_id,
+			} ) ) }
+			onChange={ onChange }
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+		/>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/finance/components/provider-select/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/components/provider-select/style.scss
@@ -1,0 +1,25 @@
+.woocommerce-finance-provider-select {
+	display: flex;
+	flex-direction: column;
+	gap: $gap-smaller;
+	margin-block-end: $gap;
+
+	&__label {
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1.4;
+		text-transform: uppercase;
+	}
+
+	&__toggle.components-button {
+		justify-content: space-between;
+		min-inline-size: 280px;
+		block-size: 40px;
+		padding-inline: $gap-small;
+		background: $white;
+	}
+
+	&__menu {
+		min-inline-size: 280px;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/finance/constants.ts
+++ b/plugins/woocommerce/client/admin/client/finance/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { WC_ADMIN_NAMESPACE } from '@woocommerce/data';
+
+export const FINANCE_API_PATH = `${ WC_ADMIN_NAMESPACE }/payments/finance`;
+
+export const DEFAULT_PER_PAGE = 10;
+
+export const PER_PAGE_SIZES = [ 10, 25, 50, 100 ];
+
+export const PAYMENTS_SETTINGS_PATH = 'admin.php?page=wc-settings&tab=checkout';

--- a/plugins/woocommerce/client/admin/client/finance/data/api.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/api.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { FINANCE_API_PATH } from '../constants';
+
+export type PayoutsPageQuery = {
+	cursor: string | null;
+	perPage: number;
+};
+
+export const getProvidersPath = (): string => `${ FINANCE_API_PATH }/providers`;
+
+export const getBalancesPath = ( providerId: string ): string =>
+	`${ FINANCE_API_PATH }/providers/${ encodeURIComponent(
+		providerId
+	) }/balance`;
+
+export const getPayoutsPath = (
+	providerId: string,
+	{ cursor, perPage }: PayoutsPageQuery
+): string =>
+	addQueryArgs(
+		`${ FINANCE_API_PATH }/providers/${ encodeURIComponent(
+			providerId
+		) }/payouts`,
+		{
+			per_page: perPage,
+			...( cursor ? { next_cursor: cursor } : {} ),
+		}
+	);

--- a/plugins/woocommerce/client/admin/client/finance/data/test/use-last-provider.test.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/test/use-last-provider.test.ts
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks/dom';
+import { useUserPreferences } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { useLastProvider } from '../use-last-provider';
+import type { FinanceProvider } from '../../types';
+
+jest.mock( '@woocommerce/data', () => ( {
+	useUserPreferences: jest.fn(),
+} ) );
+
+const mockUseUserPreferences = useUserPreferences as unknown as jest.Mock;
+const mockUpdateUserPreferences = jest.fn( () => Promise.resolve() );
+
+const makeProvider = ( id: string ): FinanceProvider => ( {
+	provider_id: id,
+	title: id,
+	icon_url: null,
+	data_types: [ { type: 'payouts', schema_version: 1 } ],
+} );
+
+const providers = [ makeProvider( 'bacs' ), makeProvider( 'cheque' ) ];
+
+describe( 'useLastProvider', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseUserPreferences.mockReturnValue( {
+			updateUserPreferences: mockUpdateUserPreferences,
+		} );
+	} );
+
+	it( 'falls back to the first provider without persisting it', () => {
+		const { result } = renderHook( () => useLastProvider( providers ) );
+
+		expect( result.current.selectedId ).toBe( 'bacs' );
+		expect( mockUpdateUserPreferences ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses the stored provider when it is available', () => {
+		mockUseUserPreferences.mockReturnValue( {
+			payments_finance_last_provider: 'cheque',
+			updateUserPreferences: mockUpdateUserPreferences,
+		} );
+
+		const { result } = renderHook( () => useLastProvider( providers ) );
+
+		expect( result.current.selectedId ).toBe( 'cheque' );
+	} );
+
+	it( 'ignores a stored provider that is no longer available', () => {
+		mockUseUserPreferences.mockReturnValue( {
+			payments_finance_last_provider: 'stripe',
+			updateUserPreferences: mockUpdateUserPreferences,
+		} );
+
+		const { result } = renderHook( () => useLastProvider( providers ) );
+
+		expect( result.current.selectedId ).toBe( 'bacs' );
+	} );
+
+	it( 'returns null without providers', () => {
+		const { result } = renderHook( () => useLastProvider( [] ) );
+
+		expect( result.current.selectedId ).toBeNull();
+	} );
+
+	it( 'persists an explicit selection', () => {
+		const { result } = renderHook( () => useLastProvider( providers ) );
+
+		act( () => result.current.selectProvider( 'cheque' ) );
+
+		expect( result.current.selectedId ).toBe( 'cheque' );
+		expect( mockUpdateUserPreferences ).toHaveBeenCalledWith( {
+			payments_finance_last_provider: 'cheque',
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/finance/data/test/use-payouts-page.test.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/test/use-payouts-page.test.ts
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks/dom';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { usePayoutsPage } from '../use-payouts-page';
+import { getBalancesPath, getPayoutsPath } from '../api';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const emptyPage = {
+	schema_version: 1,
+	items: [],
+	has_more: false,
+	next_cursor: null,
+	prev_cursor: null,
+};
+
+describe( 'finance API paths', () => {
+	it( 'builds the payouts path with the page size and an optional cursor', () => {
+		expect( getPayoutsPath( 'bacs', { cursor: null, perPage: 10 } ) ).toBe(
+			'/wc-admin/payments/finance/providers/bacs/payouts?per_page=10'
+		);
+		expect(
+			getPayoutsPath( 'bacs', { cursor: 'abc/def', perPage: 25 } )
+		).toBe(
+			'/wc-admin/payments/finance/providers/bacs/payouts?per_page=25&next_cursor=abc%2Fdef'
+		);
+	} );
+
+	it( 'encodes the provider id', () => {
+		expect( getBalancesPath( 'my gateway' ) ).toBe(
+			'/wc-admin/payments/finance/providers/my%20gateway/balance'
+		);
+	} );
+} );
+
+describe( 'usePayoutsPage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not fetch without a provider', () => {
+		const { result } = renderHook( () =>
+			usePayoutsPage( null, { cursor: null, perPage: 10 } )
+		);
+
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.page ).toBeNull();
+	} );
+
+	it( 'fetches the page for the provider and cursor', async () => {
+		mockApiFetch.mockResolvedValueOnce( emptyPage );
+
+		const { result, waitForNextUpdate } = renderHook( () =>
+			usePayoutsPage( 'bacs', { cursor: 'c2', perPage: 25 } )
+		);
+
+		expect( result.current.isLoading ).toBe( true );
+		await waitForNextUpdate();
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/wc-admin/payments/finance/providers/bacs/payouts?per_page=25&next_cursor=c2',
+		} );
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.page ).toEqual( emptyPage );
+		expect( result.current.error ).toBeNull();
+	} );
+
+	it( 'ignores the response of a superseded request', async () => {
+		let resolveFirst: ( value: unknown ) => void = () => {};
+		mockApiFetch
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveFirst = resolve;
+					} )
+			)
+			.mockResolvedValueOnce( { ...emptyPage, next_cursor: 'second' } );
+
+		const { result, rerender, waitForNextUpdate } = renderHook(
+			( { providerId }: { providerId: string } ) =>
+				usePayoutsPage( providerId, { cursor: null, perPage: 10 } ),
+			{ initialProps: { providerId: 'bacs' } }
+		);
+
+		rerender( { providerId: 'cheque' } );
+		await waitForNextUpdate();
+
+		expect( result.current.page?.next_cursor ).toBe( 'second' );
+
+		resolveFirst( { ...emptyPage, next_cursor: 'first' } );
+		await Promise.resolve();
+
+		expect( result.current.page?.next_cursor ).toBe( 'second' );
+	} );
+
+	it( 'exposes a normalised error', async () => {
+		mockApiFetch.mockRejectedValueOnce( {
+			code: 'woocommerce_rest_payments_finance_provider_error',
+			message: 'The provider is unavailable.',
+		} );
+
+		const { result, waitForNextUpdate } = renderHook( () =>
+			usePayoutsPage( 'bacs', { cursor: null, perPage: 10 } )
+		);
+		await waitForNextUpdate();
+
+		expect( result.current.error ).toEqual( {
+			code: 'woocommerce_rest_payments_finance_provider_error',
+			message: 'The provider is unavailable.',
+		} );
+		expect( result.current.page ).toBeNull();
+	} );
+
+	it( 'falls back to a generic message for unexpected errors', async () => {
+		mockApiFetch.mockRejectedValueOnce( new TypeError( '' ) );
+
+		const { result, waitForNextUpdate } = renderHook( () =>
+			usePayoutsPage( 'bacs', { cursor: null, perPage: 10 } )
+		);
+		await waitForNextUpdate();
+
+		expect( result.current.error?.code ).toBe( 'unknown_error' );
+		expect( result.current.error?.message ).toBe(
+			'Something went wrong. Please try again.'
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/finance/data/use-api-request.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/use-api-request.ts
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { FinanceError } from '../types';
+
+export type ApiRequestState< T > = {
+	data: T | null;
+	isLoading: boolean;
+	error: FinanceError | null;
+};
+
+export type ApiRequestResult< T > = ApiRequestState< T > & {
+	refetch: () => void;
+};
+
+const toFinanceError = ( error: unknown ): FinanceError => {
+	const { code, message } = ( error ?? {} ) as Partial< FinanceError >;
+
+	return {
+		code: typeof code === 'string' ? code : 'unknown_error',
+		message:
+			typeof message === 'string' && message
+				? message
+				: __(
+						'Something went wrong. Please try again.',
+						'woocommerce'
+				  ),
+	};
+};
+
+/**
+ * Fetch a GET endpoint and expose its state. A new path supersedes the request in flight,
+ * so a late response for an old path is ignored. The previous data is kept while the next
+ * request loads. Pass null to skip fetching.
+ *
+ * @param path REST path, or null to skip.
+ */
+export function useApiRequest< T >(
+	path: string | null
+): ApiRequestResult< T > {
+	const [ state, setState ] = useState< ApiRequestState< T > >( {
+		data: null,
+		isLoading: path !== null,
+		error: null,
+	} );
+	const [ reloadToken, setReloadToken ] = useState( 0 );
+	const requestId = useRef( 0 );
+
+	useEffect( () => {
+		requestId.current += 1;
+		const currentRequestId = requestId.current;
+
+		if ( path === null ) {
+			setState( { data: null, isLoading: false, error: null } );
+			return;
+		}
+
+		setState( ( prev ) => ( { ...prev, isLoading: true, error: null } ) );
+
+		apiFetch< T >( { path } )
+			.then( ( data ) => {
+				if ( currentRequestId === requestId.current ) {
+					setState( { data, isLoading: false, error: null } );
+				}
+			} )
+			.catch( ( error: unknown ) => {
+				if ( currentRequestId === requestId.current ) {
+					setState( {
+						data: null,
+						isLoading: false,
+						error: toFinanceError( error ),
+					} );
+				}
+			} );
+	}, [ path, reloadToken ] );
+
+	const refetch = useCallback( () => setReloadToken( ( t ) => t + 1 ), [] );
+
+	return { ...state, refetch };
+}

--- a/plugins/woocommerce/client/admin/client/finance/data/use-finance-providers.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/use-finance-providers.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { getProvidersPath } from './api';
+import { useApiRequest } from './use-api-request';
+import type { FinanceProvider, FinanceProvidersResponse } from '../types';
+
+const NO_PROVIDERS: FinanceProvider[] = [];
+
+export function useFinanceProviders() {
+	const { data, isLoading, error, refetch } =
+		useApiRequest< FinanceProvidersResponse >( getProvidersPath() );
+
+	return {
+		providers: data?.providers ?? NO_PROVIDERS,
+		isLoading,
+		error,
+		refetch,
+	};
+}

--- a/plugins/woocommerce/client/admin/client/finance/data/use-last-provider.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/use-last-provider.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { useMemo, useState } from '@wordpress/element';
+import { useUserPreferences } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import type { FinanceProvider } from '../types';
+
+/**
+ * Track the provider selected on the Payouts page, persisted per user. Falls back to the first
+ * provider when nothing valid is stored; only an explicit selection is persisted.
+ *
+ * @param providers The providers the user can pick from.
+ */
+export function useLastProvider( providers: FinanceProvider[] ) {
+	const { payments_finance_last_provider: storedId, updateUserPreferences } =
+		useUserPreferences();
+	const [ pickedId, setPickedId ] = useState< string | null >( null );
+
+	const selectedId = useMemo( () => {
+		const isKnown = ( id: string | null | undefined ): id is string =>
+			!! id && providers.some( ( p ) => p.provider_id === id );
+
+		if ( isKnown( pickedId ) ) {
+			return pickedId;
+		}
+		if ( isKnown( storedId ) ) {
+			return storedId;
+		}
+		return providers[ 0 ]?.provider_id ?? null;
+	}, [ pickedId, storedId, providers ] );
+
+	const selectProvider = ( id: string ) => {
+		setPickedId( id );
+		Promise.resolve(
+			updateUserPreferences( { payments_finance_last_provider: id } )
+		).catch( () => {
+			// The selection still applies for this session even when it cannot be persisted.
+		} );
+	};
+
+	return { selectedId, selectProvider };
+}

--- a/plugins/woocommerce/client/admin/client/finance/data/use-payouts-page.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/use-payouts-page.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { getPayoutsPath, PayoutsPageQuery } from './api';
+import { useApiRequest } from './use-api-request';
+import type { FinancePage, Payout } from '../types';
+
+/**
+ * Fetch one page of payouts of a provider. Pass a null provider to skip fetching.
+ *
+ * @param providerId The provider id, or null.
+ * @param query      The cursor and page size.
+ */
+export function usePayoutsPage(
+	providerId: string | null,
+	query: PayoutsPageQuery
+) {
+	const { data, isLoading, error, refetch } = useApiRequest<
+		FinancePage< Payout >
+	>( providerId ? getPayoutsPath( providerId, query ) : null );
+
+	return { page: data, isLoading, error, refetch };
+}

--- a/plugins/woocommerce/client/admin/client/finance/data/use-provider-balances.ts
+++ b/plugins/woocommerce/client/admin/client/finance/data/use-provider-balances.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { getBalancesPath } from './api';
+import { useApiRequest } from './use-api-request';
+import type { Balance, FinancePage } from '../types';
+
+const NO_BALANCES: Balance[] = [];
+
+/**
+ * Fetch the balances of a provider. Pass null to skip fetching.
+ *
+ * @param providerId The provider id, or null.
+ */
+export function useProviderBalances( providerId: string | null ) {
+	const { data, isLoading, error, refetch } = useApiRequest<
+		FinancePage< Balance >
+	>( providerId ? getBalancesPath( providerId ) : null );
+
+	return {
+		balances: data?.items ?? NO_BALANCES,
+		isLoading,
+		error,
+		refetch,
+	};
+}

--- a/plugins/woocommerce/client/admin/client/finance/overview/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/overview/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	Notice,
+	Spinner,
+} from '@wordpress/components';
+import { EmptyContent } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/settings';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useFinanceProviders } from '../data/use-finance-providers';
+import { ProviderTable } from './provider-table';
+import { PAYMENTS_SETTINGS_PATH } from '../constants';
+import './style.scss';
+
+export const FinanceOverview = () => {
+	const { providers, isLoading, error } = useFinanceProviders();
+	const settingsUrl = getAdminLink( PAYMENTS_SETTINGS_PATH );
+
+	let body;
+	if ( isLoading ) {
+		body = <Spinner />;
+	} else if ( providers.length === 0 ) {
+		body = (
+			<EmptyContent
+				title={ __( 'No payout providers', 'woocommerce' ) }
+				message={ __(
+					'Connect a payment provider that shares its balance and payouts to see them here.',
+					'woocommerce'
+				) }
+				actionLabel={ __( 'Manage payment providers', 'woocommerce' ) }
+				actionURL={ settingsUrl }
+			/>
+		);
+	} else {
+		body = <ProviderTable providers={ providers } />;
+	}
+
+	return (
+		<div className="woocommerce-finance-overview">
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error.message }
+				</Notice>
+			) }
+			<Card>
+				<CardHeader>
+					<h2 className="woocommerce-finance-overview__title">
+						{ __( 'Payout providers', 'woocommerce' ) }
+					</h2>
+				</CardHeader>
+				<CardBody>{ body }</CardBody>
+				<CardFooter>
+					<Button variant="link" href={ settingsUrl }>
+						{ __( 'Add or manage providers', 'woocommerce' ) }
+					</Button>
+				</CardFooter>
+			</Card>
+		</div>
+	);
+};
+
+/*
+ * Exported as default to support code-splitting and lazy loading.
+ */
+export default FinanceOverview;

--- a/plugins/woocommerce/client/admin/client/finance/overview/provider-table.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/overview/provider-table.tsx
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { Button, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useProviderBalances } from '../data/use-provider-balances';
+import { useAmountFormatter, AmountFormatter } from '../utils/format-amount';
+import { EMPTY_VALUE } from '../utils/format-date';
+import { ProviderCell } from '../components/provider-cell';
+import type { Balance, FinanceProvider } from '../types';
+
+const supportsBalance = ( provider: FinanceProvider ): boolean =>
+	provider.data_types.some( ( dataType ) => dataType.type === 'balance' );
+
+type ProviderRowProps = {
+	provider: FinanceProvider;
+	formatAmount: AmountFormatter;
+};
+
+const BalanceCells = ( {
+	balances,
+	formatAmount,
+}: {
+	balances: Balance[];
+	formatAmount: AmountFormatter;
+} ) => (
+	<>
+		<td>
+			{ balances.map( ( balance ) => (
+				<div key={ balance.currency }>
+					{ formatAmount( balance.amount, balance.currency ) }
+				</div>
+			) ) }
+		</td>
+		<td>
+			{ balances.map( ( balance ) => (
+				<div key={ balance.currency }>
+					{ balance.available_amount === null
+						? EMPTY_VALUE
+						: formatAmount(
+								balance.available_amount,
+								balance.currency
+						  ) }
+				</div>
+			) ) }
+		</td>
+		<td className="woocommerce-finance-provider-table__actions">
+			{ balances.map( ( balance ) =>
+				balance.payout_link ? (
+					<Button
+						key={ balance.currency }
+						variant="secondary"
+						href={ balance.payout_link.url }
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ balance.payout_link.title }
+					</Button>
+				) : null
+			) }
+		</td>
+	</>
+);
+
+const ProviderRow = ( { provider, formatAmount }: ProviderRowProps ) => {
+	const hasBalance = supportsBalance( provider );
+	const { balances, isLoading, error } = useProviderBalances(
+		hasBalance ? provider.provider_id : null
+	);
+
+	let cells;
+	if ( ! hasBalance ) {
+		cells = (
+			<td
+				colSpan={ 3 }
+				className="woocommerce-finance-provider-table__note"
+			>
+				{ __( 'Balance not available', 'woocommerce' ) }
+			</td>
+		);
+	} else if ( isLoading ) {
+		cells = (
+			<td colSpan={ 3 }>
+				<Spinner />
+			</td>
+		);
+	} else if ( error ) {
+		cells = (
+			<td
+				colSpan={ 3 }
+				className="woocommerce-finance-provider-table__note"
+			>
+				{ error.message }
+			</td>
+		);
+	} else if ( balances.length === 0 ) {
+		cells = (
+			<td
+				colSpan={ 3 }
+				className="woocommerce-finance-provider-table__note"
+			>
+				{ EMPTY_VALUE }
+			</td>
+		);
+	} else {
+		cells = (
+			<BalanceCells balances={ balances } formatAmount={ formatAmount } />
+		);
+	}
+
+	return (
+		<tr>
+			<th scope="row">
+				<ProviderCell
+					provider={ provider }
+					fallbackId={ provider.provider_id }
+				/>
+			</th>
+			{ cells }
+		</tr>
+	);
+};
+
+type ProviderTableProps = {
+	providers: FinanceProvider[];
+};
+
+/**
+ * One row per connected provider with its balance, available funds and payout link per currency.
+ */
+export const ProviderTable = ( { providers }: ProviderTableProps ) => {
+	const formatAmount = useAmountFormatter();
+
+	return (
+		<div className="woocommerce-finance-provider-table__scroll">
+			<table className="woocommerce-finance-provider-table">
+				<thead>
+					<tr>
+						<th scope="col">{ __( 'Provider', 'woocommerce' ) }</th>
+						<th scope="col">{ __( 'Balance', 'woocommerce' ) }</th>
+						<th scope="col">
+							{ __( 'Available funds', 'woocommerce' ) }
+						</th>
+						<th scope="col">
+							<span className="screen-reader-text">
+								{ __( 'Actions', 'woocommerce' ) }
+							</span>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ providers.map( ( provider ) => (
+						<ProviderRow
+							key={ provider.provider_id }
+							provider={ provider }
+							formatAmount={ formatAmount }
+						/>
+					) ) }
+				</tbody>
+			</table>
+		</div>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/finance/overview/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/overview/style.scss
@@ -1,0 +1,49 @@
+.woocommerce-finance-overview {
+	&__title {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+	}
+
+	.components-notice {
+		margin: 0 0 $gap;
+	}
+}
+
+.woocommerce-finance-provider-table__scroll {
+	overflow-x: auto;
+}
+
+.woocommerce-finance-provider-table {
+	inline-size: 100%;
+	border-collapse: collapse;
+
+	th,
+	td {
+		padding-block: $gap-small;
+		padding-inline: $gap-smaller;
+		text-align: start;
+		vertical-align: top;
+		border-block-end: 1px solid $gray-200;
+	}
+
+	thead th {
+		color: $gray-700;
+		font-weight: 600;
+	}
+
+	tbody tr:last-child {
+		th,
+		td {
+			border-block-end: none;
+		}
+	}
+
+	&__note {
+		color: $gray-700;
+	}
+
+	&__actions {
+		text-align: end;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/finance/overview/test/overview.test.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/overview/test/overview.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, within } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { FinanceOverview } from '..';
+import type { Balance, FinanceProvider } from '../../types';
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: ( path: string ) => `https://example.test/wp-admin/${ path }`,
+	getSetting: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const provider = (
+	id: string,
+	title: string,
+	dataTypes: FinanceProvider[ 'data_types' ] = [
+		{ type: 'balance', schema_version: 1 },
+		{ type: 'payouts', schema_version: 1 },
+	]
+): FinanceProvider => ( {
+	provider_id: id,
+	title,
+	icon_url: null,
+	data_types: dataTypes,
+} );
+
+const balance = ( overrides: Partial< Balance > = {} ): Balance => ( {
+	provider_id: 'bacs',
+	currency: 'USD',
+	amount: '100.00',
+	available_amount: '80.00',
+	payout_link: null,
+	...overrides,
+} );
+
+const page = ( items: Balance[] ) => ( {
+	schema_version: 1,
+	items,
+	has_more: false,
+	next_cursor: null,
+	prev_cursor: null,
+} );
+
+const mockEndpoints = ( responses: Record< string, unknown > ) => {
+	mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+		const match = Object.keys( responses ).find( ( key ) =>
+			path.endsWith( key )
+		);
+		return match
+			? Promise.resolve( responses[ match ] )
+			: Promise.reject( {
+					code: 'not_found',
+					message: `No mock for ${ path }`,
+			  } );
+	} );
+};
+
+describe( 'FinanceOverview', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows the empty state with a link to Payments settings when there are no providers', async () => {
+		mockEndpoints( { '/providers': { providers: [] } } );
+
+		render( <FinanceOverview /> );
+
+		expect(
+			await screen.findByText( 'No payout providers' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: 'Manage payment providers' } )
+		).toHaveAttribute(
+			'href',
+			'https://example.test/wp-admin/admin.php?page=wc-settings&tab=checkout'
+		);
+	} );
+
+	it( 'renders one row per provider with balances per currency and the payout link', async () => {
+		mockEndpoints( {
+			'/providers': {
+				providers: [
+					provider( 'bacs', 'Bank transfer' ),
+					provider( 'cheque', 'Cheque', [
+						{ type: 'payouts', schema_version: 1 },
+					] ),
+				],
+			},
+			'/providers/bacs/balance': page( [
+				balance( {
+					payout_link: {
+						title: 'Instant payout',
+						url: 'https://provider.test/payout',
+					},
+				} ),
+				balance( {
+					currency: 'EUR',
+					amount: '50.00',
+					available_amount: null,
+				} ),
+			] ),
+		} );
+
+		render( <FinanceOverview /> );
+
+		await screen.findByRole( 'link', { name: 'Instant payout' } );
+		const bacsRow = screen.getByRole( 'row', { name: /Bank transfer/ } );
+		expect(
+			within( bacsRow ).getByText( 'Bank transfer' )
+		).toBeInTheDocument();
+		expect(
+			within( bacsRow ).getAllByText( /100/ ).length
+		).toBeGreaterThan( 0 );
+		expect( within( bacsRow ).getAllByText( /50/ ).length ).toBeGreaterThan(
+			0
+		);
+		expect( within( bacsRow ).getByText( '—' ) ).toBeInTheDocument();
+		expect(
+			within( bacsRow ).getByRole( 'link', { name: 'Instant payout' } )
+		).toHaveAttribute( 'href', 'https://provider.test/payout' );
+
+		const chequeRow = screen.getByRole( 'row', { name: /Cheque/ } );
+		expect(
+			within( chequeRow ).getByText( 'Balance not available' )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole( 'link', { name: 'Add or manage providers' } )
+		).toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalledWith( {
+			path: expect.stringContaining( '/providers/cheque/balance' ),
+		} );
+	} );
+
+	it( 'shows the balance error inside the provider row', async () => {
+		mockEndpoints( {
+			'/providers': {
+				providers: [ provider( 'bacs', 'Bank transfer' ) ],
+			},
+		} );
+
+		render( <FinanceOverview /> );
+
+		await waitFor( () =>
+			expect(
+				screen.getByText(
+					'No mock for /wc-admin/payments/finance/providers/bacs/balance'
+				)
+			).toBeInTheDocument()
+		);
+	} );
+
+	it( 'shows the providers error as a notice', async () => {
+		mockApiFetch.mockRejectedValue( {
+			code: 'rest_forbidden',
+			message: 'Sorry, you are not allowed to do that.',
+		} );
+
+		render( <FinanceOverview /> );
+
+		// The message is also announced in a live region, so match the visible notice.
+		expect(
+			(
+				await screen.findAllByText(
+					'Sorry, you are not allowed to do that.'
+				)
+			).some( ( element ) => element.closest( '.components-notice' ) )
+		).toBe( true );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/finance/payouts/fields.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/fields.tsx
@@ -39,9 +39,7 @@ export const DEFAULT_VISIBLE_FIELDS = [
 	PAYOUT_FIELD_IDS.providerLink,
 ];
 
-const PINNED_FIELDS: string[] = [
-	PAYOUT_FIELD_IDS.provider,
-];
+const PINNED_FIELDS: string[] = [ PAYOUT_FIELD_IDS.provider ];
 
 /**
  * Keep the provider as the first column, whatever order the view asks for.

--- a/plugins/woocommerce/client/admin/client/finance/payouts/fields.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { Field } from '@wordpress/dataviews';
 
@@ -16,37 +17,62 @@ import type { FinanceProvider, Payout } from '../types';
 
 export const PAYOUT_FIELD_IDS = {
 	provider: 'provider',
+	id: 'id',
 	amount: 'amount',
 	status: 'status',
 	dateInitiated: 'date_initiated',
 	dateExpected: 'date_expected',
 	bankAccount: 'bank_account',
 	providerStatus: 'provider_status',
+	providerLink: 'provider_link',
 } as const;
 
 export const DEFAULT_VISIBLE_FIELDS = [
-	PAYOUT_FIELD_IDS.amount,
-	PAYOUT_FIELD_IDS.status,
+	PAYOUT_FIELD_IDS.provider,
 	PAYOUT_FIELD_IDS.dateInitiated,
-	PAYOUT_FIELD_IDS.dateExpected,
+	PAYOUT_FIELD_IDS.status,
+	PAYOUT_FIELD_IDS.providerStatus,
 	PAYOUT_FIELD_IDS.bankAccount,
+	PAYOUT_FIELD_IDS.id,
+	PAYOUT_FIELD_IDS.dateExpected,
+	PAYOUT_FIELD_IDS.amount,
+	PAYOUT_FIELD_IDS.providerLink,
+];
+
+const PINNED_FIELDS: string[] = [
+	PAYOUT_FIELD_IDS.provider,
+];
+
+/**
+ * Keep the provider as the first column, whatever order the view asks for.
+ *
+ * DataViews can only lock column moving for the whole table, so the order is normalised instead.
+ *
+ * @param fields The visible field ids from the view.
+ */
+export const pinPayoutFields = ( fields?: string[] ): string[] => [
+	...PINNED_FIELDS,
+	...( fields ?? [] ).filter( ( id ) => ! PINNED_FIELDS.includes( id ) ),
 ];
 
 type FieldDeps = {
 	providersById: Record< string, FinanceProvider >;
 	formatAmount: AmountFormatter;
+	onSelectPayout: ( payout: Payout ) => void;
 };
 
 /**
  * DataViews fields for a payout. Sorting and filtering are off because the API supports neither.
  *
- * @param deps               The dependencies used to render cells.
- * @param deps.providersById The known providers keyed by id.
- * @param deps.formatAmount  The amount formatter.
+ * @param deps                The dependencies used to render cells.
+ * @param deps.providersById  The known providers keyed by id.
+ * @param deps.formatAmount   The amount formatter.
+ * @param deps.onSelectPayout Called with the payout whose id was clicked.
  */
 export const getPayoutFields = ( {
 	providersById,
 	formatAmount,
+	onSelectPayout,
 }: FieldDeps ): Field< Payout >[] => [
 	{
 		id: PAYOUT_FIELD_IDS.provider,
@@ -61,6 +87,23 @@ export const getPayoutFields = ( {
 				provider={ providersById[ item.provider_id ] }
 				fallbackId={ item.provider_id }
 			/>
+		),
+	},
+	{
+		id: PAYOUT_FIELD_IDS.id,
+		label: __( 'Payout ID', 'woocommerce' ),
+		enableSorting: false,
+		enableHiding: false,
+		filterBy: false,
+		getValue: ( { item } ) => item.id,
+		render: ( { item } ) => (
+			<Button
+				className="woocommerce-finance-payouts__id-button"
+				variant="link"
+				onClick={ () => onSelectPayout( item ) }
+			>
+				{ item.id }
+			</Button>
 		),
 	},
 	{
@@ -109,5 +152,23 @@ export const getPayoutFields = ( {
 		enableSorting: false,
 		filterBy: false,
 		getValue: ( { item } ) => item.provider_status ?? EMPTY_VALUE,
+	},
+	{
+		id: PAYOUT_FIELD_IDS.providerLink,
+		label: __( 'Provider link', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) => item.provider_link?.title ?? EMPTY_VALUE,
+		render: ( { item } ) =>
+			item.provider_link?.url ? (
+				<ExternalLink
+					href={ item.provider_link.url }
+					rel="noopener noreferrer"
+				>
+					{ item.provider_link.title }
+				</ExternalLink>
+			) : (
+				EMPTY_VALUE
+			),
 	},
 ];

--- a/plugins/woocommerce/client/admin/client/finance/payouts/fields.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/fields.tsx
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { ProviderCell } from '../components/provider-cell';
+import { PayoutStatusBadge } from '../components/payout-status-badge';
+import { AmountFormatter } from '../utils/format-amount';
+import { formatFinanceDate, EMPTY_VALUE } from '../utils/format-date';
+import { getPayoutStatusLabel, PAYOUT_STATUSES } from '../utils/payout-status';
+import type { FinanceProvider, Payout } from '../types';
+
+export const PAYOUT_FIELD_IDS = {
+	provider: 'provider',
+	amount: 'amount',
+	status: 'status',
+	dateInitiated: 'date_initiated',
+	dateExpected: 'date_expected',
+	bankAccount: 'bank_account',
+	providerStatus: 'provider_status',
+} as const;
+
+export const DEFAULT_VISIBLE_FIELDS = [
+	PAYOUT_FIELD_IDS.amount,
+	PAYOUT_FIELD_IDS.status,
+	PAYOUT_FIELD_IDS.dateInitiated,
+	PAYOUT_FIELD_IDS.dateExpected,
+	PAYOUT_FIELD_IDS.bankAccount,
+];
+
+type FieldDeps = {
+	providersById: Record< string, FinanceProvider >;
+	formatAmount: AmountFormatter;
+};
+
+/**
+ * DataViews fields for a payout. Sorting and filtering are off because the API supports neither.
+ *
+ * @param deps               The dependencies used to render cells.
+ * @param deps.providersById The known providers keyed by id.
+ * @param deps.formatAmount  The amount formatter.
+ */
+export const getPayoutFields = ( {
+	providersById,
+	formatAmount,
+}: FieldDeps ): Field< Payout >[] => [
+	{
+		id: PAYOUT_FIELD_IDS.provider,
+		label: __( 'Provider', 'woocommerce' ),
+		enableSorting: false,
+		enableHiding: false,
+		filterBy: false,
+		getValue: ( { item } ) =>
+			providersById[ item.provider_id ]?.title ?? item.provider_id,
+		render: ( { item } ) => (
+			<ProviderCell
+				provider={ providersById[ item.provider_id ] }
+				fallbackId={ item.provider_id }
+			/>
+		),
+	},
+	{
+		id: PAYOUT_FIELD_IDS.amount,
+		label: __( 'Amount', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) => formatAmount( item.amount, item.currency ),
+	},
+	{
+		id: PAYOUT_FIELD_IDS.status,
+		label: __( 'Status', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		elements: PAYOUT_STATUSES.map( ( status ) => ( {
+			value: status,
+			label: getPayoutStatusLabel( status ),
+		} ) ),
+		getValue: ( { item } ) => item.status,
+		render: ( { item } ) => <PayoutStatusBadge status={ item.status } />,
+	},
+	{
+		id: PAYOUT_FIELD_IDS.dateInitiated,
+		label: __( 'Date initiated', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) => formatFinanceDate( item.date_initiated ),
+	},
+	{
+		id: PAYOUT_FIELD_IDS.dateExpected,
+		label: __( 'Expected date', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) => formatFinanceDate( item.date_expected ),
+	},
+	{
+		id: PAYOUT_FIELD_IDS.bankAccount,
+		label: __( 'Bank account', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) => item.bank_account ?? EMPTY_VALUE,
+	},
+	{
+		id: PAYOUT_FIELD_IDS.providerStatus,
+		label: __( 'Provider status', 'woocommerce' ),
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) => item.provider_status ?? EMPTY_VALUE,
+	},
+];

--- a/plugins/woocommerce/client/admin/client/finance/payouts/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/index.tsx
@@ -6,6 +6,7 @@ import { Notice, Spinner } from '@wordpress/components';
 import { EmptyContent } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
+import type { ReactNode } from 'react';
 import type { View, DataViews as DataViewsType } from '@wordpress/dataviews';
 // @ts-expect-error - The /wp entry has no resolvable types under legacy node module resolution; see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#dataviews
 import { DataViews as DataViewsWp } from '@wordpress/dataviews/wp';
@@ -22,8 +23,8 @@ import { FinanceDrawer } from '../components/drawer';
 import { PayoutDetails } from './payout-details';
 import {
 	getPayoutFields,
+	pinPayoutFields,
 	DEFAULT_VISIBLE_FIELDS,
-	PAYOUT_FIELD_IDS,
 } from './fields';
 import {
 	getPaginationInfo,
@@ -44,18 +45,23 @@ const DEFAULT_VIEW: View = {
 	page: 1,
 	perPage: DEFAULT_PER_PAGE,
 	fields: DEFAULT_VISIBLE_FIELDS,
-	titleField: PAYOUT_FIELD_IDS.provider,
-	showTitle: true,
 	layout: {},
 };
 
 const DEFAULT_LAYOUTS = { table: {} };
+
+// Body class that paints the whole admin page white while the Payouts page is mounted.
+const PAGE_BODY_CLASS = 'woocommerce-finance-payouts-page';
 
 const supportsPayouts = ( provider: FinanceProvider ): boolean =>
 	provider.data_types.some( ( dataType ) => dataType.type === 'payouts' );
 
 const getItemId = ( payout: Payout ): string =>
 	`${ payout.provider_id }:${ payout.id }`;
+
+const PayoutsWrapper = ( { children }: { children: ReactNode } ) => {
+	return <div className="woocommerce-finance-payouts">{ children }</div>;
+};
 
 export const FinancePayouts = () => {
 	const {
@@ -78,6 +84,11 @@ export const FinancePayouts = () => {
 		[ providers ]
 	);
 
+	useEffect( () => {
+		document.body.classList.add( PAGE_BODY_CLASS );
+		return () => document.body.classList.remove( PAGE_BODY_CLASS );
+	}, [] );
+
 	const { selectedId, selectProvider } = useLastProvider( payoutProviders );
 	const pagination = useCursorPagination( DEFAULT_PER_PAGE );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
@@ -99,7 +110,12 @@ export const FinancePayouts = () => {
 
 	const formatAmount = useAmountFormatter();
 	const fields = useMemo(
-		() => getPayoutFields( { providersById, formatAmount } ),
+		() =>
+			getPayoutFields( {
+				providersById,
+				formatAmount,
+				onSelectPayout: setSelectedPayout,
+			} ),
 		[ providersById, formatAmount ]
 	);
 
@@ -122,30 +138,30 @@ export const FinancePayouts = () => {
 			return;
 		}
 
-		setView( nextView );
+		setView( { ...nextView, fields: pinPayoutFields( nextView.fields ) } );
 	};
 
 	if ( isLoadingProviders ) {
 		return (
-			<div className="woocommerce-finance-payouts">
+			<PayoutsWrapper>
 				<Spinner />
-			</div>
+			</PayoutsWrapper>
 		);
 	}
 
 	if ( providersError ) {
 		return (
-			<div className="woocommerce-finance-payouts">
+			<PayoutsWrapper>
 				<Notice status="error" isDismissible={ false }>
 					{ providersError.message }
 				</Notice>
-			</div>
+			</PayoutsWrapper>
 		);
 	}
 
 	if ( payoutProviders.length === 0 ) {
 		return (
-			<div className="woocommerce-finance-payouts">
+			<PayoutsWrapper>
 				<EmptyContent
 					title={ __( 'No payout providers', 'woocommerce' ) }
 					message={ __(
@@ -158,7 +174,7 @@ export const FinancePayouts = () => {
 					) }
 					actionURL={ getAdminLink( PAYMENTS_SETTINGS_PATH ) }
 				/>
-			</div>
+			</PayoutsWrapper>
 		);
 	}
 
@@ -169,7 +185,7 @@ export const FinancePayouts = () => {
 	);
 
 	return (
-		<div className="woocommerce-finance-payouts">
+		<PayoutsWrapper>
 			<ProviderSelect
 				providers={ payoutProviders }
 				value={ selectedId }
@@ -195,8 +211,6 @@ export const FinancePayouts = () => {
 				config={ { perPageSizes: PER_PAGE_SIZES } }
 				search={ false }
 				getItemId={ getItemId }
-				onClickItem={ setSelectedPayout }
-				isItemClickable={ () => true }
 				empty={
 					<p className="woocommerce-finance-payouts__empty">
 						{ __(
@@ -218,7 +232,7 @@ export const FinancePayouts = () => {
 					/>
 				</FinanceDrawer>
 			) }
-		</div>
+		</PayoutsWrapper>
 	);
 };
 

--- a/plugins/woocommerce/client/admin/client/finance/payouts/index.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/index.tsx
@@ -1,0 +1,228 @@
+/**
+ * External dependencies
+ */
+import { useMemo, useState, useEffect } from '@wordpress/element';
+import { Notice, Spinner } from '@wordpress/components';
+import { EmptyContent } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/settings';
+import { __ } from '@wordpress/i18n';
+import type { View, DataViews as DataViewsType } from '@wordpress/dataviews';
+// @ts-expect-error - The /wp entry has no resolvable types under legacy node module resolution; see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#dataviews
+import { DataViews as DataViewsWp } from '@wordpress/dataviews/wp';
+
+/**
+ * Internal dependencies
+ */
+import { useFinanceProviders } from '../data/use-finance-providers';
+import { useLastProvider } from '../data/use-last-provider';
+import { usePayoutsPage } from '../data/use-payouts-page';
+import { useAmountFormatter } from '../utils/format-amount';
+import { ProviderSelect } from '../components/provider-select';
+import { FinanceDrawer } from '../components/drawer';
+import { PayoutDetails } from './payout-details';
+import {
+	getPayoutFields,
+	DEFAULT_VISIBLE_FIELDS,
+	PAYOUT_FIELD_IDS,
+} from './fields';
+import {
+	getPaginationInfo,
+	useCursorPagination,
+} from './use-cursor-pagination';
+import {
+	DEFAULT_PER_PAGE,
+	PAYMENTS_SETTINGS_PATH,
+	PER_PAGE_SIZES,
+} from '../constants';
+import type { FinanceProvider, Payout } from '../types';
+import './style.scss';
+
+const DataViews = DataViewsWp as typeof DataViewsType;
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: DEFAULT_PER_PAGE,
+	fields: DEFAULT_VISIBLE_FIELDS,
+	titleField: PAYOUT_FIELD_IDS.provider,
+	showTitle: true,
+	layout: {},
+};
+
+const DEFAULT_LAYOUTS = { table: {} };
+
+const supportsPayouts = ( provider: FinanceProvider ): boolean =>
+	provider.data_types.some( ( dataType ) => dataType.type === 'payouts' );
+
+const getItemId = ( payout: Payout ): string =>
+	`${ payout.provider_id }:${ payout.id }`;
+
+export const FinancePayouts = () => {
+	const {
+		providers,
+		isLoading: isLoadingProviders,
+		error: providersError,
+	} = useFinanceProviders();
+	const payoutProviders = useMemo(
+		() => providers.filter( supportsPayouts ),
+		[ providers ]
+	);
+	const providersById = useMemo(
+		() =>
+			Object.fromEntries(
+				providers.map( ( provider ) => [
+					provider.provider_id,
+					provider,
+				] )
+			),
+		[ providers ]
+	);
+
+	const { selectedId, selectProvider } = useLastProvider( payoutProviders );
+	const pagination = useCursorPagination( DEFAULT_PER_PAGE );
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ selectedPayout, setSelectedPayout ] = useState< Payout | null >(
+		null
+	);
+
+	const { page, isLoading, error } = usePayoutsPage( selectedId, {
+		cursor: pagination.cursor,
+		perPage: pagination.perPage,
+	} );
+
+	const { registerNext } = pagination;
+	useEffect( () => {
+		if ( page ) {
+			registerNext( page.next_cursor );
+		}
+	}, [ page, registerNext ] );
+
+	const formatAmount = useAmountFormatter();
+	const fields = useMemo(
+		() => getPayoutFields( { providersById, formatAmount } ),
+		[ providersById, formatAmount ]
+	);
+
+	const onChangeProvider = ( providerId: string ) => {
+		pagination.reset();
+		setSelectedPayout( null );
+		selectProvider( providerId );
+	};
+
+	const onChangeView = ( nextView: View ) => {
+		const nextPerPage = nextView.perPage ?? DEFAULT_PER_PAGE;
+		const nextPage = nextView.page ?? 1;
+
+		if ( nextPerPage !== pagination.perPage ) {
+			pagination.reset( nextPerPage );
+		} else if (
+			nextPage !== pagination.page &&
+			! pagination.goToPage( nextPage )
+		) {
+			return;
+		}
+
+		setView( nextView );
+	};
+
+	if ( isLoadingProviders ) {
+		return (
+			<div className="woocommerce-finance-payouts">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( providersError ) {
+		return (
+			<div className="woocommerce-finance-payouts">
+				<Notice status="error" isDismissible={ false }>
+					{ providersError.message }
+				</Notice>
+			</div>
+		);
+	}
+
+	if ( payoutProviders.length === 0 ) {
+		return (
+			<div className="woocommerce-finance-payouts">
+				<EmptyContent
+					title={ __( 'No payout providers', 'woocommerce' ) }
+					message={ __(
+						'Connect a payment provider that shares its payouts to see them here.',
+						'woocommerce'
+					) }
+					actionLabel={ __(
+						'Manage payment providers',
+						'woocommerce'
+					) }
+					actionURL={ getAdminLink( PAYMENTS_SETTINGS_PATH ) }
+				/>
+			</div>
+		);
+	}
+
+	const paginationInfo = getPaginationInfo(
+		pagination.state,
+		page ? page.items.length : null,
+		page?.has_more ?? false
+	);
+
+	return (
+		<div className="woocommerce-finance-payouts">
+			<ProviderSelect
+				providers={ payoutProviders }
+				value={ selectedId }
+				onChange={ onChangeProvider }
+			/>
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error.message }
+				</Notice>
+			) }
+			<DataViews< Payout >
+				view={ {
+					...view,
+					page: pagination.page,
+					perPage: pagination.perPage,
+				} }
+				onChangeView={ onChangeView }
+				fields={ fields }
+				data={ page?.items ?? [] }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				config={ { perPageSizes: PER_PAGE_SIZES } }
+				search={ false }
+				getItemId={ getItemId }
+				onClickItem={ setSelectedPayout }
+				isItemClickable={ () => true }
+				empty={
+					<p className="woocommerce-finance-payouts__empty">
+						{ __(
+							'No payouts found for this provider.',
+							'woocommerce'
+						) }
+					</p>
+				}
+			/>
+			{ selectedPayout && (
+				<FinanceDrawer
+					title={ __( 'Payout details', 'woocommerce' ) }
+					onClose={ () => setSelectedPayout( null ) }
+				>
+					<PayoutDetails
+						payout={ selectedPayout }
+						provider={ providersById[ selectedPayout.provider_id ] }
+						formatAmount={ formatAmount }
+					/>
+				</FinanceDrawer>
+			) }
+		</div>
+	);
+};
+
+/*
+ * Exported as default to support code-splitting and lazy loading.
+ */
+export default FinancePayouts;

--- a/plugins/woocommerce/client/admin/client/finance/payouts/payout-details.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/payout-details.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { ReactNode } from 'react';
 
@@ -81,14 +81,17 @@ export const PayoutDetails = ( {
 					</div>
 				) ) }
 			</dl>
-			{ payout.link && (
+			{ payout?.provider_link?.url && (
 				<Button
-					variant="secondary"
-					href={ payout.link.url }
+					className="woocommerce-finance-payout-details__provider-link"
+					variant="primary"
+					href={ payout.provider_link.url }
 					target="_blank"
-					rel="noreferrer"
+					rel="noreferrer noopener"
 				>
-					{ payout.link.title }
+					{ payout.provider_link?.title ??
+						__( 'Payout details', 'woocommerce' ) }
+					<Icon icon="external" />
 				</Button>
 			) }
 		</div>

--- a/plugins/woocommerce/client/admin/client/finance/payouts/payout-details.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/payout-details.tsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ProviderCell } from '../components/provider-cell';
+import { PayoutStatusBadge } from '../components/payout-status-badge';
+import { AmountFormatter } from '../utils/format-amount';
+import { formatFinanceDate, EMPTY_VALUE } from '../utils/format-date';
+import type { FinanceProvider, Payout } from '../types';
+
+type PayoutDetailsProps = {
+	payout: Payout;
+	provider?: FinanceProvider;
+	formatAmount: AmountFormatter;
+};
+
+/**
+ * Read-only summary of one payout, shown in the details drawer.
+ */
+export const PayoutDetails = ( {
+	payout,
+	provider,
+	formatAmount,
+}: PayoutDetailsProps ) => {
+	const rows: { label: string; value: ReactNode }[] = [
+		{
+			label: __( 'Provider', 'woocommerce' ),
+			value: (
+				<ProviderCell
+					provider={ provider }
+					fallbackId={ payout.provider_id }
+				/>
+			),
+		},
+		{
+			label: __( 'Amount', 'woocommerce' ),
+			value: formatAmount( payout.amount, payout.currency ),
+		},
+		{
+			label: __( 'Status', 'woocommerce' ),
+			value: <PayoutStatusBadge status={ payout.status } />,
+		},
+		{
+			label: __( 'Date initiated', 'woocommerce' ),
+			value: formatFinanceDate( payout.date_initiated ),
+		},
+		{
+			label: __( 'Expected date', 'woocommerce' ),
+			value: formatFinanceDate( payout.date_expected ),
+		},
+		{
+			label: __( 'Bank account', 'woocommerce' ),
+			value: payout.bank_account ?? EMPTY_VALUE,
+		},
+		{
+			label: __( 'Provider status', 'woocommerce' ),
+			value: payout.provider_status ?? EMPTY_VALUE,
+		},
+		{
+			label: __( 'Payout ID', 'woocommerce' ),
+			value: payout.id,
+		},
+	];
+
+	return (
+		<div className="woocommerce-finance-payout-details">
+			<dl className="woocommerce-finance-payout-details__list">
+				{ rows.map( ( row ) => (
+					<div
+						key={ row.label }
+						className="woocommerce-finance-payout-details__row"
+					>
+						<dt>{ row.label }</dt>
+						<dd>{ row.value }</dd>
+					</div>
+				) ) }
+			</dl>
+			{ payout.link && (
+				<Button
+					variant="secondary"
+					href={ payout.link.url }
+					target="_blank"
+					rel="noreferrer"
+				>
+					{ payout.link.title }
+				</Button>
+			) }
+		</div>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/finance/payouts/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/style.scss
@@ -1,0 +1,47 @@
+@import "@wordpress/dataviews/build-style/style.css";
+
+.woocommerce-finance-payouts {
+	.woocommerce-finance-provider-select {
+		max-inline-size: 320px;
+		margin-block-end: $gap;
+	}
+
+	.components-notice {
+		margin: 0 0 $gap;
+	}
+
+	.dataviews-wrapper {
+		background-color: $white;
+		border: 1px solid $gray-200;
+		border-radius: 4px;
+	}
+
+	&__empty {
+		margin: 0;
+		padding: $gap-large;
+		text-align: center;
+		color: $gray-700;
+	}
+}
+
+.woocommerce-finance-payout-details {
+	&__list {
+		margin: 0 0 $gap;
+	}
+
+	&__row {
+		display: grid;
+		grid-template-columns: minmax(120px, 1fr) 2fr;
+		gap: $gap-small;
+		padding-block: $gap-small;
+		border-block-end: 1px solid $gray-200;
+
+		dt {
+			color: $gray-700;
+		}
+
+		dd {
+			margin: 0;
+		}
+	}
+}

--- a/plugins/woocommerce/client/admin/client/finance/payouts/style.scss
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/style.scss
@@ -1,10 +1,10 @@
 @import "@wordpress/dataviews/build-style/style.css";
 
+body.woocommerce-finance-payouts-page {
+	background: $white;
+}
+
 .woocommerce-finance-payouts {
-	.woocommerce-finance-provider-select {
-		max-inline-size: 320px;
-		margin-block-end: $gap;
-	}
 
 	.components-notice {
 		margin: 0 0 $gap;
@@ -16,7 +16,19 @@
 		border-radius: 4px;
 	}
 
-	&__empty {
+	.woocommerce-finance-payouts__id-button.components-button {
+		padding: 0;
+		block-size: auto;
+		font-family: monospace;
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+		}
+	}
+
+	.woocommerce-finance-payouts__empty {
 		margin: 0;
 		padding: $gap-large;
 		text-align: center;
@@ -25,11 +37,11 @@
 }
 
 .woocommerce-finance-payout-details {
-	&__list {
+	.woocommerce-finance-payout-details__list {
 		margin: 0 0 $gap;
 	}
 
-	&__row {
+	.woocommerce-finance-payout-details__row {
 		display: grid;
 		grid-template-columns: minmax(120px, 1fr) 2fr;
 		gap: $gap-small;
@@ -43,5 +55,10 @@
 		dd {
 			margin: 0;
 		}
+	}
+
+	.woocommerce-finance-payout-details__provider-link {
+		width: 100%;
+		justify-content: center;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/finance/payouts/test/payouts.test.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/test/payouts.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import { useUserPreferences } from '@woocommerce/data';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -21,12 +21,17 @@ import type { FinanceProvider, Payout } from '../../types';
 type CapturedProps = {
 	view: { page?: number; perPage?: number; fields?: string[] };
 	onChangeView: ( view: CapturedProps[ 'view' ] ) => void;
-	fields: { id: string; enableSorting?: boolean; filterBy?: unknown }[];
+	fields: {
+		id: string;
+		enableSorting?: boolean;
+		enableHiding?: boolean;
+		filterBy?: unknown;
+		render?: ( props: { item: Payout } ) => ReactElement;
+	}[];
 	data: Payout[];
 	isLoading: boolean;
 	paginationInfo: { totalItems: number; totalPages: number };
 	search?: boolean;
-	onClickItem: ( item: Payout ) => void;
 	empty: ReactNode;
 };
 
@@ -162,8 +167,55 @@ describe( 'FinancePayouts', () => {
 			'/wc-admin/payments/finance/providers/bacs/payouts?per_page=10',
 		] );
 		expect(
-			screen.queryByLabelText( 'Payout provider' )
-		).not.toBeInTheDocument();
+			screen.getByRole( 'button', { name: /Payout provider/ } )
+		).toBeDisabled();
+	} );
+
+	it( 'pins the provider and payout id as the first non-hideable columns', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		render( <FinancePayouts /> );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+
+		expect( captured?.view.fields?.slice( 0, 2 ) ).toEqual( [
+			'provider',
+			'id',
+		] );
+		[ 'provider', 'id' ].forEach( ( id ) => {
+			expect(
+				captured?.fields.find( ( field ) => field.id === id )
+					?.enableHiding
+			).toBe( false );
+		} );
+
+		act(
+			() =>
+				captured?.onChangeView( {
+					...captured.view,
+					fields: [ 'amount', 'id', 'status', 'provider' ],
+				} )
+		);
+
+		expect( captured?.view.fields ).toEqual( [
+			'provider',
+			'id',
+			'amount',
+			'status',
+		] );
+	} );
+
+	it( 'paints the page white only while mounted', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		const { unmount } = render( <FinancePayouts /> );
+
+		expect( document.body ).toHaveClass(
+			'woocommerce-finance-payouts-page'
+		);
+		unmount();
+		expect( document.body ).not.toHaveClass(
+			'woocommerce-finance-payouts-page'
+		);
 	} );
 
 	it( 'fetches the next page with the stored cursor and can go back', async () => {
@@ -242,9 +294,15 @@ describe( 'FinancePayouts', () => {
 		act( () => captured?.onChangeView( { ...captured.view, page: 2 } ) );
 		await waitFor( () => expect( captured?.data ).toHaveLength( 1 ) );
 
-		fireEvent.change( screen.getByLabelText( 'Payout provider' ), {
-			target: { value: 'cheque' },
+		const toggle = screen.getByRole( 'button', {
+			name: /Payout provider/,
 		} );
+		expect( toggle ).toBeEnabled();
+		expect( toggle ).toHaveTextContent( 'Bank transfer' );
+		fireEvent.click( toggle );
+		fireEvent.click(
+			await screen.findByRole( 'menuitemradio', { name: 'Cheque' } )
+		);
 
 		await waitFor( () =>
 			expect( payoutRequests()[ 2 ] ).toBe(
@@ -276,13 +334,17 @@ describe( 'FinancePayouts', () => {
 		);
 	} );
 
-	it( 'opens the details drawer for the clicked payout', async () => {
+	it( 'opens the details drawer when the payout id is clicked', async () => {
 		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
 
 		render( <FinancePayouts /> );
 		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
 
-		act( () => captured?.onClickItem( captured.data[ 1 ] ) );
+		// The DataViews mock renders no cells, so mount the id cell on its own and click it.
+		const IdCell = captured?.fields.find( ( field ) => field.id === 'id' )
+			?.render as ( props: { item: Payout } ) => ReactElement;
+		render( <IdCell item={ captured?.data[ 1 ] as Payout } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'po_2' } ) );
 
 		const dialog = screen.getByRole( 'dialog', { name: 'Payout details' } );
 		expect( dialog ).toHaveTextContent( 'po_2' );

--- a/plugins/woocommerce/client/admin/client/finance/payouts/test/payouts.test.tsx
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/test/payouts.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * External dependencies
+ */
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { useUserPreferences } from '@woocommerce/data';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { FinancePayouts } from '..';
+import type { FinanceProvider, Payout } from '../../types';
+
+type CapturedProps = {
+	view: { page?: number; perPage?: number; fields?: string[] };
+	onChangeView: ( view: CapturedProps[ 'view' ] ) => void;
+	fields: { id: string; enableSorting?: boolean; filterBy?: unknown }[];
+	data: Payout[];
+	isLoading: boolean;
+	paginationInfo: { totalItems: number; totalPages: number };
+	search?: boolean;
+	onClickItem: ( item: Payout ) => void;
+	empty: ReactNode;
+};
+
+let captured: CapturedProps | null = null;
+
+jest.mock( '@wordpress/dataviews/wp', () => ( {
+	DataViews: ( props: CapturedProps ) => {
+		captured = props;
+		return <div data-testid="dataviews" />;
+	},
+} ) );
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@woocommerce/data', () => ( {
+	...jest.requireActual( '@woocommerce/data' ),
+	useUserPreferences: jest.fn(),
+} ) );
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: ( path: string ) => `https://example.test/wp-admin/${ path }`,
+	getSetting: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+const mockUseUserPreferences = useUserPreferences as unknown as jest.Mock;
+const mockUpdateUserPreferences = jest.fn( () => Promise.resolve() );
+
+const provider = (
+	id: string,
+	title: string,
+	dataTypes: FinanceProvider[ 'data_types' ] = [
+		{ type: 'payouts', schema_version: 1 },
+	]
+): FinanceProvider => ( {
+	provider_id: id,
+	title,
+	icon_url: null,
+	data_types: dataTypes,
+} );
+
+const payout = ( providerId: string, id: string ): Payout => ( {
+	provider_id: providerId,
+	id,
+	currency: 'USD',
+	amount: '10.00',
+	bank_account: 'Bank ••••1234',
+	date_initiated: '2026-09-01T10:00:00Z',
+	date_expected: null,
+	status: 'complete',
+	provider_status: null,
+} );
+
+const getQuery = ( path: string ) =>
+	new URL( `https://example.test${ path }` ).searchParams;
+
+const mockApi = ( providers: FinanceProvider[] ) => {
+	mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+		if ( path.endsWith( '/providers' ) ) {
+			return Promise.resolve( { providers } );
+		}
+		const providerId = path.split( '/providers/' )[ 1 ].split( '/' )[ 0 ];
+		const cursor = getQuery( path ).get( 'next_cursor' );
+		if ( ! cursor ) {
+			return Promise.resolve( {
+				schema_version: 1,
+				items: [
+					payout( providerId, 'po_1' ),
+					payout( providerId, 'po_2' ),
+				],
+				has_more: true,
+				next_cursor: 'cursor-2',
+				prev_cursor: null,
+			} );
+		}
+		return Promise.resolve( {
+			schema_version: 1,
+			items: [ payout( providerId, 'po_3' ) ],
+			has_more: false,
+			next_cursor: null,
+			prev_cursor: 'cursor-1',
+		} );
+	} );
+};
+
+const payoutRequests = () =>
+	mockApiFetch.mock.calls
+		.map( ( [ { path } ] ) => path as string )
+		.filter( ( path ) => path.includes( '/payouts' ) );
+
+describe( 'FinancePayouts', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		captured = null;
+		mockUseUserPreferences.mockReturnValue( {
+			updateUserPreferences: mockUpdateUserPreferences,
+		} );
+	} );
+
+	it( 'shows the empty state when no provider supports payouts', async () => {
+		mockApi( [
+			provider( 'bacs', 'Bank transfer', [
+				{ type: 'balance', schema_version: 1 },
+			] ),
+		] );
+
+		render( <FinancePayouts /> );
+
+		expect(
+			await screen.findByText( 'No payout providers' )
+		).toBeInTheDocument();
+		expect( screen.queryByTestId( 'dataviews' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a read-only table for the first page of the default provider', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		render( <FinancePayouts /> );
+
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+
+		expect( captured?.search ).toBe( false );
+		expect(
+			captured?.fields.every( ( field ) => field.enableSorting === false )
+		).toBe( true );
+		expect(
+			captured?.fields.every( ( field ) => field.filterBy === false )
+		).toBe( true );
+		expect( captured?.view.page ).toBe( 1 );
+		expect( captured?.paginationInfo ).toEqual( {
+			totalItems: 3,
+			totalPages: 2,
+		} );
+		expect( payoutRequests() ).toEqual( [
+			'/wc-admin/payments/finance/providers/bacs/payouts?per_page=10',
+		] );
+		expect(
+			screen.queryByLabelText( 'Payout provider' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'fetches the next page with the stored cursor and can go back', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		render( <FinancePayouts /> );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+
+		act( () => captured?.onChangeView( { ...captured.view, page: 2 } ) );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 1 ) );
+
+		expect( captured?.view.page ).toBe( 2 );
+		expect( captured?.paginationInfo ).toEqual( {
+			totalItems: 11,
+			totalPages: 2,
+		} );
+		expect( payoutRequests()[ 1 ] ).toBe(
+			'/wc-admin/payments/finance/providers/bacs/payouts?per_page=10&next_cursor=cursor-2'
+		);
+
+		act( () => captured?.onChangeView( { ...captured.view, page: 1 } ) );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+
+		expect( captured?.view.page ).toBe( 1 );
+		expect( payoutRequests()[ 2 ] ).toBe(
+			'/wc-admin/payments/finance/providers/bacs/payouts?per_page=10'
+		);
+	} );
+
+	it( 'ignores a jump to a page without a known cursor', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		render( <FinancePayouts /> );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+
+		act( () => captured?.onChangeView( { ...captured.view, page: 5 } ) );
+
+		expect( captured?.view.page ).toBe( 1 );
+		expect( payoutRequests() ).toHaveLength( 1 );
+	} );
+
+	it( 'restarts from the first page when the page size changes', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		render( <FinancePayouts /> );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+		act( () => captured?.onChangeView( { ...captured.view, page: 2 } ) );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 1 ) );
+
+		act(
+			() =>
+				captured?.onChangeView( {
+					...captured.view,
+					perPage: 25,
+					page: 2,
+				} )
+		);
+
+		await waitFor( () =>
+			expect( payoutRequests()[ 2 ] ).toBe(
+				'/wc-admin/payments/finance/providers/bacs/payouts?per_page=25'
+			)
+		);
+		expect( captured?.view.page ).toBe( 1 );
+		expect( captured?.view.perPage ).toBe( 25 );
+	} );
+
+	it( 'switches provider, restarts pagination and persists the choice', async () => {
+		mockApi( [
+			provider( 'bacs', 'Bank transfer' ),
+			provider( 'cheque', 'Cheque' ),
+		] );
+
+		render( <FinancePayouts /> );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+		act( () => captured?.onChangeView( { ...captured.view, page: 2 } ) );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 1 ) );
+
+		fireEvent.change( screen.getByLabelText( 'Payout provider' ), {
+			target: { value: 'cheque' },
+		} );
+
+		await waitFor( () =>
+			expect( payoutRequests()[ 2 ] ).toBe(
+				'/wc-admin/payments/finance/providers/cheque/payouts?per_page=10'
+			)
+		);
+		expect( captured?.view.page ).toBe( 1 );
+		expect( mockUpdateUserPreferences ).toHaveBeenCalledWith( {
+			payments_finance_last_provider: 'cheque',
+		} );
+	} );
+
+	it( 'starts on the stored provider', async () => {
+		mockUseUserPreferences.mockReturnValue( {
+			payments_finance_last_provider: 'cheque',
+			updateUserPreferences: mockUpdateUserPreferences,
+		} );
+		mockApi( [
+			provider( 'bacs', 'Bank transfer' ),
+			provider( 'cheque', 'Cheque' ),
+		] );
+
+		render( <FinancePayouts /> );
+
+		await waitFor( () =>
+			expect( payoutRequests()[ 0 ] ).toBe(
+				'/wc-admin/payments/finance/providers/cheque/payouts?per_page=10'
+			)
+		);
+	} );
+
+	it( 'opens the details drawer for the clicked payout', async () => {
+		mockApi( [ provider( 'bacs', 'Bank transfer' ) ] );
+
+		render( <FinancePayouts /> );
+		await waitFor( () => expect( captured?.data ).toHaveLength( 2 ) );
+
+		act( () => captured?.onClickItem( captured.data[ 1 ] ) );
+
+		const dialog = screen.getByRole( 'dialog', { name: 'Payout details' } );
+		expect( dialog ).toHaveTextContent( 'po_2' );
+		expect( dialog ).toHaveTextContent( 'Bank ••••1234' );
+		expect( dialog ).toHaveTextContent( 'Completed' );
+	} );
+
+	it( 'shows a payouts error above the table', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			path.endsWith( '/providers' )
+				? Promise.resolve( {
+						providers: [ provider( 'bacs', 'Bank transfer' ) ],
+				  } )
+				: Promise.reject( {
+						code: 'woocommerce_rest_payments_finance_provider_error',
+						message: 'Bank transfer is unavailable.',
+				  } )
+		);
+
+		render( <FinancePayouts /> );
+
+		// The message is also announced in a live region, so match the visible notice.
+		expect(
+			(
+				await screen.findAllByText( 'Bank transfer is unavailable.' )
+			).some( ( element ) => element.closest( '.components-notice' ) )
+		).toBe( true );
+		expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/finance/payouts/test/use-cursor-pagination.test.ts
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/test/use-cursor-pagination.test.ts
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks/dom';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getPaginationInfo,
+	useCursorPagination,
+} from '../use-cursor-pagination';
+
+describe( 'getPaginationInfo', () => {
+	it( 'reports nothing while the page is unknown', () => {
+		expect(
+			getPaginationInfo(
+				{ page: 1, perPage: 10, cursors: [ null ] },
+				null,
+				false
+			)
+		).toEqual( { totalItems: 0, totalPages: 0 } );
+	} );
+
+	it( 'exposes one extra page while the API reports more items', () => {
+		expect(
+			getPaginationInfo(
+				{ page: 1, perPage: 10, cursors: [ null ] },
+				10,
+				true
+			)
+		).toEqual( { totalItems: 11, totalPages: 2 } );
+	} );
+
+	it( 'stops at the current page when there are no more items', () => {
+		expect(
+			getPaginationInfo(
+				{ page: 3, perPage: 10, cursors: [ null, 'b', 'c' ] },
+				4,
+				false
+			)
+		).toEqual( { totalItems: 24, totalPages: 3 } );
+	} );
+
+	it( 'keeps already visited pages reachable when navigating back', () => {
+		expect(
+			getPaginationInfo(
+				{ page: 1, perPage: 10, cursors: [ null, 'b', 'c' ] },
+				10,
+				true
+			)
+		).toEqual( { totalItems: 11, totalPages: 3 } );
+	} );
+} );
+
+describe( 'useCursorPagination', () => {
+	it( 'starts on the first page without a cursor', () => {
+		const { result } = renderHook( () => useCursorPagination( 25 ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 25 );
+		expect( result.current.cursor ).toBeNull();
+	} );
+
+	it( 'registers the next cursor once per page and only at the frontier', () => {
+		const { result } = renderHook( () => useCursorPagination( 10 ) );
+
+		act( () => result.current.registerNext( 'page-2' ) );
+		act( () => result.current.registerNext( 'page-2-again' ) );
+
+		expect( result.current.state.cursors ).toEqual( [ null, 'page-2' ] );
+
+		act( () => result.current.registerNext( null ) );
+
+		expect( result.current.state.cursors ).toEqual( [ null, 'page-2' ] );
+	} );
+
+	it( 'only moves to pages with a known cursor', () => {
+		const { result } = renderHook( () => useCursorPagination( 10 ) );
+		let moved = false;
+
+		act( () => {
+			moved = result.current.goToPage( 2 );
+		} );
+		expect( moved ).toBe( false );
+		expect( result.current.page ).toBe( 1 );
+
+		act( () => result.current.registerNext( 'page-2' ) );
+		act( () => {
+			moved = result.current.goToPage( 2 );
+		} );
+		expect( moved ).toBe( true );
+		expect( result.current.page ).toBe( 2 );
+		expect( result.current.cursor ).toBe( 'page-2' );
+
+		act( () => {
+			moved = result.current.goToPage( 0 );
+		} );
+		expect( moved ).toBe( false );
+	} );
+
+	it( 'does not register a cursor when not on the last known page', () => {
+		const { result } = renderHook( () => useCursorPagination( 10 ) );
+
+		act( () => result.current.registerNext( 'page-2' ) );
+		act( () => {
+			result.current.goToPage( 2 );
+		} );
+		act( () => result.current.registerNext( 'page-3' ) );
+		act( () => {
+			result.current.goToPage( 1 );
+		} );
+		act( () => result.current.registerNext( 'page-2-replayed' ) );
+
+		expect( result.current.state.cursors ).toEqual( [
+			null,
+			'page-2',
+			'page-3',
+		] );
+	} );
+
+	it( 'resets to the first page and optionally changes the page size', () => {
+		const { result } = renderHook( () => useCursorPagination( 10 ) );
+
+		act( () => result.current.registerNext( 'page-2' ) );
+		act( () => {
+			result.current.goToPage( 2 );
+		} );
+		act( () => result.current.reset( 50 ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 50 );
+		expect( result.current.state.cursors ).toEqual( [ null ] );
+
+		act( () => result.current.reset() );
+		expect( result.current.perPage ).toBe( 50 );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/finance/payouts/use-cursor-pagination.ts
+++ b/plugins/woocommerce/client/admin/client/finance/payouts/use-cursor-pagination.ts
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+
+export type CursorPaginationState = {
+	page: number;
+	perPage: number;
+	// cursors[ i ] is the cursor that fetches page i + 1; the first page has no cursor.
+	cursors: ( string | null )[];
+};
+
+/**
+ * Map DataViews' page-number pagination onto the API's opaque cursors.
+ *
+ * DataViews can only request pages we hold a cursor for, plus the page after the current one
+ * once its cursor arrives, so `totalPages` never claims a page that cannot be fetched.
+ *
+ * @param state         The pagination state.
+ * @param state.page    The current page number.
+ * @param state.perPage The page size.
+ * @param state.cursors The cursors of the known pages.
+ * @param itemCount     The number of items on the current page, or null while unknown.
+ * @param hasMore       Whether the API reported more items after the current page.
+ */
+export const getPaginationInfo = (
+	{ page, perPage, cursors }: CursorPaginationState,
+	itemCount: number | null,
+	hasMore: boolean
+): { totalItems: number; totalPages: number } => {
+	if ( itemCount === null ) {
+		return { totalItems: 0, totalPages: 0 };
+	}
+
+	return {
+		totalItems: ( page - 1 ) * perPage + itemCount + ( hasMore ? 1 : 0 ),
+		totalPages: Math.max( cursors.length, hasMore ? page + 1 : page ),
+	};
+};
+
+export function useCursorPagination( initialPerPage: number ) {
+	const [ state, setState ] = useState< CursorPaginationState >( {
+		page: 1,
+		perPage: initialPerPage,
+		cursors: [ null ],
+	} );
+
+	const reset = useCallback( ( perPage?: number ) => {
+		setState( ( prev ) => ( {
+			page: 1,
+			perPage: perPage ?? prev.perPage,
+			cursors: [ null ],
+		} ) );
+	}, [] );
+
+	// Store the cursor of the page after the current one, once per page.
+	const registerNext = useCallback( ( nextCursor: string | null ) => {
+		setState( ( prev ) => {
+			if ( ! nextCursor || prev.cursors.length !== prev.page ) {
+				return prev;
+			}
+			return { ...prev, cursors: [ ...prev.cursors, nextCursor ] };
+		} );
+	}, [] );
+
+	const knownPages = state.cursors.length;
+	const goToPage = useCallback(
+		( page: number ): boolean => {
+			if ( page < 1 || page > knownPages ) {
+				return false;
+			}
+			setState( ( prev ) => ( { ...prev, page } ) );
+			return true;
+		},
+		[ knownPages ]
+	);
+
+	return {
+		page: state.page,
+		perPage: state.perPage,
+		cursor: state.cursors[ state.page - 1 ] ?? null,
+		state,
+		reset,
+		registerNext,
+		goToPage,
+	};
+}

--- a/plugins/woocommerce/client/admin/client/finance/types.ts
+++ b/plugins/woocommerce/client/admin/client/finance/types.ts
@@ -44,8 +44,7 @@ export type Payout = {
 	date_expected: string | null;
 	status: PayoutStatus;
 	provider_status: string | null;
-	// Not sent by the API yet; reserved for a link to the payout in the provider dashboard.
-	link?: FinanceLink;
+	provider_link: FinanceLink | null;
 };
 
 export type FinancePage< T > = {

--- a/plugins/woocommerce/client/admin/client/finance/types.ts
+++ b/plugins/woocommerce/client/admin/client/finance/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Types mirroring the finance REST API schemas in
+ * plugins/woocommerce/src/Internal/Admin/Payments/Finance/FinanceDataSchemas.php.
+ */
+
+export type FinanceDataType = 'balance' | 'payouts';
+
+export type FinanceProvider = {
+	provider_id: string;
+	title: string;
+	icon_url: string | null;
+	data_types: {
+		type: FinanceDataType;
+		schema_version: number;
+	}[];
+};
+
+export type FinanceProvidersResponse = {
+	providers: FinanceProvider[];
+};
+
+export type FinanceLink = {
+	title: string;
+	url: string;
+};
+
+export type Balance = {
+	provider_id: string;
+	currency: string;
+	amount: string;
+	available_amount: string | null;
+	payout_link: FinanceLink | null;
+};
+
+export type PayoutStatus = 'pending' | 'complete' | 'failed';
+
+export type Payout = {
+	provider_id: string;
+	id: string;
+	currency: string;
+	amount: string;
+	bank_account: string | null;
+	date_initiated: string;
+	date_expected: string | null;
+	status: PayoutStatus;
+	provider_status: string | null;
+	// Not sent by the API yet; reserved for a link to the payout in the provider dashboard.
+	link?: FinanceLink;
+};
+
+export type FinancePage< T > = {
+	schema_version: number;
+	items: T[];
+	has_more: boolean;
+	next_cursor: string | null;
+	prev_cursor: string | null;
+};
+
+export type FinanceError = {
+	code: string;
+	message: string;
+};

--- a/plugins/woocommerce/client/admin/client/finance/utils/format-amount.ts
+++ b/plugins/woocommerce/client/admin/client/finance/utils/format-amount.ts
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { useContext, useMemo } from '@wordpress/element';
+import { CurrencyContext } from '@woocommerce/currency';
+
+export type AmountFormatter = ( amount: string, currency: string ) => string;
+
+/**
+ * Format a decimal amount string in a currency. The store currency uses the WooCommerce
+ * formatting settings; any other currency uses the browser locale.
+ *
+ * @param amount                  Decimal amount in major units.
+ * @param currency                ISO 4217 currency code.
+ * @param store                   The store currency instance from CurrencyContext.
+ * @param store.getCurrencyConfig Returns the store currency config.
+ * @param store.formatAmount      Formats an amount in the store currency.
+ */
+export const formatAmount = (
+	amount: string,
+	currency: string,
+	store: {
+		getCurrencyConfig: () => { code: string };
+		formatAmount: ( amount: number | string ) => string;
+	}
+): string => {
+	const value = Number( amount );
+	const fallback = `${ amount } ${ currency }`;
+
+	if ( ! Number.isFinite( value ) ) {
+		return fallback;
+	}
+
+	if ( currency === store.getCurrencyConfig().code ) {
+		return store.formatAmount( value );
+	}
+
+	try {
+		return new Intl.NumberFormat( undefined, {
+			style: 'currency',
+			currency,
+		} ).format( value );
+	} catch {
+		return fallback;
+	}
+};
+
+export function useAmountFormatter(): AmountFormatter {
+	const store = useContext( CurrencyContext );
+
+	return useMemo(
+		() => ( amount: string, currency: string ) =>
+			formatAmount( amount, currency, store ),
+		[ store ]
+	);
+}

--- a/plugins/woocommerce/client/admin/client/finance/utils/format-date.ts
+++ b/plugins/woocommerce/client/admin/client/finance/utils/format-date.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { dateI18n } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '~/utils/admin-settings';
+
+export const EMPTY_VALUE = '—';
+
+/**
+ * Format an RFC 3339 date in the site date format and timezone.
+ *
+ * @param date The date string, or null.
+ */
+export const formatFinanceDate = ( date: string | null ): string => {
+	if ( ! date ) {
+		return EMPTY_VALUE;
+	}
+
+	return dateI18n(
+		getAdminSetting( 'dateFormat', 'F j, Y' ),
+		date,
+		undefined
+	);
+};

--- a/plugins/woocommerce/client/admin/client/finance/utils/payout-status.ts
+++ b/plugins/woocommerce/client/admin/client/finance/utils/payout-status.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PayoutStatus } from '../types';
+
+export type PayoutStatusVariant = 'success' | 'warning' | 'error' | 'info';
+
+export const PAYOUT_STATUSES: PayoutStatus[] = [
+	'pending',
+	'complete',
+	'failed',
+];
+
+export const getPayoutStatusLabel = ( status: string ): string => {
+	switch ( status ) {
+		case 'pending':
+			return __( 'Pending', 'woocommerce' );
+		case 'complete':
+			return __( 'Completed', 'woocommerce' );
+		case 'failed':
+			return __( 'Failed', 'woocommerce' );
+		default:
+			return status;
+	}
+};
+
+export const getPayoutStatusVariant = (
+	status: string
+): PayoutStatusVariant => {
+	switch ( status ) {
+		case 'pending':
+			return 'warning';
+		case 'complete':
+			return 'success';
+		case 'failed':
+			return 'error';
+		default:
+			return 'info';
+	}
+};

--- a/plugins/woocommerce/client/admin/client/finance/utils/test/format-amount.test.ts
+++ b/plugins/woocommerce/client/admin/client/finance/utils/test/format-amount.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { formatAmount } from '../format-amount';
+
+const store = {
+	getCurrencyConfig: () => ( { code: 'USD' } ),
+	formatAmount: ( amount: number | string ) => `$${ amount } store`,
+};
+
+describe( 'formatAmount', () => {
+	it( 'uses the store formatter for the store currency', () => {
+		expect( formatAmount( '12.50', 'USD', store ) ).toBe( '$12.5 store' );
+	} );
+
+	it( 'uses the browser locale for other currencies', () => {
+		const expected = new Intl.NumberFormat( undefined, {
+			style: 'currency',
+			currency: 'EUR',
+		} ).format( 12.5 );
+
+		expect( formatAmount( '12.50', 'EUR', store ) ).toBe( expected );
+	} );
+
+	it( 'falls back to the raw amount and code for an unknown currency', () => {
+		expect( formatAmount( '12.50', 'NOPE', store ) ).toBe( '12.50 NOPE' );
+	} );
+
+	it( 'falls back to the raw amount when it is not numeric', () => {
+		expect( formatAmount( 'n/a', 'USD', store ) ).toBe( 'n/a USD' );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/layout/controller.js
+++ b/plugins/woocommerce/client/admin/client/layout/controller.js
@@ -72,6 +72,13 @@ const MobileAppLoginPage = lazy( () =>
 	import( /* webpackChunkName: "mobile-app-login" */ '../mobile-app-login' )
 );
 
+const FinanceOverview = lazy( () =>
+	import( /* webpackChunkName: "finance-overview" */ '../finance/overview' )
+);
+const FinancePayouts = lazy( () =>
+	import( /* webpackChunkName: "finance-payouts" */ '../finance/payouts' )
+);
+
 export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
 export const getPages = ( reports = [] ) => {
@@ -163,6 +170,41 @@ export const getPages = ( reports = [] ) => {
 			},
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 			capability: 'view_woocommerce_reports',
+		} );
+	}
+
+	if ( isFeatureEnabled( 'payments_finance' ) ) {
+		const financeBreadcrumb = [
+			'/finance/overview',
+			__( 'Finance', 'woocommerce' ),
+		];
+		pages.push( {
+			container: FinanceOverview,
+			path: '/finance/overview',
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				financeBreadcrumb,
+				__( 'Overview', 'woocommerce' ),
+			],
+			wpOpenMenu: 'toplevel_page_wc-admin-path--finance-overview',
+			navArgs: {
+				id: 'woocommerce-finance-overview',
+			},
+			capability: 'manage_woocommerce',
+		} );
+		pages.push( {
+			container: FinancePayouts,
+			path: '/finance/payouts',
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				financeBreadcrumb,
+				__( 'Payouts', 'woocommerce' ),
+			],
+			wpOpenMenu: 'toplevel_page_wc-admin-path--finance-overview',
+			navArgs: {
+				id: 'woocommerce-finance-payouts',
+			},
+			capability: 'manage_woocommerce',
 		} );
 	}
 

--- a/plugins/woocommerce/client/admin/client/layout/test/controller.test.js
+++ b/plugins/woocommerce/client/admin/client/layout/test/controller.test.js
@@ -50,6 +50,36 @@ describe( 'getPages', () => {
 			expect( paths ).not.toContain( path );
 		} );
 	} );
+
+	it( 'registers finance pages under the Finance menu when payments_finance is enabled', () => {
+		isFeatureEnabled.mockImplementation(
+			( feature ) => feature === 'payments_finance'
+		);
+
+		const pages = getPages().filter( ( page ) =>
+			page.path.startsWith( '/finance/' )
+		);
+
+		expect( pages.map( ( page ) => page.path ) ).toEqual( [
+			'/finance/overview',
+			'/finance/payouts',
+		] );
+		pages.forEach( ( page ) => {
+			expect( page.wpOpenMenu ).toBe(
+				'toplevel_page_wc-admin-path--finance-overview'
+			);
+			expect( page.capability ).toBe( 'manage_woocommerce' );
+		} );
+	} );
+
+	it( 'does not register finance pages when payments_finance is disabled', () => {
+		isFeatureEnabled.mockReturnValue( false );
+
+		const paths = getPages().map( ( page ) => page.path );
+
+		expect( paths ).not.toContain( '/finance/overview' );
+		expect( paths ).not.toContain( '/finance/payouts' );
+	} );
 } );
 
 describe( 'updateLinkHref', () => {

--- a/plugins/woocommerce/src/Internal/Admin/Payments/Finance/FinanceController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Payments/Finance/FinanceController.php
@@ -34,14 +34,23 @@ class FinanceController implements RegisterHooksInterface {
 	private FinanceRestController $rest_controller;
 
 	/**
+	 * The finance admin menu.
+	 *
+	 * @var FinanceMenu
+	 */
+	private FinanceMenu $menu;
+
+	/**
 	 * Initialize dependencies.
 	 *
 	 * @internal
 	 *
 	 * @param FinanceRestController $rest_controller The finance REST controller.
+	 * @param FinanceMenu           $menu            The finance admin menu.
 	 */
-	final public function init( FinanceRestController $rest_controller ): void {
+	final public function init( FinanceRestController $rest_controller, FinanceMenu $menu ): void {
 		$this->rest_controller = $rest_controller;
+		$this->menu            = $menu;
 	}
 
 	/**
@@ -54,7 +63,7 @@ class FinanceController implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Handle the init hook: register the REST controller when the feature is enabled.
+	 * Handle the init hook: register the REST controller and the admin menu when the feature is enabled.
 	 *
 	 * @internal
 	 */
@@ -64,6 +73,7 @@ class FinanceController implements RegisterHooksInterface {
 		}
 
 		$this->rest_controller->register();
+		$this->menu->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Payments/Finance/FinanceMenu.php
+++ b/plugins/woocommerce/src/Internal/Admin/Payments/Finance/FinanceMenu.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Finance admin menu.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Payments\Finance;
+
+use Automattic\WooCommerce\Admin\PageController;
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the Finance top-level admin menu and its wc-admin pages.
+ *
+ * @internal
+ */
+class FinanceMenu implements RegisterHooksInterface {
+
+	/**
+	 * The id of the top-level Finance page.
+	 *
+	 * @var string
+	 */
+	public const PARENT_ID = 'woocommerce-finance';
+
+	/**
+	 * The wc-admin path of the Overview page, which is also the top-level menu target.
+	 *
+	 * @var string
+	 */
+	public const OVERVIEW_PATH = '/finance/overview';
+
+	/**
+	 * The wc-admin path of the Payouts page.
+	 *
+	 * @var string
+	 */
+	public const PAYOUTS_PATH = '/finance/payouts';
+
+	/**
+	 * The admin menu position, between Payments (56) and Analytics (57).
+	 *
+	 * @var float
+	 */
+	public const MENU_POSITION = 56.5;
+
+	/**
+	 * The capability required to see the Finance pages. Matches the finance REST API permission.
+	 *
+	 * @var string
+	 */
+	public const CAPABILITY = 'manage_woocommerce';
+
+	/**
+	 * The user preference that stores the last provider selected on the Payouts page.
+	 *
+	 * @var string
+	 */
+	public const LAST_PROVIDER_USER_DATA_FIELD = 'payments_finance_last_provider';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 11.2.0
+	 */
+	public function register(): void {
+		add_action( 'admin_menu', array( $this, 'handle_admin_menu' ) );
+		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'handle_woocommerce_admin_get_user_data_fields' ) );
+	}
+
+	/**
+	 * Handle the admin_menu hook: add the Finance menu and its pages.
+	 *
+	 * The top-level item bypasses PageController::register_page() because that method rounds the
+	 * position to an integer, which would place Finance after Analytics.
+	 *
+	 * @internal
+	 */
+	public function handle_admin_menu(): void {
+		$parent = $this->get_parent_page();
+
+		add_menu_page(
+			$parent['title'],
+			$parent['title'],
+			$parent['capability'],
+			$parent['path'],
+			array( PageController::class, 'page_wrapper' ),
+			$parent['icon'],
+			$parent['position']
+		);
+
+		PageController::get_instance()->connect_page( $parent );
+
+		foreach ( $this->get_sub_pages() as $page ) {
+			wc_admin_register_page( $page );
+		}
+	}
+
+	/**
+	 * Handle the woocommerce_admin_get_user_data_fields filter: expose the Finance user preferences.
+	 *
+	 * @internal
+	 *
+	 * @param mixed $fields The user data fields exposed over the WP user endpoint.
+	 * @return array
+	 */
+	public function handle_woocommerce_admin_get_user_data_fields( $fields ): array {
+		if ( ! is_array( $fields ) ) {
+			$fields = array();
+		}
+
+		$fields[] = self::LAST_PROVIDER_USER_DATA_FIELD;
+
+		return $fields;
+	}
+
+	/**
+	 * Get the definition of the top-level Finance page, in the PageController::connect_page() format.
+	 *
+	 * @return array
+	 */
+	public function get_parent_page(): array {
+		return array(
+			'id'         => self::PARENT_ID,
+			'title'      => __( 'Finance', 'woocommerce' ),
+			'path'       => PageController::PAGE_ROOT . '&path=' . self::OVERVIEW_PATH,
+			'capability' => self::CAPABILITY,
+			'icon'       => 'dashicons-money-alt',
+			'position'   => self::MENU_POSITION,
+			'js_page'    => true,
+		);
+	}
+
+	/**
+	 * Get the definitions of the Finance sub pages, in the wc_admin_register_page() format.
+	 *
+	 * The first sub page repeats the parent path so that the top-level menu gets a named first entry.
+	 *
+	 * @return array[]
+	 */
+	public function get_sub_pages(): array {
+		return array(
+			array(
+				'id'         => self::PARENT_ID . '-overview',
+				'title'      => __( 'Overview', 'woocommerce' ),
+				'parent'     => self::PARENT_ID,
+				'path'       => self::OVERVIEW_PATH,
+				'capability' => self::CAPABILITY,
+			),
+			array(
+				'id'         => self::PARENT_ID . '-payouts',
+				'title'      => __( 'Payouts', 'woocommerce' ),
+				'parent'     => self::PARENT_ID,
+				'path'       => self::PAYOUTS_PATH,
+				'capability' => self::CAPABILITY,
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Payments/Finance/FinanceControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Payments/Finance/FinanceControllerTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\Payments\Finance;
 
 use Automattic\WooCommerce\Internal\Admin\Payments\Finance\FinanceController;
 use Automattic\WooCommerce\Internal\Admin\Payments\Finance\FinanceDataSchemas;
+use Automattic\WooCommerce\Internal\Admin\Payments\Finance\FinanceMenu;
 use Automattic\WooCommerce\Internal\Admin\Payments\Finance\FinanceRestController;
 use Automattic\WooCommerce\Internal\Admin\Payments\Finance\FinanceService;
 use WC_Unit_Test_Case;
@@ -36,6 +37,13 @@ class FinanceControllerTest extends WC_Unit_Test_Case {
 	private FinanceRestController $rest_controller;
 
 	/**
+	 * The admin menu injected into the SUT.
+	 *
+	 * @var FinanceMenu
+	 */
+	private FinanceMenu $menu;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
@@ -44,8 +52,10 @@ class FinanceControllerTest extends WC_Unit_Test_Case {
 		$this->rest_controller = new FinanceRestController();
 		$this->rest_controller->init( $this->getMockBuilder( FinanceService::class )->getMock(), new FinanceDataSchemas() );
 
+		$this->menu = new FinanceMenu();
+
 		$this->sut = new FinanceController();
-		$this->sut->init( $this->rest_controller );
+		$this->sut->init( $this->rest_controller, $this->menu );
 	}
 
 	/**
@@ -85,10 +95,11 @@ class FinanceControllerTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $this->sut->is_enabled() );
 		$this->assertFalse( has_filter( 'woocommerce_rest_api_get_rest_namespaces', array( $this->rest_controller, 'handle_woocommerce_rest_api_get_rest_namespaces' ) ) );
+		$this->assertFalse( has_action( 'admin_menu', array( $this->menu, 'handle_admin_menu' ) ) );
 	}
 
 	/**
-	 * @testdox Should register the REST controller and its routes when the feature is enabled.
+	 * @testdox Should register the REST controller, its routes and the admin menu when the feature is enabled.
 	 */
 	public function test_registers_rest_controller_and_routes_when_enabled(): void {
 		update_option( self::OPTION, 'yes' );
@@ -97,6 +108,7 @@ class FinanceControllerTest extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $this->sut->is_enabled() );
 		$this->assertSame( 10, has_filter( 'woocommerce_rest_api_get_rest_namespaces', array( $this->rest_controller, 'handle_woocommerce_rest_api_get_rest_namespaces' ) ) );
+		$this->assertSame( 10, has_action( 'admin_menu', array( $this->menu, 'handle_admin_menu' ) ) );
 
 		$this->clear_rest_server();
 		$routes = rest_get_server()->get_routes( 'wc-admin' );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Payments/Finance/FinanceMenuTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Payments/Finance/FinanceMenuTest.php
@@ -1,0 +1,174 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Payments\Finance;
+
+use Automattic\WooCommerce\Admin\PageController;
+use Automattic\WooCommerce\Internal\Admin\Payments\Finance\FinanceMenu;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the FinanceMenu class.
+ */
+class FinanceMenuTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Admin menu globals mutated by add_menu_page() and add_submenu_page().
+	 *
+	 * @var string[]
+	 */
+	private const MENU_GLOBALS = array( 'menu', 'submenu', 'admin_page_hooks', '_registered_pages', '_parent_pages' );
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var FinanceMenu
+	 */
+	private FinanceMenu $sut;
+
+	/**
+	 * Backup of the admin menu globals and the PageController pages.
+	 *
+	 * @var array|null
+	 */
+	private ?array $menu_backup = null;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new FinanceMenu();
+	}
+
+	/**
+	 * Restore the admin menu state mutated by the menu registration tests.
+	 */
+	public function tearDown(): void {
+		try {
+			if ( null !== $this->menu_backup ) {
+				foreach ( self::MENU_GLOBALS as $global_name ) {
+					if ( array_key_exists( $global_name, $this->menu_backup['globals'] ) ) {
+						$GLOBALS[ $global_name ] = $this->menu_backup['globals'][ $global_name ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the pre-test values.
+					} else {
+						unset( $GLOBALS[ $global_name ] );
+					}
+				}
+
+				$pages_property = new \ReflectionProperty( PageController::class, 'pages' );
+				$pages_property->setAccessible( true );
+				$pages_property->setValue( PageController::get_instance(), $this->menu_backup['pages'] );
+
+				$this->menu_backup = null;
+			}
+		} finally {
+			parent::tearDown();
+		}
+	}
+
+	/**
+	 * @testdox Should attach the admin menu and user data fields hooks on register().
+	 */
+	public function test_register_attaches_hooks(): void {
+		$this->sut->register();
+
+		$this->assertSame( 10, has_action( 'admin_menu', array( $this->sut, 'handle_admin_menu' ) ) );
+		$this->assertSame( 10, has_filter( 'woocommerce_admin_get_user_data_fields', array( $this->sut, 'handle_woocommerce_admin_get_user_data_fields' ) ) );
+	}
+
+	/**
+	 * @testdox Should define the parent page with an unrounded position between Payments and Analytics.
+	 */
+	public function test_parent_page_definition(): void {
+		$parent = $this->sut->get_parent_page();
+
+		$this->assertSame( 'woocommerce-finance', $parent['id'] );
+		$this->assertSame( 'wc-admin&path=/finance/overview', $parent['path'] );
+		$this->assertSame( 'manage_woocommerce', $parent['capability'] );
+		$this->assertSame( 56.5, $parent['position'] );
+		$this->assertTrue( $parent['js_page'] );
+	}
+
+	/**
+	 * @testdox Should define Overview and Payouts sub pages under the Finance parent, Overview first and sharing the parent path.
+	 */
+	public function test_sub_pages_definition(): void {
+		$sub_pages = $this->sut->get_sub_pages();
+
+		$this->assertSame( array( 'woocommerce-finance-overview', 'woocommerce-finance-payouts' ), array_column( $sub_pages, 'id' ) );
+		$this->assertSame( array( '/finance/overview', '/finance/payouts' ), array_column( $sub_pages, 'path' ) );
+		$this->assertSame( array( 'woocommerce-finance', 'woocommerce-finance' ), array_column( $sub_pages, 'parent' ) );
+		$this->assertSame( array( 'manage_woocommerce', 'manage_woocommerce' ), array_column( $sub_pages, 'capability' ) );
+	}
+
+	/**
+	 * @testdox Should add the Finance top-level menu at position 56.5 with the Overview and Payouts sub menus.
+	 */
+	public function test_handle_admin_menu_registers_menu_and_sub_menus(): void {
+		global $menu, $submenu;
+
+		$this->backup_menu_state();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->sut->handle_admin_menu();
+
+		$parent_path = 'wc-admin&path=/finance/overview';
+
+		$this->assertArrayHasKey( '56.5', $menu, 'The Finance menu should keep its fractional position.' );
+		$this->assertSame( $parent_path, $menu['56.5'][2] );
+		$this->assertSame( 'manage_woocommerce', $menu['56.5'][1] );
+
+		$this->assertArrayHasKey( $parent_path, $submenu );
+		$this->assertSame(
+			array( 'Overview', 'Payouts' ),
+			array_column( $submenu[ $parent_path ], 0 )
+		);
+		$this->assertSame(
+			array( $parent_path, 'wc-admin&path=/finance/payouts' ),
+			array_column( $submenu[ $parent_path ], 2 )
+		);
+
+		$this->assertSame( $parent_path, PageController::get_instance()->get_path_from_id( 'woocommerce-finance' ) );
+	}
+
+	/**
+	 * @testdox Should append the last provider preference to the user data fields without dropping existing ones.
+	 */
+	public function test_handle_user_data_fields_appends_preference(): void {
+		$fields = $this->sut->handle_woocommerce_admin_get_user_data_fields( array( 'existing_field' ) );
+
+		$this->assertSame( array( 'existing_field', 'payments_finance_last_provider' ), $fields );
+	}
+
+	/**
+	 * @testdox Should treat a non-array user data fields value as empty.
+	 */
+	public function test_handle_user_data_fields_with_invalid_input(): void {
+		$fields = $this->sut->handle_woocommerce_admin_get_user_data_fields( 'not-an-array' );
+
+		$this->assertSame( array( 'payments_finance_last_provider' ), $fields );
+	}
+
+	/**
+	 * Snapshot the admin menu globals and the PageController pages, then start from an empty admin menu.
+	 */
+	private function backup_menu_state(): void {
+		global $menu, $submenu;
+
+		$backup_globals = array();
+		foreach ( self::MENU_GLOBALS as $global_name ) {
+			if ( isset( $GLOBALS[ $global_name ] ) ) {
+				$backup_globals[ $global_name ] = $GLOBALS[ $global_name ];
+			}
+		}
+
+		$this->menu_backup = array(
+			'globals' => $backup_globals,
+			'pages'   => PageController::get_instance()->get_pages(),
+		);
+
+		$menu    = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR explores a new `Finance` menu with _Overview_ and _Payouts_ sub-items that use the data from https://github.com/woocommerce/woocommerce/pull/68549. As for the underlying PR, this PR also uses the `payments_finance` feature flag. Beyond that protection, this PR implements an initial UI for the _Finance_ -> _Payouts_ tab that includes most of the data we expect to have available to us, as well as the interaction pattern for opening a drawer on the right of the page and supporting pagination. There is a basic UI skeleton for the _Finance_ -> _Overview_ page.

_Note:_ The bulk of this implementation was written using Claude, and I have not reviewed it extensively yet -- the goal of this PR is to serve as a proof of concept.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

**Screen recording**

https://github.com/user-attachments/assets/5697f63e-b3a4-4522-857d-4ea6652239da

This was recorded with this code along with the code from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5931

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
