### PR TITLE
Keep the push token list readable when push notifications are disabled

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -295,32 +295,6 @@ class PushTokenRestController extends RestApiControllerBase {
 	}
 
 	/**
-	 * Validates that the request is signed with a Jetpack blog token,
-	 * ensuring only WPCOM can access this endpoint.
-	 *
-	 * @since 10.8.0
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
-	 * @return bool|WP_Error
-	 */
-	public function authorize_as_from_wpcom( WP_REST_Request $request ) {
-		if ( ! wc_get_container()->get( PushNotifications::class )->should_be_enabled() ) {
-			return false;
-		}
-
-		if ( $this->is_signed_with_blog_token() ) {
-			return true;
-		}
-
-		return new WP_Error(
-			'woocommerce_rest_cannot_view',
-			__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
-			array( 'status' => rest_authorization_required_code() )
-		);
-	}
-
-	/**
 	 * Get the accepted arguments for the POST request.
 	 *
 	 * @since 10.6.0

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -74,6 +74,11 @@ class PushNotifications {
 		// the state and fall back if needed.
 		wc_get_container()->get( PushNotificationStatusRestController::class )->register();
 
+		// Registered ahead of the enablement check so the token list can still be
+		// read on a store that has been switched off. The write routes stay gated
+		// in their permission callbacks, as does everything below.
+		( new PushTokenRestController() )->register();
+
 		if ( ! $this->should_be_enabled() ) {
 			return;
 		}
@@ -82,7 +87,6 @@ class PushNotifications {
 
 		wc_get_container()->get( PendingNotificationStore::class )->register();
 
-		( new PushTokenRestController() )->register();
 		( new PushNotificationRestController() )->register();
 		( new NotificationPreferencesRestController() )->register();
 		( new NewOrderNotificationTrigger() )->register();

--- a/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
@@ -39,6 +39,32 @@ trait AuthorizesPushNotificationRequests {
 	}
 
 	/**
+	 * Checks the request is signed with the Jetpack blog token, so only WPCOM
+	 * can reach the endpoint.
+	 *
+	 * The module does not have to be enabled. WPCOM reads a disabled store to see
+	 * which devices it has registered, and a store is most worth looking at once
+	 * push notifications have been switched off for it.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return bool|WP_Error
+	 *
+	 * @since 11.2.0
+	 */
+	public function authorize_as_from_wpcom( WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Kept so every permission callback in this trait takes the same argument.
+		if ( $this->is_signed_with_blog_token() ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'woocommerce_rest_cannot_view',
+			__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
 	 * Checks the caller is either WPCOM or an allowed user, without requiring
 	 * the module to be enabled.
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1404,9 +1404,33 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should reject WPCOM tokens endpoint when push notifications are disabled.
+	 * @testdox Should allow the WPCOM tokens endpoint when push notifications are disabled,
+	 * so a store that has been switched off can still be inspected.
 	 */
-	public function test_authorize_as_from_wpcom_returns_false_when_disabled(): void {
+	public function test_authorize_as_from_wpcom_allows_blog_token_when_disabled(): void {
+		$this->mock_jetpack_connection_manager_is_connected( false );
+
+		$controller = new class() extends PushTokenRestController {
+			/**
+			 * Stands in for a request WPCOM signed with the Jetpack blog token.
+			 *
+			 * @return bool
+			 */
+			protected function is_signed_with_blog_token(): bool {
+				return true;
+			}
+		};
+
+		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+
+		$this->assertTrue( $controller->authorize_as_from_wpcom( $request ) );
+	}
+
+	/**
+	 * @testdox Should reject the WPCOM tokens endpoint without a blog token when push
+	 * notifications are disabled.
+	 */
+	public function test_authorize_as_from_wpcom_rejects_without_blog_token_when_disabled(): void {
 		$this->mock_jetpack_connection_manager_is_connected( false );
 
 		$controller = new PushTokenRestController();
@@ -1414,7 +1438,8 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 
 		$result = $controller->authorize_as_from_wpcom( $request );
 
-		$this->assertFalse( $result );
+		$this->assertWPError( $result );
+		$this->assertSame( 'woocommerce_rest_cannot_view', $result->get_error_code() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\NotificationPreferencesRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushNotificationRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushNotificationStatusRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
@@ -14,6 +17,8 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Logger;
 use WC_Unit_Test_Case;
+use WP_Http;
+use WP_REST_Request;
 
 /**
  * PushNotifications test.
@@ -30,6 +35,8 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	 * Tear down the test case.
 	 */
 	public function tearDown(): void {
+		wp_set_current_user( 0 );
+
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
@@ -206,9 +213,10 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests that on_init does not register post types when Jetpack is not connected.
+	 * @testdox Tests that on_init does not register post types when Jetpack is not connected,
+	 * leaving the tokens endpoint to register them if it is called.
 	 */
-	public function test_on_init_does_not_register_post_types_when_disabled() {
+	public function test_on_init_does_not_register_post_types_when_jetpack_is_not_connected() {
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
 
 		$this->jetpack_connection_manager_mock
@@ -221,14 +229,32 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse(
 			post_type_exists( PushToken::POST_TYPE ),
-			'Push token post type should not be registered when disabled'
+			'Push token post type should not be registered when Jetpack is not connected'
 		);
 	}
 
 	/**
-	 * @testdox Tests that on_init registers the status controller but no other controllers when disabled.
+	 * @testdox Tests that on_init does not register post types when disabled via the filter.
 	 */
-	public function test_on_init_registers_only_status_controller_when_disabled() {
+	public function test_on_init_does_not_register_post_types_when_disabled_via_filter() {
+		add_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
+		$push_notifications = new PushNotifications();
+		$push_notifications->on_init();
+
+		remove_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
+		$this->assertFalse(
+			post_type_exists( PushToken::POST_TYPE ),
+			'Push token post type should not be registered when disabled via the filter'
+		);
+	}
+
+	/**
+	 * @testdox Tests that on_init registers the status and token controllers, but not the send
+	 * or preferences controllers, when Jetpack is not connected.
+	 */
+	public function test_on_init_registers_status_and_token_controllers_when_jetpack_is_not_connected() {
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
 
 		$this->jetpack_connection_manager_mock
@@ -239,6 +265,170 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 		$push_notifications = new PushNotifications();
 		$push_notifications->on_init();
 
+		$registered = $this->get_registered_rest_controllers();
+
+		$this->assertContains( PushNotificationStatusRestController::class, $registered );
+		$this->assertContains( PushTokenRestController::class, $registered );
+		$this->assertNotContains( PushNotificationRestController::class, $registered );
+		$this->assertNotContains( NotificationPreferencesRestController::class, $registered );
+	}
+
+	/**
+	 * @testdox Tests that on_init registers the status and token controllers, but not the send
+	 * or preferences controllers, when disabled via the filter.
+	 */
+	public function test_on_init_registers_status_and_token_controllers_when_disabled_via_filter() {
+		add_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
+		$push_notifications = new PushNotifications();
+		$push_notifications->on_init();
+
+		remove_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
+		$registered = $this->get_registered_rest_controllers();
+
+		$this->assertContains( PushNotificationStatusRestController::class, $registered );
+		$this->assertContains( PushTokenRestController::class, $registered );
+		$this->assertNotContains( PushNotificationRestController::class, $registered );
+		$this->assertNotContains( NotificationPreferencesRestController::class, $registered );
+	}
+
+	/**
+	 * @testdox Tests that the tokens endpoint returns the store's registered tokens while
+	 * the module is disabled via the filter.
+	 */
+	public function test_tokens_endpoint_returns_tokens_when_disabled_via_filter() {
+		add_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
+		try {
+			$tokens = $this->dispatch_tokens_request_after_on_init( 'filter-disabled-token' );
+		} finally {
+			remove_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+		}
+
+		$this->assertCount( 1, $tokens );
+		$this->assertSame( 'filter-disabled-token', $tokens[0]['token'] );
+	}
+
+	/**
+	 * @testdox Tests that the tokens endpoint returns the store's registered tokens while
+	 * Jetpack is not connected.
+	 */
+	public function test_tokens_endpoint_returns_tokens_when_jetpack_is_not_connected() {
+		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$tokens = $this->dispatch_tokens_request_after_on_init( 'disconnected-token' );
+
+		$this->assertCount( 1, $tokens );
+		$this->assertSame( 'disconnected-token', $tokens[0]['token'] );
+	}
+
+	/**
+	 * @testdox Tests that registering a token is refused while the module is disabled.
+	 */
+	public function test_token_registration_is_refused_when_disabled_via_filter() {
+		add_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
+		try {
+			wp_set_current_user( self::factory()->user->create( array( 'role' => 'shop_manager' ) ) );
+
+			( new PushNotifications() )->on_init();
+
+			$server = $this->create_rest_server_with_routes(
+				array( array( new PushTokenRestController(), 'register_routes' ) ),
+				true
+			);
+
+			$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
+			$request->set_param( 'token', str_repeat( 'a', 64 ) );
+			$request->set_param( 'platform', PushToken::PLATFORM_APPLE );
+			$request->set_param( 'device_uuid', 'refused-device-uuid' );
+			$request->set_param( 'origin', PushToken::ORIGIN_WOOCOMMERCE_IOS );
+			$request->set_param( 'device_locale', 'en_US' );
+
+			$response = $server->dispatch( $request );
+		} finally {
+			remove_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+		}
+
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_status() );
+	}
+
+	/**
+	 * Stores one token against a shop manager, runs on_init with the post type
+	 * unregistered, then dispatches a GET to the tokens endpoint as WPCOM and returns
+	 * the tokens it responded with.
+	 *
+	 * @param string $token The token value to store.
+	 * @return array[]
+	 */
+	private function dispatch_tokens_request_after_on_init( string $token ): array {
+		$push_notifications = new PushNotifications();
+
+		// Seed the token the way an enabled store would have, then drop the post type
+		// again, so the request starts from the state a disabled store is left in.
+		$push_notifications->register_post_types();
+
+		wc_get_container()->get( PushTokensDataStore::class )->create(
+			array(
+				'user_id'       => self::factory()->user->create( array( 'role' => 'shop_manager' ) ),
+				'token'         => $token,
+				'platform'      => PushToken::PLATFORM_APPLE,
+				'device_uuid'   => 'device-' . $token,
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+				'device_locale' => 'en_US',
+			)
+		);
+
+		unregister_post_type( PushToken::POST_TYPE );
+
+		$push_notifications->on_init();
+
+		$this->assertFalse(
+			post_type_exists( PushToken::POST_TYPE ),
+			'Push token post type should still be unregistered when the request is dispatched'
+		);
+
+		$controller = new class() extends PushTokenRestController {
+			/**
+			 * Stands in for a request WPCOM signed with the Jetpack blog token.
+			 *
+			 * @return bool
+			 */
+			protected function is_signed_with_blog_token(): bool {
+				return true;
+			}
+		};
+
+		$server = $this->create_rest_server_with_routes(
+			array( array( $controller, 'register_routes' ) ),
+			true
+		);
+
+		$response = $server->dispatch( new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$this->assertFalse(
+			post_type_exists( PushToken::POST_TYPE ),
+			'Reading the token list should not need the push token post type registered'
+		);
+
+		return $response->get_data()['tokens'];
+	}
+
+	/**
+	 * Returns the controller classes that have added themselves to the WooCommerce REST
+	 * API namespaces.
+	 *
+	 * @return string[]
+	 */
+	private function get_registered_rest_controllers(): array {
 		// The status controller registers on rest_api_init rather than during
 		// on_init, so a front-end request does not resolve it for nothing. WooCommerce
 		// applies the namespaces filter on rest_api_init at priority 10, and the
@@ -248,10 +438,8 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Triggering an existing filter from RestApiControllerBase, not defining one.
 		$namespaces = apply_filters( 'woocommerce_rest_api_get_rest_namespaces', array( 'wc/v3' => array() ) );
-		$registered = array_values( $namespaces['wc/v3'] );
 
-		$this->assertContains( PushNotificationStatusRestController::class, $registered );
-		$this->assertNotContains( PushTokenRestController::class, $registered );
+		return array_values( $namespaces['wc/v3'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes AINFRA-2889

Disabling enhanced push notifications for a store is the usual first step when a merchant reports that notifications are not arriving. It also took away the endpoint that lists the devices registered against the store, so we could no longer see which devices exist, which platforms they are on, or whether the merchant has any at all.

**WordPress.com can now read a store's push token list while the module is disabled, so a store that has been switched off can still be inspected.**

-   Reading the token list works while the `woocommerce_enhanced_push_notifications_disabled` filter is set. It returned 404 before.
-   The `wc_push_token` post type still only registers while the module is enabled, so a disabled store does no work for it. The token queries run as plain SQL against `wp_posts` and carry no capability restriction, so the list is complete without it.
-   The read is still restricted to requests WordPress.com signs with the Jetpack blog token. No new caller can reach it, and the response is unchanged.
-   Everything else stays gated. Registering a token and deleting one are refused while the module is disabled, the send endpoint still refuses, and no notification is dispatched whatever tokens the store holds.

A store with Jetpack disconnected holds no blog token, so WordPress.com cannot reach the endpoint there at all. Reading a disconnected store's tokens needs host or WP-CLI access and is out of scope here.

Two things change for WordPress.com reading the token list from this version onwards:

-   A 404 means the WooCommerce version is too old, rather than the feature being off.
-   A 200 does not mean the feature is enabled.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Written following the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/).

The token list is readable only by WordPress.com, which signs its requests with the Jetpack blog token, and you cannot produce that signature from the site. The steps below check the two things the change controls, which are that the route is registered and no longer gated on the module being enabled, and that it returns the store's real tokens.

#### Prerequisites

**Before testing, ensure:**

-   You have replaced the WooCommerce core files on a test site with the files from this PR
-   Jetpack is connected on that site. Push notifications are switched on by the connection, there is no separate setting
-   You have opened the site in the WooCommerce iOS or Android app, which registers a push token against it
-   You have WP-CLI access to the site
-   You know the username of an administrator on the site

#### Switching the module off

Save the following as `wp-content/mu-plugins/disable-push-notifications.php`.

```php
<?php
/**
 * Plugin Name: Disable enhanced push notifications
 */

add_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
```

Create `wp-content/mu-plugins/` first if it does not exist, which is common on a new site. WordPress reports nothing when a mu-plugin is missing or in the wrong place, so there is no error to tell you it did not load. The module then stays enabled and every step below passes either way.

#### Steps

1.  Check the route is registered and refuses the caller rather than reporting no such route.

    ```sh
    wp eval '
    $response = rest_do_request( new WP_REST_Request( "GET", "/wc-push-notifications/push-tokens" ) );
    printf( "%d %s" . PHP_EOL, $response->get_status(), wp_json_encode( $response->get_data() ) );'
    ```

    **Expected result: `401` with `{"code":"woocommerce_rest_cannot_view",...}`, which is the response WordPress.com would get without a blog token signature. On trunk this is `404 {"code":"rest_no_route",...}`.**

2.  Check the handler returns the stored tokens without the `wc_push_token` post type. This calls the handler directly, standing in for the signature you cannot produce, and prints whether the post type is registered on either side of the call.

    ```sh
    wp eval '
    printf( "post type before: %s" . PHP_EOL, post_type_exists( "wc_push_token" ) ? "yes" : "no" );
    $controller = new Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController();
    $request    = new WP_REST_Request( "GET", "/wc-push-notifications/push-tokens" );
    $request->set_param( "page", 1 );
    $request->set_param( "per_page", 100 );
    $response = $controller->index( $request );
    printf( "%d %s" . PHP_EOL, $response->get_status(), wp_json_encode( $response->get_data() ) );
    printf( "post type after: %s" . PHP_EOL, post_type_exists( "wc_push_token" ) ? "yes" : "no" );'
    ```

    **Expected result: `post type before: no`, then `200` followed by a `tokens` array holding the device you opened the site with, then `post type after: no`. Both `no` values matter, since together they show the list was read without the post type rather than the handler registering it along the way.**

3.  Check that registering a token is still refused, replacing `YOUR_ADMIN_USERNAME`. WordPress validates arguments before it runs the permission check, so the `origin` below has to be a real one or you get a 400 instead of the refusal.

    ```sh
    wp eval --user=YOUR_ADMIN_USERNAME '
    $request = new WP_REST_Request( "POST", "/wc-push-notifications/push-tokens" );
    $request->set_param( "token", str_repeat( "a", 64 ) );
    $request->set_param( "platform", "apple" );
    $request->set_param( "device_uuid", "manual-test-device" );
    $request->set_param( "origin", "com.automattic.woocommerce" );
    $request->set_param( "device_locale", "en_US" );
    $response = rest_do_request( $request );
    printf( "%d %s" . PHP_EOL, $response->get_status(), wp_json_encode( $response->get_data() ) );'
    ```

    **Expected result:** `403` with `{"code":"rest_forbidden",...}`. On trunk this is `404`, because the route did not exist at all.

4.  Check that sending is still refused.

    ```sh
    wp eval --user=YOUR_ADMIN_USERNAME '
    $response = rest_do_request( new WP_REST_Request( "POST", "/wc-push-notifications/send" ) );
    printf( "%d %s" . PHP_EOL, $response->get_status(), wp_json_encode( $response->get_data() ) );'
    ```

    **Expected result:** `404` with `{"code":"rest_no_route",...}`, the same as on trunk.

<!-- End testing instructions -->

### Testing that has already taken place:

I have run through the testing instructions above.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal only change - it moves when an internal REST route is registered, and that route is read by WordPress.com. Nothing changes in the store UI or in what a merchant receives.

</details>

### Use of AI Tools

Authored with Claude Code (Claude Opus 5). The change was specified, reviewed and verified by me.
