### PR TITLE
Fix upgrade inbox action accumulation during execution

### DIFF
--- a/plugins/woocommerce/changelog/fix-upgrade-inbox-action-pileup
+++ b/plugins/woocommerce/changelog/fix-upgrade-inbox-action-pileup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate remote inbox update actions from accumulating while an existing action is running or waiting asynchronously.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -52,19 +52,30 @@ class RemoteInboxNotificationsEngine extends RemoteSpecsEngine {
 		add_action(
 			'woocommerce_updated',
 			function () {
-				$next_hook = WC()->queue()->get_next(
+				$queue = WC()->queue();
+				// A date lookup cannot represent running actions or pending async actions.
+				foreach ( array( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::STATUS_RUNNING ) as $status ) {
+					$actions = $queue->search(
+						array(
+							'hook'     => 'woocommerce_run_on_woocommerce_admin_updated',
+							'args'     => array(),
+							'group'    => 'woocommerce-remote-inbox-engine',
+							'status'   => $status,
+							'per_page' => 1,
+						),
+						'ids'
+					);
+					if ( ! empty( $actions ) ) {
+						return;
+					}
+				}
+
+				$queue->schedule_single(
+					time(),
 					'woocommerce_run_on_woocommerce_admin_updated',
 					array(),
 					'woocommerce-remote-inbox-engine'
 				);
-				if ( null === $next_hook ) {
-					WC()->queue()->schedule_single(
-						time(),
-						'woocommerce_run_on_woocommerce_admin_updated',
-						array(),
-						'woocommerce-remote-inbox-engine'
-					);
-				}
 			}
 		);
 

--- a/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php
@@ -1,0 +1,251 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\RemoteInboxNotifications;
+
+use ActionScheduler;
+use ActionScheduler_Store;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
+use WC_Queue;
+use WC_Queue_Interface;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for upgrade-triggered remote inbox scheduling.
+ *
+ * @covers \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine
+ */
+class RemoteInboxNotificationsEngineTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The upgrade action hook.
+	 */
+	private const HOOK = 'woocommerce_run_on_woocommerce_admin_updated';
+
+	/**
+	 * The engine's action group.
+	 */
+	private const GROUP = 'woocommerce-remote-inbox-engine';
+
+	/**
+	 * Initialize only the engine's update listener. The parent restores hooks and database fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		remove_all_actions( 'woocommerce_updated' );
+		RemoteInboxNotificationsEngine::init();
+	}
+
+	/**
+	 * @testdox Repeated updates do not add pending copies while an upgrade action is running.
+	 * @dataProvider running_action_provider
+	 *
+	 * @param int $pending_count Existing pending copies alongside the running action.
+	 */
+	public function test_running_action_prevents_accumulation( int $pending_count ): void {
+		$running_id = as_schedule_single_action( time() - 60, self::HOOK, array(), self::GROUP );
+		ActionScheduler::store()->log_execution( $running_id );
+		for ( $i = 0; $i < $pending_count; $i++ ) {
+			as_schedule_single_action( time() - 30, self::HOOK, array(), self::GROUP );
+		}
+		for ( $i = 0; $i < 10; $i++ ) {
+			as_schedule_single_action( time() - 120, 'unrelated_upgrade_backlog', array( $i ), self::GROUP );
+		}
+
+		$this->assertSame( ActionScheduler_Store::STATUS_RUNNING, ActionScheduler::store()->get_status( $running_id ), 'The stored action must be running.' );
+		$this->assertTrue( as_next_scheduled_action( self::HOOK, array(), self::GROUP ), 'A running action masks pending dates in the Action Scheduler lookup.' );
+		$this->assertNull( WC()->queue()->get_next( self::HOOK, array(), self::GROUP ), 'The date-based queue lookup cannot represent running work.' );
+
+		$this->fire_updates();
+
+		$this->assertCount( $pending_count, $this->pending_actions(), 'Repeated updates must not grow the pending backlog while an action runs.' );
+	}
+
+	/**
+	 * Existing backlog sizes for a running action.
+	 *
+	 * @return array<string, array{int}>
+	 */
+	public function running_action_provider(): array {
+		return array(
+			'running alone'        => array( 0 ),
+			'running with backlog' => array( 3 ),
+		);
+	}
+
+	/**
+	 * @testdox A pending async upgrade action prevents additional scheduled copies.
+	 */
+	public function test_pending_async_action_prevents_accumulation(): void {
+		$action_id = as_enqueue_async_action( self::HOOK, array(), self::GROUP );
+		$this->assertInstanceOf( \ActionScheduler_NullSchedule::class, ActionScheduler::store()->fetch_action( $action_id )->get_schedule() );
+		$this->assertTrue( as_next_scheduled_action( self::HOOK, array(), self::GROUP ) );
+		$this->assertNull( WC()->queue()->get_next( self::HOOK, array(), self::GROUP ) );
+
+		$this->fire_updates();
+
+		$this->assertSame( array( $action_id ), $this->pending_actions(), 'Pending async work must prevent another copy even without a scheduled date.' );
+	}
+
+	/**
+	 * @testdox Repeated updates schedule one action when there is no active upgrade work.
+	 * @dataProvider finished_action_provider
+	 *
+	 * @param string|null $status Existing finished action status, or null for an empty queue.
+	 */
+	public function test_schedules_after_finished_work( ?string $status ): void {
+		if ( null !== $status ) {
+			$action_id = as_schedule_single_action( time() - 60, self::HOOK, array(), self::GROUP );
+			$store     = ActionScheduler::store();
+			if ( ActionScheduler_Store::STATUS_COMPLETE === $status ) {
+				$store->mark_complete( $action_id );
+			} elseif ( ActionScheduler_Store::STATUS_FAILED === $status ) {
+				$store->mark_failure( $action_id );
+			} else {
+				$store->cancel_action( $action_id );
+			}
+		}
+
+		$this->fire_updates();
+
+		$this->assertCount( 1, $this->pending_actions(), 'There should be exactly one fresh action after repeated updates.' );
+	}
+
+	/**
+	 * Inactive queue states that allow a fresh action.
+	 *
+	 * @return array<string, array{string|null}>
+	 */
+	public function finished_action_provider(): array {
+		return array(
+			'empty'     => array( null ),
+			'completed' => array( ActionScheduler_Store::STATUS_COMPLETE ),
+			'failed'    => array( ActionScheduler_Store::STATUS_FAILED ),
+			'canceled'  => array( ActionScheduler_Store::STATUS_CANCELED ),
+		);
+	}
+
+	/**
+	 * @testdox An ordinary pending action prevents duplicate upgrade work.
+	 */
+	public function test_pending_scheduled_action_prevents_accumulation(): void {
+		$action_id = as_schedule_single_action( time() + 60, self::HOOK, array(), self::GROUP );
+
+		$this->fire_updates();
+
+		$this->assertSame( array( $action_id ), $this->pending_actions(), 'The existing pending action should be reused.' );
+	}
+
+	/**
+	 * @testdox Pending and running work with a different hook, arguments or group does not suppress upgrade work.
+	 * @dataProvider unrelated_action_provider
+	 *
+	 * @param string $hook  The unrelated action's hook.
+	 * @param array  $args  The unrelated action's arguments.
+	 * @param string $group The unrelated action's group.
+	 */
+	public function test_unrelated_work_does_not_suppress_scheduling( string $hook, array $args, string $group ): void {
+		$action_id = as_schedule_single_action( time() - 60, $hook, $args, $group );
+		ActionScheduler::store()->log_execution( $action_id );
+		as_schedule_single_action( time() - 30, $hook, $args, $group );
+
+		$this->fire_updates();
+
+		$this->assertCount( 1, $this->pending_actions(), 'Only work matching the exact hook, arguments and group should suppress scheduling.' );
+	}
+
+	/**
+	 * Actions differing in exactly one part of the engine's scope.
+	 *
+	 * @return array<string, array{string, array, string}>
+	 */
+	public function unrelated_action_provider(): array {
+		return array(
+			'different hook'  => array( 'unrelated_upgrade_action', array(), self::GROUP ),
+			'different args'  => array( self::HOOK, array( 'unrelated' ), self::GROUP ),
+			'different group' => array( self::HOOK, array(), 'unrelated-upgrade-group' ),
+		);
+	}
+
+	/**
+	 * @testdox Replacement queues control scheduling through the existing queue interface.
+	 * @dataProvider replacement_queue_provider
+	 *
+	 * @param string|null $active_status Existing active work, or null for an empty queue.
+	 */
+	public function test_replacement_queue_controls_scheduling( ?string $active_status ): void {
+		$queue         = $this->createMock( WC_Queue_Interface::class );
+		$should_create = null === $active_status;
+		$queue->expects( $this->never() )->method( 'get_next' );
+		$queue->method( 'search' )->willReturnCallback(
+			function ( array $args, string $return_format ) use ( &$active_status ): array {
+				$this->assertContains( $args['status'], array( ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING ), 'Replacement queues receive a scalar status.' );
+				$this->assertSame( self::HOOK, $args['hook'] );
+				$this->assertSame( array(), $args['args'] );
+				$this->assertSame( self::GROUP, $args['group'] );
+				$this->assertSame( 1, $args['per_page'] );
+				$this->assertSame( 'ids', $return_format );
+				return $active_status === $args['status'] ? array( 123 ) : array();
+			}
+		);
+		$queue->expects( $should_create ? $this->once() : $this->never() )
+			->method( 'schedule_single' )
+			->with( $this->isType( 'int' ), self::HOOK, array(), self::GROUP )
+			->willReturnCallback(
+				function () use ( &$active_status ): int {
+					$active_status = ActionScheduler_Store::STATUS_PENDING;
+					return 123;
+				}
+			);
+		$original_queue = WC()->queue();
+		$instance       = new \ReflectionProperty( WC_Queue::class, 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, $queue );
+		try {
+			$this->fire_updates();
+		} finally {
+			$instance->setValue( null, $original_queue );
+		}
+	}
+
+	/**
+	 * Active states exposed by a replacement queue.
+	 *
+	 * @return array<string, array{string|null}>
+	 */
+	public function replacement_queue_provider(): array {
+		return array(
+			'empty'   => array( null ),
+			'pending' => array( ActionScheduler_Store::STATUS_PENDING ),
+			'running' => array( ActionScheduler_Store::STATUS_RUNNING ),
+		);
+	}
+
+	/**
+	 * Fire repeated upgrade events while the queue is not being drained.
+	 */
+	private function fire_updates(): void {
+		for ( $i = 0; $i < 10; $i++ ) {
+			do_action( 'woocommerce_updated' );
+		}
+	}
+
+	/**
+	 * Get all pending upgrade actions in the engine's exact scope.
+	 *
+	 * @return array<int>
+	 */
+	private function pending_actions(): array {
+		$action_ids = as_get_scheduled_actions(
+			array(
+				'hook'     => self::HOOK,
+				'args'     => array(),
+				'group'    => self::GROUP,
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+		return array_map( 'intval', $action_ids );
+	}
+}

--- a/sdd/task-95-upgrade-action-pileup/notes.md
+++ b/sdd/task-95-upgrade-action-pileup/notes.md
@@ -1,0 +1,99 @@
+# Stop upgrade inbox action accumulation
+
+## Problem
+
+Task: Stop the woocommerce_run_on_woocommerce_admin_updated pile-up during upgrade. Closes <https://github.com/woocommerce/woocommerce/issues/48414>.
+
+Reproduced on the provisioned wp-env site at localhost:8796, WooCommerce 11.2.0-dev and Action Scheduler 4.1.0, before production changes. Seeded 1,000 overdue unrelated actions and one overdue target action. Ten `woocommerce_updated` events with the target pending left one pending copy. Ran the target through `ActionScheduler_QueueRunner::process_action()` in one PHP process, holding its callback while a second PHP process fired ten update events. Pending target copies increased from zero to ten, one per event, while one target was running. Every lookup returned `as_next=true`, `wc_next=null`. The runner completed normally and left ten pending copies.
+
+The guard is present in tag 8.9.3 and commit 4c9bcbc30e (2023-05-09, PR #38159). It fails because Action Scheduler checks running actions before pending actions, so a running match masks even an existing pending backlog. WC_Action_Queue::get_next converts only numeric results to WC_DateTime, discarding boolean true. Pending NullSchedule actions share this blind spot. Before initialization AS returns false, but scheduling also returns zero, so that condition alone does not explain accumulation.
+
+This establishes a reproducible mechanism, not proof of the original merchant's full upgrade loop or why their update events repeated. PR #49243 fixes a separate premature-shutdown cleanup problem.
+
+## Approach
+
+Fix the engine's existence decision using queue operations that recognize pending and running work, including async work, without changing WC_Queue_Interface or WC_Action_Queue::get_next's WC_DateTime|null contract. Prefer the existing search API over adding a required interface method or bypassing custom queues. Keep schedule_single and hook/args/group unchanged. Do not invent a date for boolean results or broaden get_next to boolean. Do not perform a repository-wide caller migration or backlog deletion. The existing check-then-insert concurrency race between independent producers is outside this reproduced running-action issue.
+
+Blast radius: 13 production get_next call sites across 10 files; AnalyticsImports calls format/getTimestamp on the result. Queue replacement is supported via woocommerce_queue_class. Preserve these contracts and document the scoped consumer change and remaining manual tests in the draft PR.
+
+## Tasks
+
+- [x] Add failing scheduling regressions in `plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php`: initialize the engine with isolated hooks, create real Action Scheduler records, fire repeated `woocommerce_updated` events while a matching action is running (both alone and with pending copies), and assert no additional pending work; cover pending async `NullSchedule` work too. Acceptance: the running and async cases fail against the current guard for the reproduced reason; fixtures and hooks are restored. Dependencies: none.
+- [x] Replace the engine's timestamp-based existence decision in `plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php`: query the existing queue `search()` API for pending and running actions using separate scalar statuses, exact hook/empty args/group, `per_page => 1`, and `ids`; return immediately on either match, otherwise keep the existing `schedule_single()` call. Explain briefly why a date lookup misses running/async actions. Acceptance: regression tests pass; no interface, `get_next()`, callback signature, or scheduling payload changes; no AS-only helper bypasses replacement queues. Dependencies: first task.
+- [x] Complete boundary coverage in `plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php`: verify repeated events without active work schedule exactly one copy, ordinary pending work blocks duplicates, completed/failed/canceled work permits a fresh copy, and unrelated hooks/args/groups do not suppress the target. Exercise a replacement queue through its existing `search()` and `schedule_single()` API with scalar status filters. Acceptance: focused container PHPUnit passes and tests verify observable scheduling behavior. Dependencies: second task.
+- [x] Validate and record results in `sdd/task-95-upgrade-action-pileup/notes.md`: replay the original two-process wp-env reproduction with the same unrelated backlog and held callback; verify pending count stays zero while running, existing pending copies do not increase, and one later event schedules a new copy after completion. Run focused engine and existing inbox/queue PHPUnit coverage inside wp-env, both required PHP lint commands, and PHPStan on changed PHP files. Acceptance: before/after evidence is recorded, all applicable checks pass without baseline additions, and reproduction fixtures are cleaned up. Dependencies: third task.
+- [x] Add `plugins/woocommerce/changelog/fix-upgrade-inbox-action-pileup` and finalize review evidence in `sdd/task-95-upgrade-action-pileup/notes.md`: record preserved external queue/date contracts, bounded query cost, unchanged check-then-insert race, original merchant reproduction limits, and remaining actual-upgrade/high-volume/multisite/custom-queue manual testing. Acceptance: SDD review clears findings and draft PR material includes the task quote, issue closure, historical guard explanation, measured reproduction, scoped change, and validation limits. Dependencies: fourth task.
+
+## Implementation Notes
+
+### Validation profile
+
+- PHPUnit: `pnpm test:php:env -- --filter '<focused classes>'` inside plugins/woocommerce, then relevant queue and inbox coverage.
+- Lint: `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch`.
+- Types: `composer exec -- phpstan analyse <modified PHP files> --memory-limit=2G` inside plugins/woocommerce; no baseline additions.
+- QA: replay the two-process reproduction before and after; cover pending async and initialization behavior.
+- Review: SDD reviewer with WooCommerce code-review and performance guidance. No repo-level subagents found.
+- Browser available through CUA; no UI changes expected, so WP-CLI is the relevant QA surface.
+- Repo skills: backend-dev, performance, dev-cycle, local-env, markdown, git-commit, git-draft-pr.
+
+### Investigation
+
+- Used the provisioned wp-env site without changing its port overrides.
+- Real Action Scheduler store and runner used, no mocked statuses or queue results in the reproduction. The callback was deliberately held open to make the concurrency window deterministic.
+
+### Iteration 1
+
+#### Implementation
+
+- Added the isolated engine scheduling test class and ran it before changing production code. The container run failed all three regression cases: running alone accumulated 10 pending actions instead of zero; running with three pending copies accumulated 13 instead of three; a pending NullSchedule action accumulated additional scheduled copies. The real stored running/async records returned `as_next_scheduled_action() === true` and `get_next() === null` as expected.
+- Replaced only the engine's existence lookup with scalar pending and running searches using exact hook, empty arguments, group, one ID per query, and early return on a match. `schedule_single()` and all shared queue/date contracts remain unchanged. Searches use the existing replacement-queue API and never load full actions in production.
+- Added boundary coverage for ordinary pending work, empty queues, completed/failed/canceled work, and independent hook/argument/group mismatches. A stateful test double of the existing queue interface controls whether scheduling is allowed for empty, pending and running states. Test hooks and database state use the parent test case's restoration, and replacement queue state is restored in `finally`.
+- Focused validation passed inside the provisioned container: `pnpm test:php:env -- --filter RemoteInboxNotificationsEngineTest`, PHPUnit 9.6.35 on PHP 8.1.34, 14 tests and 269 assertions. The parent run owns live replay, broader validation and final delivery.
+
+#### Live QA
+
+- Replayed the exact two-process fixture after the fix: 1,000 overdue unrelated actions; ten pending-only updates left one target; real runner callback held open while ten independent-process updates left zero pending targets throughout. The runner completed normally. Ten later events created exactly one fresh pending target.
+- Pending async fixture: before the fix, one NullSchedule action grew to eleven pending actions after ten events; after the fix it remained one. Regression tests cover the async failure without assuming every event must create another action, since equal scheduled-date ordering can expose a dated copy after one is inserted.
+- Forced only the Action Scheduler initialized flag false temporarily: initialized=0, as_next=false, schedule_result=0, pending=0. Restored the flag immediately. This is a controlled API-state probe, not an actual failed-upgrade reproduction.
+- Confirmed the same running-first/boolean implementation in Action Scheduler tag 3.7.4, the reporter's version. get_next's numeric conversion was intentional in ebb8ced803dd (2020) to let new webhook states queue while an earlier delivery is running.
+- Fixtures were removed using their exact hook/group IDs; no old pending jobs were repaired or deleted as part of the product fix. PHPUnit resets this disposable site's plugin activation; WooCommerce was reactivated before live replay.
+
+#### Validation limitations
+
+- The staged diff lint passes with no errors or warnings. Before commit, branch lint cannot retrieve the newly added test from HEAD and emits NoCodeFound; it was rerun after commit and passed with no changed-code errors or warnings. Full-file PHPCS finds only the existing missing strict_types declaration on the unchanged first line of the engine; adding it could change unrelated runtime semantics, so it is left unchanged.
+- Production PHPStan passes. An attempted source-and-test invocation reports only unresolved WC_Unit_Test_Case and inherited test methods because the repository's PHPStan configuration covers source/includes, not the test framework. No baseline or configuration was changed to hide those errors. Tests are validated through container PHPUnit and PHPCS.
+
+#### Validator results
+
+- Linter: PASS on staged PHP diff and final committed branch diff, including the new test. Required `lint:php:changes` also exited zero (no unstaged files). JavaScript branch lint correctly reports no changed files.
+- Types: PASS for production PHP, no errors. Test-inclusive PHPStan limitations are documented above.
+- Tests: PASS, 198 tests and 512 assertions across the requested focused filter (169/473), existing inbox coverage (10/15), and existing webhook coverage (19/24). Entire WooCommerce suite and multisite were not run.
+- QA: PASS for the controlled two-process and async reproductions. After all tests, WooCommerce was reactivated and the site was verified at localhost:8796 with zero reproduction backlog and zero active target actions.
+- Reviewer: PASS. The full code review pipeline returned APPROVE with zero findings from six specialists; the independent decision critic returned STAND. Reviews covered code correctness, queue contracts, concurrency, performance, PHP tests, and WooCommerce regressions. The changelog was also checked. No implementation revision was required.
+
+### Final Summary
+
+#### Key Decisions
+
+- Reproduced the running-action blind spot before changing production code. The existing guard predates the report; boolean `true` from Action Scheduler becomes `null` in the queue's date lookup, and running work masks pending copies.
+- Changed only the engine's existence decision to bounded pending/running searches through the existing queue API. Preserved `WC_Queue_Interface`, `get_next()` return types, replacement-queue support, and scheduling payloads. Existing duplicate actions and the independent check-then-insert race remain outside scope.
+
+#### Deviations from Spec
+
+- No implementation deviations. Test-inclusive PHPStan could not resolve the repository's test framework; production PHPStan passed, and container PHPUnit plus changed-code PHPCS validated the tests without baseline changes.
+
+#### Status
+
+- Completed 5 of 5 tasks in 1 implementation-loop iteration. Exit reason: success.
+- The 14 new tests passed with 269 assertions after demonstrating the expected failures. Combined targeted coverage passed: 198 tests, 512 assertions. Staged and post-commit branch lint passed; production PHPStan passed.
+- Full review verdict: APPROVE, six specialists, zero findings; independent decision critic: STAND.
+
+#### Evidence
+
+- With 1,000 overdue unrelated actions and a real running target, ten update events increased pending targets from zero to ten before the fix and left zero after it. Later events scheduled exactly one new target after completion.
+- Ten events increased the pending async fixture from one to eleven before the fix and left one after it. The controlled uninitialized-state probe scheduled nothing. Reproduction fixtures were removed and site activation restored.
+- Evidence is textual in this log and prepared PR material. Local working artifacts belong in ignored `artifacts/task-95/evidence`; no screenshots or GIFs were needed.
+
+#### Remaining manual validation
+
+- An actual historical upgrade with the reporter's repeated-update trigger, Action Scheduler High Volume with two threads, multisite, and real third-party replacement queues. The controlled reproduction establishes the mechanism, not the original merchant's complete loop. The entire WooCommerce suite was not run.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

> Task: Stop the woocommerce_run_on_woocommerce_admin_updated pile-up during upgrade. Closes https://github.com/woocommerce/woocommerce/issues/48414.

Repeated upgrade events add a new inbox update action while an existing copy is running, even when pending copies already exist. The engine now searches for pending and running work through the existing WooCommerce queue API before scheduling, including pending async actions without a date.

The null guard already existed in 8.9.3 and commit 4c9bcbc30e (2023-05-09). Action Scheduler's `as_next_scheduled_action()` checks RUNNING first and returns `true`, masking pending copies; `WC_Action_Queue::get_next()` converts only numeric results to dates and returns `null` for that boolean. The July 2024 formatting change did not introduce this behavior. A pending `NullSchedule` also returns `true`. Before AS initialization, lookup returns `false` but scheduling returns `0`, so that condition alone did not create a backlog.

**Backward compatibility:** `WC_Queue_Interface` and `get_next()` remain unchanged. Before this change, 13 production call sites used its documented `WC_DateTime|null` return, including date dereferences in AnalyticsImports. Its treatment of running actions was intentional for webhooks. This consumer uses existing `search()` and `schedule_single()` methods on the selected queue, including externally supplied implementations, with scalar status values and at most one matching ID per query. No required interface method, hook signature, action arguments, or group changed. The intended behavior change is that running/async inbox updates suppress redundant scheduling.

**Scope:** This reproduces the action accumulation mechanism, not the historical merchant's entire upgrade failure or the source of repeated update events. It does not drain existing duplicates or make check-then-insert atomic between simultaneous producers. #49243 concerns separate premature-shutdown cleanup. Queue searches remain site scoped, with no new global or install-path dependency; multisite has not been manually tested.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #48414.
Closes WOOPLUG-2294

Bug introduced in PR #38159, which restored the executable update hook and empty argument matching used by this reproduction. The date-only queue semantics predate that change (ebb8ced803dd, 2020).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Use a disposable wp-env site with no existing `woocommerce_run_on_woocommerce_admin_updated` actions. Run the commands below with WP-CLI inside that site's container (`pnpm wp-env:test run cli wp ...` from `plugins/woocommerce`).

1. Seed a backlog and one target action:

```bash
wp eval '$h="woocommerce_run_on_woocommerce_admin_updated"; $g="woocommerce-remote-inbox-engine"; for($i=0;$i<1000;$i++){as_schedule_single_action(time()-7200,"task95_backlog",array($i),"task95-reproduction");} as_schedule_single_action(time()-3600,$h,array(),$g); for($i=0;$i<10;$i++){do_action("woocommerce_updated");} echo ActionScheduler::store()->query_actions(array("hook"=>$h,"group"=>$g,"status"=>ActionScheduler_Store::STATUS_PENDING),"count");'
```

Both branches should have one pending target after these ten updates.

2. In terminal A, run that target and deliberately hold its real callback open:

```bash
wp eval '$h="woocommerce_run_on_woocommerce_admin_updated"; $g="woocommerce-remote-inbox-engine"; add_action($h,static function(){echo "RUNNING - execute terminal B now\n"; sleep(30);},1); $id=ActionScheduler::store()->query_action(array("hook"=>$h,"group"=>$g,"status"=>ActionScheduler_Store::STATUS_PENDING)); ActionScheduler_QueueRunner::instance()->process_action($id,"task95-reproduction");'
```

3. Once terminal A prints RUNNING, execute in terminal B:

```bash
wp eval '$h="woocommerce_run_on_woocommerce_admin_updated"; $g="woocommerce-remote-inbox-engine"; for($i=1;$i<=10;$i++){do_action("woocommerce_updated"); echo $i . ": " . ActionScheduler::store()->query_actions(array("hook"=>$h,"group"=>$g,"status"=>ActionScheduler_Store::STATUS_PENDING),"count") . " pending\n";}'
```

Before the fix, pending copies grow from 1 through 10. After the fix, pending copies remain at 0 throughout the running window. Once terminal A completes, another update should enqueue one action, and repeated updates should leave exactly that one pending.

4. On a clean fixture, seed `as_enqueue_async_action($h, array(), $g)` instead of a dated action and repeat ten update events. Before the fix, additional pending copies can accumulate (eleven in the recorded live run; equal-date ordering can stop growth earlier). After the fix there is exactly one.
5. Run the regression tests with `pnpm test:php:env -- --filter RemoteInboxNotificationsEngineTest` from `plugins/woocommerce`.
6. Remove only these disposable fixture actions when finished. Existing completed, failed, and canceled actions must not block a fresh update; different hooks, arguments, and groups must not block it either.

Still needs manual testing: a full historical upgrade with Action Scheduler High Volume configured for two runners, the original merchant's plugin/object-cache combination, multisite, and real third-party queue replacements. The controlled reproduction holds the callback open to expose the running window deterministically.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- **Reproduced before editing production code:** single-site wp-env at localhost:8796, WooCommerce 11.2.0-dev, Action Scheduler 4.1.0, PHP 8.1.34. Seeded 1,000 overdue unrelated actions plus one target. A real queue runner executed the target in one PHP process; another process fired ten upgrade events while the callback was held open.

| Controlled scenario | Before | After |
| --- | --- | --- |
| Ten updates, one dated target pending | 1 pending | 1 pending |
| Ten updates while one target runs | 0 -> 1 -> 2 -> ... -> 10 pending | 0 pending throughout |
| Ten updates with one pending NullSchedule | 1 -> 11 pending in the recorded live run | 1 pending |
| Ten updates after target completion | Not needed for diagnosis | Exactly 1 new pending |

- In the running window, `as_next_scheduled_action()` returned `true` and `WC()->queue()->get_next()` returned `null` on every event. The async regression test also verifies growth without assuming a particular tie order for equal scheduled dates.
- Confirmed running-first lookup and boolean return behavior in [Action Scheduler 3.7.4 source](https://github.com/woocommerce/action-scheduler/blob/3.7.4/functions.php), and confirmed the guard in WooCommerce tag 8.9.3. The old versions were inspected, not installed for this runtime reproduction.
- Three new regression cases failed before the source fix (running alone: 10 pending instead of 0; running with three pending copies: 13 instead of 3; async work: additional copies). The final new class passes 14 tests / 269 assertions.
- **198 focused and related tests / 512 assertions passed** via `pnpm test:php:env`: new scheduling tests, existing inbox engine/SpecRunner/transformers, remote-spec rules, queue and webhook tests. PHPUnit 9.6.35, PHP 8.1.34. The entire WooCommerce PHP suite was not run.
- Staged PHP diff lint and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` pass with no changed-code errors or warnings. Production PHPStan passes. A test-inclusive PHPStan attempt cannot resolve the test framework under the repository's production-only configuration; tests were checked with PHPUnit and PHPCS instead. No baseline changes.
- All reproduction action fixtures were removed. Verified zero fixture backlog and zero active target actions; reactivated WooCommerce after the test bootstrap reset.
- Full code review completed with six specialist approvals, zero findings, and an independent final decision check. No implementation revision was required.
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually using the changelog CLI: `plugins/woocommerce/changelog/fix-upgrade-inbox-action-pileup`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex investigated, reproduced, implemented, tested, and reviewed this change.
