### PR TITLE
Use View Config for Product settings layout

### DIFF
--- a/packages/js/settings-ui/changelog/add-view-config-layouts
+++ b/packages/js/settings-ui/changelog/add-view-config-layouts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support WordPress View Config layouts in the settings UI.

--- a/packages/js/settings-ui/package.json
+++ b/packages/js/settings-ui/package.json
@@ -38,10 +38,13 @@
 		"@woocommerce/sanitize": "workspace:*",
 		"@wordpress/admin-ui": "catalog:wp-bundled",
 		"@wordpress/components": "catalog:wp-min",
+		"@wordpress/core-data": "catalog:wp-min",
+		"@wordpress/data": "catalog:wp-min",
 		"@wordpress/dataviews": "17.1.0",
 		"@wordpress/date": "catalog:wp-min",
 		"@wordpress/element": "catalog:wp-min",
-		"@wordpress/i18n": "catalog:wp-min"
+		"@wordpress/i18n": "catalog:wp-min",
+		"@wordpress/views": "1.11.0"
 	},
 	"devDependencies": {
 		"@babel/core": "catalog:tooling",

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -816,6 +816,11 @@ const SettingsUIPageContent = ( {
 					{ saveNotice.message }
 				</Notice>
 			) : null }
+			{ viewConfigDecision.source === 'view-config' ? (
+				<Notice status="info" isDismissible={ false }>
+					{ __( 'This page uses View Config.', 'woocommerce' ) }
+				</Notice>
+			) : null }
 			<div className="wc-settings-ui">
 				<DataForm
 					data={ values }

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -33,6 +33,11 @@ import type {
 	SettingsValues,
 } from './types';
 import { areValuesEqual } from './values';
+import { selectViewConfigLayout } from './view-config';
+import {
+	useViewConfigRuntime,
+	type ViewConfigRuntimeResult,
+} from './view-config-runtime';
 
 type SaveNotice = {
 	status: 'success' | 'error';
@@ -432,14 +437,19 @@ const ShellHeader = ( {
 	);
 };
 
-export const SettingsUIPage = ( {
-	schema,
-	page,
-	section,
-}: {
+type SettingsUIPageProps = {
 	schema: SettingsUISchema;
 	page?: string;
 	section?: string;
+};
+
+const SettingsUIPageContent = ( {
+	schema,
+	page,
+	section,
+	viewConfigRuntime,
+}: SettingsUIPageProps & {
+	viewConfigRuntime: ViewConfigRuntimeResult;
 } ) => {
 	const [ initialValues, setInitialValues ] = useState< SettingsValues >(
 		() => getInitialValues( schema )
@@ -694,6 +704,20 @@ export const SettingsUIPage = ( {
 		[ dataFormAdapter, values ]
 	);
 	const allFields = useMemo( () => getAllFields( schema ), [ schema ] );
+	const knownFieldIds = useMemo(
+		() => new Set( allFields.map( ( field ) => field.id ) ),
+		[ allFields ]
+	);
+	const viewConfigDecision = useMemo(
+		() =>
+			selectViewConfigLayout( {
+				request: schema.viewConfig || { supported: false },
+				runtime: viewConfigRuntime,
+				localForm: dataForm,
+				knownFieldIds,
+			} ),
+		[ dataForm, knownFieldIds, schema.viewConfig, viewConfigRuntime ]
+	);
 	const fieldsById = useMemo(
 		() => new Map( allFields.map( ( field ) => [ field.id, field ] ) ),
 		[ allFields ]
@@ -746,6 +770,26 @@ export const SettingsUIPage = ( {
 			</Button>
 		) : undefined;
 
+	if ( viewConfigDecision.status === 'loading' ) {
+		return (
+			<ShellHeader
+				schema={ schema }
+				context={ context }
+				values={ values }
+				initialValues={ initialValues }
+			>
+				<div
+					className="wc-settings-ui wc-settings-ui--loading"
+					role="status"
+					aria-live="polite"
+					aria-busy="true"
+				>
+					{ __( 'Loading settings…', 'woocommerce' ) }
+				</div>
+			</ShellHeader>
+		);
+	}
+
 	return (
 		<ShellHeader
 			schema={ schema }
@@ -776,7 +820,7 @@ export const SettingsUIPage = ( {
 				<DataForm
 					data={ values }
 					fields={ dataFormAdapter.fields }
-					form={ dataForm }
+					form={ viewConfigDecision.form }
 					onChange={ handleDataFormChange }
 				/>
 				{ ! showHeader && saveButton ? (
@@ -800,5 +844,43 @@ export const SettingsUIPage = ( {
 				</div>
 			) : null }
 		</ShellHeader>
+	);
+};
+
+const ViewConfigSettingsUIPage = ( props: SettingsUIPageProps ) => {
+	const request = props.schema.viewConfig as {
+		supported: true;
+		kind: string;
+		name: string;
+		version: number;
+	};
+	const runtime = useViewConfigRuntime( {
+		kind: request.kind,
+		name: request.name,
+	} );
+
+	return <SettingsUIPageContent { ...props } viewConfigRuntime={ runtime } />;
+};
+
+export const SettingsUIPage = ( props: SettingsUIPageProps ) => {
+	const request = props.schema.viewConfig;
+	const hasIdentity =
+		request?.supported &&
+		typeof request.kind === 'string' &&
+		Boolean( request.kind ) &&
+		typeof request.name === 'string' &&
+		Boolean( request.name ) &&
+		typeof request.version === 'number';
+
+	return hasIdentity ? (
+		<ViewConfigSettingsUIPage { ...props } />
+	) : (
+		<SettingsUIPageContent
+			{ ...props }
+			viewConfigRuntime={ {
+				status: 'resolved',
+				config: request?.supported ? {} : undefined,
+			} }
+		/>
 	);
 };

--- a/packages/js/settings-ui/src/test/settings-ui-page-view-config.test.tsx
+++ b/packages/js/settings-ui/src/test/settings-ui-page-view-config.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { ReactNode } from 'react';
+
+jest.mock( '@wordpress/admin-ui', () => ( {
+	NavigableRegion: ( {
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	} ) => <div className={ className }>{ children }</div>,
+} ) );
+
+const useViewConfigRuntime = jest.fn();
+
+jest.mock( '../view-config-runtime', () => ( {
+	useViewConfigRuntime: ( request: unknown ) =>
+		useViewConfigRuntime( request ),
+} ) );
+
+jest.mock( '../diagnostics', () => ( {
+	error: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { SettingsUIPage } from '../settings-ui-page';
+import type { SettingsUISchema } from '../types';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const schema: SettingsUISchema = {
+	id: 'products',
+	section: 'default',
+	save: { adapter: 'form_post' },
+	viewConfig: {
+		supported: true,
+		kind: 'woocommerce-settings',
+		name: 'products:default',
+		version: 1,
+	},
+	groups: {
+		contact: {
+			id: 'contact',
+			fields: [
+				{
+					id: 'email',
+					label: 'Email',
+					type: 'text',
+					value: 'old@example.com',
+				},
+				{
+					id: 'phone',
+					label: 'Phone',
+					type: 'text',
+					value: '555-0100',
+				},
+			],
+		},
+	},
+};
+
+const validConfig = {
+	kind: 'woocommerce-settings',
+	name: 'products:default',
+	version: 1,
+	form: { fields: [ { id: 'contact', children: [ 'email' ] } ] },
+};
+
+const renderPage = () => {
+	const form = document.createElement( 'form' );
+	form.id = 'mainform';
+	document.body.appendChild( form );
+	const container = document.createElement( 'div' );
+	form.appendChild( container );
+	const root = createRoot( container );
+
+	// eslint-disable-next-line testing-library/no-unnecessary-act
+	act( () => root.render( <SettingsUIPage schema={ schema } /> ) );
+
+	return { container, form, root };
+};
+
+describe( 'SettingsUIPage View Config', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'mounts the local form after a delayed request failure', () => {
+		useViewConfigRuntime.mockReturnValue( { status: 'loading' } );
+		const { container, root } = renderPage();
+
+		useViewConfigRuntime.mockReturnValue( {
+			status: 'failed',
+			error: new Error( 'Forbidden' ),
+		} );
+		// eslint-disable-next-line testing-library/no-unnecessary-act
+		act( () => root.render( <SettingsUIPage schema={ schema } /> ) );
+
+		expect(
+			container.querySelectorAll( 'input:not([type="hidden"])' )
+		).toHaveLength( 2 );
+		expect(
+			container.querySelectorAll( '.woocommerce-save-button' )
+		).toHaveLength( 1 );
+		act( () => root.unmount() );
+	} );
+
+	it( 'uses the local form when the remote layout adds an unknown field', () => {
+		useViewConfigRuntime.mockReturnValue( {
+			status: 'resolved',
+			config: {
+				...validConfig,
+				form: {
+					fields: [ { id: 'contact', children: [ 'unknown' ] } ],
+				},
+			},
+		} );
+		const { container, root } = renderPage();
+
+		expect(
+			container.querySelectorAll( 'input:not([type="hidden"])' )
+		).toHaveLength( 2 );
+		act( () => root.unmount() );
+	} );
+
+	it( 'keeps omitted field values in the form-post bridge', () => {
+		useViewConfigRuntime.mockReturnValue( {
+			status: 'resolved',
+			config: validConfig,
+		} );
+		const { container, form, root } = renderPage();
+
+		expect(
+			container.querySelectorAll( 'input:not([type="hidden"])' )
+		).toHaveLength( 1 );
+		expect( form.querySelector( 'input[name="phone"]' ) ).toHaveValue(
+			'555-0100'
+		);
+
+		act( () => root.unmount() );
+	} );
+} );

--- a/packages/js/settings-ui/src/test/settings-ui-page-view-config.test.tsx
+++ b/packages/js/settings-ui/src/test/settings-ui-page-view-config.test.tsx
@@ -109,6 +109,9 @@ describe( 'SettingsUIPage View Config', () => {
 		expect(
 			container.querySelectorAll( '.woocommerce-save-button' )
 		).toHaveLength( 1 );
+		expect( container ).not.toHaveTextContent(
+			'This page uses View Config.'
+		);
 		act( () => root.unmount() );
 	} );
 
@@ -127,6 +130,9 @@ describe( 'SettingsUIPage View Config', () => {
 		expect(
 			container.querySelectorAll( 'input:not([type="hidden"])' )
 		).toHaveLength( 2 );
+		expect( container ).not.toHaveTextContent(
+			'This page uses View Config.'
+		);
 		act( () => root.unmount() );
 	} );
 
@@ -143,6 +149,7 @@ describe( 'SettingsUIPage View Config', () => {
 		expect( form.querySelector( 'input[name="phone"]' ) ).toHaveValue(
 			'555-0100'
 		);
+		expect( container ).toHaveTextContent( 'This page uses View Config.' );
 
 		act( () => root.unmount() );
 	} );

--- a/packages/js/settings-ui/src/types.ts
+++ b/packages/js/settings-ui/src/types.ts
@@ -100,12 +100,20 @@ export type SettingsUIShell = {
 	navigationComponent?: string;
 };
 
+export type SettingsUIViewConfig = {
+	supported: boolean;
+	kind?: string;
+	name?: string;
+	version?: number;
+};
+
 export type SettingsUISchema = {
 	id: string;
 	title?: string;
 	section?: string;
 	save?: SettingsUISaveStrategy;
 	shell?: SettingsUIShell;
+	viewConfig?: SettingsUIViewConfig;
 	groups: Record< string, SettingsUIGroup >;
 };
 

--- a/packages/js/settings-ui/src/view-config-runtime.ts
+++ b/packages/js/settings-ui/src/view-config-runtime.ts
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useViewConfig } from '@wordpress/views';
+
+const VIEW_CONFIG_TIMEOUT_MS = 5000;
+
+export type ViewConfigRuntimeResult =
+	| { status: 'loading' }
+	| { status: 'failed'; error: unknown }
+	| { status: 'resolved'; config: unknown };
+
+type ResolutionSelectors = {
+	hasFinishedResolution: (
+		selectorName: string,
+		args: readonly unknown[]
+	) => boolean;
+	getResolutionError: (
+		selectorName: string,
+		args: readonly unknown[]
+	) => unknown;
+};
+
+/**
+ * Keep the WordPress View Config and resolution APIs private so callers only
+ * depend on terminal states that WooCommerce controls.
+ */
+export const useViewConfigRuntime = ( {
+	kind,
+	name,
+}: {
+	kind: string;
+	name: string;
+} ): ViewConfigRuntimeResult => {
+	const config = useViewConfig( { kind, name } );
+	const { hasFinished, resolutionError } = useSelect(
+		( select ) => {
+			const selectors = select(
+				coreStore
+			) as unknown as ResolutionSelectors;
+			const args = [ kind, name ] as const;
+
+			return {
+				hasFinished: selectors.hasFinishedResolution(
+					'getViewConfig',
+					args
+				),
+				resolutionError: selectors.getResolutionError(
+					'getViewConfig',
+					args
+				),
+			};
+		},
+		[ kind, name ]
+	);
+	const identity = `${ kind }\u0000${ name }`;
+	const [ timedOutIdentity, setTimedOutIdentity ] = useState< string >();
+	const hasTimedOut = timedOutIdentity === identity;
+
+	useEffect( () => {
+		if ( hasFinished || hasTimedOut || resolutionError ) {
+			return undefined;
+		}
+
+		const timeout = window.setTimeout(
+			() => setTimedOutIdentity( identity ),
+			VIEW_CONFIG_TIMEOUT_MS
+		);
+
+		return () => window.clearTimeout( timeout );
+	}, [ hasFinished, hasTimedOut, identity, resolutionError ] );
+
+	return useMemo( () => {
+		if ( resolutionError ) {
+			return { status: 'failed', error: resolutionError };
+		}
+
+		if ( hasTimedOut ) {
+			return {
+				status: 'failed',
+				error: new Error( 'view_config_timeout' ),
+			};
+		}
+
+		if ( ! hasFinished ) {
+			return { status: 'loading' };
+		}
+
+		return { status: 'resolved', config };
+	}, [ config, hasFinished, hasTimedOut, resolutionError ] );
+};

--- a/packages/js/settings-ui/src/view-config.ts
+++ b/packages/js/settings-ui/src/view-config.ts
@@ -14,6 +14,7 @@ export type ViewConfigLayoutDecision =
 	| {
 			status: 'ready';
 			form: Form;
+			source: 'local' | 'view-config';
 	  };
 
 type ViewConfigResponse = {
@@ -142,7 +143,7 @@ export const selectViewConfigLayout = ( {
 	knownFieldIds: ReadonlySet< string >;
 } ): ViewConfigLayoutDecision => {
 	if ( ! request.supported ) {
-		return { status: 'ready', form: localForm };
+		return { status: 'ready', form: localForm, source: 'local' };
 	}
 
 	if ( runtime.status === 'loading' ) {
@@ -150,7 +151,7 @@ export const selectViewConfigLayout = ( {
 	}
 
 	if ( runtime.status === 'failed' ) {
-		return { status: 'ready', form: localForm };
+		return { status: 'ready', form: localForm, source: 'local' };
 	}
 
 	const response = isObject( runtime.config )
@@ -166,6 +167,6 @@ export const selectViewConfigLayout = ( {
 			: undefined;
 
 	return form
-		? { status: 'ready', form }
-		: { status: 'ready', form: localForm };
+		? { status: 'ready', form, source: 'view-config' }
+		: { status: 'ready', form: localForm, source: 'local' };
 };

--- a/packages/js/settings-ui/src/view-config.ts
+++ b/packages/js/settings-ui/src/view-config.ts
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import type { Form, FormField } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { SettingsUIViewConfig } from './types';
+import type { ViewConfigRuntimeResult } from './view-config-runtime';
+
+export type ViewConfigLayoutDecision =
+	| { status: 'loading' }
+	| {
+			status: 'ready';
+			form: Form;
+	  };
+
+type ViewConfigResponse = {
+	kind?: unknown;
+	name?: unknown;
+	version?: unknown;
+	form?: unknown;
+};
+
+const isObject = ( value: unknown ): value is Record< string, unknown > =>
+	typeof value === 'object' && value !== null && ! Array.isArray( value );
+
+const LAYOUT_TYPES = new Set( [
+	'regular',
+	'panel',
+	'card',
+	'row',
+	'details',
+] );
+
+const hasValidLayout = ( value: Record< string, unknown > ) =>
+	typeof value.layout === 'undefined' ||
+	( isObject( value.layout ) &&
+		typeof value.layout.type === 'string' &&
+		LAYOUT_TYPES.has( value.layout.type ) );
+
+const getValidForm = (
+	form: unknown,
+	knownFieldIds: ReadonlySet< string >
+): Form | undefined => {
+	if (
+		! isObject( form ) ||
+		! Array.isArray( form.fields ) ||
+		! hasValidLayout( form )
+	) {
+		return undefined;
+	}
+
+	if ( form.fields.length === 0 ) {
+		return undefined;
+	}
+
+	const seenIds = new Set< string >();
+	const normalizedGroups: FormField[] = [];
+	for ( const group of form.fields ) {
+		if (
+			! isObject( group ) ||
+			typeof group.id !== 'string' ||
+			! group.id ||
+			! Array.isArray( group.children ) ||
+			group.children.length === 0 ||
+			! hasValidLayout( group )
+		) {
+			return undefined;
+		}
+
+		if ( seenIds.has( group.id ) ) {
+			return undefined;
+		}
+
+		seenIds.add( group.id );
+		const normalizedChildren: Array< FormField | string > = [];
+
+		for ( const leaf of group.children ) {
+			const id =
+				typeof leaf === 'string' ? leaf : isObject( leaf ) && leaf.id;
+
+			if (
+				typeof id !== 'string' ||
+				! id ||
+				( isObject( leaf ) &&
+					( 'children' in leaf || ! hasValidLayout( leaf ) ) ) ||
+				seenIds.has( id ) ||
+				! knownFieldIds.has( id )
+			) {
+				return undefined;
+			}
+
+			seenIds.add( id );
+			normalizedChildren.push(
+				typeof leaf === 'string'
+					? leaf
+					: {
+							id,
+							...( typeof leaf.layout === 'undefined'
+								? {}
+								: {
+										layout: leaf.layout as FormField[ 'layout' ],
+								  } ),
+					  }
+			);
+		}
+
+		normalizedGroups.push( {
+			id: group.id,
+			...( typeof group.label === 'string'
+				? { label: group.label }
+				: {} ),
+			...( typeof group.description === 'string'
+				? { description: group.description }
+				: {} ),
+			...( typeof group.layout === 'undefined'
+				? {}
+				: { layout: group.layout as FormField[ 'layout' ] } ),
+			children: normalizedChildren,
+		} );
+	}
+
+	return {
+		...( typeof form.layout === 'undefined'
+			? {}
+			: { layout: form.layout as Form[ 'layout' ] } ),
+		fields: normalizedGroups,
+	};
+};
+
+export const selectViewConfigLayout = ( {
+	request,
+	runtime,
+	localForm,
+	knownFieldIds,
+}: {
+	request: SettingsUIViewConfig;
+	runtime: ViewConfigRuntimeResult;
+	localForm: Form;
+	knownFieldIds: ReadonlySet< string >;
+} ): ViewConfigLayoutDecision => {
+	if ( ! request.supported ) {
+		return { status: 'ready', form: localForm };
+	}
+
+	if ( runtime.status === 'loading' ) {
+		return { status: 'loading' };
+	}
+
+	if ( runtime.status === 'failed' ) {
+		return { status: 'ready', form: localForm };
+	}
+
+	const response = isObject( runtime.config )
+		? ( runtime.config as ViewConfigResponse )
+		: undefined;
+	const form =
+		response &&
+		response.kind === request.kind &&
+		response.name === request.name &&
+		( typeof request.version === 'undefined' ||
+			response.version === request.version )
+			? getValidForm( response.form, knownFieldIds )
+			: undefined;
+
+	return form
+		? { status: 'ready', form }
+		: { status: 'ready', form: localForm };
+};

--- a/plugins/woocommerce/changelog/add-view-config-product-settings
+++ b/plugins/woocommerce/changelog/add-view-config-product-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Use WordPress View Config for the modern Product settings layout.

--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -378,6 +378,10 @@ const jsConfig = {
 						return null;
 					}
 
+					if ( request === '@wordpress/views' ) {
+						return null;
+					}
+
 					if ( request.startsWith( '@wordpress/theme' ) ) {
 						return null;
 					}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -476,6 +476,17 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 				}
 			}
 
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only request override that changes rendering only.
+			$rendering_mode = isset( $_GET['wc_settings_ui'] ) ? wp_unslash( $_GET['wc_settings_ui'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Type checked and sanitized below.
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+			if (
+				is_string( $rendering_mode )
+				&& 'classic' === sanitize_key( $rendering_mode )
+			) {
+				echo '<div class="notice notice-info inline"><p>' . esc_html__( 'This page uses the classic settings UI.', 'woocommerce' ) . '</p></div>';
+			}
+
 			// We can't use "get_settings_for_section" here
 			// for compatibility with derived classes overriding "get_settings".
 			$settings = $this->get_settings( $section );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1516,6 +1516,7 @@ final class WooCommerce {
 	 */
 	public function register_wp_admin_settings() {
 		$pages = WC_Admin_Settings::get_settings_pages();
+		\Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIViewConfig::register_rest_filter();
 		foreach ( $pages as $page ) {
 			$this->register_wp_admin_settings_for( $page, 'page' );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIRequestContext;
+use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIViewConfig;
 use Automattic\WooCommerce\Internal\Utilities\PriceSeparators;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
@@ -437,8 +438,9 @@ class Settings {
 				return $settings;
 			}
 
-			$page_id     = $context->get_page_id();
-			$section_key = $context->get_current_section_key();
+			$page_id              = $context->get_page_id();
+			$section_key          = $context->get_current_section_key();
+			$schema['viewConfig'] = SettingsUIViewConfig::get_metadata( $page_id, $section_key );
 		} catch ( \Throwable $e ) {
 			return $settings;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
@@ -210,6 +210,45 @@ class SettingsUIRequestContext {
 	}
 
 	/**
+	 * Resolve a context from a normalized page and section identity.
+	 *
+	 * This resolver does not read wp-admin request globals, so REST callbacks can
+	 * build the same schema as an HTML settings request.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param string $page_id Settings page id.
+	 * @param string $section_key Section id, or "default" for the default section.
+	 * @return SettingsUIRequestContext|null
+	 */
+	public static function for_identity( string $page_id, string $section_key ): ?SettingsUIRequestContext {
+		if ( ! self::is_normalized_identity_part( $page_id ) || ! self::is_normalized_identity_part( $section_key ) ) {
+			return null;
+		}
+
+		if ( ! class_exists( '\WC_Admin_Settings' ) ) {
+			return null;
+		}
+
+		$section = self::DEFAULT_SECTION_KEY === $section_key ? '' : $section_key;
+
+		foreach ( \WC_Admin_Settings::get_settings_pages() as $settings_page ) {
+			if ( ! $settings_page instanceof \WC_Settings_Page || $settings_page->get_id() !== $page_id ) {
+				continue;
+			}
+
+			$context = self::for_settings_page( $settings_page, $section );
+			if ( ! $context->get_settings_ui_page() ) {
+				continue;
+			}
+
+			return self::has_section( $settings_page->get_sections(), $section ) ? $context : null;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Reset cached request contexts.
 	 */
 	public static function reset(): void {
@@ -266,6 +305,33 @@ class SettingsUIRequestContext {
 	 */
 	private static function get_section_key( string $section ): string {
 		return '' === $section ? self::DEFAULT_SECTION_KEY : $section;
+	}
+
+	/**
+	 * Check whether an identity part is already in its canonical form.
+	 *
+	 * @param string $part Identity part.
+	 * @return bool
+	 */
+	private static function is_normalized_identity_part( string $part ): bool {
+		return '' !== $part && sanitize_title( $part ) === $part;
+	}
+
+	/**
+	 * Check whether a settings page declares a section.
+	 *
+	 * @param array  $sections Settings sections keyed by section id.
+	 * @param string $section Section id. Empty string means the default section.
+	 * @return bool
+	 */
+	private static function has_section( array $sections, string $section ): bool {
+		foreach ( array_keys( $sections ) as $candidate ) {
+			if ( is_string( $candidate ) && $candidate === $section && ( '' === $candidate || sanitize_title( $candidate ) === $candidate ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -226,6 +226,47 @@ class SettingsUISchema {
 		return self::canonicalize_schema_values_for_source( $schema, true );
 	}
 
+	/**
+	 * Build the layout-only DataForm configuration for a settings schema.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param array $schema Valid Settings UI schema.
+	 * @return array DataForm layout containing group and field identities only.
+	 */
+	public static function get_dataform_layout( array $schema ): array {
+		self::assert_valid_schema( $schema );
+
+		$form_fields = array();
+		foreach ( $schema['groups'] as $group ) {
+			$form_field = array(
+				'id'       => $group['id'],
+				'layout'   => ! empty( $group['title'] )
+					? array(
+						'type'          => 'card',
+						'isCollapsible' => false,
+					)
+					: array(
+						'type'       => 'card',
+						'withHeader' => false,
+					),
+				'children' => array_column( $group['fields'], 'id' ),
+			);
+
+			if ( ! empty( $group['title'] ) ) {
+				$form_field['label'] = $group['title'];
+			}
+
+			if ( ! empty( $group['description'] ) ) {
+				$form_field['description'] = wp_strip_all_tags( html_entity_decode( $group['description'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
+			}
+
+			$form_fields[] = $form_field;
+		}
+
+		return array( 'fields' => $form_fields );
+	}
+
 	// Exception messages are not HTML output. Dynamic values are sanitized once
 	// by invalid_schema() before the exception crosses the schema boundary.
 	// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIViewConfig.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIViewConfig.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Settings UI View Config integration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provides layout-only View Config data for WooCommerce settings.
+ *
+ * @since 11.2.0
+ */
+final class SettingsUIViewConfig {
+
+	/**
+	 * WooCommerce View Config entity kind.
+	 *
+	 * @var string
+	 */
+	private const KIND = 'woocommerce-settings';
+
+	/**
+	 * Products settings page id.
+	 *
+	 * @var string
+	 */
+	private const PAGE_ID = 'products';
+
+	/**
+	 * Identity separator. It cannot occur in a sanitize_title() result.
+	 *
+	 * @var string
+	 */
+	private const IDENTITY_SEPARATOR = ':';
+
+	/**
+	 * Check whether the public WordPress View Config API is available.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @return bool
+	 */
+	public static function is_supported(): bool {
+		return function_exists( 'wp_get_entity_view_config_hook_name' ) && class_exists( '\WP_View_Config_Data' );
+	}
+
+	/**
+	 * Get client metadata for a settings page and section.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param string $page_id Settings page id.
+	 * @param string $section_key Section id, or "default" for the default section.
+	 * @return array View Config support and identity metadata.
+	 */
+	public static function get_metadata( string $page_id, string $section_key ): array {
+		if ( self::PAGE_ID !== $page_id || ! self::is_supported() ) {
+			return array( 'supported' => false );
+		}
+
+		$name = self::get_name( $page_id, $section_key );
+		if ( null === $name ) {
+			return array( 'supported' => false );
+		}
+
+		return array(
+			'supported' => true,
+			'kind'      => self::KIND,
+			'name'      => $name,
+			'version'   => 1,
+		);
+	}
+
+	/**
+	 * Register the request-aware View Config filter loader.
+	 *
+	 * @since 11.2.0
+	 */
+	public static function register_rest_filter(): void {
+		if ( ! self::is_supported() ) {
+			return;
+		}
+
+		add_filter( 'rest_pre_dispatch', array( self::class, 'register_filter_for_request' ), 10, 3 );
+	}
+
+	/**
+	 * Register the View Config filter for a Products request.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param mixed            $response Result to send to the client. Usually null.
+	 * @param \WP_REST_Server  $server REST server instance.
+	 * @param \WP_REST_Request $request Current REST request.
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return mixed Unchanged response.
+	 */
+	public static function register_filter_for_request( $response, \WP_REST_Server $server, \WP_REST_Request $request ) {
+		if ( '/wp/v2/view-config' !== $request->get_route() ) {
+			return $response;
+		}
+
+		$kind = $request->get_param( 'kind' );
+		$name = $request->get_param( 'name' );
+		if ( self::KIND !== $kind || ! is_string( $name ) || null === self::parse_name( $name ) ) {
+			return $response;
+		}
+
+		// @phpstan-ignore-next-line function.notFound (WordPress 7.1 API is guarded by register_rest_filter().)
+		add_filter( wp_get_entity_view_config_hook_name( self::KIND, $name ), array( self::class, 'provide_layout' ), 10, 2 );
+
+		return $response;
+	}
+
+	/**
+	 * Set the WooCommerce-owned form layout for a View Config request.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param mixed $data View Config data container.
+	 * @param array $entity Requested entity identity.
+	 * @return mixed Unchanged or updated View Config data container.
+	 */
+	public static function provide_layout( $data, array $entity ) {
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown -- WooCommerce registers this capability.
+		// @phpstan-ignore-next-line class.notFound (WordPress 7.1 API is guarded by is_supported().)
+		if ( ! self::is_supported() || ! $data instanceof \WP_View_Config_Data || ! current_user_can( 'manage_woocommerce' ) ) {
+			return $data;
+		}
+
+		if ( self::KIND !== ( $entity['kind'] ?? null ) || ! is_string( $entity['name'] ?? null ) ) {
+			return $data;
+		}
+
+		$identity = self::parse_name( $entity['name'] );
+		if ( null === $identity ) {
+			return $data;
+		}
+
+		if ( ! function_exists( 'woocommerce_settings_get_option' ) ) {
+			if ( ! defined( 'WC_ABSPATH' ) ) {
+				return $data;
+			}
+
+			require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
+		}
+
+		$context = SettingsUIRequestContext::for_identity( $identity['page'], $identity['section'] );
+		$schema  = $context ? $context->get_schema() : null;
+		if ( ! is_array( $schema ) ) {
+			return $data;
+		}
+
+		// @phpstan-ignore-next-line class.notFound (WordPress 7.1 API is guarded by is_supported().)
+		return $data->set(
+			array( 'form' => SettingsUISchema::get_dataform_layout( $schema ) ),
+			// @phpstan-ignore-next-line class.notFound (WordPress 7.1 API is guarded by is_supported().)
+			\WP_View_Config_Data::LATEST_VERSION
+		);
+	}
+
+	/**
+	 * Build a canonical page-and-section entity name.
+	 *
+	 * @param string $page_id Settings page id.
+	 * @param string $section_key Section id, or "default" for the default section.
+	 * @return string|null Canonical name, or null for invalid input.
+	 */
+	private static function get_name( string $page_id, string $section_key ): ?string {
+		if ( self::PAGE_ID !== $page_id || ! self::is_normalized_part( $section_key ) ) {
+			return null;
+		}
+
+		return $page_id . self::IDENTITY_SEPARATOR . $section_key;
+	}
+
+	/**
+	 * Parse a canonical page-and-section entity name.
+	 *
+	 * @param string $name Entity name.
+	 * @return array{page: string, section: string}|null Parsed identity, or null when malformed.
+	 */
+	private static function parse_name( string $name ): ?array {
+		$parts = explode( self::IDENTITY_SEPARATOR, $name );
+		if ( 2 !== count( $parts ) || self::PAGE_ID !== $parts[0] || ! self::is_normalized_part( $parts[1] ) ) {
+			return null;
+		}
+
+		return array(
+			'page'    => $parts[0],
+			'section' => $parts[1],
+		);
+	}
+
+	/**
+	 * Check whether an identity part is already in its canonical form.
+	 *
+	 * @param string $part Identity part.
+	 * @return bool
+	 */
+	private static function is_normalized_part( string $part ): bool {
+		return '' !== $part && sanitize_title( $part ) === $part;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -561,6 +561,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 		$this->assertSame( $expected_query, $_GET, 'The override must not alter page or section routing.' );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		$this->assertSame( 'existing-class', $classes );
+		$this->assertStringContainsString( 'This page uses the classic settings UI.', $classic_output );
 		$this->assertStringContainsString( 'name="woocommerce_settings_ui_drill_down_test"', $classic_output );
 		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $classic_output );
 		$this->assertTrue( empty( $GLOBALS['hide_save_button'] ), 'The classic Save button should remain visible.' );
@@ -575,6 +576,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 		$settings_ui_output = ob_get_clean();
 
 		$this->assertStringContainsString( 'data-wc-settings-ui="1"', $settings_ui_output );
+		$this->assertStringNotContainsString( 'This page uses the classic settings UI.', $settings_ui_output );
 		$this->assertTrue( Features::is_enabled( 'settings-ui' ) );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIViewConfigIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIViewConfigIntegrationTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Settings UI View Config integration tests.
+ *
+ * @package WooCommerce\Tests\Internal\Admin\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
+
+use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIViewConfig;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests the Settings UI View Config REST integration.
+ */
+class SettingsUIViewConfigIntegrationTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Should return the Products layout through the public View Config REST route.
+	 */
+	public function test_public_api_returns_the_products_layout(): void {
+		if ( ! SettingsUIViewConfig::is_supported() ) {
+			$this->markTestSkipped( 'WordPress View Config is not available.' );
+		}
+
+		$callback       = array( SettingsUIViewConfig::class, 'register_filter_for_request' );
+		$was_registered = false !== has_filter( 'rest_pre_dispatch', $callback );
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		SettingsUIViewConfig::register_rest_filter();
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/view-config' );
+		$request->set_query_params(
+			array(
+				'kind' => 'woocommerce-settings',
+				'name' => 'products:default',
+			)
+		);
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotEmpty( $data['form']['fields'] ?? array() );
+
+		wp_set_current_user( 0 );
+		if ( ! $was_registered ) {
+			remove_filter( 'rest_pre_dispatch', $callback, 10 );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIViewConfigTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIViewConfigTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Settings UI View Config tests.
+ *
+ * @package WooCommerce\Tests\Internal\Admin\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
+
+use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUISchema;
+use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIViewConfig;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Settings UI View Config integration.
+ */
+class SettingsUIViewConfigTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Should expose no View Config identity when WordPress lacks the public API.
+	 */
+	public function test_metadata_matches_wordpress_support(): void {
+		$metadata = SettingsUIViewConfig::get_metadata( 'products', 'default' );
+		$this->assertSame( array( 'supported' => false ), SettingsUIViewConfig::get_metadata( 'general', 'default' ) );
+
+		if ( SettingsUIViewConfig::is_supported() ) {
+			$this->assertTrue( $metadata['supported'] );
+			$this->assertSame( 'woocommerce-settings', $metadata['kind'] );
+			$this->assertSame( 'products:default', $metadata['name'] );
+			$this->assertSame( 1, $metadata['version'] );
+		} else {
+			$this->assertSame( array( 'supported' => false ), $metadata, 'Unsupported sites must not receive a request identity.' );
+		}
+	}
+
+	/**
+	 * @testdox Should convert the Woo schema to a layout with existing field ids only.
+	 */
+	public function test_builds_layout_only_form_from_schema(): void {
+		$schema = array(
+			'id'      => 'products',
+			'title'   => 'Products',
+			'section' => 'default',
+			'save'    => array( 'adapter' => 'form_post' ),
+			'shell'   => array( 'title' => 'Products' ),
+			'groups'  => array(
+				'product_options' => array(
+					'id'          => 'product_options',
+					'title'       => 'Product options',
+					'description' => '<p>Choose product units.</p>',
+					'fields'      => array(
+						array(
+							'id'        => 'woocommerce_weight_unit',
+							'type'      => 'select',
+							'label'     => 'Weight unit',
+							'value'     => 'kg',
+							'component' => 'unsafe-component',
+						),
+					),
+				),
+			),
+		);
+
+		$form = SettingsUISchema::get_dataform_layout( $schema );
+
+		$this->assertSame(
+			array(
+				'fields' => array(
+					array(
+						'id'          => 'product_options',
+						'layout'      => array(
+							'type'          => 'card',
+							'isCollapsible' => false,
+						),
+						'children'    => array( 'woocommerce_weight_unit' ),
+						'label'       => 'Product options',
+						'description' => 'Choose product units.',
+					),
+				),
+			),
+			$form,
+			'The View Config form should contain only layout and existing identities.'
+		);
+		$this->assertStringNotContainsString( 'unsafe-component', wp_json_encode( $form ) );
+		$this->assertStringNotContainsString( 'value', wp_json_encode( $form ) );
+		$this->assertStringNotContainsString( 'nonce', wp_json_encode( $form ) );
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2293,6 +2293,12 @@ importers:
       '@wordpress/components':
         specifier: catalog:wp-min
         version: 30.6.5(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/core-data':
+        specifier: catalog:wp-min
+        version: 7.33.9(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/data':
+        specifier: catalog:wp-min
+        version: 10.33.1(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/dataviews':
         specifier: 17.1.0
         version: 17.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
@@ -2305,6 +2311,9 @@ importers:
       '@wordpress/i18n':
         specifier: catalog:wp-min
         version: 6.6.1
+      '@wordpress/views':
+        specifier: 1.11.0
+        version: 1.11.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
     devDependencies:
       '@babel/core':
         specifier: catalog:tooling


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Use the public WordPress View Config API to supply the DataForm layout for the existing modern Product Settings page. The current WooCommerce schema still owns field declarations, values, controls, visibility rules, and saving.

This is a small implementation example for WOOPRD-3613. It supports the Product settings sections only. General Settings, Accounts & Privacy, and other settings pages are not enabled in this PR. A separate local experiment also tested Accounts & Privacy, and it rendered as expected.

The client validates the returned identity, layout types, and field IDs. It uses the existing local layout when View Config is unavailable, denied, delayed, or invalid. Classic settings are unchanged.

Known View Config API limitation: WordPress protects the REST route with `edit_posts`, while WooCommerce protects settings with `manage_woocommerce`. A user with only `manage_woocommerce` can receive a denied View Config request. In that case, this implementation uses the local layout and the page continues to work.

This change is additive. It does not remove or change public WooCommerce hooks, settings IDs, save behavior, or classic rendering. It does not change site-scoped data or multisite behavior. Because it changes the admin runtime and uses a public WordPress API, it needs an independent human review.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

No visual change is expected. The Product Settings page keeps the current DataForm layout; the source of that layout changes to View Config.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use a WordPress version that includes the public View Config API and enable the WooCommerce Settings UI feature.
2. Open **WooCommerce > Settings > Products**. Check the General, Inventory, and Downloadable products sections.
3. Confirm that each section renders with its current fields and layout. In the browser network tools, confirm that the page requests `/wp/v2/view-config` with kind `woocommerce-settings` and the matching `products:<section>` name.
4. Change a safe Product setting, save it, and reload the page. Confirm that the value persists.
5. Add `wc_settings_ui=classic` to the URL. Confirm that the classic Product Settings page still renders and saves.
6. Test on an older WordPress version, or deny the View Config request. Confirm that the modern Product Settings page uses its local layout and remains usable.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused Jest tests pass: request failure fallback, invalid field fallback, and hidden value preservation.
- Settings UI TypeScript checks pass.
- Settings UI ESLint checks pass for the changed files.
- The Settings UI package build passes.
- PHP syntax checks pass for all changed PHP files.
- Direct PHPCS checks pass for the new PHP class and tests.
- PHPStan passes for the new View Config integration class.
- Branch PHP lint passes. Branch JavaScript lint has no errors and reports 13 existing warnings in `webpack.config.js`.
- The Product Inventory page rendered in the local WordPress environment. A separate broader experiment also confirmed that Accounts & Privacy rendered correctly through View Config.
- The PHP REST integration test was added but did not run locally because the Docker test environment did not start.
- The full Settings UI Jest suite did not complete in this worktree because the local package store exposed an existing ESM transform problem. The focused new test suite passes.
- Codex helped write the code, tests, review, and this PR draft. I reviewed the scope and validation results. An external Claude review was attempted, but it could not read the worktree and produced no findings.

### Post-Deploy Monitoring & Validation

During release candidate testing, check the default, Inventory, and Downloadable products sections. A blank page, missing field, or failed save is a regression. There is no dedicated metric or log for this path. If a regression occurs, disable the Settings UI feature or use `wc_settings_ui=classic` while the Settings team investigates.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually for WooCommerce Core and `@woocommerce/settings-ui`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex helped write the implementation, tests, review, and PR draft. The author reviewed the scope and validation results.
