### PR TITLE
Force LF line endings for shell scripts, patches and .mjs/.cjs/.yaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 *.md    text    eol=lf
 *.json  text    eol=lf
 *.yml   text    eol=lf
+*.yaml  text    eol=lf
 
 # Force LF In Code Files
 *.php   text    eol=lf
@@ -11,6 +12,13 @@
 *.jsx   text    eol=lf
 *.ts    text    eol=lf
 *.tsx   text    eol=lf
+*.mjs   text    eol=lf
+*.cjs   text    eol=lf
 *.css   text    eol=lf
 *.scss  text    eol=lf
 *.flf   text    eol=lf
+
+# Force LF In Files Executed Or Parsed By Build Tooling
+# Shell scripts fail with CRLF, and `git apply` rejects patches with CRLF hunks.
+*.sh    text    eol=lf
+*.patch text    eol=lf


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`.gitattributes` sets `* text=auto` and forces `eol=lf` for 11 extensions, but misses several types the build tooling executes or parses. On Windows those fall back to `core.eol` (native, CRLF) and the build breaks.

| Extension | Tracked files | Why it needs LF |
| --- | --- | --- |
| `.sh` | 66 | Invoked directly, e.g. `sh ./client/blocks/bin/copy-blocks-json.sh` in `test:php:env`. CRLF fails on the shebang line. |
| `.patch` | 9 | `packages/js/internal-build` applies these with `git apply`, which rejects CRLF hunks. |
| `.mjs` | 59 | Consistency with the existing `.js`/`.cjs` handling. |
| `.cjs` | 4 | Same. |
| `.yaml` | 3 | Consistency with the existing `.yml` rule. |

The `.patch` gap blocks `pnpm install` outright:

```
build:project:type-overrides: Failed to apply patch type-overrides\@wordpress\block-editor.patch
error: packages/js/internal-build/type-overrides/@wordpress/block-editor/index.d.ts: patch does not apply
```

The change is additive and follows the convention already used for `.php`, `.js` and `.json`. `CONTRIBUTING.md` already asks contributors to use LF endings, so this enforces the documented intent for the remaining file types.

Closes #68564.

### Screenshots or screen recordings:

Not applicable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

On Windows, or on any platform by simulating the Windows default:

1. `git config core.autocrlf true` in a clone of this branch.
2. Delete and re-checkout an affected file: `rm packages/js/internal-build/type-overrides/@wordpress/block-editor.patch && git checkout -- packages/js/internal-build/type-overrides/@wordpress/`
3. Confirm it comes back with LF endings: `file packages/js/internal-build/type-overrides/@wordpress/block-editor.patch` should not report "CRLF line terminators".
4. Repeat step 2 against `trunk` and confirm the same file does report CRLF there.
5. Run `pnpm install` and confirm the `internal-build` type-overrides step reports "Applied patch" for all five patches rather than "patch does not apply".

<!-- End testing instructions -->

### Testing that has already taken place:

Found while setting up a first-time development environment on Windows 11 (pnpm 10.33.0, Node 24.21.0, Git for Windows with the default `core.autocrlf=true`). `pnpm install` failed at the `internal-build` postinstall with the error above. Setting `core.autocrlf=false` and `core.eol=lf` locally and re-checking-out the five `.patch` files fixed it, and `pnpm install` then completed and applied all five patches.

The extension counts in the table come from `git ls-files "*.<ext>" | wc -l` against `trunk`.

One consequence worth flagging for reviewers: `.gitattributes` changes only take effect on checkout, so contributors with an existing clone will need to re-checkout the affected files (for example `git rm --cached -r . && git reset --hard`) before they see the change. New clones get it automatically.

I have not verified the `.sh` failure end to end on a fresh Windows clone; that one is included because it is the same root cause and the scripts are invoked directly by package scripts. If reviewers would rather keep this PR to `.patch` alone, I am happy to narrow it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
