### PR TITLE
Fix product responses crashing after a global attribute is deleted

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-273-stale-attribute-readers
+++ b/plugins/woocommerce/changelog/fix-wooairr-273-stale-attribute-readers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep product responses, admin variation screens and CSV exports working for products loaded before one of their global attributes is deleted in the same request.

--- a/plugins/woocommerce/changelog/fix-wooairr-273-stale-attribute-readers
+++ b/plugins/woocommerce/changelog/fix-wooairr-273-stale-attribute-readers
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Keep product responses, admin variation screens and CSV exports working for products loaded before one of their global attributes is deleted in the same request.
+Keep product responses, admin variation screens and CSV exports working after one of a product's global attributes is deleted.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -50,7 +50,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 							<?php /* translators: WooCommerce attribute label */ ?>
 							<option value=""><?php echo esc_html( sprintf( __( 'No default %s&hellip;', 'woocommerce' ), wc_attribute_label( $attribute->get_name() ) ) ); ?></option>
 							<?php if ( $attribute->is_taxonomy() ) : ?>
-								<?php foreach ( $attribute->get_terms() as $option ) : ?>
+								<?php foreach ( (array) $attribute->get_terms() as $option ) : ?>
 									<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 									<option <?php selected( $selected_value, $option->slug ); ?> value="<?php echo esc_attr( $option->slug ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option->name, $option, $attribute->get_name(), $product_object ) ); ?></option>
 									<?php /* phpcs:enable */ ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -37,7 +37,7 @@ defined( 'ABSPATH' ) || exit;
 					?>
 				</option>
 				<?php if ( $attribute->is_taxonomy() ) : ?>
-					<?php foreach ( $attribute->get_terms() as $option ) : ?>
+					<?php foreach ( (array) $attribute->get_terms() as $option ) : ?>
 						<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 						<option <?php selected( $selected_value, $option->slug ); ?> value="<?php echo esc_attr( $option->slug ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option->name, $option, $attribute->get_name(), $product_object ) ); ?></option>
 						<?php /* phpcs:enable */ ?>

--- a/plugins/woocommerce/includes/class-wc-product-attribute.php
+++ b/plugins/woocommerce/includes/class-wc-product-attribute.php
@@ -61,15 +61,19 @@ class WC_Product_Attribute implements ArrayAccess {
 	/**
 	 * Get taxonomy object.
 	 *
+	 * Returns null when the attribute is not a taxonomy, or when its global attribute is no longer loaded, for example right after it is deleted.
+	 *
 	 * @return array|null
 	 */
 	public function get_taxonomy_object() {
 		global $wc_product_attributes;
-		return $this->is_taxonomy() ? $wc_product_attributes[ $this->get_name() ] : null;
+		return $this->is_taxonomy() && isset( $wc_product_attributes[ $this->get_name() ] ) ? $wc_product_attributes[ $this->get_name() ] : null;
 	}
 
 	/**
 	 * Gets terms from the stored options.
+	 *
+	 * Returns null when the attribute is not a taxonomy, or when its taxonomy is not registered, for example right after the attribute is deleted.
 	 *
 	 * @return array|null
 	 */

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -714,7 +714,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 						$row[ 'attributes:name' . $i ] = html_entity_decode( wc_attribute_label( $attribute->get_name(), $product ), ENT_QUOTES );
 
 						if ( $attribute->is_taxonomy() ) {
-							$terms  = $attribute->get_terms();
+							$terms  = (array) $attribute->get_terms();
 							$values = array();
 
 							foreach ( $terms as $term ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -338,7 +338,10 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	 * @return string
 	 */
 	protected function get_attribute_taxonomy_label( $name ) {
-		$tax    = get_taxonomy( $name );
+		$tax = get_taxonomy( $name );
+		if ( ! $tax ) {
+			return wc_attribute_taxonomy_slug( $name );
+		}
 		$labels = get_taxonomy_labels( $tax );
 
 		return $labels->singular_name;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -601,7 +601,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return     string
 	 */
 	protected function get_attribute_taxonomy_label( $name ) {
-		$tax    = get_taxonomy( $name );
+		$tax = get_taxonomy( $name );
+		if ( ! $tax ) {
+			return wc_attribute_taxonomy_slug( $name );
+		}
 		$labels = get_taxonomy_labels( $tax );
 
 		return $labels->singular_name;
@@ -640,7 +643,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 		// Taxonomy attribute name.
 		if ( $attribute->is_taxonomy() ) {
 			$taxonomy = $attribute->get_taxonomy_object();
-			return $taxonomy->attribute_label;
+			return $taxonomy ? $taxonomy->attribute_label : $slug;
 		}
 
 		// Custom product attribute name.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4281,7 +4281,7 @@ function wc_display_product_attributes( $product ) {
 			foreach ( $attribute_values as $attribute_value ) {
 				$value_name = esc_html( $attribute_value->name );
 
-				if ( $attribute_taxonomy->attribute_public ) {
+				if ( $attribute_taxonomy && $attribute_taxonomy->attribute_public ) {
 					$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
 				} else {
 					$values[] = $value_name;

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -19057,12 +19057,6 @@ parameters:
 			path: includes/export/abstract-wc-csv-exporter.php
 
 		-
-			message: '#^Argument of an invalid type array\|null supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: includes/export/class-wc-product-csv-exporter.php
-
-		-
 			message: '#^Argument of an invalid type array\|stdClass supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -24673,12 +24667,6 @@ parameters:
 			path: includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
 
 		-
-			message: '#^Parameter \#1 \$tax of function get_taxonomy_labels expects WP_Taxonomy, WP_Taxonomy\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
-
-		-
 			message: '#^Parameter \#1 \$title of function sanitize_title expects string, array\|string given\.$#'
 			identifier: argument.type
 			count: 2
@@ -26840,12 +26828,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$sku of method WC_Product\:\:set_sku\(\) expects string, array\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
-
-		-
-			message: '#^Parameter \#1 \$tax of function get_taxonomy_labels expects WP_Taxonomy, WP_Taxonomy\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -84,7 +84,7 @@ class ProductSpecifications extends AbstractBlock {
 					foreach ( $attribute_values as $attribute_value ) {
 						$value_name = esc_html( $attribute_value->name );
 
-						if ( $attribute_taxonomy->attribute_public ) {
+						if ( $attribute_taxonomy && $attribute_taxonomy->attribute_public ) {
 							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
 						} else {
 							$values[] = $value_name;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -892,7 +892,7 @@ class ProductSchema extends AbstractSchema {
 				continue;
 			}
 
-			$terms = $attribute->is_taxonomy() ? array_map( [ $this, 'prepare_product_attribute_taxonomy_value' ], $attribute->get_terms() ) : array_map( [ $this, 'prepare_product_attribute_value' ], $attribute->get_options() );
+			$terms = $attribute->is_taxonomy() ? array_map( [ $this, 'prepare_product_attribute_taxonomy_value' ], (array) $attribute->get_terms() ) : array_map( [ $this, 'prepare_product_attribute_value' ], $attribute->get_options() );
 			// Custom attribute names are sanitized to be the array keys.
 			// So when we do the array_key_exists check below we also need to sanitize the attribute names.
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-attribute-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-attribute-test.php
@@ -1,0 +1,52 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the WC_Product_Attribute class.
+ *
+ * @package WooCommerce\Tests\Includes
+ */
+class WC_Product_Attribute_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox get_taxonomy_object() returns null without a warning after the global attribute is deleted.
+	 */
+	public function test_get_taxonomy_object_returns_null_without_warning_after_attribute_deletion(): void {
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$this->assertSame( 'Stale Finish', $attribute->get_taxonomy_object()->attribute_label, 'The taxonomy object should be available before the deletion.' );
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		$warnings = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		try {
+			$taxonomy_object = $attribute->get_taxonomy_object();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertNull( $taxonomy_object );
+		$this->assertSame( array(), $warnings, 'Reading the taxonomy object of a deleted attribute should not raise a warning.' );
+	}
+
+	/**
+	 * @testdox get_terms() still returns null after the attribute taxonomy is unregistered.
+	 */
+	public function test_get_terms_returns_null_after_attribute_deletion(): void {
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$this->assertCount( 1, $attribute->get_terms(), 'The attribute should have its term before the deletion.' );
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		$this->assertNull( $attribute->get_terms(), 'Callers rely on null to detect a taxonomy that is not registered.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
+++ b/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
@@ -203,4 +203,41 @@ class WC_Product_CSV_Exporter_Test extends \WC_Unit_Test_Case {
 			}
 		}
 	}
+
+	/**
+	 * @testdox Exporting a product loaded before its global attribute is deleted leaves the value empty without a warning.
+	 */
+	public function test_export_row_for_product_loaded_before_its_global_attribute_is_deleted(): void {
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$product   = new WC_Product_Simple();
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+		$product = wc_get_product( $product->get_id() );
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		$exporter          = new WC_Product_CSV_Exporter();
+		$generate_row_data = ( new ReflectionClass( WC_Product_CSV_Exporter::class ) )->getMethod( 'generate_row_data' );
+		$generate_row_data->setAccessible( true );
+		$warnings = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		try {
+			$row = $generate_row_data->invoke( $exporter, $product );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $warnings, 'Exporting the product should not raise warnings.' );
+		$this->assertSame( '', $row['attributes:value1'] );
+		$this->assertSame( 1, $row['attributes:taxonomy1'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller-tests.php
@@ -1,6 +1,8 @@
 <?php
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Internal\Caches\ProductCache;
+
 /**
  * Tests for the REST API v1 products controller.
  *
@@ -52,6 +54,49 @@ class WC_REST_Products_V1_Controller_Test extends WC_REST_Unit_Test_Case {
 		$this->assertSame( array(), $warnings, 'Serializing the product should not raise warnings.' );
 		$data = $response->get_data();
 		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['attributes'], 'name' ) );
+		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['default_attributes'], 'name' ) );
+	}
+
+	/**
+	 * @testdox Getting a product whose global attribute was deleted in an earlier request uses the attribute slug as its default attribute name.
+	 */
+	public function test_get_item_for_product_whose_global_attribute_was_deleted_in_an_earlier_request(): void {
+		update_option( 'woocommerce_feature_product_instance_caching_enabled', 'yes' );
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$product   = new WC_Product_Variable();
+		$product->set_name( 'Stale attribute product' );
+		$product->set_attributes( array( $attribute ) );
+		$product->set_default_attributes( array( $attribute->get_name() => 'matte' ) );
+		$product->save();
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		// Drop every copy of the product so the request below reads it from the database, the way a later request would.
+		wc_get_container()->get( ProductCache::class )->flush();
+		wp_cache_flush();
+
+		$warnings = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		try {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->get_id() ) );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $warnings, 'Serializing the product should not raise warnings.' );
+		$data = $response->get_data();
+		// A fresh read drops the deleted attribute, but the default attribute stays in post meta.
+		$this->assertSame( array(), $data['attributes'] );
 		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['default_attributes'], 'name' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller-tests.php
@@ -1,0 +1,57 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the REST API v1 products controller.
+ *
+ * @package WooCommerce\Tests\RestApi
+ */
+class WC_REST_Products_V1_Controller_Test extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Set up an administrator for the requests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * @testdox Getting a product loaded before its global attribute is deleted uses the attribute slug as its name.
+	 */
+	public function test_get_item_for_product_loaded_before_its_global_attribute_is_deleted(): void {
+		update_option( 'woocommerce_feature_product_instance_caching_enabled', 'yes' );
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$product   = new WC_Product_Variable();
+		$product->set_name( 'Stale attribute product' );
+		$product->set_attributes( array( $attribute ) );
+		$product->set_default_attributes( array( $attribute->get_name() => 'matte' ) );
+		$product->save();
+		wc_get_product( $product->get_id() );
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		$warnings = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		try {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->get_id() ) );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $warnings, 'Serializing the product should not raise warnings.' );
+		$data = $response->get_data();
+		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['attributes'], 'name' ) );
+		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['default_attributes'], 'name' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -466,4 +466,53 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 404, $response->get_status(), 'Variations should be handled by the variations endpoint.' );
 		$this->assertSame( 'woocommerce_rest_invalid_product_id', $response->get_data()['code'] );
 	}
+
+	/**
+	 * @testdox Getting a product loaded before its global attribute is deleted uses the attribute slug as its name.
+	 */
+	public function test_get_item_for_product_loaded_before_its_global_attribute_is_deleted(): void {
+		update_option( 'woocommerce_feature_product_instance_caching_enabled', 'yes' );
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$product   = new WC_Product_Variable();
+		$product->set_name( 'Stale attribute product' );
+		$product->set_attributes( array( $attribute ) );
+		$product->set_default_attributes( array( $attribute->get_name() => 'matte' ) );
+		$product->save();
+		wc_get_product( $product->get_id() );
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		$warnings = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		try {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $warnings, 'Serializing the product should not raise warnings.' );
+		$data = $response->get_data();
+		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['attributes'], 'name' ) );
+		$this->assertSame( array( 'stale-finish' ), wp_list_pluck( $data['default_attributes'], 'name' ) );
+	}
+
+	/**
+	 * @testdox The deprecated get_attribute_taxonomy_label() returns the attribute slug for a taxonomy that is not registered.
+	 */
+	public function test_deprecated_attribute_taxonomy_label_for_unregistered_taxonomy(): void {
+		$get_label = new ReflectionMethod( WC_REST_Products_V2_Controller::class, 'get_attribute_taxonomy_label' );
+		$get_label->setAccessible( true );
+
+		$this->assertSame( 'not-registered', $get_label->invoke( $this->endpoint, 'pa_not-registered' ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -278,4 +278,46 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertSame( 'page/%#%/', $pagination_args['format'] );
 		$this->assertStringContainsString( 'href="https://example.test/shop/"', $markup );
 	}
+
+	/**
+	 * @testdox wc_display_product_attributes() renders term names when the taxonomy is registered but missing from the global attribute list.
+	 */
+	public function test_display_product_attributes_without_global_attribute_entry(): void {
+		global $wc_product_attributes;
+
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$product   = new WC_Product_Simple();
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$taxonomy        = $attribute->get_name();
+		$taxonomy_object = $wc_product_attributes[ $taxonomy ];
+		unset( $wc_product_attributes[ $taxonomy ] );
+		$warnings     = array();
+		$buffer_level = ob_get_level();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		ob_start();
+		try {
+			wc_display_product_attributes( $product );
+			$markup = (string) ob_get_clean();
+		} finally {
+			restore_error_handler();
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
+			$wc_product_attributes[ $taxonomy ] = $taxonomy_object;
+		}
+
+		$this->assertSame( array(), $warnings, 'Rendering the attributes should not raise warnings.' );
+		$this->assertStringContainsString( 'Matte', $markup );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -941,4 +941,44 @@ class Products extends ControllerTestCase {
 		$this->assertEquals( 404, $response->get_status() );
 		$this->assertFalse( get_transient( 'wc_related_' . $nonexistent_id ), 'No transient should be created for a non-existent product.' );
 	}
+
+	/**
+	 * @testdox Getting a product loaded before its global attribute is deleted returns 200 and the attribute without terms.
+	 */
+	public function test_get_item_for_product_loaded_before_its_global_attribute_is_deleted(): void {
+		update_option( 'woocommerce_feature_product_instance_caching_enabled', 'yes' );
+		$attribute = \WC_Helper_Product::create_product_attribute_object( 'Stale Finish', array( 'Matte' ) );
+		$product   = new \WC_Product_Simple();
+		$product->set_name( 'Stale attribute product' );
+		$product->set_status( ProductStatus::PUBLISH );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+		wc_get_product( $product->get_id() );
+
+		wc_delete_attribute( $attribute->get_id() );
+
+		$warnings = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Capturing the warning is the assertion; PHPUnit would otherwise convert it to an exception.
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting -- Reads the level only, to skip warnings silenced with @.
+				if ( error_reporting() & $errno ) {
+					$warnings[] = $errstr;
+				}
+				return true;
+			}
+		);
+		try {
+			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_id() ) );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $warnings, 'Serializing the product should not raise warnings.' );
+		$attributes = $response->get_data()['attributes'];
+		$this->assertCount( 1, $attributes, 'The cached product still carries the deleted attribute for the rest of the request.' );
+		$this->assertSame( $attribute->get_name(), $attributes[0]->taxonomy );
+		$this->assertSame( array(), $attributes[0]->terms );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Refs WOOAIRR-273.

(For Bug Fixes) Bug introduced in PR #68212, except the REST v1 default attribute crash below, which is older.

Product responses no longer crash when one of a product's global attributes has been deleted.

**Why**

Deleting a global attribute leaves references behind, and several readers assume the taxonomy is still registered.

Since #68212, the delete unregisters the taxonomy right away, which is intended. A product loaded earlier in that request still carries the attribute, and with product instance caching on, the default for new stores, any later `wc_get_product()` returns such an object.

The default attribute outlives the request too. A fresh read drops the deleted attribute, but nothing cleans it out of `_default_attributes` post meta, and REST v1 resolves that meta key straight against the taxonomy registry. This one predates #68212.

**What broke**

Same request, for a product loaded before the delete:

- The Store API products endpoint threw an uncaught `TypeError`.
- The REST v1 products endpoint threw a fatal `Error`.
- REST v2 and v3 returned the attribute name as `null`, with PHP warnings.
- The admin variation screens and the CSV exporter logged PHP warnings.

Every later request, for a variable product with a default attribute set: REST v1 threw a fatal `Error`.

**What changed**

- Each reader now checks for the missing taxonomy before using it.
- The three PHPStan baseline entries these checks resolve are removed.

**What stays the same**

- No signature, hook or return value changes. Every check does nothing for a registered taxonomy.
- What #68212 intended: the taxonomy is gone after the delete, and the deletion hook still fires first.
- The stale `_default_attributes` meta. These checks stop it crashing reads, they do not clean it up.

**Trade-offs**

- A response shows a deleted attribute with its slug as the name and no terms. Before, it crashed or returned `null`.
- Not tested on multisite.

<details>
<summary>Code: nine one-line checks at the readers of a deleted attribute</summary>

- `WC_Product_Attribute::get_taxonomy_object()` checks that the global entry exists.
- The Store API product schema, the two admin variation views and the CSV exporter cast `get_terms()` to an array. `get_terms()` itself still returns `null` for a missing taxonomy.
- The REST v1 and v2 label helpers, and the v2 attribute name, fall back to the attribute slug, matching v3.
- `wc_display_product_attributes()` and the Product Specifications block check for `null`.
</details>

This changes REST responses and code in `includes/`, so it needs an independent human review. Over to a reviewer.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Each numbered step below has to run as its own request. `wc_create_attribute()` does not register the taxonomy, so the attribute only exists as a taxonomy from the next request on, and the last failure only shows up once the product is read fresh from the database.

1. Run the new tests and confirm they pass:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'WC_Product_Attribute_Test|_loaded_before_its_global_attribute_is_deleted|_deleted_in_an_earlier_request|test_display_product_attributes_without_global_attribute_entry|test_deprecated_attribute_taxonomy_label_for_unregistered_taxonomy'
    ```

2. Create a global attribute:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval 'var_dump( wc_create_attribute( array( "name" => "Stale check", "slug" => "stale-check" ) ) );'
    ```

3. In a new request, create a variable product that uses it as a default attribute, and note the printed product ID as `<product_id>`:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '$t = wp_insert_term( "Red", "pa_stale-check" ); $a = new WC_Product_Attribute(); $a->set_id( wc_attribute_taxonomy_id_by_name( "stale-check" ) ); $a->set_name( "pa_stale-check" ); $a->set_options( array( $t["term_id"] ) ); $a->set_visible( true ); $a->set_variation( true ); $p = new WC_Product_Variable(); $p->set_name( "Stale check product" ); $p->set_attributes( array( $a ) ); $p->set_default_attributes( array( "pa_stale-check" => "red" ) ); echo $p->save(), "\n";'
    ```

4. In a new request, load the product, delete the attribute, then read the product through every API:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp --user=1 eval '$id = <product_id>; wc_get_product( $id )->get_attributes(); wc_delete_attribute( wc_attribute_taxonomy_id_by_name( "stale-check" ) ); foreach ( array( "/wc/store/v1/products/", "/wc/v1/products/", "/wc/v2/products/", "/wc/v3/products/" ) as $route ) { echo $route, " ", rest_do_request( new WP_REST_Request( "GET", $route . $id ) )->get_status(), "\n"; }'
    ```

    - [ ] Confirm all four routes print `200` and no PHP warning or error appears. On trunk, the command stops at the Store API route with `TypeError: array_map(): Argument #2 ($array) must be of type array, null given`.

5. In a new request, with the attribute already deleted, read the product through REST v1 again:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp --user=1 eval '$id = <product_id>; $r = rest_do_request( new WP_REST_Request( "GET", "/wc/v1/products/" . $id ) ); echo "status ", $r->get_status(), "\n"; $d = $r->get_data(); echo "attributes ", wp_json_encode( wp_list_pluck( $d["attributes"], "name" ) ), "\n"; echo "default_attributes ", wp_json_encode( wp_list_pluck( $d["default_attributes"], "name" ) ), "\n";'
    ```

    - [ ] Confirm the command prints `status 200`, then `attributes []`, then `default_attributes ["stale-check"]`. The deleted attribute is gone from the product, and the default attribute left behind in post meta falls back to its slug. On trunk, the command fails with `Fatal error: Uncaught Error: Attempt to assign property "labels" on bool`. Repeating this step keeps failing on trunk.

6. Clean up:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval 'wc_get_product( <product_id> )->delete( true );'
    ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Environment: `wp-env`, PHP 8.1, single site, product instance caching on.

- Each same-request failure reproduced on trunk with a product loaded before the delete. With this change, the Store API and REST v1, v2 and v3 return `200` with the slug as the attribute name, and no warnings.
- The REST v1 later-request failure reproduced on trunk for a variable product with a default attribute set, on a fresh request with the product read from the database. With this change it returns `200`, no attributes, and the default attribute under its slug.
- The admin variation views and the CSV exporter render without warnings.
- The 9 new tests pass, and fail with the checks removed.
- The touched test classes plus the related products suites ran 651 tests. The one error and one skip also happen on trunk without this change: a `TypeError` in `LookupDataStore`, and a test marked flaky.
- `lint:php:changes`, `lint:changes:branch` and a full PHPStan run with an empty cache report nothing.
- Two independent code review passes, plus PR review. The first found the REST v1 same-request path and the review found the later-request one, both included here.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The code, tests, and verification were produced with Claude Code (Anthropic) under my direction, starting from an AI regression-review report on #68212 and including independent adversarial review passes. I reviewed the design, the diff, and the evidence and take responsibility for the result.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)



