### PR TITLE
Fix untrash falling back to pending reported as failed

### DIFF
--- a/plugins/woocommerce/changelog/fix-68518-untrash-invalid-previous-status
+++ b/plugins/woocommerce/changelog/fix-68518-untrash-invalid-previous-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed order notes and trash metadata not being cleaned up when an HPOS order is restored from the trash and its previous status is no longer valid.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2890,7 +2890,7 @@ FROM $order_meta_table
 				)
 			);
 
-			$previous_status = 'pending';
+			$previous_status = OrderInternalStatus::PENDING;
 		} elseif ( $previous_state_is_invalid ) {
 			// If we cannot restore to pending, we should probably stand back and let the merchant intervene some other way.
 			wc_get_logger()->warning(

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -619,6 +619,31 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	}
 
 	/**
+	 * @testdox When the order's previous status is no longer registered, untrash falls back to pending and still reports success.
+	 */
+	public function test_cot_datastore_untrash_falls_back_to_pending_for_invalid_previous_status() {
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = $this->create_complex_cot_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->save();
+
+		$this->sut->trash_order( $order );
+		$this->sut->read( $order );
+
+		// Simulate the plugin that registered the order's previous status being deactivated.
+		$order->update_meta_data( '_wp_trash_meta_status', 'wc-unregistered-status' );
+		$order->save_meta_data();
+
+		$this->sut->read( $order );
+		$result = $this->sut->untrash_order( $order );
+
+		$this->assertTrue( $result, 'untrash_order() should report success on the pending fallback path' );
+		$this->assertSame( OrderStatus::PENDING, $order->get_status() );
+		$this->assertEmpty( $order->get_meta( '_wp_trash_meta_status' ), 'Trash meta should still be cleaned up on the pending fallback path' );
+	}
+
+	/**
 	 * @testdox Notes are still restored on untrash even without a comment-status record.
 	 */
 	public function test_cot_datastore_untrash_restores_notes_with_no_trash_meta_record() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When an HPOS order's previous status is no longer registered (for example, the plugin that provided a custom status was deactivated), untrashing the order set it to `pending`, but a mismatch between the prefixed/non-prefixed status name resulted in the operation being reported as failed and some of the metadata cleanup and order note restore skipped.

This PR fixes the fallback to use `OrderInternalStatus::PENDING` so the check passes and the rest of the restore (meta cleanup, note restoration, and the success return value) runs as expected.

Closes #68518, WOOPLUG-7717.


### How to test the changes in this Pull Request:

1. Enable HPOS: `wp wc hpos enable`.
2. Register a temporary custom order status by adding the snippet below as a must-use plugin (or via the Code Snippets plugin):
   ```php
   add_filter( 'wc_order_statuses', function ( $statuses ) {
       $statuses['wc-custom-status'] = 'Custom status';
       return $statuses;
   } );

   add_action( 'init', function () {
       register_post_status( 'wc-custom-status', array(
           'label'                     => 'Custom status',
           'public'                    => false,
           'exclude_from_search'       => false,
           'show_in_admin_all_list'    => true,
           'show_in_admin_status_list' => true,
           'label_count'               => _n_noop( 'Custom status <span class="count">(%s)</span>', 'Custom status <span class="count">(%s)</span>' ),
       ) );
   } );
   ```
3. Create an order, add a note to it, and set its status to "Custom status".
4. Trash the order, then restore it. It should go back to "Custom status" with the note still visible.
5. Trash the order again.
6. Remove the snippet (or deactivate it), so `wc-custom-status` is no longer registered.
7. Restore the order from the trash and check that:
   - The order status is "Pending payment", with no error shown.
   - The note from step 3 is visible again.
   - No leftover trash metadata remains: `wp db query "SELECT meta_key FROM wp_wc_orders_meta WHERE order_id = <order_id> AND meta_key LIKE '_wp_trash_meta_%'"` should return no rows.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.