### PR TITLE
[CI] Accept 402 responses in the docs link check

### DIFF
--- a/.github/workflows/docs-link-check/pr.toml
+++ b/.github/workflows/docs-link-check/pr.toml
@@ -30,7 +30,7 @@ max_redirects = 0
 
 # Only 400, 404, and 410 (plus transport failures) fail the check. Auth challenges, bot
 # blocks, rate limits, and server errors do not prove a link is dead.
-accept = "200..=399,401,403,405..=409,411..=599"
+accept = "200..=399,401..=403,405..=409,411..=599"
 timeout = 10
 max_retries = 2
 max_concurrency = 4


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Refs WOOAIRR-244.

(For Bug Fixes) Bug introduced in PR #68421.

The docs link check on pull requests now treats a `402` response like `401` and `403`: the page exists but is gated, so the link is not dead.

**Why**

The check should fail only on responses that prove a link is dead: `400`, `404`, `410`, and network failures. The comment in `pr.toml` and #68421 both say so. But the `accept` list named `401` and `403` separately and skipped `402`. So a `402 Payment Required` from an approved host failed the check.

**What changed**

- `accept` now lists `401..=403` as one range. The comment is accurate as written.

**What stays the same**

- The scheduled crawl keeps its stricter list on purpose.
- No approved host returns `402` today. A live run over all 1,532 doc links found twelve `404`s and no `402`, so nothing that passes or fails today changes.

**Trade-offs**

- This PR's own CI does not run the live link check, because no docs Markdown changes. Step 2 of the testing instructions is the proof.

A one-line CI config change. Over to a reviewer.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This PR's own CI runs the link-check policy test but not the live link check, since no docs Markdown changes, so step 2 is the proof for the `accept` change.

1. Run the policy test from the repository root, with lychee on your `PATH`:

    ```sh
    bash .github/workflows/scripts/docs-link-check-policy-test.sh
    ```

    - [ ] Confirm it prints `PASS: docs link-check policy`.

2. Check the `accept` list against a local server that answers with any status code. This needs Python 3 and lychee (the workflow pins 0.24.2). It copies `pr.toml` with localhost allowed, then checks one link per status code:

    ```sh
    REPO="$(git rev-parse --show-toplevel)"
    cd "$(mktemp -d)"
    cat > server.py <<'EOF'
    import http.server
    class H(http.server.BaseHTTPRequestHandler):
        def do_GET(self):
            self.send_response(int(self.path.strip('/')))
            self.end_headers()
        do_HEAD = do_GET
    http.server.ThreadingHTTPServer(('127.0.0.1', 9544), H).serve_forever()
    EOF
    python3 server.py 2>/dev/null & SERVER=$!
    for code in 200 400 401 402 403 404 410 429 500; do echo "- <http://127.0.0.1:9544/$code>"; done > links.md
    sed -e 's/^exclude_all_private = true/exclude_all_private = false/' -e "s|^include = \[|include = [ '^http://127\\\\.0\\\\.0\\\\.1:9544/',|" "$REPO/.github/workflows/docs-link-check/pr.toml" > pr-local.toml
    sleep 1; lychee --config pr-local.toml links.md; echo "lychee exit: $?"; kill $SERVER
    ```

    - [ ] Confirm lychee rejects only `400`, `404` and `410`. On trunk it also rejects `402 Payment Required`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran step 2 with the pinned lychee 0.24.2 against this branch's `pr.toml` and trunk's. This branch rejects `400`, `404` and `410`. Trunk also rejects `402`. `401`, `403`, `429` and `500` pass on both.
- The policy test passes on this branch. It checks which hosts the check contacts, not which status codes it accepts.
- A live run over all 1,532 doc links on the approved hosts returned twelve `404`s and no `402`.
- Two independent review passes. The second confirmed the local result, and that no other file states the status-code rule.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Only a GitHub Actions config file under `.github/` changes; nothing in a released package or plugin.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The change and its verification were produced with Claude Code (Anthropic) under my direction, starting from an AI regression-review report on #68421 and including independent review passes. I reviewed the diff and the evidence and take responsibility for the result.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

