### PR TITLE
Fix missing gap between columns in Cart and Checkout editor

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/filled-cart-block/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/filled-cart-block/editor.scss
@@ -6,6 +6,7 @@
 		display: flex;
 		flex-flow: row wrap;
 		align-items: flex-start;
+		column-gap: $gap-largest;
 	}
 	.wc-block-components-main,
 	.wc-block-components-sidebar,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
@@ -6,6 +6,7 @@
 		display: flex;
 		flex-flow: row wrap;
 		align-items: flex-start;
+		column-gap: $gap-largest;
 		padding-left: 5px;
 
 		&:has(> :first-child.wp-block-woocommerce-checkout-totals-block) {
@@ -98,6 +99,7 @@ body.wc-lock-selected-block--remove {
 	> .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-wrap: wrap;
+		column-gap: $gap-largest;
 		margin: 0 auto $gap;
 		position: relative;
 		&:has(> :last-child.wp-block-woocommerce-checkout-fields-block) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to #68363. That PR replaced the percentage `padding-left`/`padding-right` on `.wc-block-components-main` and `.wc-block-components-sidebar` with a `column-gap` on the `.wc-block-components-sidebar-layout` flex parent. On the frontend that is equivalent. In the block editor it is not: the Checkout and filled Cart editor styles force `.wc-block-components-sidebar-layout` to `display: block` and lay the two columns out through `.block-editor-block-list__layout` instead, so the new `column-gap` never applies and the fields column renders flush against the 360px order summary column.

This adds the same `column-gap` to those editor flex containers. It is editor-only; frontend layout is unchanged.

Fixes WOOAIRR-281 (flagged by the AI regression review on #68363).

Bug introduced in PR #68363.

### Screenshots or screen recordings:

Measured in the block editor at a 1050px canvas (two-column layout), distance from the right edge of the fields column to the left edge of the order summary column:

| Page | Before | After |
| ---- | ------ | ----- |
| Checkout editor | 0px | 48px |
| Cart editor | 0px | 48px |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store using the block Cart and Checkout pages, add a couple of products to the cart.
2. Open the **Checkout** page in the block editor with an editor canvas wide enough for the two-column layout (roughly 1000px or more; collapse the settings sidebar if needed).
3. Confirm there is a visible gutter (48px) between the checkout fields column and the order summary column. On trunk the two columns touch.
4. Repeat for the **Cart** page: there should be the same gutter between the cart items and the cart totals.
5. Open the Checkout page on the frontend at a wide viewport and confirm the layout is unchanged from trunk (the gutter was already present there).

<!-- End testing instructions -->

### Testing that has already taken place:

- Verified before/after in the block editor for both Cart and Checkout by measuring the column bounding boxes with Playwright (table above), on a local Docker site with a classic theme and on wp-env with a block theme.
- Confirmed the frontend Checkout flex parent still reports `column-gap: 48px` and is unaffected.
- `stylelint` clean on both changed SCSS files.
- Rebuilt the blocks bundle and checked the emitted `wc-blocks-editor-style.css` contains the new `column-gap` on all three editor selectors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Fixes a regression introduced by #68363, which has not been released yet, so its existing changelog entry already covers this change.

</details>

### Use of AI Tools

Investigated and authored with Claude Code (Claude Opus 5), including the Playwright measurements. I reviewed the change and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)