### PR TITLE
Hide a store alert once its end date has passed

### DIFF
--- a/plugins/woocommerce/changelog/fix-rin-expired-notes
+++ b/plugins/woocommerce/changelog/fix-rin-expired-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide a remote inbox notification's store alert once its end date has passed, even if the notification is no longer being served.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -163,41 +163,58 @@ class RemoteInboxNotificationsEngine extends RemoteSpecsEngine {
 	 * @return void
 	 */
 	public static function retire_expired_alerts() {
-		$notes = Notes::get_notes(
-			'edit',
-			array(
-				'type'     => array( Note::E_WC_ADMIN_NOTE_ERROR, Note::E_WC_ADMIN_NOTE_UPDATE ),
-				'status'   => array( Note::E_WC_ADMIN_NOTE_UNACTIONED ),
-				// Alerts are shown one at a time and only a handful are ever live at once.
-				'per_page' => 100,
-			)
-		);
+		try {
+			$data_store = Notes::load_data_store();
 
-		// Read the date the same way a live spec would, so a note behaves the same either way.
-		$rule_processor = new PublishBeforeTimeRuleProcessor();
-
-		foreach ( $notes as $note_id => $note_data ) {
-			$content_data = $note_data['content_data'];
-
-			if ( ! isset( $content_data->publish_before ) ) {
-				continue;
+			// A filtered data store may not have this internal read.
+			if ( ! $data_store->has_callable( 'lookup_notes' ) ) {
+				return;
 			}
 
-			$rule = (object) array( 'publish_before' => $content_data->publish_before );
+			// Read the rows rather than building a Note for each one, which would query the
+			// table again per note. Most runs have nothing to change.
+			// @phpstan-ignore-next-line method.notFound -- proxied by WC_Data_Store::__call() and guarded by has_callable() above.
+			$notes = $data_store->lookup_notes(
+				array(
+					'type'   => array( Note::E_WC_ADMIN_NOTE_ERROR, Note::E_WC_ADMIN_NOTE_UPDATE ),
+					'status' => array( Note::E_WC_ADMIN_NOTE_UNACTIONED ),
+					'source' => array( 'woocommerce.com' ),
+				)
+			);
 
-			// The date is stored in a free form column, so don't trust it to be readable.
-			if ( ! $rule_processor->validate( $rule ) || $rule_processor->process( $rule, new \stdClass() ) ) {
-				continue;
+			// Read the date the same way a live spec would, so a note behaves the same either way.
+			$rule_processor = new PublishBeforeTimeRuleProcessor();
+
+			foreach ( $notes as $note_row ) {
+				$content_data = json_decode( $note_row->content_data );
+
+				if ( ! isset( $content_data->publish_before ) ) {
+					continue;
+				}
+
+				$rule = (object) array( 'publish_before' => $content_data->publish_before );
+
+				// The date is stored in a free form column, so don't trust it to be readable.
+				if ( ! $rule_processor->validate( $rule ) || $rule_processor->process( $rule, new \stdClass() ) ) {
+					continue;
+				}
+
+				$note = Notes::get_note( $note_row->note_id );
+
+				if ( ! $note instanceof Note ) {
+					continue;
+				}
+
+				$note->set_status( Note::E_WC_ADMIN_NOTE_PENDING );
+				$note->save();
 			}
-
-			$note = Notes::get_note( $note_id );
-
-			if ( ! $note instanceof Note ) {
-				continue;
-			}
-
-			$note->set_status( Note::E_WC_ADMIN_NOTE_PENDING );
-			$note->save();
+		} catch ( \Throwable $e ) {
+			// run() also fires on plugin activation, where an unusable notes data store would
+			// otherwise break the activation. log_errors() only writes on dev and local.
+			wc_get_logger()->error(
+				'Could not retire expired store alerts: ' . $e->getMessage(),
+				array( 'source' => 'remote-inbox-notifications' )
+			);
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\RemoteSpecs\RemoteSpecsEngine;
 use Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\StoredStateSetupForProducts;
+use Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\PublishBeforeTimeRuleProcessor;
 
 /**
  * Remote Inbox Notifications engine.
@@ -123,6 +124,8 @@ class RemoteInboxNotificationsEngine extends RemoteSpecsEngine {
 	 * Go through the specs and run them.
 	 */
 	public static function run() {
+		self::retire_expired_alerts();
+
 		$specs = RemoteInboxNotificationsDataSourcePoller::get_instance()->get_specs_from_data_sources();
 
 		if ( false === $specs || ! is_countable( $specs ) || count( $specs ) === 0 ) {
@@ -141,6 +144,60 @@ class RemoteInboxNotificationsEngine extends RemoteSpecsEngine {
 
 		if ( count( $errors ) > 0 ) {
 			self::log_errors( $errors );
+		}
+	}
+
+	/**
+	 * Hide store alerts whose end date has passed.
+	 *
+	 * An alert normally stops showing when its spec's rules are re-evaluated and no longer
+	 * pass, which can only happen while the spec is still being served. Notes created from a
+	 * spec with a publish_before_time rule keep that date, so they can also stop showing on
+	 * their own once the date passes and the spec is gone.
+	 *
+	 * Only error and update notes are checked, since they are the ones shown as an alert.
+	 * Other note types have never expired on their own.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @return void
+	 */
+	public static function retire_expired_alerts() {
+		$notes = Notes::get_notes(
+			'edit',
+			array(
+				'type'     => array( Note::E_WC_ADMIN_NOTE_ERROR, Note::E_WC_ADMIN_NOTE_UPDATE ),
+				'status'   => array( Note::E_WC_ADMIN_NOTE_UNACTIONED ),
+				// Alerts are shown one at a time and only a handful are ever live at once.
+				'per_page' => 100,
+			)
+		);
+
+		// Read the date the same way a live spec would, so a note behaves the same either way.
+		$rule_processor = new PublishBeforeTimeRuleProcessor();
+
+		foreach ( $notes as $note_id => $note_data ) {
+			$content_data = $note_data['content_data'];
+
+			if ( ! isset( $content_data->publish_before ) ) {
+				continue;
+			}
+
+			$rule = (object) array( 'publish_before' => $content_data->publish_before );
+
+			// The date is stored in a free form column, so don't trust it to be readable.
+			if ( ! $rule_processor->validate( $rule ) || $rule_processor->process( $rule, new \stdClass() ) ) {
+				continue;
+			}
+
+			$note = Notes::get_note( $note_id );
+
+			if ( ! $note instanceof Note ) {
+				continue;
+			}
+
+			$note->set_status( Note::E_WC_ADMIN_NOTE_PENDING );
+			$note->save();
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -62,10 +62,17 @@ class SpecRunner {
 			return;
 		}
 
+		// Keep the end date on the note so it can retire itself if the spec stops being served.
+		$content_data   = isset( $spec->content_data ) ? $spec->content_data : (object) array();
+		$publish_before = self::get_publish_before( $spec );
+		if ( null !== $publish_before ) {
+			$content_data->publish_before = $publish_before;
+		}
+
 		// Set up the note.
 		$note->set_title( $locale->title );
 		$note->set_content( $locale->content );
-		$note->set_content_data( isset( $spec->content_data ) ? $spec->content_data : (object) array() );
+		$note->set_content_data( $content_data );
 		$note->set_status( $status );
 		$note->set_type( $spec->type );
 		$note->set_name( $spec->slug );
@@ -78,6 +85,30 @@ class SpecRunner {
 		$note->set_actions( self::get_actions( $spec ) );
 
 		$note->save();
+	}
+
+	/**
+	 * Get the date from the spec's publish_before_time rule, if it has one.
+	 *
+	 * Only top level rules are read. A rule nested inside an `or` doesn't describe the
+	 * spec's own end date, so it can't stand in for one.
+	 *
+	 * @param object $spec The spec.
+	 *
+	 * @return string|null The date, or null if the spec has no publish_before_time rule.
+	 */
+	private static function get_publish_before( $spec ) {
+		if ( ! isset( $spec->rules ) || ! is_array( $spec->rules ) ) {
+			return null;
+		}
+
+		foreach ( $spec->rules as $rule ) {
+			if ( isset( $rule->type, $rule->publish_before ) && 'publish_before_time' === $rule->type ) {
+				return $rule->publish_before;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php
@@ -14,8 +14,20 @@ use WC_Unit_Test_Case;
  */
 class RemoteInboxNotificationsEngineTest extends WC_Unit_Test_Case {
 
-	private const PAST   = '2020-01-01 00:00:00';
-	private const FUTURE = '2999-01-01 00:00:00';
+	private const PAST            = '2020-01-01 00:00:00';
+	private const FUTURE          = '2999-01-01 00:00:00';
+	private const SPECS_TRANSIENT = 'woocommerce_admin_remote_inbox_notifications_specs';
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		try {
+			delete_transient( self::SPECS_TRANSIENT );
+		} finally {
+			parent::tearDown();
+		}
+	}
 
 	/**
 	 * @testdox An alert whose end date has passed stops showing.
@@ -123,14 +135,48 @@ class RemoteInboxNotificationsEngineTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Notes from another source are left alone.
+	 */
+	public function test_notes_from_another_source_are_left_alone(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_UPDATE, Note::E_WC_ADMIN_NOTE_UNACTIONED, self::PAST, 'woocommerce-core' );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			( new Note( $note_id ) )->get_status(),
+			'Only notes from woocommerce.com carry a remote inbox end date.'
+		);
+	}
+
+	/**
+	 * @testdox The daily engine run retires expired alerts.
+	 */
+	public function test_run_retires_expired_alerts(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_UPDATE, Note::E_WC_ADMIN_NOTE_UNACTIONED, self::PAST );
+
+		// An empty spec list for the current locale keeps run() from fetching the feed.
+		set_transient( self::SPECS_TRANSIENT, array( get_user_locale() => array() ) );
+
+		RemoteInboxNotificationsEngine::run();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_PENDING,
+			( new Note( $note_id ) )->get_status(),
+			'run() should retire an expired alert even when no specs are served.'
+		);
+	}
+
+	/**
 	 * Create an admin note.
 	 *
 	 * @param string      $type           Note type.
 	 * @param string      $status         Note status.
 	 * @param string|null $publish_before End date to store on the note, or null to store none.
+	 * @param string      $source         Note source.
 	 * @return int Note ID.
 	 */
-	private function create_note( string $type, string $status, ?string $publish_before ): int {
+	private function create_note( string $type, string $status, ?string $publish_before, string $source = 'woocommerce.com' ): int {
 		$content_data = new \stdClass();
 
 		if ( null !== $publish_before ) {
@@ -143,7 +189,7 @@ class RemoteInboxNotificationsEngineTest extends WC_Unit_Test_Case {
 		$note->set_content( 'Test content' );
 		$note->set_content_data( $content_data );
 		$note->set_type( $type );
-		$note->set_source( 'woocommerce.com' );
+		$note->set_source( $source );
 		$note->set_status( $status );
 		$note->save();
 

--- a/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngineTest.php
@@ -1,0 +1,152 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\RemoteInboxNotifications;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for retiring store alerts whose end date has passed.
+ *
+ * @covers \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine::retire_expired_alerts
+ */
+class RemoteInboxNotificationsEngineTest extends WC_Unit_Test_Case {
+
+	private const PAST   = '2020-01-01 00:00:00';
+	private const FUTURE = '2999-01-01 00:00:00';
+
+	/**
+	 * @testdox An alert whose end date has passed stops showing.
+	 * @dataProvider alert_type_provider
+	 *
+	 * @param string $type Note type.
+	 */
+	public function test_expired_alert_is_set_to_pending( string $type ): void {
+		$note_id = $this->create_note( $type, Note::E_WC_ADMIN_NOTE_UNACTIONED, self::PAST );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_PENDING,
+			( new Note( $note_id ) )->get_status(),
+			'An alert past its end date should be hidden.'
+		);
+	}
+
+	/**
+	 * Alert note types.
+	 *
+	 * @return array[]
+	 */
+	public function alert_type_provider(): array {
+		return array(
+			'error'  => array( Note::E_WC_ADMIN_NOTE_ERROR ),
+			'update' => array( Note::E_WC_ADMIN_NOTE_UPDATE ),
+		);
+	}
+
+	/**
+	 * @testdox An alert is left alone until its end date passes.
+	 */
+	public function test_unexpired_alert_keeps_showing(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_UPDATE, Note::E_WC_ADMIN_NOTE_UNACTIONED, self::FUTURE );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			( new Note( $note_id ) )->get_status(),
+			'An alert that has not reached its end date should keep showing.'
+		);
+	}
+
+	/**
+	 * @testdox A note with no end date is left alone.
+	 */
+	public function test_note_without_an_end_date_keeps_showing(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_UPDATE, Note::E_WC_ADMIN_NOTE_UNACTIONED, null );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			( new Note( $note_id ) )->get_status(),
+			'A note with no end date has nothing to expire against.'
+		);
+	}
+
+	/**
+	 * @testdox An unreadable end date is ignored rather than hiding the alert.
+	 */
+	public function test_unreadable_end_date_keeps_showing(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_UPDATE, Note::E_WC_ADMIN_NOTE_UNACTIONED, 'whenever' );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			( new Note( $note_id ) )->get_status(),
+			'A date that cannot be read should not be treated as passed.'
+		);
+	}
+
+	/**
+	 * @testdox Notes that are not shown as an alert are left alone.
+	 */
+	public function test_other_note_types_are_left_alone(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_MARKETING, Note::E_WC_ADMIN_NOTE_UNACTIONED, self::PAST );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			( new Note( $note_id ) )->get_status(),
+			'Only error and update notes are shown as an alert, so only those expire.'
+		);
+	}
+
+	/**
+	 * @testdox An alert the merchant already acted on is not reopened or changed.
+	 */
+	public function test_actioned_alert_is_left_alone(): void {
+		$note_id = $this->create_note( Note::E_WC_ADMIN_NOTE_UPDATE, Note::E_WC_ADMIN_NOTE_ACTIONED, self::PAST );
+
+		RemoteInboxNotificationsEngine::retire_expired_alerts();
+
+		$this->assertSame(
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			( new Note( $note_id ) )->get_status(),
+			'An actioned note is already hidden and should keep its status.'
+		);
+	}
+
+	/**
+	 * Create an admin note.
+	 *
+	 * @param string      $type           Note type.
+	 * @param string      $status         Note status.
+	 * @param string|null $publish_before End date to store on the note, or null to store none.
+	 * @return int Note ID.
+	 */
+	private function create_note( string $type, string $status, ?string $publish_before ): int {
+		$content_data = new \stdClass();
+
+		if ( null !== $publish_before ) {
+			$content_data->publish_before = $publish_before;
+		}
+
+		$note = new Note();
+		$note->set_name( 'phpunit-remote-inbox-alert' );
+		$note->set_title( 'Test note' );
+		$note->set_content( 'Test content' );
+		$note->set_content_data( $content_data );
+		$note->set_type( $type );
+		$note->set_source( 'woocommerce.com' );
+		$note->set_status( $status );
+		$note->save();
+
+		return $note->get_id();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/SpecRunnerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/RemoteInboxNotifications/SpecRunnerTest.php
@@ -1,0 +1,130 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\RemoteInboxNotifications;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the end date a spec leaves on the note it creates.
+ *
+ * @covers \Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner::run_spec
+ */
+class SpecRunnerTest extends WC_Unit_Test_Case {
+
+	private const SLUG = 'phpunit-spec-runner-note';
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		try {
+			Notes::delete_notes_with_name( self::SLUG );
+		} finally {
+			parent::tearDown();
+		}
+	}
+
+	/**
+	 * @testdox A spec with an end date leaves it on the note.
+	 */
+	public function test_publish_before_time_is_stored_on_the_note(): void {
+		$note = $this->run_spec(
+			array(
+				array(
+					'type'           => 'publish_before_time',
+					'publish_before' => '2999-01-01 00:00:00',
+				),
+			)
+		);
+
+		$this->assertSame(
+			'2999-01-01 00:00:00',
+			$note->get_content_data()->publish_before,
+			'The note should keep the end date so it can expire without the spec.'
+		);
+	}
+
+	/**
+	 * @testdox A spec with no end date leaves none on the note.
+	 */
+	public function test_no_end_date_is_stored_when_the_spec_has_no_publish_before_time(): void {
+		$note = $this->run_spec(
+			array(
+				array(
+					'type'          => 'publish_after_time',
+					'publish_after' => '2020-01-01 00:00:00',
+				),
+			)
+		);
+
+		$this->assertFalse(
+			property_exists( $note->get_content_data(), 'publish_before' ),
+			'A spec without an end date has nothing to store.'
+		);
+	}
+
+	/**
+	 * @testdox An end date nested in an or rule is not read as the spec's own.
+	 */
+	public function test_nested_publish_before_time_is_ignored(): void {
+		$note = $this->run_spec(
+			array(
+				array(
+					'type'     => 'or',
+					'operands' => array(
+						array(
+							array(
+								'type'           => 'publish_before_time',
+								'publish_before' => '2999-01-01 00:00:00',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertFalse(
+			property_exists( $note->get_content_data(), 'publish_before' ),
+			'A nested rule describes one branch, not when the spec itself ends.'
+		);
+	}
+
+	/**
+	 * Run a spec with the given rules and return the note it created.
+	 *
+	 * @param array $rules Spec rules.
+	 * @return Note The created note.
+	 */
+	private function run_spec( array $rules ): Note {
+		$spec = json_decode(
+			(string) wp_json_encode(
+				array(
+					'slug'    => self::SLUG,
+					'type'    => Note::E_WC_ADMIN_NOTE_UPDATE,
+					'status'  => Note::E_WC_ADMIN_NOTE_UNACTIONED,
+					'source'  => 'woocommerce.com',
+					'locales' => array(
+						array(
+							'locale'  => 'en_US',
+							'title'   => 'Test note',
+							'content' => 'Test content',
+						),
+					),
+					'actions' => array(),
+					'rules'   => $rules,
+				)
+			)
+		);
+
+		SpecRunner::run_spec( $spec, new \stdClass() );
+
+		$note = Notes::get_note_by_name( self::SLUG );
+		$this->assertInstanceOf( Note::class, $note, 'The spec should have created a note.' );
+
+		return $note;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A remote inbox notification of type `error` or `update` shows as an alert across the top of the admin. It stops showing when its rules are checked again and no longer pass. That only happens while woocommerce.com is still serving it. Once it stops being served, the alert can never go away, and the merchant keeps seeing it.

This saves the notification's end date on the note, and hides alerts past that date during the daily run. The date is read with the same rule processor as before, so a note behaves the same either way.

Only notifications with an end date are affected. Notes already stuck have no date saved and are left alone.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You need a local woocommerce.com at `https://woocommerce.test` to create the test notification, and the local core env at `http://localhost:8888` pointed at it.

1. Check out this branch. No build needed, the change is PHP only.
2. Point the store at your local woocommerce.com. Add this as an mu-plugin on `localhost:8888`:

   ```php
   add_filter( 'woo_com_base_url', fn() => 'https://woocommerce.test/' );
   add_filter( 'http_request_args', function ( $args ) {
       $args['sslverify'] = false;
       $args['reject_unsafe_urls'] = false;
       return $args;
   } );
   add_filter( 'http_request_host_is_external', fn( $external, $host ) => 'woocommerce.test' === $host ? true : $external, 10, 2 );
   ```

3. On `woocommerce.test`, [add](https://woocommerce.test/wp-admin/post-new.php?post_type=banner) an Ad of type Inbox notification.

    <kbd><img width="406" height="294" alt="image" src="https://github.com/user-attachments/assets/0041a11d-f6d0-4c2e-a779-e9d9b8f72083" /></kbd>

4. Set the slug, set Type to Update, tick API Version 2.0, and fill in the title and content. Leave Rules empty. The end date is the only rule this test needs, and the feed adds it for you.

   <kbd><img width="782" height="621" alt="image" src="https://github.com/user-attachments/assets/b698c721-6f03-4407-ac24-9545f967a307" /></kbd>

5. In the Publish box, set the end date a few minutes from now, then publish.

    <kbd><img width="303" height="385" alt="image" src="https://github.com/user-attachments/assets/cec0a619-3a2c-4ed2-910f-511198627d7b" /></kbd>

    The feed writes that date in woocommerce.com's own timezone, and the store reads it as UTC. If `woocommerce.test` is not set to UTC, subtract its offset from the end date or the window lands hours away from where you meant it.

6. Open `https://woocommerce.test/wp-json/wccom/inbox-notifications/2.0/notifications.json` and find your notification. Its rules should include `publish_before_time` with the date you set.
7. On `localhost:8888`, go to WooCommerce > Status > Tools and click Refresh Remote Inbox Notifications. The alert appears at the top of the WooCommerce admin.

   ```sh
   wp db query "SELECT name, status, content_data FROM wp_wc_admin_notes WHERE name = 'your-slug'"
   ```

    ```
    name             status       content_data
    test-pr-68576    unactioned   {"publish_before":"2026-09-11 09:46:12"}
    ```

    `content_data` holds the end date. On trunk it would be `{}`.

    how the note is rendered:

    <kbd><img width="408" height="165" alt="image" src="https://github.com/user-attachments/assets/fb5fee5f-a3d7-401b-99b5-ca58a781fcb6" /></kbd>

8. Set the notification to draft on `woocommerce.test`, while its end date is still in the future. It leaves the feed, so the store can no longer read its rules. This is the state that gets stuck.
9. Wait for the end date to pass. Clear the store's copy of the feed, then run the engine:

   ```sh
   wp transient delete woocommerce_admin_remote_inbox_notifications_specs
   wp eval 'Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine::run();'
   ```

   Clearing the transient matters. With the old feed still cached, the existing path would hide the alert and this change would never run.
10. The alert is gone, and the query from step 7 now shows `pending`.
11. Check that trunk does the opposite with the same note. Put it back and run the engine without the fix:

    ```sh
    wp db query "UPDATE wp_wc_admin_notes SET status = 'unactioned' WHERE name = 'your-slug'"
    git checkout trunk
    wp eval 'Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine::run();'
    ```

    The note stays `unactioned` and the alert keeps showing, with nothing left that could ever hide it. Check this branch back out.

<!-- End testing instructions -->

### Testing that has already taken place:

Ten new unit tests. The 167 existing tests around notes and remote inbox notifications still pass. PHPStan and phpcs are clean on the changed files.

Also run end to end on a local store against a local woocommerce.com. The note kept the end date, stayed visible while the notification was drafted and the date was still ahead, and moved to `pending` once the date passed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added manually in `plugins/woocommerce/changelog/fix-rin-expired-notes`.

### Use of AI Tools

Written with Claude Code. I reviewed the change and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
