### PR TITLE
Surface Store API engine errors in debug mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-47095-store-api-debug-errors
+++ b/plugins/woocommerce/changelog/fix-47095-store-api-debug-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return safe debug details for unexpected Store API engine errors.

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -72,6 +72,7 @@
 - [woocommerce_store_api_cart_item_images](#woocommerce_store_api_cart_item_images)
 - [woocommerce_store_api_cart_item_quantity_validation](#woocommerce_store_api_cart_item_quantity_validation)
 - [woocommerce_store_api_disable_nonce_check](#woocommerce_store_api_disable_nonce_check)
+- [woocommerce_store_api_expose_error_details](#woocommerce_store_api_expose_error_details)
 - [`woocommerce_store_api_product_quantity_{$value_type}`](#woocommerce_store_api_product_quantity_value_type)
 - [woocommerce_store_api_rate_limit_id](#woocommerce_store_api_rate_limit_id)
 - [woocommerce_store_api_rate_limit_options](#woocommerce_store_api_rate_limit_options)
@@ -1796,6 +1797,36 @@ This can be used to disable the nonce check when testing API endpoints via a RES
 
 - [StoreApi/Routes/V1/AbstractCartRoute.php](../../../../../../src/StoreApi/Routes/V1/AbstractCartRoute.php)
 - [StoreApi/Routes/V1/ShopperListsNonceCheck.php](../../../../../../src/StoreApi/Routes/V1/ShopperListsNonceCheck.php)
+
+---
+
+## woocommerce_store_api_expose_error_details
+
+
+Filters whether unexpected Store API failures include the error message and exception class in the response.
+
+```php
+apply_filters( 'woocommerce_store_api_expose_error_details', bool $expose_error_details )
+```
+
+### Description
+
+Details are only ever sent to users who can manage WooCommerce; this filter cannot bypass that check. It defaults to WP_DEBUG so store staff can debug a production store without enabling debug mode site-wide.
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $expose_error_details | bool | Whether to include the error message and exception class. Defaults to WP_DEBUG. |
+
+### Returns
+
+
+`bool`
+
+### Source
+
+- [StoreApi/Utilities/UnexpectedErrorResponse.php](../../../../../../src/StoreApi/Utilities/UnexpectedErrorResponse.php)
 
 ---
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\StoreApi\Utilities\UnexpectedErrorResponse;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
@@ -106,30 +107,17 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Convert a failure during cart session loading into a client-safe error response.
 	 *
-	 * The original error is logged rather than returned, so nothing internal reaches the client.
+	 * Error details are returned only to managers when debug details are enabled.
 	 *
 	 * @param  \Throwable $error The error that occurred while loading the cart session.
 	 * @return \WP_REST_Response The error response to return to the client.
 	 */
 	protected function get_cart_session_error_response( \Throwable $error ) {
-		wc_get_logger()->error(
-			sprintf(
-				'Store API could not load the cart session: %1$s in %2$s:%3$d',
-				$error->getMessage(),
-				$error->getFile(),
-				$error->getLine()
-			),
-			array(
-				'source'    => 'store-api',
-				'exception' => $error,
-			)
-		);
-
 		return $this->error_to_response(
-			$this->get_route_error_response(
-				'woocommerce_rest_unknown_server_error',
-				__( 'The cart could not be loaded. Please try again.', 'woocommerce' ),
-				500
+			UnexpectedErrorResponse::create(
+				$error,
+				sprintf( '%s while loading the cart session', static::class ),
+				__( 'The cart could not be loaded. Please try again.', 'woocommerce' )
 			)
 		);
 	}
@@ -162,6 +150,8 @@ abstract class AbstractCartRoute extends AbstractRoute {
 				$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 			} catch ( \Exception $error ) {
 				$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
+			} catch ( \Throwable $error ) {
+				return $this->add_response_headers( $this->error_to_response( UnexpectedErrorResponse::create( $error, static::class ) ) );
 			}
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractRoute.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
+use Automattic\WooCommerce\StoreApi\Utilities\UnexpectedErrorResponse;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Routes\RouteInterface;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
@@ -102,6 +103,8 @@ abstract class AbstractRoute implements RouteInterface {
 			$response = $this->get_route_error_response_from_object( $error->getError(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
 			$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
+		} catch ( \Throwable $error ) {
+			$response = UnexpectedErrorResponse::create( $error, static::class );
 		}
 
 		return is_wp_error( $response ) ? $this->error_to_response( $response ) : $response;

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
+use Automattic\WooCommerce\StoreApi\Utilities\UnexpectedErrorResponse;
 use Automattic\WooCommerce\StoreApi\Routes\RouteInterface;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use WP_REST_Request;
@@ -127,6 +128,8 @@ class Batch extends AbstractRoute implements RouteInterface {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
 			$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
+		} catch ( \Throwable $error ) {
+			$response = UnexpectedErrorResponse::create( $error, static::class );
 		}
 
 		if ( is_wp_error( $response ) ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
+use Automattic\WooCommerce\StoreApi\Utilities\UnexpectedErrorResponse;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use Automattic\WooCommerce\StoreApi\Exceptions\InvalidCartException;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
@@ -175,6 +176,8 @@ class Checkout extends AbstractCartRoute {
 				$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 			} catch ( \Exception $error ) {
 				$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
+			} catch ( \Throwable $error ) {
+				$response = UnexpectedErrorResponse::create( $error, static::class );
 			}
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/UnexpectedErrorResponse.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/UnexpectedErrorResponse.php
@@ -1,0 +1,84 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Utilities;
+
+use Automattic\Jetpack\Constants;
+use WP_Error;
+
+/**
+ * Builds safe Store API responses for unexpected engine failures.
+ *
+ * @internal
+ */
+final class UnexpectedErrorResponse {
+	/**
+	 * Maximum number of backtrace frames recorded in the log context.
+	 */
+	private const MAX_BACKTRACE_FRAMES = 10;
+
+	/**
+	 * Log an engine failure and create its Store API response.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param \Throwable  $error           Unexpected engine failure.
+	 * @param string      $failure_context Context in which the failure occurred.
+	 * @param string|null $public_message  Message shown to clients without debug access.
+	 * @return WP_Error
+	 */
+	public static function create( \Throwable $error, string $failure_context, ?string $public_message = null ): WP_Error {
+		try {
+			wc_get_logger()->critical(
+				sprintf(
+					'Store API request failed in %1$s: %2$s: %3$s in %4$s:%5$d',
+					$failure_context,
+					get_class( $error ),
+					$error->getMessage(),
+					$error->getFile(),
+					$error->getLine()
+				),
+				array(
+					'source'    => 'store-api',
+					'exception' => $error,
+					// Same shape the fatal-error shutdown handler logs, so log handlers and readers see one trace format.
+					'backtrace' => array_slice( explode( "\n", $error->getTraceAsString() ), 0, self::MAX_BACKTRACE_FRAMES ),
+				)
+			);
+		} catch ( \Throwable $logging_error ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Logging is best-effort here and must not prevent the safe response from being returned.
+		}
+
+		$message = $public_message ?? __( 'Internal server error', 'woocommerce' );
+		$data    = array( 'status' => 500 );
+
+		if ( self::can_expose_details() ) {
+			$message                 = $error->getMessage();
+			$data['exception_class'] = get_class( $error );
+		}
+
+		return new WP_Error( 'woocommerce_rest_unknown_server_error', $message, $data );
+	}
+
+	/**
+	 * Whether the current request may receive the failure message and class.
+	 *
+	 * @return bool
+	 */
+	private static function can_expose_details(): bool {
+		/**
+		 * Filters whether unexpected Store API failures include the error message and exception class in the response.
+		 *
+		 * Details are only ever sent to users who can manage WooCommerce; this filter cannot bypass that check. It defaults to WP_DEBUG so store staff can debug a production store without enabling debug mode site-wide.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param bool $expose_error_details Whether to include the error message and exception class. Defaults to WP_DEBUG.
+		 *
+		 * @return bool
+		 */
+		$expose_error_details = (bool) apply_filters( 'woocommerce_store_api_expose_error_details', Constants::is_true( 'WP_DEBUG' ) );
+
+		return $expose_error_details && current_user_can( 'manage_woocommerce' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ConfiguredFailureRouteTrait.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ConfiguredFailureRouteTrait.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Shared fixture behavior for Store API routes that fail on demand.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Lets a fixture route throw a configured failure from its request handler.
+ */
+trait ConfiguredFailureRouteTrait {
+	/**
+	 * Failure thrown during route dispatch, or null to succeed.
+	 *
+	 * @var \Throwable|null
+	 */
+	private $failure;
+
+	/**
+	 * Create the fixture without production constructor dependencies.
+	 *
+	 * @param \Throwable|null $failure Failure thrown during route dispatch, or null to succeed.
+	 */
+	public function __construct( ?\Throwable $failure = null ) {
+		$this->failure = $failure;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_path() {
+		return '/configured-failure-fixture';
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_args() {
+		return array();
+	}
+
+	/**
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool
+	 */
+	protected function requires_nonce( WP_REST_Request $request ) {
+		unset( $request ); // Avoid parameter not used PHPCS errors.
+		return false;
+	}
+
+	/**
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 * @throws \Throwable The configured fixture failure, when one is set.
+	 */
+	protected function get_response_by_request_method( WP_REST_Request $request ) {
+		unset( $request ); // Avoid parameter not used PHPCS errors.
+		if ( $this->failure ) {
+			throw $this->failure;
+		}
+
+		return new WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * @param WP_REST_Response $response Response object.
+	 * @return WP_REST_Response
+	 */
+	protected function add_response_headers( WP_REST_Response $response ) {
+		return $response;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/UnexpectedErrorHandlingTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/UnexpectedErrorHandlingTest.php
@@ -1,0 +1,359 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
+use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractRoute;
+use Automattic\WooCommerce\StoreApi\Routes\V1\Batch;
+use Automattic\WooCommerce\StoreApi\Routes\V1\Checkout;
+use WC_Unit_Test_Case;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Tests for unexpected Store API route errors.
+ */
+class UnexpectedErrorHandlingTest extends WC_Unit_Test_Case {
+	/**
+	 * Set up the current user.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( 0 );
+		Constants::set_constant( 'WP_DEBUG', false );
+	}
+
+	/**
+	 * Restore the current user.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		Constants::clear_single_constant( 'WP_DEBUG' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should mask an engine failure from a public abstract route response.
+	 */
+	public function test_abstract_route_masks_engine_failure(): void {
+		$route    = $this->create_abstract_route( new \TypeError( 'Fixture abstract route failure.' ) );
+		$response = $route->get_response( new WP_REST_Request( 'GET', '/unexpected-error-fixture' ) );
+
+		$this->assert_generic_error_response( $response );
+	}
+
+	/**
+	 * @testdox Should mask an engine failure from a public cart route response.
+	 */
+	public function test_cart_route_masks_engine_failure(): void {
+		$route    = $this->create_cart_route( new \TypeError( 'Fixture cart route failure.' ) );
+		$response = $route->get_response( new WP_REST_Request( 'GET', '/unexpected-cart-error-fixture' ) );
+
+		$this->assert_generic_error_response( $response );
+	}
+
+	/**
+	 * @testdox Should show limited cart-session failure details to managers in debug mode.
+	 */
+	public function test_cart_session_failure_shows_limited_details_to_managers_in_debug_mode(): void {
+		Constants::set_constant( 'WP_DEBUG', true );
+		$this->login_as_administrator();
+		$route = $this->create_cart_route( new \TypeError( 'Fixture cart session failure.' ), true );
+
+		$response = $route->get_response( new WP_REST_Request( 'GET', '/unexpected-cart-error-fixture' ) );
+
+		$this->assertSame( 500, $response->get_status(), 'Cart-session engine failures should keep status 500.' );
+		$this->assertSame(
+			array(
+				'code'    => 'woocommerce_rest_unknown_server_error',
+				'message' => 'Fixture cart session failure.',
+				'data'    => array(
+					'status'          => 500,
+					'exception_class' => \TypeError::class,
+				),
+			),
+			$response->get_data(),
+			'Debug responses for managers should include only the cart-session failure message and class.'
+		);
+	}
+
+	/**
+	 * @testdox Should preserve the public cart-session failure message.
+	 */
+	public function test_cart_session_failure_preserves_public_message(): void {
+		$route = $this->create_cart_route( new \TypeError( 'Fixture cart session failure.' ), true );
+
+		$response = $route->get_response( new WP_REST_Request( 'GET', '/unexpected-cart-error-fixture' ) );
+
+		$this->assertSame( 500, $response->get_status(), 'Cart-session engine failures should keep status 500.' );
+		$this->assertSame(
+			array(
+				'code'    => 'woocommerce_rest_unknown_server_error',
+				'message' => __( 'The cart could not be loaded. Please try again.', 'woocommerce' ),
+				'data'    => array( 'status' => 500 ),
+			),
+			$response->get_data(),
+			'Public cart-session errors should retain their established client-safe response.'
+		);
+	}
+
+	/**
+	 * @testdox Should not run cart update side effects after an engine failure.
+	 */
+	public function test_cart_route_skips_update_side_effects_after_engine_failure(): void {
+		$route    = $this->create_cart_route( new \TypeError( 'Fixture cart update failure.' ) );
+		$response = $route->get_response( new WP_REST_Request( 'POST', '/unexpected-cart-error-fixture' ) );
+
+		$this->assert_generic_error_response( $response );
+	}
+
+	/**
+	 * @testdox Should preserve cart update side effects after a successful update request.
+	 */
+	public function test_cart_route_preserves_update_side_effects_after_success(): void {
+		$this->expectException( \LogicException::class );
+		$this->expectExceptionMessage( 'Cart update side effects reached.' );
+
+		$route = $this->create_cart_route( null );
+		$route->get_response( new WP_REST_Request( 'POST', '/unexpected-cart-error-fixture' ) );
+	}
+
+	/**
+	 * @testdox Should mask an engine failure from a public checkout route response.
+	 */
+	public function test_checkout_route_masks_engine_failure(): void {
+		$route    = $this->create_checkout_route( new \TypeError( 'Fixture checkout route failure.' ) );
+		$response = $route->get_response( new WP_REST_Request( 'GET', '/unexpected-checkout-error-fixture' ) );
+
+		$this->assert_generic_error_response( $response );
+	}
+
+	/**
+	 * @testdox Should mask an engine failure from a public batch route response.
+	 */
+	public function test_batch_route_masks_engine_failure(): void {
+		$response = $this->dispatch_batch_route( new \TypeError( 'Fixture batch route failure.' ) );
+
+		$this->assert_generic_error_response( $response );
+	}
+
+	/**
+	 * @testdox Should preserve the existing ordinary exception response for the $route_kind route.
+	 * @testWith ["abstract"]
+	 *           ["cart"]
+	 *           ["checkout"]
+	 *           ["batch"]
+	 *
+	 * @param string $route_kind Which route fixture to dispatch through.
+	 */
+	public function test_ordinary_exception_response_is_unchanged( string $route_kind ): void {
+		$failure = new \RuntimeException( 'Fixture ordinary exception.' );
+		switch ( $route_kind ) {
+			case 'cart':
+				$route = $this->create_cart_route( $failure );
+				break;
+			case 'checkout':
+				$route = $this->create_checkout_route( $failure );
+				break;
+			case 'batch':
+				$route = null;
+				break;
+			default:
+				$route = $this->create_abstract_route( $failure );
+		}
+
+		$response = $route
+			? $route->get_response( new WP_REST_Request( 'GET', '/unexpected-error-fixture' ) )
+			: $this->dispatch_batch_route( $failure );
+
+		$this->assertSame( 500, $response->get_status(), 'Ordinary exception responses should keep status 500.' );
+		$this->assertSame(
+			array(
+				'code'    => 'woocommerce_rest_unknown_server_error',
+				'message' => 'Fixture ordinary exception.',
+				'data'    => array( 'status' => 500 ),
+			),
+			$response->get_data(),
+			'Ordinary exception responses should remain byte-for-byte compatible.'
+		);
+	}
+
+	/**
+	 * @testdox Should preserve expected route error details.
+	 */
+	public function test_expected_route_exception_response_is_unchanged(): void {
+		$route = $this->create_abstract_route(
+			new RouteException(
+				'fixture_expected_error',
+				'Fixture expected error.',
+				409,
+				array( 'fixture' => true )
+			)
+		);
+
+		$response = $route->get_response( new WP_REST_Request( 'GET', '/unexpected-error-fixture' ) );
+
+		$this->assertSame( 409, $response->get_status(), 'Expected route errors should keep their status.' );
+		$this->assertSame(
+			array(
+				'code'    => 'fixture_expected_error',
+				'message' => 'Fixture expected error.',
+				'data'    => array(
+					'fixture' => true,
+					'status'  => 409,
+				),
+			),
+			$response->get_data(),
+			'Expected route errors should keep their public payload.'
+		);
+	}
+
+	/**
+	 * Dispatch a batch request whose inner REST server dispatch throws the given failure.
+	 *
+	 * @param \Throwable $failure Failure thrown by the REST server while serving the batch.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_batch_route( \Throwable $failure ): WP_REST_Response {
+		global $wp_rest_server;
+
+		$original_server = $wp_rest_server;
+		$wp_rest_server  = new class( $failure ) extends WP_REST_Server {
+			/** @var \Throwable */
+			private $failure;
+
+			/**
+			 * @param \Throwable $failure Failure thrown while serving the batch.
+			 */
+			public function __construct( \Throwable $failure ) {
+				parent::__construct();
+				$this->failure = $failure;
+			}
+
+			/**
+			 * @param WP_REST_Request $batch_request Batch request.
+			 * @throws \Throwable Always throws the configured fixture failure.
+			 */
+			public function serve_batch_request_v1( WP_REST_Request $batch_request ) {
+				throw $this->failure;
+			}
+		};
+
+		try {
+			$request = new WP_REST_Request( 'POST', '/unexpected-batch-error-fixture' );
+			$request->set_param(
+				'requests',
+				array(
+					array( 'path' => '/wc/store/v1/products' ),
+				)
+			);
+
+			$route = new class() extends Batch {
+				/**
+				 * Create the fixture without production constructor dependencies.
+				 */
+				public function __construct() {}
+			};
+
+			return $route->get_response( $request );
+		} finally {
+			$wp_rest_server = $original_server;
+		}
+	}
+
+	/**
+	 * Create a generic route with a configurable failure.
+	 *
+	 * @param \Throwable $failure Failure thrown during route dispatch.
+	 * @return AbstractRoute
+	 */
+	private function create_abstract_route( \Throwable $failure ): AbstractRoute {
+		return new class( $failure ) extends AbstractRoute {
+			use ConfiguredFailureRouteTrait;
+		};
+	}
+
+	/**
+	 * Create a cart route with a configurable dispatch failure.
+	 *
+	 * @param \Throwable|null $failure            Configured route failure, or null for success.
+	 * @param bool            $fail_while_loading Whether to fail while loading the cart session.
+	 * @return AbstractCartRoute
+	 */
+	private function create_cart_route( ?\Throwable $failure, bool $fail_while_loading = false ): AbstractCartRoute {
+		return new class( $failure, $fail_while_loading ) extends AbstractCartRoute {
+			use ConfiguredFailureRouteTrait {
+				__construct as private configure_failure;
+			}
+
+			/** @var bool */
+			private $fail_while_loading;
+
+			/**
+			 * @param \Throwable|null $failure            Configured route failure, or null for success.
+			 * @param bool            $fail_while_loading Whether to fail while loading the cart session.
+			 */
+			public function __construct( ?\Throwable $failure, bool $fail_while_loading ) {
+				$this->configure_failure( $failure );
+				$this->fail_while_loading = $fail_while_loading;
+			}
+
+			/**
+			 * @param WP_REST_Request $request Request object.
+			 * @throws \Throwable The configured fixture failure, when set to fail while loading.
+			 */
+			protected function load_cart_session( WP_REST_Request $request ) {
+				if ( $this->fail_while_loading ) {
+					throw $this->failure;
+				}
+			}
+
+			/**
+			 * @param WP_REST_Request $request Request object.
+			 * @throws \LogicException Always throws if this side effect is reached.
+			 */
+			protected function cart_updated( WP_REST_Request $request ) {
+				throw new \LogicException( 'Cart update side effects reached.' );
+			}
+		};
+	}
+
+	/**
+	 * Create a checkout route with a configurable dispatch failure.
+	 *
+	 * @param \Throwable $failure Failure thrown during route dispatch.
+	 * @return Checkout
+	 */
+	private function create_checkout_route( \Throwable $failure ): Checkout {
+		return new class( $failure ) extends Checkout {
+			use ConfiguredFailureRouteTrait;
+
+			/**
+			 * @param WP_REST_Request $request Request object.
+			 */
+			protected function load_cart_session( WP_REST_Request $request ) {}
+		};
+	}
+
+	/**
+	 * Assert a generic public Store API error response.
+	 *
+	 * @param WP_REST_Response $response Response object.
+	 */
+	private function assert_generic_error_response( WP_REST_Response $response ): void {
+		$this->assertSame( 500, $response->get_status(), 'Engine failures should become status-500 Store API responses.' );
+		$this->assertSame(
+			array(
+				'code'    => 'woocommerce_rest_unknown_server_error',
+				'message' => __( 'Internal server error', 'woocommerce' ),
+				'data'    => array( 'status' => 500 ),
+			),
+			$response->get_data(),
+			'Public Store API responses must not disclose engine-error details.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/UnexpectedErrorResponseTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/UnexpectedErrorResponseTest.php
@@ -1,0 +1,151 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\StoreApi\Utilities\UnexpectedErrorResponse;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
+use WC_Logger_Interface;
+use WC_Unit_Test_Case;
+use WP_Error;
+
+/**
+ * Tests for the UnexpectedErrorResponse class.
+ */
+class UnexpectedErrorResponseTest extends WC_Unit_Test_Case {
+	use LoggerSpyTrait;
+
+	/**
+	 * Set up the current user.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( 0 );
+		Constants::set_constant( 'WP_DEBUG', false );
+	}
+
+	/**
+	 * Restore the current user.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		Constants::clear_single_constant( 'WP_DEBUG' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should disclose engine failure details only to managers in debug mode.
+	 * @testWith [null, false, false]
+	 *           ["customer", false, false]
+	 *           [null, true, false]
+	 *           ["administrator", false, false]
+	 *           ["administrator", true, true]
+	 *
+	 * @param string|null $role                Current user's role, or null for a guest.
+	 * @param bool        $debug_enabled       Whether debug mode is enabled.
+	 * @param bool        $should_show_details Whether error details should be disclosed.
+	 */
+	public function test_discloses_engine_failure_details_only_to_managers_in_debug_mode( ?string $role, bool $debug_enabled, bool $should_show_details ): void {
+		Constants::set_constant( 'WP_DEBUG', $debug_enabled );
+		if ( null !== $role ) {
+			$this->login_as_role( $role );
+		}
+
+		$result = UnexpectedErrorResponse::create( new \TypeError( 'Fixture engine failure.' ), self::class );
+
+		$this->assert_error_response( $result, $should_show_details, 'Engine failure disclosure should require both debug mode and manager capability.' );
+	}
+
+	/**
+	 * @testdox Should log the engine failure as critical with a bounded backtrace.
+	 */
+	public function test_logs_engine_failure_as_critical_with_bounded_backtrace(): void {
+		$error = new \TypeError( 'Fixture logged engine failure.' );
+
+		UnexpectedErrorResponse::create( $error, self::class );
+
+		$this->assertLogged(
+			'critical',
+			self::class,
+			array(
+				'source'    => 'store-api',
+				'exception' => $error,
+			)
+		);
+		$this->assertCount( 1, $this->captured_logs );
+		$message = $this->captured_logs[0]['message'];
+		$this->assertStringContainsString( \TypeError::class, $message );
+		$this->assertStringContainsString( 'Fixture logged engine failure.', $message );
+
+		$backtrace = $this->captured_logs[0]['context']['backtrace'];
+		$this->assertIsArray( $backtrace );
+		$this->assertGreaterThanOrEqual( 1, count( $backtrace ) );
+		$this->assertLessThanOrEqual( 10, count( $backtrace ) );
+		$this->assertStringStartsWith( '#0 ', $backtrace[0] );
+	}
+
+	/**
+	 * @testdox Should return a safe response when logging fails.
+	 */
+	public function test_returns_safe_response_when_logging_fails(): void {
+		$logger = $this->createMock( WC_Logger_Interface::class );
+		$logger
+			->method( 'critical' )
+			->willThrowException( new \RuntimeException( 'Fixture logger failure.' ) );
+		add_filter( 'woocommerce_logging_class', fn() => $logger );
+
+		$result = UnexpectedErrorResponse::create( new \TypeError( 'Fixture engine failure.' ), self::class );
+
+		$this->assert_error_response( $result, false, 'A logging failure must not change the safe response.' );
+	}
+
+	/**
+	 * @testdox Should let the disclosure filter override debug mode but never the capability check.
+	 * @testWith ["administrator", false, true, true]
+	 *           ["customer", false, true, false]
+	 *           ["administrator", true, false, false]
+	 *
+	 * @param string $role                Current user's role.
+	 * @param bool   $debug_enabled       Whether debug mode is enabled.
+	 * @param bool   $filter_value        Value returned by the disclosure filter.
+	 * @param bool   $should_show_details Whether error details should be disclosed.
+	 */
+	public function test_filter_overrides_debug_mode_but_not_capability( string $role, bool $debug_enabled, bool $filter_value, bool $should_show_details ): void {
+		Constants::set_constant( 'WP_DEBUG', $debug_enabled );
+		$this->login_as_role( $role );
+
+		$received_default = null;
+		add_filter(
+			'woocommerce_store_api_expose_error_details',
+			static function ( $expose ) use ( $filter_value, &$received_default ) {
+				$received_default = $expose;
+				return $filter_value;
+			}
+		);
+
+		$result = UnexpectedErrorResponse::create( new \TypeError( 'Fixture engine failure.' ), self::class );
+
+		$this->assertSame( $debug_enabled, $received_default, 'The filter default must be the debug mode state.' );
+		$this->assert_error_response( $result, $should_show_details, 'Disclosure must require the capability even when the filter allows it.' );
+	}
+
+	/**
+	 * Assert the error response for a fixture engine failure, masked or disclosed.
+	 *
+	 * @param WP_Error $result          Response created for the fixture failure.
+	 * @param bool     $details_shown   Whether the message and exception class should be disclosed.
+	 * @param string   $failure_message Assertion message.
+	 */
+	private function assert_error_response( WP_Error $result, bool $details_shown, string $failure_message ): void {
+		$expected_message = $details_shown ? 'Fixture engine failure.' : __( 'Internal server error', 'woocommerce' );
+		$expected_data    = array( 'status' => 500 );
+		if ( $details_shown ) {
+			$expected_data['exception_class'] = \TypeError::class;
+		}
+
+		$this->assertSame( 'woocommerce_rest_unknown_server_error', $result->get_error_code(), 'Engine failures should use the established error code.' );
+		$this->assertSame( $expected_message, $result->get_error_message(), $failure_message );
+		$this->assertSame( $expected_data, $result->get_error_data(), 'Response data must follow the same gate as the message.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Engine errors thrown while a Store API route runs now return a controlled response instead of escaping to WordPress's fatal handler, where a `TypeError` or other non-`Exception` `Throwable` left clients with a bare `internal server error` even in debug mode. Closes #47095.

**What changed:**
- A new `@internal` builder, `StoreApi\Utilities\UnexpectedErrorResponse`, is called from a trailing `catch ( \Throwable )` in each of the four route dispatchers.
- It logs one `critical` event with a ten-frame trace under the `backtrace` context key, the same shape the fatal-error shutdown handler writes, and returns a generic status-500 response to every client.
- The message and class are added only for a user who can `manage_woocommerce`, and only when `WP_DEBUG` is on or the new `woocommerce_store_api_expose_error_details` filter allows it; the capability check is not filterable.
- The cart-session path from #67769 uses the same builder, keeping its public message, headers, and signature.
- In `AbstractCartRoute` an engine failure returns immediately, so `cart_updated()` never runs after a failed dispatch.
- The filter is documented in the published Store API hook reference (`hooks/filters.md`), regenerated with `build:docs`.

**What stayed:** expected `RouteException` and `InvalidCartException` payloads, the ordinary-`Exception` message in all four dispatchers, nonce, Cart-Token, totals, and Checkout cleanup.

**Backward compatibility (High-Impact):** the failure payload is externally visible and conditionally discloses diagnostic text, and the filter is a new public hook, modelled on `woocommerce_return_previous_exceptions` from #47489. No signature, schema, nonce, or auth behaviour changes. Failures outside the route `try` blocks still reach WordPress.

**Question for you:** these failures used to reach remote logging as fatals and no longer do. Opting in needs a Remote Logging owner sign-off (see #65510), so I left it out.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

These steps start from a fresh store with WooCommerce active. They force a deterministic engine error inside a Store API route, then check who can see its details.

**Set up the store and the probe**

1. Go to WooCommerce > Products > Add new, set a name and a price of `10`, and publish the product.
2. Create the file `wp-content/mu-plugins/engine-error-probe.php` with exactly this content:

```php
<?php
add_action( 'woocommerce_cart_calculate_fees', function () {
	if ( isset( $_SERVER['HTTP_X_FORCE_ERROR'] ) ) {
		throw new \TypeError( 'Synthetic Store API engine failure.' );
	}
} );
```

3. In `wp-config.php`, set `define( 'WP_DEBUG', true );`.

**Case 1: a logged-out shopper sees only a generic error**

4. In a terminal, run `curl -s -i -H 'X-Force-Error: 1' https://your-site.example/wp-json/wc/store/v1/cart`.
5. Confirm the status line is `HTTP/1.1 500`.
6. Confirm the body is exactly `{"code":"woocommerce_rest_unknown_server_error","message":"Internal server error","data":{"status":500}}`, with no file, line, class, or trace.
7. Go to WooCommerce > Status > Logs, open the latest `store-api` log, and confirm it records one `CRITICAL` entry with the class `TypeError`, the message `Synthetic Store API engine failure.`, the file and line, and a `backtrace` list in its context.

**Case 2: an administrator in debug mode sees the details**

8. Log into wp-admin as an administrator.
9. Open the browser developer console on any wp-admin page.
10. Paste and run `fetch('/wp-json/wc/store/v1/cart', { headers: { 'X-Force-Error': '1' } }).then(r => r.json()).then(console.log);`.
11. Confirm the logged object is `{code: "woocommerce_rest_unknown_server_error", message: "Synthetic Store API engine failure.", data: {status: 500, exception_class: "TypeError"}}`.

**Case 3: the same administrator with debug off is back to generic**

12. In `wp-config.php`, set `define( 'WP_DEBUG', false );`.
13. Repeat steps 9 and 10.
14. Confirm the logged object is `{code: "woocommerce_rest_unknown_server_error", message: "Internal server error", data: {status: 500}}`, with no `exception_class`.

**Case 4: the filter exposes details to staff without debug mode**

15. Keep `WP_DEBUG` set to `false` and add this line to the end of `wp-content/mu-plugins/engine-error-probe.php`: `add_filter( 'woocommerce_store_api_expose_error_details', '__return_true' );`
16. Repeat steps 9 and 10 as the administrator.
17. Confirm the logged object is `{code: "woocommerce_rest_unknown_server_error", message: "Synthetic Store API engine failure.", data: {status: 500, exception_class: "TypeError"}}`.
18. In a terminal, run `curl -s -i -H 'X-Force-Error: 1' https://your-site.example/wp-json/wc/store/v1/cart` as a logged-out shopper.
19. Confirm the body is still the generic `{"code":"woocommerce_rest_unknown_server_error","message":"Internal server error","data":{"status":500}}`.

**Case 5: normal traffic is unaffected**

20. Delete `wp-content/mu-plugins/engine-error-probe.php`.
21. As a logged-out shopper, request `https://your-site.example/wp-json/wc/store/v1/products` and `https://your-site.example/wp-json/wc/store/v1/cart`.
22. Confirm both return `HTTP/1.1 200` with their normal JSON payloads.
23. Restore your original `WP_DEBUG` value in `wp-config.php`.

<details>

<summary>Automated unit suites pass: 23 tests, 66 assertions</summary>

```sh
cd plugins/woocommerce
pnpm test:php:env -- --filter 'UnexpectedErrorResponseTest|UnexpectedErrorHandlingTest'
```

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

Logging before and after, as seen in WooCommerce > Status > Logs:

| | Before (escaped fatal) | After (this PR) |
|---|---|---|
| Source / level | `fatal-errors` / `critical` | `store-api` / `critical` |
| Backtrace in context | yes | yes, capped at ten frames |
| Survives a `critical` log threshold | yes | yes |
| Remote logging for opted-in stores | eligible | not eligible (no `remote-logging` opt-in) |
| PHP error log | yes | no (the error is now caught) |

Verified on local wp-env (WooCommerce `11.2.0-dev`, PHP 8.1):

- Unit suites pass on the final tree: 23 tests, 66 assertions. The neighbouring Cart, Checkout, and Batch route suites pass: 110 tests, 434 assertions.
- Real HTTP across a guest, customer, shop manager, and administrator, with debug on and off and with the filter on and off: only managers and administrators saw the message and class, and only when debug mode or the filter allowed it. No trace, file, line, or logger context ever reached the public body, and each failure logged one `critical` entry with a capped backtrace. The response shapes are pinned by the unit tests.
- PHPStan on the changed files, Semgrep (85 rules, 0 findings), and PHP lint on the changed files and on the branch diff are clean. No baseline change.
- Infection over the branch diff, scoped to the two covering suites: 106 mutants, 74 killed. Every escaped mutant is either on a pre-existing line of the four route files that Infection includes because the file is in the diff (the `RouteException` and `InvalidCartException` arms, nonce and header handling, default status codes), or the one equivalent mutant in new code (dropping the `(bool)` cast on the filter result, which changes nothing under `&&`). An earlier run showed the ordinary-`Exception` arm in the cart, checkout, and batch dispatchers had no test, so that test now runs through all four.
- Not tested against third-party extensions that subclass these routes. Signatures and callers are unchanged, so overrides are expected to keep working.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog entry created manually in the branch</summary>

#### Comment

Added manually as `plugins/woocommerce/changelog/fix-47095-store-api-debug-errors`.

</details>

### Use of AI Tools

Claude Code (Anthropic) was used to reproduce the issue, write the change and its tests, run the verification and runtime checks above, and draft this description. Every claim here is backed by a command or test run locally, and a human owns the final review. See the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
