### PR TITLE
[tests] Move 7 Cart and Checkout notice E2E tests to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-cart-checkout-notices
+++ b/plugins/woocommerce/changelog/testops-234-cart-checkout-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move 7 Cart and Checkout notice template E2E tests to a new NoticesTest PHPUnit matrix, keeping one browser title per theme.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/cart/cart-checkout-block-notices.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/cart/cart-checkout-block-notices.shopper.block_theme.spec.ts
@@ -6,9 +6,7 @@ import {
 	test as base,
 	wpCLI,
 	BLOCK_THEME_SLUG,
-	BLOCK_CHILD_THEME_WITH_BLOCK_NOTICES_FILTER_SLUG,
 	BLOCK_CHILD_THEME_WITH_BLOCK_NOTICES_TEMPLATE_SLUG,
-	BLOCK_CHILD_THEME_WITH_CLASSIC_NOTICES_TEMPLATE_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -44,54 +42,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 	} );
 
-	test( 'default block notice templates, except for coupon errors, are visible', async ( {
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText( 'Coupon code applied successfully.', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is visible.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-success svg' )
-		).toBeVisible();
-
-		await page.reload();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText( 'Coupon code "testcoupon" already applied!', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is hidden.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-error svg' )
-		).toBeHidden();
-
-		await page.getByLabel( 'Remove Polo from cart' ).click();
-
-		await expect(
-			page.getByText( 'Your cart is currently empty.', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is visible.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-success svg' )
-		).toBeVisible();
-	} );
-
 	test( 'custom block notice templates, except for coupon errors, are visible by template overwrite', async ( {
 		requestUtils,
 		frontendUtils,
@@ -110,8 +60,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 				'BLOCK SUCCESS NOTICE: Coupon code applied successfully.'
 			)
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is visible.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-success svg' )
 		).toBeVisible();
@@ -125,8 +73,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 				'BLOCK ERROR NOTICE: Coupon code "testcoupon" already applied!'
 			)
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is hidden.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-error svg' )
 		).toBeHidden();
@@ -136,118 +82,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await expect(
 			page.getByText( 'BLOCK INFO NOTICE: Your cart is currently empty.' )
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is visible.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-success svg' )
-		).toBeVisible();
-
-		await requestUtils.activateTheme( BLOCK_THEME_SLUG );
-	} );
-
-	test( 'classic notice templates, except for coupon errors, are visible by template overwrite', async ( {
-		requestUtils,
-		frontendUtils,
-		page,
-	} ) => {
-		await requestUtils.activateTheme(
-			BLOCK_CHILD_THEME_WITH_CLASSIC_NOTICES_TEMPLATE_SLUG
-		);
-
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				'CLASSIC SUCCESS NOTICE: Coupon code applied successfully.'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-message' )
-		).toBeVisible();
-
-		await page.reload();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				'CLASSIC ERROR NOTICE: Coupon code "testcoupon" already applied!'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-error' )
-		).toBeHidden();
-
-		await page.getByLabel( 'Remove Polo from cart' ).click();
-
-		await expect(
-			page.getByText(
-				'CLASSIC INFO NOTICE: Your cart is currently empty.'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-info' )
-		).toBeVisible();
-
-		await requestUtils.activateTheme( BLOCK_THEME_SLUG );
-	} );
-
-	test( 'default classic notice templates cannot be triggered by filter', async ( {
-		requestUtils,
-		frontendUtils,
-		page,
-	} ) => {
-		await requestUtils.activateTheme(
-			BLOCK_CHILD_THEME_WITH_BLOCK_NOTICES_FILTER_SLUG
-		);
-
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText( 'Coupon code applied successfully.', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes and that the SVG is visible.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-success svg' )
-		).toBeVisible();
-
-		await page.reload();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText( 'Coupon code "testcoupon" already applied!', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes and that the SVG is hidden.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-error svg' )
-		).toBeHidden();
-
-		await page.getByLabel( 'Remove Polo from cart' ).click();
-
-		await expect(
-			page.getByText( 'Your cart is currently empty.', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes and that the SVG is visible.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-success svg' )
 		).toBeVisible();
@@ -271,12 +105,9 @@ test.describe( 'Shopper → Notice Templates', () => {
 				}
 			)
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is hidden.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-error svg' )
 		).toBeHidden();
-
 		await expect( page.locator( '.coupon-error-notice' ) ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/cart/cart-checkout-block-notices.shopper.classic_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/cart/cart-checkout-block-notices.shopper.classic_theme.spec.ts
@@ -6,19 +6,14 @@ import {
 	test as base,
 	wpCLI,
 	CLASSIC_THEME_SLUG,
-	CLASSIC_CHILD_THEME_WITH_CLASSIC_NOTICES_TEMPLATE_SLUG,
 	CLASSIC_CHILD_THEME_WITH_BLOCK_NOTICES_FILTER_SLUG,
-	CLASSIC_CHILD_THEME_WITH_BLOCK_NOTICES_TEMPLATE_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
  */
 import { CheckoutPage } from '../checkout/checkout.page';
-import {
-	REGULAR_PRICED_PRODUCT_NAME,
-	INVALID_COUPON,
-} from '../checkout/constants';
+import { REGULAR_PRICED_PRODUCT_NAME } from '../checkout/constants';
 
 const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
 	checkoutPageObject: async ( { page }, use ) => {
@@ -46,160 +41,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 	} );
 
-	test( 'default classic notice templates, except for coupon errors, are visible', async ( {
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText( 'Coupon code applied successfully.', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-message' )
-		).toBeVisible();
-
-		await page.reload();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText( 'Coupon code "testcoupon" already applied!', {
-				exact: true,
-			} )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-error' )
-		).toBeHidden();
-
-		await page.getByLabel( 'Remove Polo from cart' ).click();
-
-		await expect(
-			page.getByText( 'Your cart is currently empty.', { exact: true } )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-info' )
-		).toBeVisible();
-	} );
-
-	test( 'custom classic notice templates, except for coupon errors, are visible by template overwrite', async ( {
-		requestUtils,
-		frontendUtils,
-		page,
-	} ) => {
-		await requestUtils.activateTheme(
-			CLASSIC_CHILD_THEME_WITH_CLASSIC_NOTICES_TEMPLATE_SLUG
-		);
-
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				'CLASSIC SUCCESS NOTICE: Coupon code applied successfully.'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-message' )
-		).toBeVisible();
-
-		await page.reload();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				'CLASSIC ERROR NOTICE: Coupon code "testcoupon" already applied!'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-error' )
-		).toBeHidden();
-
-		await page.getByLabel( 'Remove Polo from cart' ).click();
-
-		await expect(
-			page.getByText(
-				'CLASSIC INFO NOTICE: Your cart is currently empty.'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the classic notices.
-		await expect(
-			page.locator( '.woocommerce-notices-wrapper .woocommerce-info' )
-		).toBeVisible();
-
-		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
-	} );
-
-	test( 'custom block notice templates, except for coupon errors, are visible by template overwrite', async ( {
-		requestUtils,
-		frontendUtils,
-		page,
-	} ) => {
-		await requestUtils.activateTheme(
-			CLASSIC_CHILD_THEME_WITH_BLOCK_NOTICES_TEMPLATE_SLUG
-		);
-
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				'BLOCK SUCCESS NOTICE: Coupon code applied successfully.'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is visible.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-success svg' )
-		).toBeVisible();
-
-		await page.reload();
-		await page.getByPlaceholder( 'Coupon code' ).fill( 'testcoupon' );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				'BLOCK ERROR NOTICE: Coupon code "testcoupon" already applied!'
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is hidden.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-error svg' )
-		).toBeHidden();
-
-		await page.getByLabel( 'Remove Polo from cart' ).click();
-
-		await expect(
-			page.getByText( 'BLOCK INFO NOTICE: Your cart is currently empty.' )
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is visible.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-success svg' )
-		).toBeVisible();
-
-		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
-	} );
-
 	test( 'default block notice templates, except for coupon errors, are visible by filter', async ( {
 		requestUtils,
 		frontendUtils,
@@ -216,8 +57,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await expect(
 			page.getByText( 'Coupon code applied successfully.' )
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes and that the SVG is visible.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-success svg' )
 		).toBeVisible();
@@ -229,8 +68,6 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await expect(
 			page.getByText( 'Coupon code "testcoupon" already applied!' )
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes and that the SVG is hidden.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-error svg' )
 		).toBeHidden();
@@ -240,37 +77,10 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await expect(
 			page.getByText( 'Your cart is currently empty.' )
 		).toBeVisible();
-
-		// We're explicitly checking the CSS classes and that the SVG is visible.
 		await expect(
 			page.locator( '.wc-block-components-notice-banner.is-success svg' )
 		).toBeVisible();
 
 		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
-	} );
-
-	test( 'coupon inline notice is visible', async ( {
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.goToCartShortcode();
-		await page.getByPlaceholder( 'Coupon code' ).fill( INVALID_COUPON );
-		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
-
-		await expect(
-			page.getByText(
-				`Coupon "${ INVALID_COUPON }" cannot be applied because it does not exist.`,
-				{
-					exact: true,
-				}
-			)
-		).toBeVisible();
-
-		// We're explicitly checking the CSS classes of the block notices, and that the SVG is hidden.
-		await expect(
-			page.locator( '.wc-block-components-notice-banner.is-error svg' )
-		).toBeHidden();
-
-		await expect( page.locator( '.coupon-error-notice' ) ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/NoticesTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/NoticesTest.php
@@ -1,0 +1,486 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Domain\Services;
+
+use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\Notices;
+use WC_Unit_Test_Case;
+use WP_Hook;
+
+/**
+ * Tests for the Notices service.
+ */
+class NoticesTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Original active theme stylesheet slug.
+	 *
+	 * @var string|null
+	 */
+	private static $original_theme = null;
+
+	/**
+	 * Hooks restored after each test.
+	 *
+	 * @var string[]
+	 */
+	private const SNAPSHOT_HOOKS = array(
+		'after_setup_theme',
+		'wc_get_template',
+		'wp_head',
+		'woocommerce_kses_notice_allowed_tags',
+		'woocommerce_use_block_notices_in_classic_theme',
+		'doing_it_wrong_trigger_error',
+	);
+
+	/**
+	 * Action counts restored after each test.
+	 *
+	 * @var string[]
+	 */
+	private const SNAPSHOT_ACTION_COUNTS = array(
+		'after_setup_theme',
+		'wp_head',
+	);
+
+	/**
+	 * Original hook state.
+	 *
+	 * @var array<string, WP_Hook|null>
+	 */
+	private $hook_snapshots = array();
+
+	/**
+	 * Original action counts.
+	 *
+	 * @var array<string, int|null>
+	 */
+	private $action_counts = array();
+
+	/**
+	 * Original style queue state.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $style_snapshot = array();
+
+	/**
+	 * Theme directories registered before each test.
+	 *
+	 * @var string[]
+	 */
+	private $theme_directories = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_theme_directories;
+
+		$this->theme_directories = $wp_theme_directories;
+		register_theme_directory( trailingslashit( WC_ABSPATH ) . 'tests/e2e/themes/blocks' );
+		search_theme_directories( true );
+		if ( null === self::$original_theme ) {
+			self::$original_theme = get_stylesheet();
+		}
+		$this->snapshot_hooks();
+		$this->snapshot_action_counts();
+		$this->snapshot_styles();
+		$this->reset_wc_blocks_style_queue();
+		wc_clear_template_cache();
+	}
+
+	/**
+	 * Restore test fixtures.
+	 */
+	public function tearDown(): void {
+		global $wp_theme_directories;
+
+		if ( null !== self::$original_theme && get_stylesheet() !== self::$original_theme ) {
+			switch_theme( self::$original_theme );
+		}
+
+		$this->restore_hooks();
+		$this->restore_action_counts();
+		$this->restore_styles();
+		wc_clear_template_cache();
+		$wp_theme_directories = $this->theme_directories; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the exact theme roots registered before this test.
+		search_theme_directories( true );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Restore the original theme after the class completes.
+	 */
+	public static function tearDownAfterClass(): void {
+		if ( null !== self::$original_theme && get_stylesheet() !== self::$original_theme ) {
+			switch_theme( self::$original_theme );
+		}
+	}
+
+	/**
+	 * @testdox Notices activate the expected hooks, locate the expected template, and enqueue styles for every block-theme branch.
+	 */
+	public function test_block_theme_notice_template_matrix(): void {
+		$this->setExpectedIncorrectUsage( 'WP_Block_Templates_Registry::register' );
+		add_filter( 'doing_it_wrong_trigger_error', array( $this, 'suppress_block_template_registry_notice' ), 10, 4 );
+
+		foreach ( array( false, true ) as $opt_in_filter ) {
+			foreach ( array( 'none', 'block', 'classic' ) as $fixture_kind ) {
+				foreach ( array( 'notices/error.php', 'notices/notice.php', 'notices/success.php' ) as $template_name ) {
+					$this->assert_notice_template_row( 'twentytwentyfour', $opt_in_filter, $fixture_kind, $template_name );
+				}
+			}
+		}
+	}
+
+	/**
+	 * @testdox Notices activate the expected hooks, locate the expected template, and enqueue styles for every classic-theme branch.
+	 */
+	public function test_classic_theme_notice_template_matrix(): void {
+		foreach ( array( false, true ) as $opt_in_filter ) {
+			foreach ( array( 'none', 'block', 'classic' ) as $fixture_kind ) {
+				foreach ( array( 'notices/error.php', 'notices/notice.php', 'notices/success.php' ) as $template_name ) {
+					$this->assert_notice_template_row( 'storefront', $opt_in_filter, $fixture_kind, $template_name );
+				}
+			}
+		}
+	}
+
+	/**
+	 * @testdox Notices leave unrelated templates untouched.
+	 */
+	public function test_unrelated_templates_pass_through_unchanged(): void {
+		$base_template = wc_locate_template( 'cart/cart-empty.php' );
+		$resolved      = ( new Notices( new Package( 'test', WC_ABSPATH ) ) )->get_notices_template(
+			$base_template,
+			'cart/cart-empty.php',
+			array(),
+			'',
+			trailingslashit( WC_ABSPATH ) . 'templates/'
+		);
+
+		$this->assertSame( $base_template, $resolved, 'The service should not replace templates outside the three notice files.' );
+		$this->assertFalse( wp_style_is( 'wc-blocks-style', 'enqueued' ), 'Passing through an unrelated template must not enqueue block notice styles.' );
+	}
+
+	/**
+	 * @testdox Notices preserve existing allowed tags and add the exact SVG/path allow-list.
+	 */
+	public function test_notice_kses_tags_preserve_existing_tags_and_add_svg_support(): void {
+		$sut          = new Notices( new Package( 'test', WC_ABSPATH ) );
+		$allowed_tags = array(
+			'a' => array(
+				'href' => true,
+			),
+		);
+
+		$sut->init();
+
+		/**
+		 * Run the notices allow-list filter through the live callback stack.
+		 *
+		 * @since 11.1.0
+		 */
+		$result = apply_filters( 'woocommerce_kses_notice_allowed_tags', $allowed_tags );
+
+		$this->assertArrayHasKey( 'a', $result, 'Existing allow-listed tags should be preserved.' );
+		$this->assertSame( $allowed_tags['a'], $result['a'], 'Existing allow-listed tag attributes should remain unchanged.' );
+		$this->assertSame(
+			array(
+				'aria-hidden' => true,
+				'xmlns'       => true,
+				'width'       => true,
+				'height'      => true,
+				'viewbox'     => true,
+				'focusable'   => true,
+			),
+			$result['svg'] ?? null,
+			'The filter should add the exact SVG attributes used by block notices.'
+		);
+		$this->assertSame(
+			array(
+				'd' => true,
+			),
+			$result['path'] ?? null,
+			'The filter should add the exact SVG path attributes used by block notices.'
+		);
+	}
+
+	/**
+	 * Snapshot the hooks touched by the suite.
+	 */
+	private function snapshot_hooks(): void {
+		foreach ( self::SNAPSHOT_HOOKS as $hook_name ) {
+			$this->hook_snapshots[ $hook_name ] = isset( $GLOBALS['wp_filter'][ $hook_name ] ) ? clone $GLOBALS['wp_filter'][ $hook_name ] : null;
+		}
+	}
+
+	/**
+	 * Restore the hooks touched by the suite.
+	 */
+	private function restore_hooks(): void {
+		foreach ( self::SNAPSHOT_HOOKS as $hook_name ) {
+			if ( $this->hook_snapshots[ $hook_name ] instanceof WP_Hook ) {
+				$GLOBALS['wp_filter'][ $hook_name ] = clone $this->hook_snapshots[ $hook_name ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the exact hook stack captured at setUp.
+			} elseif ( isset( $GLOBALS['wp_filter'][ $hook_name ] ) ) {
+				unset( $GLOBALS['wp_filter'][ $hook_name ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Remove callbacks registered by this test.
+			}
+		}
+	}
+
+	/**
+	 * Snapshot the action counts touched by the suite.
+	 */
+	private function snapshot_action_counts(): void {
+		foreach ( self::SNAPSHOT_ACTION_COUNTS as $action_name ) {
+			$this->action_counts[ $action_name ] = $GLOBALS['wp_actions'][ $action_name ] ?? null;
+		}
+	}
+
+	/**
+	 * Restore the action counts touched by the suite.
+	 */
+	private function restore_action_counts(): void {
+		foreach ( self::SNAPSHOT_ACTION_COUNTS as $action_name ) {
+			if ( null !== $this->action_counts[ $action_name ] ) {
+				$GLOBALS['wp_actions'][ $action_name ] = $this->action_counts[ $action_name ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action count captured at setUp.
+			} elseif ( isset( $GLOBALS['wp_actions'][ $action_name ] ) ) {
+				unset( $GLOBALS['wp_actions'][ $action_name ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Remove counts introduced by this test.
+			}
+		}
+	}
+
+	/**
+	 * Snapshot the style queue state touched by the suite.
+	 */
+	private function snapshot_styles(): void {
+		$wp_styles            = wp_styles();
+		$this->style_snapshot = array(
+			'queue'  => $wp_styles->queue,
+			'done'   => $wp_styles->done,
+			'to_do'  => $wp_styles->to_do,
+			'groups' => $wp_styles->groups,
+			'args'   => $wp_styles->args,
+		);
+	}
+
+	/**
+	 * Restore the style queue state touched by the suite.
+	 */
+	private function restore_styles(): void {
+		$wp_styles         = wp_styles();
+		$wp_styles->queue  = $this->style_snapshot['queue'];
+		$wp_styles->done   = $this->style_snapshot['done'];
+		$wp_styles->to_do  = $this->style_snapshot['to_do'];
+		$wp_styles->groups = $this->style_snapshot['groups'];
+		$wp_styles->args   = $this->style_snapshot['args'];
+	}
+
+	/**
+	 * Remove wc-blocks-style from the working queue so each test starts clean.
+	 */
+	private function reset_wc_blocks_style_queue(): void {
+		$wp_styles        = wp_styles();
+		$wp_styles->queue = array_values( array_diff( $wp_styles->queue, array( 'wc-blocks-style' ) ) );
+		$wp_styles->done  = array_values( array_diff( $wp_styles->done, array( 'wc-blocks-style' ) ) );
+		$wp_styles->to_do = array_values( array_diff( $wp_styles->to_do, array( 'wc-blocks-style' ) ) );
+		unset( $wp_styles->args['wc-blocks-style'] );
+	}
+
+	/**
+	 * Assert one row from the notices matrix.
+	 *
+	 * @param string $theme_slug Active base theme slug.
+	 * @param bool   $opt_in_filter Whether the classic-theme opt-in filter returns true.
+	 * @param string $fixture_kind Fixture type.
+	 * @param string $template_name Notice template to resolve.
+	 */
+	private function assert_notice_template_row( string $theme_slug, bool $opt_in_filter, string $fixture_kind, string $template_name ): void {
+		$this->restore_hooks();
+		$this->restore_action_counts();
+		$this->restore_styles();
+		$this->reset_wc_blocks_style_queue();
+		wc_clear_template_cache();
+
+		$sut               = new Notices( new Package( 'test', WC_ABSPATH ) );
+		$active_theme_slug = $this->get_active_theme_slug( $theme_slug, $fixture_kind );
+
+		if ( 'twentytwentyfour' === $theme_slug ) {
+			add_filter( 'doing_it_wrong_trigger_error', array( $this, 'suppress_block_template_registry_notice' ), 10, 4 );
+		}
+
+		switch_theme( $active_theme_slug );
+		add_filter(
+			'woocommerce_use_block_notices_in_classic_theme',
+			$opt_in_filter ? '__return_true' : '__return_false'
+		);
+
+		$sut->init();
+
+		$this->assertSame(
+			10,
+			has_filter( 'woocommerce_kses_notice_allowed_tags', array( $sut, 'add_kses_notice_allowed_tags' ) ),
+			'The SVG/path allow-list callback should always be registered at priority 10.'
+		);
+
+		/**
+		 * Trigger the service's theme-setup gate after init() has registered its callbacks.
+		 *
+		 * @since 11.1.0
+		 */
+		do_action( 'after_setup_theme' );
+
+		$service_is_active = wp_is_block_theme() || $opt_in_filter;
+		$expected_path     = $this->get_expected_template_path( $theme_slug, $fixture_kind, $template_name, $service_is_active );
+		$result            = $this->resolve_notice_template( $template_name );
+
+		$this->assertSame(
+			$service_is_active ? 10 : false,
+			has_filter( 'wc_get_template', array( $sut, 'get_notices_template' ) ),
+			'The wc_get_template callback should match the theme/filter activation branch.'
+		);
+		$this->assertSame(
+			$service_is_active ? 10 : false,
+			has_action( 'wp_head', array( $sut, 'enqueue_notice_styles' ) ),
+			'The wp_head enqueue callback should match the theme/filter activation branch.'
+		);
+		$this->assertSame(
+			$expected_path,
+			$result['located'],
+			'The resolved template path should follow the exact theme/filter/fixture matrix.'
+		);
+		$this->assertSame(
+			$service_is_active && 'none' === $fixture_kind,
+			$result['style_enqueued_after_resolution'],
+			'The packaged block template should enqueue wc-blocks-style during resolution only when no child override handled the template.'
+		);
+
+		ob_start();
+		/**
+		 * Mirror the front-end head render so the shared stylesheet enqueue can run.
+		 *
+		 * @since 11.1.0
+		 */
+		do_action( 'wp_head' );
+		ob_end_clean();
+
+		$this->assertSame(
+			$service_is_active,
+			wp_style_is( 'wc-blocks-style', 'enqueued' ),
+			'The shared notice stylesheet should only be enqueued after wp_head when block notices are active.'
+		);
+	}
+
+	/**
+	 * Resolve a notice template through the real Woo template loader.
+	 *
+	 * @param string $template_name Template name.
+	 * @return array{located: string, style_enqueued_after_resolution: bool}
+	 */
+	private function resolve_notice_template( string $template_name ): array {
+		$captured_template = '';
+		$capture_callback  = static function ( $name, $template_path, $located ) use ( $template_name, &$captured_template ): void {
+			if ( $template_name === $name ) {
+				$captured_template = $located;
+			}
+		};
+
+		wc_clear_template_cache();
+		add_action( 'woocommerce_before_template_part', $capture_callback, 10, 3 );
+
+		try {
+			wc_get_template_html(
+				$template_name,
+				array(
+					'notices' => array(
+						array(
+							'notice' => 'Test notice',
+							'data'   => array(),
+						),
+					),
+				)
+			);
+		} finally {
+			remove_action( 'woocommerce_before_template_part', $capture_callback, 10 );
+		}
+
+		$this->assertNotSame( '', $captured_template, 'Resolving the notice template should capture the located path from the real Woo template loader.' );
+
+		return array(
+			'located'                         => $captured_template,
+			'style_enqueued_after_resolution' => wp_style_is( 'wc-blocks-style', 'enqueued' ),
+		);
+	}
+
+	/**
+	 * Resolve the active theme slug for a matrix row.
+	 *
+	 * @param string $theme_slug Active theme slug.
+	 * @param string $fixture_kind Fixture type.
+	 * @return string
+	 */
+	private function get_active_theme_slug( string $theme_slug, string $fixture_kind ): string {
+		if ( 'none' === $fixture_kind ) {
+			return $theme_slug;
+		}
+
+		return 'twentytwentyfour' === $theme_slug
+			? sprintf( 'twentytwentyfour-child__%s-notices-template', $fixture_kind )
+			: sprintf( 'storefront-child__%s-notices-template', $fixture_kind );
+	}
+
+	/**
+	 * Compute the exact expected resolved template path for a matrix row.
+	 *
+	 * @param string $theme_slug Active theme slug.
+	 * @param string $fixture_kind Fixture type.
+	 * @param string $template_name Template name.
+	 * @param bool   $service_is_active Whether block notices are active.
+	 * @return string
+	 */
+	private function get_expected_template_path(
+		string $theme_slug,
+		string $fixture_kind,
+		string $template_name,
+		bool $service_is_active
+	): string {
+		if ( 'none' !== $fixture_kind ) {
+			$active_theme_slug = $this->get_active_theme_slug( $theme_slug, $fixture_kind );
+
+			return trailingslashit( get_theme_root( $active_theme_slug ) ) . $active_theme_slug . '/woocommerce/' . $template_name;
+		}
+
+		if ( $service_is_active ) {
+			return trailingslashit( WC_ABSPATH ) . 'templates/block-' . $template_name;
+		}
+
+		return trailingslashit( WC_ABSPATH ) . 'templates/' . $template_name;
+	}
+
+	/**
+	 * Suppress the unrelated block template registry duplicate warning during block-theme setup.
+	 *
+	 * @param bool   $trigger_error Whether WordPress should trigger the warning.
+	 * @param string $function_name Function reporting incorrect usage.
+	 * @param string $message Warning message.
+	 * @param string $version Version that introduced the warning.
+	 * @return bool
+	 */
+	public function suppress_block_template_registry_notice( bool $trigger_error, string $function_name, string $message, string $version ): bool {
+		unset( $version );
+
+		if (
+			'WP_Block_Templates_Registry::register' === $function_name
+			&& str_contains( $message, 'Template "woocommerce//archive-product" is already registered.' )
+		) {
+			return false;
+		}
+
+		return $trigger_error;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The two Cart and Checkout notice specs ran ten browser titles, five per theme, to check which notice template the `Notices` service picks: block or classic markup, packaged or overridden by a child theme, with or without the classic-theme opt-in filter. That choice is made in PHP, in `Notices::get_notices_template()` and the hooks `Notices::init()` registers. This PR moves it to a new PHPUnit class, `NoticesTest`, that checks every combination. It keeps one browser title per theme as the wiring proof. The block-theme spec goes from 5 tests to 2, the classic-theme spec from 5 to 1, and `NoticesTest` adds four test methods.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| Block theme › `default block notice templates, except for coupon errors, are visible` | `NoticesTest::test_block_theme_notice_template_matrix`, no-override rows on `twentytwentyfour` with the filter off and on | browser proof that the default block notice banner renders on a real page with no override |
| Block theme › `classic notice templates, except for coupon errors, are visible by template overwrite` | `NoticesTest::test_block_theme_notice_template_matrix`, classic-override rows | browser proof that the `CLASSIC … NOTICE:` markup renders when a classic-template child theme sits on a block theme |
| Block theme › `default classic notice templates cannot be triggered by filter` | `NoticesTest::test_block_theme_notice_template_matrix`, which runs every row with the opt-in filter off and on and asserts the block templates stay active on a block theme | none |
| Classic theme › `default classic notice templates, except for coupon errors, are visible` | `NoticesTest::test_classic_theme_notice_template_matrix`, no-override rows on `storefront` with the filter off | browser proof of the default classic notice markup |
| Classic theme › `custom classic notice templates, except for coupon errors, are visible by template overwrite` | `NoticesTest::test_classic_theme_notice_template_matrix`, classic-override rows | browser proof of the classic-on-classic override markup |
| Classic theme › `custom block notice templates, except for coupon errors, are visible by template overwrite` | The same title stays in the block-theme spec; `NoticesTest::test_classic_theme_notice_template_matrix` block-override rows cover it on a classic parent theme | browser proof that starts from a classic parent theme |
| Classic theme › `coupon inline notice is visible` | The same title, byte for byte, stays in the block-theme spec | none: both copies open the classic cart shortcode page with `goToCartShortcode()`, whose inline `.coupon-error-notice` does not depend on the theme. The notice banner the title also checks is covered per theme by the retained titles and both `NoticesTest` matrices |

#### Relocated to PHPUnit

`plugins/woocommerce/tests/php/src/Blocks/Domain/Services/NoticesTest.php` is new:

- `test_block_theme_notice_template_matrix` and `test_classic_theme_notice_template_matrix` run every combination of opt-in filter (off, on), override (none, block, classic), and notice template (error, success, notice), on `twentytwentyfour` and `storefront`. For each, they assert which hooks `init()` registers, the file `get_notices_template()` resolves, and whether the `wc-blocks-style` stylesheet is enqueued.
- `test_unrelated_templates_pass_through_unchanged` checks that a non-notice template keeps its original path and enqueues no style.
- `test_notice_kses_tags_preserve_existing_tags_and_add_svg_support` checks that the KSES allow list keeps the existing tags and adds the SVG and path attributes the notice icons need.

#### The retained wiring test

Three browser titles stay, one set per theme, and they prove the service is wired into real pages:

- Block theme: `custom block notice templates, except for coupon errors, are visible by template overwrite`, and `coupon inline notice is visible`.
- Classic theme: `default block notice templates, except for coupon errors, are visible by filter`.

Both specs add products to the cart through trunk's `frontendUtils` helpers. On the #68046 branch they also passed under a cart request tracker that is not landing. So this draft's CI run is the load check for them. They pass locally on trunk's helpers (see below).

#### Where this differs from the TESTOPS-234 audit

The TESTOPS-234 audit lists both notice specs as pure E2E. They are also on the list of files where the audit and this branch reached different conclusions. On that reading, notice rendering is a browser concern, and all ten titles belong in Playwright.

This branch agrees that the rendered notice needs a browser proof, and it keeps one set per theme. It moves the rest because what varies between the ten titles is a server-side choice of template file, and a PHPUnit matrix covers every combination faster and more completely than ten page loads did.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the four new PHPUnit methods and confirm each passes:
    - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_block_theme_notice_template_matrix'`
    - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_classic_theme_notice_template_matrix'`
    - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_unrelated_templates_pass_through_unchanged'`
    - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_notice_kses_tags_preserve_existing_tags_and_add_svg_support'`
4. Confirm the new tests guard the service. In `plugins/woocommerce/src/Blocks/Domain/Services/Notices.php`, change `return array_merge( $allowed_tags, $svg_args );` to `return $svg_args;`. Re-run the KSES command above and confirm it fails at the existing-tag assertion. Revert the change.
5. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
6. Run the two notice specs with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/cart/cart-checkout-block-notices.shopper.block_theme.spec.ts tests/e2e/tests/blocks/cart/cart-checkout-block-notices.shopper.classic_theme.spec.ts`. Playwright reports `4 passed`: the `blocks setup` project plus the three titles.

<!-- End testing instructions -->

### Testing that has already taken place:

- Environment: local wp-env PHPUnit and E2E sites, the E2E site on WordPress 7.1 with a fresh `env:start:blocks` seed, on trunk `7ea8ce435e` plus this commit.
- Title selection: `--list` shows 2 titles in the block-theme spec and 1 in the classic-theme spec.
- PHPUnit, one run per new method:
    - `test_block_theme_notice_template_matrix`: `OK (1 test, 127 assertions)`
    - `test_classic_theme_notice_template_matrix`: `OK (1 test, 126 assertions)`
    - `test_unrelated_templates_pass_through_unchanged`: `OK (1 test, 2 assertions)`
    - `test_notice_kses_tags_preserve_existing_tags_and_add_svg_support`: `OK (1 test, 4 assertions)`
- Retained Playwright titles: both specs pass at `--retries=0 --workers=1`. The block-theme spec reports `3 passed` and the classic-theme spec `2 passed`, each count including the `blocks setup` project.
- Mutation-checked: one recorded mutation per behavior family, 4 in all. Each was reverted afterwards, the file was proven byte-identical, and the test passed again.
    - Renaming the `woocommerce_kses_notice_allowed_tags` hook in `init()` turns `test_block_theme_notice_template_matrix` red at the KSES callback priority check: expected `10`, got `false`.
    - Making `get_notices_template()` treat every template as a notice template turns `test_unrelated_templates_pass_through_unchanged` red at the original-path assertion.
    - Enqueueing the wrong handle in `enqueue_notice_styles()` turns the block-theme matrix red at the post-`wp_head` style assertion.
    - Returning only the SVG tags from `add_kses_notice_allowed_tags()` turns the KSES test red at the existing-tag assertion.
- Lint:
    - `verify oxlint --new-vs=HEAD` reports 0 new findings.
    - The project ESLint reports 0 errors and 2 warnings, and both warnings exist on trunk for the same files.
    - PHPCS on `NoticesTest.php` is clean, and `lint:changes:branch` is clean. `verify-staged` exits 0.
    - PHPStan is not configured for `tests/` in this repository. Run directly on `NoticesTest.php`, it only reports that it cannot see the PHPUnit and WordPress test framework, the same as for the existing tests in that directory.
- Two independent agent reviews: one on coverage and test layer, one on the diff and evidence. The first found two prose corrections, both applied: the coupon inline notice row's reason, and a canary note in the working dossier. A follow-up agent check confirmed the corrections and came back clean. These reviews do not replace human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-cart-checkout-notices`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


