### PR TITLE
[tests] Move 4 extension cart update E2E tests to Jest and PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-cart-checkout-extensibility
+++ b/plugins/woocommerce/changelog/testops-234-cart-checkout-extensibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move 4 extension cart update E2E tests to Jest and PHPUnit, covering the extensionCartUpdate wrapper, the cart thunk, the notice context, and the CartExtensions route; keep one browser title per spec.
+

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-cart-checkout-extensibility
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-cart-checkout-extensibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move 4 extension cart update E2E tests to Jest and PHPUnit, covering the extensionCartUpdate wrapper, the cart thunk, the notice context, and the CartExtensions route; keep one browser title per spec.
+

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/cart/test/thunks.ts
@@ -430,12 +430,13 @@ describe( 'applyExtensionCartUpdate', () => {
 	it( 'should include both addresses when customer data is not dirty', async () => {
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 		} )( { dispatch } as never );
 
 		expect( dispatch.receiveCart ).toHaveBeenCalledWith( mockResponse );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should set prefersCollection true when the extension response selects local pickup', async () => {
@@ -500,7 +501,7 @@ describe( 'applyExtensionCartUpdate', () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 		} )( { dispatch } as never );
@@ -509,13 +510,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
 		expect( received ).toHaveProperty( 'totals' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should strip both addresses when customer data is dirty and overwriteDirtyCustomerData is false', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: false,
@@ -525,13 +527,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
 		expect( received ).toHaveProperty( 'totals' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should include both addresses when overwriteDirtyCustomerData is true', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: true,
@@ -540,13 +543,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
 		expect( received ).toHaveProperty( 'shipping_address' );
 		expect( received ).toHaveProperty( 'billing_address' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should overwrite only shipping_address when specified as object', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: { shipping_address: true },
@@ -558,13 +562,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		} );
 		expect( received ).not.toHaveProperty( 'billing_address' );
 		expect( received ).toHaveProperty( 'totals' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should overwrite only billing_address when specified as object', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: { billing_address: true },
@@ -575,13 +580,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received.billing_address ).toEqual( {
 			address_1: '456 Bill Ave',
 		} );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should overwrite both addresses when both specified in object', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: {
@@ -597,13 +603,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received.billing_address ).toEqual( {
 			address_1: '456 Bill Ave',
 		} );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should strip both addresses when object has explicit false flags', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: {
@@ -616,13 +623,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
 		expect( received ).toHaveProperty( 'totals' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should overwrite specified address even when customer data is not dirty', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( false );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: { shipping_address: true },
@@ -637,13 +645,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received.billing_address ).toEqual( {
 			address_1: '456 Bill Ave',
 		} );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should treat null as false (no overwrite)', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData:
@@ -653,13 +662,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should treat an array as false (no overwrite)', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: [
@@ -670,13 +680,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should treat non-boolean address fields as false', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: {
@@ -688,13 +699,14 @@ describe( 'applyExtensionCartUpdate', () => {
 		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( result ).toBe( mockResponse );
 	} );
 
 	it( 'should default missing address fields to false', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();
 
-		await applyExtensionCartUpdate( {
+		const result = await applyExtensionCartUpdate( {
 			namespace: 'test',
 			data: {},
 			overwriteDirtyCustomerData: {},
@@ -703,5 +715,25 @@ describe( 'applyExtensionCartUpdate', () => {
 		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
 		expect( received ).not.toHaveProperty( 'shipping_address' );
 		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( result ).toBe( mockResponse );
+	} );
+
+	it( 'should dispatch and reject the same API error', async () => {
+		const dispatch = createMockDispatch();
+		const error = {
+			code: 'test_error',
+			message: 'This is an error with cart context.',
+			data: { status: 400, context: 'wc/cart' },
+		};
+		mockApiFetchWithHeaders.mockRejectedValueOnce( error );
+
+		await expect(
+			applyExtensionCartUpdate( {
+				namespace: 'test',
+				data: {},
+			} )( { dispatch } as never )
+		).rejects.toBe( error );
+
+		expect( dispatch.receiveError ).toHaveBeenCalledWith( error );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/utils/test/process-error-response.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/utils/test/process-error-response.ts
@@ -49,6 +49,14 @@ const errorResponse: ApiErrorResponse = {
 	},
 };
 
+const errorResponseWithoutContext: ApiErrorResponse = {
+	code: 'woocommerce_rest_cart_extensions_error',
+	message: 'There is no such namespace registered: test-plugin.',
+	data: {
+		status: 400,
+	},
+};
+
 describe( 'getNoticeContextFromErrorResponse', () => {
 	it( 'should generate notice contexts and ids for the correct fields/errors', () => {
 		const result = getNoticeContextFromErrorResponse( errorResponse );
@@ -73,9 +81,24 @@ describe( 'getNoticeContextFromErrorResponse', () => {
 		);
 		expect( result[ 0 ].context ).toEqual( 'test_context' );
 	} );
+
+	it( 'should use the cart context for a non-parameter error without a server context', () => {
+		expect(
+			getNoticeContextFromErrorResponse( errorResponseWithoutContext )
+		).toEqual( [
+			{
+				id: 'woocommerce_rest_cart_extensions_error',
+				context: 'wc/cart',
+			},
+		] );
+	} );
 } );
 
 describe( 'processErrorResponse', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'should dismiss old notices and create new ones', () => {
 		processErrorResponse( errorResponse );
 		expect( createNotice ).toHaveBeenCalledTimes( 2 );
@@ -94,6 +117,20 @@ describe( 'processErrorResponse', () => {
 			{
 				id: 'shipping_address_gov_id_mismatch',
 				context: 'wc/checkout/shipping-address',
+			}
+		);
+	} );
+
+	it( 'should create a non-parameter error notice in the cart context by default', () => {
+		processErrorResponse( errorResponseWithoutContext );
+
+		expect( createNotice ).toHaveBeenCalledTimes( 1 );
+		expect( createNotice ).toHaveBeenCalledWith(
+			'error',
+			'There is no such namespace registered: test-plugin.',
+			{
+				id: 'woocommerce_rest_cart_extensions_error',
+				context: 'wc/cart',
 			}
 		);
 	} );

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/utils/test/extension-cart-update.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/utils/test/extension-cart-update.ts
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { processErrorResponse } from '@woocommerce/block-data';
+import type { CartResponse, ExtensionCartUpdateArgs } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { extensionCartUpdate } from '../extension-cart-update';
+import { STORE_KEY } from '../../../block-data/cart/constants';
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/block-data', () => ( {
+	processErrorResponse: jest.fn(),
+} ) );
+
+const mockDispatch = dispatch as jest.MockedFunction< typeof dispatch >;
+const mockProcessErrorResponse = processErrorResponse as jest.MockedFunction<
+	typeof processErrorResponse
+>;
+const mockApplyExtensionCartUpdate = jest.fn();
+
+describe( 'extensionCartUpdate', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockDispatch.mockReturnValue( {
+			applyExtensionCartUpdate: mockApplyExtensionCartUpdate,
+		} as never );
+	} );
+
+	it.each< [ string, ExtensionCartUpdateArgs ] >( [
+		[
+			'with overwrite omitted',
+			{ namespace: 'test-extension', data: { value: 'omitted' } },
+		],
+		[
+			'with overwrite disabled',
+			{
+				namespace: 'test-extension',
+				data: { value: 'false' },
+				overwriteDirtyCustomerData: false,
+			},
+		],
+		[
+			'with overwrite enabled',
+			{
+				namespace: 'test-extension',
+				data: { value: 'true' },
+				overwriteDirtyCustomerData: true,
+			},
+		],
+		[
+			'with shipping-address overwrite enabled',
+			{
+				namespace: 'test-extension',
+				data: { value: 'shipping' },
+				overwriteDirtyCustomerData: { shipping_address: true },
+			},
+		],
+		[
+			'with billing-address overwrite enabled',
+			{
+				namespace: 'test-extension',
+				data: { value: 'billing' },
+				overwriteDirtyCustomerData: { billing_address: true },
+			},
+		],
+	] )(
+		'forwards arguments and fulfills with the same cart response %s',
+		async ( _, args ) => {
+			const response = { items: [] } as CartResponse;
+			mockApplyExtensionCartUpdate.mockResolvedValueOnce( response );
+
+			const result = await extensionCartUpdate( args );
+
+			expect( mockDispatch ).toHaveBeenCalledWith( STORE_KEY );
+			expect( mockApplyExtensionCartUpdate ).toHaveBeenCalledWith( args );
+			expect( result ).toBe( response );
+		}
+	);
+
+	it( 'rejects the same non-special error without creating a notice', async () => {
+		const error = {
+			code: 'test_error',
+			message: 'This is an extension error.',
+		};
+		mockApplyExtensionCartUpdate.mockRejectedValueOnce( error );
+
+		await expect(
+			extensionCartUpdate( {
+				namespace: 'test-extension',
+				data: {},
+			} )
+		).rejects.toBe( error );
+
+		expect( mockProcessErrorResponse ).not.toHaveBeenCalled();
+	} );
+
+	it( 'processes a special cart-extension error once and rejects that same error', async () => {
+		const error = {
+			code: 'woocommerce_rest_cart_extensions_error',
+			message: 'The cart extension could not be processed.',
+		};
+		mockApplyExtensionCartUpdate.mockRejectedValueOnce( error );
+
+		await expect(
+			extensionCartUpdate( {
+				namespace: 'test-extension',
+				data: {},
+			} )
+		).rejects.toBe( error );
+
+		expect( mockProcessErrorResponse ).toHaveBeenCalledTimes( 1 );
+		expect( mockProcessErrorResponse ).toHaveBeenCalledWith( error );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts
@@ -1,50 +1,14 @@
 /**
  * External dependencies
  */
-import { expect, test as base } from '@woocommerce/e2e-utils';
+import { expect, test } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
  */
-import { CheckoutPage } from '../checkout/checkout.page';
 import { REGULAR_PRICED_PRODUCT_NAME } from '../checkout/constants';
 
-const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
-	checkoutPageObject: async ( { page }, use ) => {
-		const pageObject = new CheckoutPage( {
-			page,
-		} );
-		await use( pageObject );
-	},
-} );
-
 test.describe( 'Shopper → Cart Extension Callbacks', () => {
-	test( 'Custom error code creates exception', async ( {
-		frontendUtils,
-		requestUtils,
-		page,
-	} ) => {
-		await requestUtils.activatePlugin(
-			'woocommerce-blocks-test-cart-extensions'
-		);
-
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
-		await frontendUtils.goToCart();
-
-		await expect(
-			page.evaluate( () =>
-				window.wc.blocksCheckout
-					.extensionCartUpdate( {
-						namespace: 'cart-extensions-test-helper',
-					} )
-					.catch( ( error ) => {
-						throw new Error( error.message );
-					} )
-			)
-		).rejects.toThrow( 'This is an error with cart context.' );
-	} );
-
 	test( 'Error code `woocommerce_rest_cart_extensions_error` creates notice', async ( {
 		frontendUtils,
 		requestUtils,
@@ -68,29 +32,6 @@ test.describe( 'Shopper → Cart Extension Callbacks', () => {
 			page
 				.locator( '.wc-block-components-notice-banner__content' )
 				.getByText( 'This is an error with cart context.' )
-		).toBeVisible();
-	} );
-
-	test( 'Invalid callback namespace creates notice', async ( {
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
-		await frontendUtils.goToCart();
-
-		await page.evaluate( () => {
-			window.wc.blocksCheckout.extensionCartUpdate( {
-				namespace: 'invalid-namespace',
-			} );
-		} );
-
-		await expect(
-			page
-				.locator( '.wc-block-components-notice-banner__content' )
-				.getByText(
-					'There is no such namespace registered: invalid-namespace.'
-				)
 		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -40,101 +40,52 @@ test.describe( 'Shopper → Extensibility', () => {
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
 	} );
+
 	test.describe( 'extensionCartUpdate', () => {
-		test( 'Response is not undefined in any code path', async ( {
-			checkoutPageObject,
-		} ) => {
-			// With no additional args.
-			let response = await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update' } ).then( ( response ) => response );"
-			);
-			let resolvedResponse = await Promise.resolve( response );
-			expect( resolvedResponse ).not.toBeUndefined();
-			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
-
-			// With overwriteDirtyCustomerData true.
-			response = await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } ).then( ( response ) => response );"
-			);
-			resolvedResponse = await Promise.resolve( response );
-			expect( resolvedResponse ).not.toBeUndefined();
-			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
-
-			// With overwriteDirtyCustomerData false.
-			response = await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: false } ).then( ( response ) => response );"
-			);
-			resolvedResponse = await Promise.resolve( response );
-			expect( resolvedResponse ).not.toBeUndefined();
-			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
-
-			// With a dirty customer object.
-			await checkoutPageObject.page
-				.getByLabel( 'Country/Region' )
-				.selectOption( 'United Kingdom (UK)' );
-			await expect(
-				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'GB' );
-			response = await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update' } ).then( ( response ) => response );"
-			);
-			resolvedResponse = await Promise.resolve( response );
-			expect( resolvedResponse ).not.toBeUndefined();
-			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
-		} );
-		test( 'Unpushed data is/is not overwritten depending on arg', async ( {
-			checkoutPageObject,
-		} ) => {
-			// First test by only partially filling in the address form.
-			await checkoutPageObject.page
-				.getByLabel( 'Country/Region' )
-				.selectOption( 'United Kingdom (UK)' );
-			await checkoutPageObject.page.getByLabel( 'Country/Region' ).blur();
-
-			await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update' } )"
-			);
-			await expect(
-				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'GB' );
-			await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } )"
-			);
-			await expect(
-				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).not.toHaveValue( 'GB' );
-
-			// Next fully test the address form (so it pushes), then run extensionCartUpdate with
-			// overwriteDirtyCustomerData: true so overwriting is possible, but since the address pushed it should not
-			// be overwritten.
-			await checkoutPageObject.fillInCheckoutWithTestData();
-			await expect(
-				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'US' );
-			await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } )"
-			);
-			await expect(
-				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'US' );
-		} );
 		test( 'Cart data can be modified by extensions', async ( {
 			checkoutPageObject,
 		} ) => {
-			await checkoutPageObject.fillInCheckoutWithTestData();
-			await checkoutPageObject.page.waitForFunction( () => {
+			const { page } = checkoutPageObject;
+			const country = page.getByLabel( 'Country/Region' );
+			await country.selectOption( 'United Kingdom (UK)' );
+			await country.blur();
+			await page.waitForFunction( () => {
 				return (
 					window.localStorage.getItem(
 						'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY'
-					) === 'false'
+					) === 'true'
 				);
 			} );
-			await checkoutPageObject.page.evaluate(
-				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', data: { 'test-name-change': true } } )"
+			await page.evaluate( () =>
+				window.wc.blocksCheckout.extensionCartUpdate( {
+					namespace: 'woocommerce-blocks-test-extension-cart-update',
+				} )
 			);
-			await expect(
-				checkoutPageObject.page.getByLabel( 'First name' )
-			).toHaveValue( 'Mr. Test' );
+			await expect( country ).toHaveValue( 'GB' );
+
+			const overwriteResponse = await page.evaluate( () =>
+				window.wc.blocksCheckout.extensionCartUpdate( {
+					namespace: 'woocommerce-blocks-test-extension-cart-update',
+					overwriteDirtyCustomerData: true,
+				} )
+			);
+			expect( overwriteResponse.shipping_address.country ).not.toBe(
+				'GB'
+			);
+			await expect( country ).toHaveValue(
+				overwriteResponse.shipping_address.country
+			);
+
+			await page.evaluate( () =>
+				window.wc.blocksCheckout.extensionCartUpdate( {
+					namespace: 'woocommerce-blocks-test-extension-cart-update',
+					data: { 'test-name-change': true },
+					overwriteDirtyCustomerData: true,
+				} )
+			);
+			await expect( page.getByLabel( 'First name' ) ).toHaveValue(
+				'Mr. Test'
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartExtensions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartExtensions.php
@@ -7,6 +7,9 @@ namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
 
 use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\ControllerTestCase;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\StoreApi;
 
 /**
  * Cart Controller Tests.
@@ -35,7 +38,7 @@ class CartExtensions extends ControllerTestCase {
 		woocommerce_store_api_register_update_callback(
 			array(
 				'namespace' => 'valid-test-plugin',
-				'callback'  => function() {
+				'callback'  => function () {
 					add_action(
 						'woocommerce_cart_calculate_fees',
 						function() {
@@ -46,10 +49,11 @@ class CartExtensions extends ControllerTestCase {
 			)
 		);
 	}
+
 	/**
-	 * Test getting cart with invalid namespace.
+	 * @testdox Invalid namespace errors expose the mapped Store API response without a context override.
 	 */
-	public function test_invalid_namespace() {
+	public function test_invalid_namespace(): void {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/extensions' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
@@ -57,10 +61,61 @@ class CartExtensions extends ControllerTestCase {
 				'namespace' => 'test-plugin',
 			)
 		);
-		$this->assertAPIResponse(
-			$request,
-			400
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status(), 'An invalid extension namespace should return HTTP 400.' );
+		$this->assertSame( 'woocommerce_rest_cart_extensions_error', $data['code'], 'The response should use the mapped cart-extension error code.' );
+		$this->assertSame( 'There is no such namespace registered: test-plugin.', $data['message'], 'The response should identify the missing namespace exactly.' );
+		$this->assertSame( 400, $data['data']['status'], 'The response data should preserve the HTTP status.' );
+		$this->assertArrayNotHasKey( 'context', $data['data'], 'The invalid-namespace response should leave notice context selection to the client.' );
+	}
+
+	/**
+	 * @testdox Extension callback RouteException data passes through the public route unchanged.
+	 */
+	public function test_callback_route_exception_passes_through(): void {
+		$extend            = StoreApi::container()->get( ExtendSchema::class );
+		$original_callback = $extend->get_update_callback( 'valid-test-plugin' );
+
+		woocommerce_store_api_register_update_callback(
+			array(
+				'namespace' => 'valid-test-plugin',
+				'callback'  => function () {
+					throw new RouteException(
+						'test_error',
+						'This is an error with cart context.',
+						400,
+						array( 'context' => 'wc/cart' )
+					);
+				},
+			)
 		);
+
+		try {
+			$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/extensions' );
+			$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+			$request->set_body_params(
+				array(
+					'namespace' => 'valid-test-plugin',
+				)
+			);
+			$response = rest_get_server()->dispatch( $request );
+			$data     = $response->get_data();
+
+			$this->assertSame( 400, $response->get_status(), 'The callback RouteException should preserve its HTTP status.' );
+			$this->assertSame( 'test_error', $data['code'], 'The callback RouteException should preserve its error code.' );
+			$this->assertSame( 'This is an error with cart context.', $data['message'], 'The callback RouteException should preserve its message.' );
+			$this->assertSame( 400, $data['data']['status'], 'The callback RouteException response data should preserve its status.' );
+			$this->assertSame( 'wc/cart', $data['data']['context'], 'The callback RouteException should preserve its notice context.' );
+		} finally {
+			woocommerce_store_api_register_update_callback(
+				array(
+					'namespace' => 'valid-test-plugin',
+					'callback'  => $original_callback,
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Two Blocks E2E specs ran six browser titles against the public `extensionCartUpdate` API. Three covered how extension callback errors surface, and three covered how the checkout form takes, or refuses, cart and customer data an extension pushes. Four of them checked decisions made in code that runs fine without a browser:

- whether the wrapper rejects with the same error;
- which notice context an error lands in;
- whether the route passes a callback's exception through unchanged;
- whether the thunk strips a dirty address unless told to overwrite it.

This PR moves those four to Jest and PHPUnit and keeps one browser title per spec. Each spec goes from 3 tests to 1, and `CartExtensions` goes from 2 test methods to 3.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| Callbacks › `Custom error code creates exception` | `extension-cart-update.ts` › `extensionCartUpdate` › `rejects the same non-special error without creating a notice`; `thunks.ts` › `applyExtensionCartUpdate` › `should dispatch and reject the same API error`; and `CartExtensions::test_callback_route_exception_passes_through`, which checks that the route keeps the callback exception's status, code, message, and context | the exact error message reaching a real browser call's `catch`. The lower tests prove that the server keeps the message and that the client rejects with the same error object |
| Callbacks › `Invalid callback namespace creates notice` | `CartExtensions::test_invalid_namespace`, which now checks the exact status, code, and message, and that there is no context. Also `process-error-response.ts` › `getNoticeContextFromErrorResponse` › `should use the cart context for a non-parameter error without a server context`, and `processErrorResponse` › `should create a non-parameter error notice in the cart context by default` | the notice banner's rendered text on the page. The lower tests check the notice call's id, context, and message |
| Extensibility › `Response is not undefined in any code path` | `thunks.ts` › `applyExtensionCartUpdate`: 13 of its 15 existing cases now assert `expect( result ).toBe( mockResponse )`. The two `prefersCollection` cases don't | none. An identity check is stronger than "not undefined", and it covers more argument shapes: `null`, an array, and non-boolean fields |
| Extensibility › `Unpushed data is/is not overwritten depending on arg` | `thunks.ts` › `applyExtensionCartUpdate` › `should strip both addresses when customer data is dirty and no overwrite specified`, `should include both addresses when overwriteDirtyCustomerData is true`, and `should overwrite specified address even when customer data is not dirty` | the case where the form was already submitted and an update with `overwriteDirtyCustomerData: true` still leaves it alone. The unit test mocks a clean store instead of running the real form store's submit, and the retained browser title does not cover this case either |
| Extensibility › `Cart data can be modified by extensions` (kept, but trimmed) | the rewritten title below, and `thunks.ts` › `should include both addresses when customer data is not dirty` for the thunk's side | the original path: fill in the whole form, let the checkout save it, wait for the dirty flag to clear, then call `extensionCartUpdate` with default arguments. The rewrite changes the name with `overwriteDirtyCustomerData: true` on a form that has not saved yet, and the unit test mocks a clean store. No test at any layer now proves that a completed save clears the dirty flag |

#### Relocated to Jest and PHPUnit

- `packages/public-api/blocks-checkout/utils/test/extension-cart-update.ts` is new. It checks that `extensionCartUpdate` forwards five argument shapes to the cart thunk and resolves with the same response. It also checks that an ordinary error rejects without a notice, and that the special `woocommerce_rest_cart_extensions_error` code is processed once and still rejects with the same error.
- `packages/public-api/block-data/cart/test/thunks.ts`: 13 of the 15 existing `applyExtensionCartUpdate` cases now also assert the resolved response. A new case checks that a failed request rejects with the original error and records it.
- `packages/public-api/block-data/utils/test/process-error-response.ts` gains two cases for an error that arrives without a context: it defaults to the cart notice context.
- `tests/php/src/Blocks/StoreApi/Routes/CartExtensions.php`: `test_invalid_namespace` now checks the exact response, and the new `test_callback_route_exception_passes_through` checks that an extension callback's exception reaches the client unchanged.

#### The retained wiring test

Two browser titles stay:

- Callbacks › ``Error code `woocommerce_rest_cart_extensions_error` creates notice``, unchanged. It proves that an extension's error reaches the shopper as a notice.
- Extensibility › `Cart data can be modified by extensions`, rewritten as one journey that checks three things:
    - a country the shopper has just picked survives an extension update that doesn't ask to overwrite it;
    - an update with `overwriteDirtyCustomerData: true` replaces it with the country the server holds;
    - data an extension pushes reaches the form.

Like trunk's `Unpushed data is/is not overwritten depending on arg`, the journey relies on the checkout waiting about 1.5 seconds before it saves a changed select, so the picked country is still unsaved while those updates run. It now also asserts that the server's country differs from the picked one, so a run slow enough to miss that window fails instead of passing without proving the overwrite.

Both specs add products to the cart through trunk's `frontendUtils` helpers. On the #68046 branch they also passed under a cart request tracker that is not landing, so this draft's CI run is the load check for them. They pass locally on trunk's helpers (see below).

#### Where this differs from the TESTOPS-234 audit

The TESTOPS-234 audit lists both specs as pure E2E, and both are on the list of files where the audit and this branch reached different conclusions. The audit's per-test pass marked all six titles as E2E. It measures the layer of each test, and it left trimming bundled browser tests for a later phase.

This branch agrees that the extension contract needs a browser proof, and it keeps one title per spec. It moves the rest because what varied between those titles was a decision in the wrapper, the thunk, the notice pipeline, or the route. Unit and route tests reach those decisions directly, with more argument shapes than the browser titles covered.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the component and data tests and confirm they pass:
    - `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath packages/public-api/blocks-checkout/utils/test/extension-cart-update.ts`
    - `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath packages/public-api/block-data/cart/test/thunks.ts`
    - `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath packages/public-api/block-data/utils/test/process-error-response.ts`
3. Confirm the wrapper test guards the special error path. In `plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/utils/extension-cart-update.ts`, change `if ( error?.code === 'woocommerce_rest_cart_extensions_error' ) {` to `if ( true ) {`. Re-run the first command and confirm `rejects the same non-special error without creating a notice` fails. Revert the change.
4. Start the PHPUnit environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test`, then run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_invalid_namespace|test_callback_route_exception_passes_through'` and confirm both tests pass.
5. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
6. Run the two specs with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts tests/e2e/tests/blocks/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts`. Confirm both titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled.

- **Focused commands.** The mutation matrix records 22 distinct focused commands for these files: 18 Jest, 2 PHPUnit, and 2 Playwright. All 22 exit 0.
    - Two of the Jest commands match no test as recorded: the ones for `should treat null as false (no overwrite)` and `should treat an array as false (no overwrite)`. Their `--testNamePattern` leaves the parentheses unescaped.
    - Re-run with the parentheses escaped, each runs its one test and passes.
- **Retained titles.** `--list` shows one title per spec, and both specs pass with `--retries=0 --workers=1`.
- **Mutation re-check.** For each behavior family, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0556` | `applyExtensionCartUpdate` resolves with the error instead of rejecting | `should dispatch and reject the same API error`: the promise resolved |
| `0599` | `includeShipping` is always true (Blocks rebuilt) | the retained `Cart data can be modified by extensions`: expected `GB`, received `US` |
| `0569` | `getNoticeContextFromErrorResponse` uses the checkout context instead of the context for the error code | `should use the cart context for a non-parameter error without a server context` |
| `0570` | `processErrorResponse` uses the checkout context instead of the context for the error code | `should create a non-parameter error notice in the cart context by default` |
| `0571` | `extensionCartUpdate` treats every error as a cart-extension error | `rejects the same non-special error without creating a notice`: one notice call, expected none |
| `0074` | `CartExtensionsSchema` returns 500 for an unknown namespace | `test_invalid_namespace`: 500 is not 400 |
| `0951` | `AbstractRoute::error_to_response` rewrites the response body status to 500 | `test_invalid_namespace`: the body status is 500, not 400 |
| `0953` | `AbstractCartRoute` replaces the exception's status with 500 | `test_callback_route_exception_passes_through`: 500 is not 400 |

- **Lint.**
    - `verify-staged` exits 0 on the amended files. oxlint over all five JS/TS files in the batch finds nothing new.
    - `lint:changes:branch` exits 0. Its 2 remaining warnings are on lines this PR does not change: the `import/named` resolver warning at `thunks.ts:4`, and `rules-of-hooks` on the Playwright fixture's `use( pageObject )`.
    - PHPCS reports 2 errors in `CartExtensions.php`, both on lines this PR does not change. Trunk has 3.
    - PHPStan doesn't analyse `tests/` in this repository's config, so it isn't a gate for these files. A direct run on `CartExtensions.php` is kept as a record.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Reviews.** Two independent agent reviews read the branch and the evidence. Their findings are applied, or declined with a written reason, and a second review of the fixes came back clean. Neither is a human review.
- **Changes on top of the #68046 state.**
    - The new Jest file imports its two types with `import type`.
    - The rewritten journey drops a request hold that never matched anything, because the checkout sends its customer update inside a batch request.
    - The journey gains the assertion that the overwrite really changed the country.

    The first two changes don't alter what the tests check, and the third makes the journey stricter.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-cart-checkout-extensibility` and `plugins/woocommerce/client/blocks/changelog/testops-234-cart-checkout-extensibility`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


