### PR TITLE
[tests] Move 5 Checkout block editor control E2E tests to Jest

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-checkout-block-editor-controls
+++ b/plugins/woocommerce/changelog/testops-234-checkout-block-editor-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move 5 Checkout block editor control E2E tests to Jest; the Checkout block merchant spec keeps 3 browser titles.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/block-settings/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/block-settings/test/index.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { BlockSettings } from '../index';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	InspectorControls: jest.fn( ( { children } ) => <div>{ children }</div> ),
+} ) );
+
+describe( 'Cart and Checkout block settings', () => {
+	it.each( [
+		{ initialValue: false, expectedValue: true },
+		{ initialValue: true, expectedValue: false },
+	] )(
+		'maps hasDarkControls=$initialValue to $expectedValue',
+		async ( { initialValue, expectedValue } ) => {
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<BlockSettings
+					attributes={ {
+						hasDarkControls: initialValue,
+						showFormStepNumbers: false,
+					} }
+					setAttributes={ setAttributes }
+				/>
+			);
+
+			const darkModeToggle = screen.getByRole( 'checkbox', {
+				name: 'Dark mode inputs',
+			} );
+			expect( darkModeToggle ).toHaveProperty( 'checked', initialValue );
+
+			await user.click( darkModeToggle );
+
+			expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hasDarkControls: expectedValue,
+			} );
+		}
+	);
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/tests/edit.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/tests/edit.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from '../edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: jest.fn( ( { children } ) => <div>{ children }</div> ),
+	RichText: jest.fn( ( { value, placeholder } ) => (
+		<span>{ value || placeholder }</span>
+	) ),
+	useBlockProps: Object.assign(
+		jest.fn( () => ( { className: '' } ) ),
+		{
+			save: jest.fn( () => ( {} ) ),
+		}
+	),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn( () => 2 ),
+} ) );
+
+jest.mock( '@woocommerce/editor-components/page-selector', () => () => null );
+
+jest.mock( '@woocommerce/base-components/cart-checkout', () => ( {
+	PlaceOrderButton: jest.fn( ( { label } ) => <button>{ label }</button> ),
+	ReturnToCartButton: jest.fn( ( { children } ) => (
+		<span>{ children }</span>
+	) ),
+} ) );
+
+jest.mock( '@woocommerce/block-settings', () => ( {
+	CHECKOUT_PAGE_ID: 1,
+} ) );
+
+const expectReturnToCartVisible = () => {
+	expect( screen.getByText( 'Return to Cart' ) ).toBeVisible();
+};
+
+const expectReturnToCartHidden = () => {
+	expect( screen.queryByText( 'Return to Cart' ) ).not.toBeInTheDocument();
+};
+
+describe( 'Checkout Actions editor', () => {
+	it.each( [
+		{ initialValue: false, expectedValue: true },
+		{ initialValue: true, expectedValue: false },
+	] )(
+		'maps showReturnToCart=$initialValue to $expectedValue and previews the current state',
+		async ( { initialValue, expectedValue } ) => {
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<Edit
+					attributes={ {
+						cartPageId: 1,
+						showReturnToCart: initialValue,
+						placeOrderButtonLabel: 'Place Order',
+						priceSeparator: '·',
+						returnToCartButtonLabel: 'Return to Cart',
+					} }
+					setAttributes={ setAttributes }
+				/>
+			);
+
+			const returnToCartToggle = screen.getByRole( 'checkbox', {
+				name: 'Show a "Return to Cart" link',
+			} );
+			expect( returnToCartToggle ).toHaveProperty(
+				'checked',
+				initialValue
+			);
+			if ( initialValue ) {
+				expectReturnToCartVisible();
+			} else {
+				expectReturnToCartHidden();
+			}
+
+			await user.click( returnToCartToggle );
+
+			expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				showReturnToCart: expectedValue,
+			} );
+		}
+	);
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/frontend.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/frontend.js
@@ -20,6 +20,12 @@ import { validationStore } from '@woocommerce/block-data';
 import * as actionCreators from '@woocommerce/block-data/validation/actions';
 import FrontendBlock from '../frontend';
 
+jest.mock( '@woocommerce/block-settings', () => ( {
+	...jest.requireActual( '@woocommerce/block-settings' ),
+	TERMS_URL: 'https://example.com/terms/',
+	PRIVACY_URL: 'https://example.com/privacy/',
+} ) );
+
 jest.mock( '@woocommerce/block-data/validation/actions', () => {
 	const actions = jest.requireActual(
 		'@woocommerce/block-data/validation/actions'
@@ -33,7 +39,35 @@ jest.mock( '@woocommerce/block-data/validation/actions', () => {
 } );
 
 describe( 'FrontendBlock', () => {
-	it( 'Renders a checkbox if the checkbox prop is true', async () => {
+	it( 'Renders the default Terms and Privacy links without a checkbox', () => {
+		render(
+			<SlotFillProvider>
+				<FrontendBlock
+					checkbox={ false }
+					text=""
+					showSeparator={ false }
+				/>
+			</SlotFillProvider>
+		);
+
+		expect(
+			screen.getByText(
+				( _, element ) =>
+					element?.tagName === 'SPAN' &&
+					element.textContent ===
+						'By proceeding with your purchase you agree to our Terms and Conditions and Privacy Policy'
+			)
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'link', { name: 'Terms and Conditions' } )
+		).toHaveAttribute( 'href', 'https://example.com/terms/' );
+		expect(
+			screen.getByRole( 'link', { name: 'Privacy Policy' } )
+		).toHaveAttribute( 'href', 'https://example.com/privacy/' );
+		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'Renders a checkbox if the checkbox prop is true', () => {
 		const { container } = render(
 			<SlotFillProvider>
 				<FrontendBlock
@@ -44,7 +78,7 @@ describe( 'FrontendBlock', () => {
 			</SlotFillProvider>
 		);
 
-		const checkbox = await findByLabelText(
+		const checkbox = queryByLabelText(
 			container,
 			'I agree to the terms and conditions'
 		);
@@ -73,6 +107,7 @@ describe( 'FrontendBlock', () => {
 
 	it( 'Clears any validation errors when the checkbox is checked', async () => {
 		const user = userEvent.setup();
+		actionCreators.clearValidationError.mockClear();
 		const { container } = render(
 			<SlotFillProvider>
 				<FrontendBlock
@@ -89,7 +124,15 @@ describe( 'FrontendBlock', () => {
 		await act( async () => {
 			await user.click( checkbox );
 		} );
-		expect( actionCreators.clearValidationError ).toHaveBeenLastCalledWith(
+		expect( actionCreators.clearValidationError ).toHaveBeenCalledTimes(
+			2
+		);
+		expect( actionCreators.clearValidationError ).toHaveBeenNthCalledWith(
+			1,
+			expect.stringMatching( /terms-and-conditions-\d/ )
+		);
+		expect( actionCreators.clearValidationError ).toHaveBeenNthCalledWith(
+			2,
 			expect.stringMatching( /terms-and-conditions-\d/ )
 		);
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/address-field-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/address-field-controls.tsx
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { AddressFieldControls } from '../address-field-controls';
+
+const mockEditEntityRecord = jest.fn();
+const mockDispatch = jest.fn( () => ( {
+	editEntityRecord: mockEditEntityRecord,
+} ) );
+const mockUseCheckoutBlockContext = jest.fn();
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: jest.fn( ( { children } ) => <div>{ children }</div> ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	dispatch: ( store: string ) => mockDispatch( store ),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+jest.mock( '../context', () => ( {
+	useCheckoutBlockContext: () => mockUseCheckoutBlockContext(),
+} ) );
+
+type FieldName = 'company' | 'address_2' | 'phone';
+type FieldState = 'hidden' | 'optional' | 'required';
+
+const fields: Array< {
+	label: string;
+	name: FieldName;
+	option: string;
+} > = [
+	{
+		label: 'Company',
+		name: 'company',
+		option: 'woocommerce_checkout_company_field',
+	},
+	{
+		label: 'Address line 2',
+		name: 'address_2',
+		option: 'woocommerce_checkout_address_2_field',
+	},
+	{
+		label: 'Phone',
+		name: 'phone',
+		option: 'woocommerce_checkout_phone_field',
+	},
+];
+
+const getField = ( state: FieldState ) => ( {
+	hidden: state === 'hidden',
+	required: state === 'required',
+} );
+
+const renderControls = ( field: FieldName, state: FieldState ) => {
+	mockUseCheckoutBlockContext.mockReturnValue( {
+		defaultFields: {
+			company: getField( field === 'company' ? state : 'hidden' ),
+			address_2: getField( field === 'address_2' ? state : 'hidden' ),
+			phone: getField( field === 'phone' ? state : 'hidden' ),
+		},
+	} );
+
+	render( <AddressFieldControls /> );
+};
+
+const expectUpdate = ( option: string, value: FieldState ) => {
+	expect( mockDispatch ).toHaveBeenCalledWith( 'core' );
+	expect( mockEditEntityRecord ).toHaveBeenCalledTimes( 1 );
+	expect( mockEditEntityRecord ).toHaveBeenCalledWith(
+		'root',
+		'site',
+		undefined,
+		{ [ option ]: value }
+	);
+};
+
+describe.each( fields )( '$label address field control', ( field ) => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows a hidden field as optional', async () => {
+		const user = userEvent.setup();
+		renderControls( field.name, 'hidden' );
+
+		const visibilityToggle = screen.getByRole( 'checkbox', {
+			name: field.label,
+		} );
+		expect( visibilityToggle ).not.toBeChecked();
+
+		await user.click( visibilityToggle );
+
+		expectUpdate( field.option, 'optional' );
+	} );
+
+	it( 'hides an optional field', async () => {
+		const user = userEvent.setup();
+		renderControls( field.name, 'optional' );
+
+		const visibilityToggle = screen.getByRole( 'checkbox', {
+			name: field.label,
+		} );
+		expect( visibilityToggle ).toBeChecked();
+		expect(
+			screen.getByRole( 'radio', { name: 'Optional' } )
+		).toBeChecked();
+
+		await user.click( visibilityToggle );
+
+		expectUpdate( field.option, 'hidden' );
+	} );
+
+	it( 'makes an optional field required', async () => {
+		const user = userEvent.setup();
+		renderControls( field.name, 'optional' );
+
+		expect(
+			screen.getByRole( 'radio', { name: 'Optional' } )
+		).toBeChecked();
+		await user.click( screen.getByRole( 'radio', { name: 'Required' } ) );
+
+		expectUpdate( field.option, 'required' );
+	} );
+
+	it( 'makes a required field optional', async () => {
+		const user = userEvent.setup();
+		renderControls( field.name, 'required' );
+
+		expect(
+			screen.getByRole( 'radio', { name: 'Required' } )
+		).toBeChecked();
+		await user.click( screen.getByRole( 'radio', { name: 'Optional' } ) );
+
+		expectUpdate( field.option, 'optional' );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/edit.tsx
@@ -1,0 +1,276 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { Form } from '@woocommerce/base-components/cart-checkout';
+import type { FormFields, ShippingAddress } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from '../edit';
+import type { Attributes } from '../types';
+
+let mockFieldSettings: Record< string, string > = {};
+let mockCapturedDefaultFields: FormFields | undefined;
+let mockRenderingCheckoutEdit = false;
+
+jest.mock( '@wordpress/data', () => {
+	const data = jest.requireActual( '@wordpress/data' );
+	return {
+		...data,
+		useSelect: (
+			mapSelect: ( select: ( store: unknown ) => unknown ) => unknown,
+			dependencies?: unknown[]
+		) => {
+			if ( mockRenderingCheckoutEdit ) {
+				return mapSelect( () => ( {
+					getEditedEntityRecord: () => mockFieldSettings,
+				} ) );
+			}
+
+			return data.useSelect( mapSelect, dependencies );
+		},
+	};
+} );
+
+jest.mock( '@wordpress/block-editor', () => {
+	const InnerBlocks = Object.assign(
+		jest.fn( () => null ),
+		{
+			Content: jest.fn( () => null ),
+		}
+	);
+	const useBlockProps = Object.assign(
+		jest.fn( () => ( {} ) ),
+		{
+			save: jest.fn( () => ( {} ) ),
+		}
+	);
+
+	return {
+		InnerBlocks,
+		InspectorControls: jest.fn( ( { children } ) => <>{ children }</> ),
+		useBlockProps,
+	};
+} );
+
+jest.mock( '@woocommerce/base-context', () => ( {
+	...jest.requireActual( '@woocommerce/base-context' ),
+	CheckoutProvider: jest.fn( ( { children } ) => <>{ children }</> ),
+	EditorProvider: jest.fn( ( { children, previewData } ) => {
+		mockCapturedDefaultFields = previewData.defaultFields;
+		return <>{ children }</>;
+	} ),
+	useCheckoutAddress: jest.fn( () => ( {
+		defaultFields: mockCapturedDefaultFields,
+	} ) ),
+} ) );
+
+jest.mock( '@woocommerce/base-components/sidebar-layout', () => ( {
+	SidebarLayout: jest.fn( ( { children, className } ) => (
+		<div className={ className }>{ children }</div>
+	) ),
+} ) );
+
+jest.mock( '@woocommerce/blocks-checkout', () => ( {
+	...jest.requireActual( '@woocommerce/blocks-checkout' ),
+	SlotFillProvider: jest.fn( ( { children } ) => <>{ children }</> ),
+} ) );
+
+jest.mock( '../../cart-checkout-shared', () => ( {
+	addClassToBody: jest.fn(),
+	BlockSettings: jest.fn( () => null ),
+	useBlockPropsWithLocking: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( '../inner-blocks', () => ( {} ) );
+
+const checkoutAttributes: Attributes = {
+	hasDarkControls: false,
+	showFormStepNumbers: false,
+	showOrderNotes: true,
+	showPolicyLinks: true,
+	showReturnToCart: false,
+	showRateAfterTaxName: false,
+	cartPageId: 1,
+	showCompanyField: false,
+	requireCompanyField: false,
+	showApartmentField: false,
+	requireApartmentField: false,
+	showPhoneField: false,
+	requirePhoneField: false,
+};
+
+const emptyShippingAddress: ShippingAddress = {
+	first_name: '',
+	last_name: '',
+	company: '',
+	address_1: '',
+	address_2: '',
+	city: '',
+	state: '',
+	postcode: '',
+	country: '',
+	phone: '',
+};
+
+const renderCheckoutEdit = (
+	fieldSettings: Record< string, string > = {},
+	hasDarkControls = false
+) => {
+	mockFieldSettings = fieldSettings;
+	mockCapturedDefaultFields = undefined;
+	mockRenderingCheckoutEdit = true;
+	const result = render(
+		<Edit
+			clientId="checkout-client-id"
+			attributes={ { ...checkoutAttributes, hasDarkControls } }
+			setAttributes={ jest.fn() }
+		/>
+	);
+	mockRenderingCheckoutEdit = false;
+
+	if ( ! mockCapturedDefaultFields ) {
+		throw new Error( 'Checkout Edit did not provide default fields.' );
+	}
+
+	return result;
+};
+
+type FieldName = 'company' | 'address_2' | 'phone';
+type FieldState = 'hidden' | 'optional' | 'required';
+
+const fieldCases: Array< {
+	field: FieldName;
+	label: string;
+	addLabel?: string;
+} > = [
+	{ field: 'company', label: 'Company' },
+	{
+		field: 'address_2',
+		label: 'Apartment, suite, etc.',
+		addLabel: '+ Add apartment, suite, etc.',
+	},
+	{ field: 'phone', label: 'Phone' },
+];
+
+const stateCases: Array< {
+	state: FieldState;
+	hidden: boolean;
+	required: boolean;
+} > = [
+	{ state: 'hidden', hidden: true, required: false },
+	{ state: 'optional', hidden: false, required: false },
+	{ state: 'required', hidden: false, required: true },
+];
+
+const expectHiddenField = ( label: string ) => {
+	expect( screen.queryByLabelText( label ) ).not.toBeInTheDocument();
+	expect(
+		screen.queryByLabelText( `${ label } (optional)` )
+	).not.toBeInTheDocument();
+};
+
+const expectHiddenAddControl = ( addLabel: string ) => {
+	expect(
+		screen.queryByRole( 'button', { name: addLabel } )
+	).not.toBeInTheDocument();
+};
+
+const expectCollapsedOptionalAddressLine = (
+	label: string,
+	addLabel: string
+) => {
+	expect( screen.getByRole( 'button', { name: addLabel } ) ).toBeVisible();
+	expect( screen.getByLabelText( label ) ).toHaveAttribute(
+		'aria-hidden',
+		'true'
+	);
+};
+
+const expectVisibleField = ( label: string, required: boolean ) => {
+	const input = screen.getByLabelText(
+		required ? label : `${ label } (optional)`
+	);
+	expect( input ).toBeVisible();
+	expect( ( input as HTMLInputElement ).required ).toBe( required );
+};
+
+describe( 'Checkout editor consumers', () => {
+	beforeEach( () => {
+		mockFieldSettings = {};
+		mockCapturedDefaultFields = undefined;
+		mockRenderingCheckoutEdit = false;
+	} );
+
+	it( 'omits the dark controls class when hasDarkControls is false', () => {
+		const { container } = renderCheckoutEdit();
+		const checkoutLayout = container.querySelector( '.wc-block-checkout' );
+
+		expect( checkoutLayout ).toBeInTheDocument();
+		expect( checkoutLayout ).not.toHaveClass( 'has-dark-controls' );
+	} );
+
+	it( 'adds the dark controls class when hasDarkControls is true', () => {
+		const { container } = renderCheckoutEdit( {}, true );
+		const checkoutLayout = container.querySelector( '.wc-block-checkout' );
+
+		expect( checkoutLayout ).toBeInTheDocument();
+		expect( checkoutLayout ).toHaveClass( 'has-dark-controls' );
+	} );
+
+	it.each(
+		fieldCases.flatMap( ( fieldCase ) =>
+			stateCases.map( ( stateCase ) => ( {
+				...fieldCase,
+				...stateCase,
+			} ) )
+		)
+	)(
+		'maps $field=$state from the root-site record into the real form',
+		( { field, label, addLabel, state, hidden, required } ) => {
+			const optionName = `woocommerce_checkout_${ field }_field`;
+			const { unmount } = renderCheckoutEdit( {
+				[ optionName ]: state,
+			} );
+			const defaultFields = mockCapturedDefaultFields as FormFields;
+
+			expect( defaultFields[ field ] ).toMatchObject( {
+				hidden,
+				required,
+			} );
+			unmount();
+
+			const fields: ( keyof FormFields )[] =
+				field === 'address_2'
+					? [ 'address_1', 'address_2' ]
+					: [ field ];
+			render(
+				<Form< ShippingAddress >
+					id="shipping"
+					addressType="shipping"
+					fields={ fields }
+					isEditing
+					onChange={ jest.fn() }
+					values={ emptyShippingAddress }
+				/>
+			);
+
+			if ( hidden ) {
+				expectHiddenField( label );
+				if ( addLabel ) {
+					expectHiddenAddControl( addLabel );
+				}
+				return;
+			}
+
+			if ( field === 'address_2' && ! required && addLabel ) {
+				expectCollapsedOptionalAddressLine( label, addLabel );
+				return;
+			}
+
+			expectVisibleField( label, required );
+		}
+	);
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-checkout-block-editor-controls
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-checkout-block-editor-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move 5 Checkout block editor control E2E tests to Jest; the Checkout block merchant spec keeps 3 browser titles.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -14,16 +14,6 @@ import {
 import { CheckoutPage } from './checkout.page';
 import { REGULAR_PRICED_PRODUCT_NAME } from './constants';
 
-declare global {
-	interface Window {
-		wcSettings: {
-			storePages: {
-				terms: { permalink: string };
-				privacy: { permalink: string };
-			};
-		};
-	}
-}
 const blockData: BlockData = {
 	name: 'Checkout',
 	slug: 'woocommerce/checkout',
@@ -104,80 +94,22 @@ test.describe( 'Merchant → Checkout', () => {
 		);
 	} );
 
-	test.describe( 'Can adjust T&S and Privacy Policy options', () => {
-		test( 'Merchant can see T&S and Privacy Policy links without checkbox', async ( {
-			page,
-			frontendUtils,
-			checkoutPageObject,
-		} ) => {
-			await frontendUtils.goToShop();
-			await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
-			await frontendUtils.goToCheckout();
-			await expect(
-				frontendUtils.page.getByText(
-					'By proceeding with your purchase you agree to our Terms and Conditions and Privacy Policy'
-				)
-			).toBeVisible();
-
-			const termsAndConditions = frontendUtils.page
-				.getByRole( 'link' )
-				.getByText( 'Terms and Conditions' )
-				.first();
-			const privacyPolicy = frontendUtils.page
-				.getByRole( 'link' )
-				.getByText( 'Privacy Policy' )
-				.first();
-
-			const { termsPageUrl, privacyPageUrl } = await page.evaluate(
-				() => {
-					const { terms, privacy } = window.wcSettings.storePages;
-
-					return {
-						termsPageUrl: terms.permalink,
-						privacyPageUrl: privacy.permalink,
-					};
-				}
-			);
-			await expect( termsAndConditions ).toHaveAttribute(
-				'href',
-				termsPageUrl
-			);
-			await expect( privacyPolicy ).toHaveAttribute(
-				'href',
-				privacyPageUrl
-			);
-			await checkoutPageObject.fillInCheckoutWithTestData();
-			await checkoutPageObject.placeOrder();
-			await expect(
-				frontendUtils.page.getByText(
-					'Thank you. Your order has been received.'
-				)
-			).toBeVisible();
-		} );
-	} );
-
-	test( 'Merchant can see T&S and Privacy Policy links with checkbox', async ( {
+	test( 'Merchant must accept T&S before checkout', async ( {
 		frontendUtils,
 		checkoutPageObject,
-		admin,
 		editor,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-		await editor.openDocumentSettingsSidebar();
 		await editor.selectBlocks(
 			blockSelectorInEditor +
 				'  [data-type="woocommerce/checkout-terms-block"]'
 		);
-		let requireTermsCheckbox = editor.page.getByRole( 'checkbox', {
+		const requireTermsCheckbox = editor.page.getByRole( 'checkbox', {
 			name: 'Require checkbox',
 			exact: true,
 		} );
 		await requireTermsCheckbox.check();
 		await editor.saveSiteEditorEntities();
+
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
@@ -191,12 +123,7 @@ test.describe( 'Merchant → Checkout', () => {
 			'aria-invalid',
 			'true'
 		);
-
-		await frontendUtils.page
-			.getByLabel(
-				'You must accept our Terms and Conditions and Privacy Policy to continue with your purchase.'
-			)
-			.check();
+		await checkboxWithError.check();
 
 		await checkoutPageObject.placeOrder();
 		await expect(
@@ -204,6 +131,22 @@ test.describe( 'Merchant → Checkout', () => {
 				'Thank you. Your order has been received'
 			)
 		).toBeVisible();
+	} );
+
+	test( 'Merchant can persist a required Company field', async ( {
+		frontendUtils,
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		await requestUtils.rest( {
+			method: 'POST',
+			path: 'e2e-options/update',
+			data: {
+				option_name: 'woocommerce_checkout_company_field',
+				option_value: 'hidden',
+			},
+		} );
 
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
@@ -213,359 +156,76 @@ test.describe( 'Merchant → Checkout', () => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.selectBlocks(
 			blockSelectorInEditor +
-				'  [data-type="woocommerce/checkout-terms-block"]'
+				'  [data-type="woocommerce/checkout-shipping-address-block"]'
 		);
-		requireTermsCheckbox = editor.page.getByRole( 'checkbox', {
-			name: 'Require checkbox',
+
+		const shippingAddressBlock = await editor.getBlockByName(
+			'woocommerce/checkout-shipping-address-block'
+		);
+		const shippingCompanyInput =
+			shippingAddressBlock.getByLabel( 'Company' );
+		const shippingCompanyToggle = editor.page.getByRole( 'checkbox', {
+			name: 'Company',
 			exact: true,
 		} );
-		await requireTermsCheckbox.uncheck();
+		const companyRequirement = editor.page.locator(
+			'.wc-block-components-require-company-field'
+		);
+
+		await expect( shippingCompanyToggle ).not.toBeChecked();
+		await expect( shippingCompanyInput ).toBeHidden();
+		await expect( async () => {
+			await shippingCompanyToggle.check();
+		} ).toPass();
+		await expect( shippingCompanyInput ).toBeVisible();
+		await expect(
+			companyRequirement.getByRole( 'radio', { name: 'Optional' } )
+		).toBeChecked();
+		await expect( shippingCompanyInput ).not.toHaveAttribute( 'required' );
+
+		const requiredCompany = companyRequirement.getByRole( 'radio', {
+			name: 'Required',
+		} );
+		await expect( async () => {
+			await requiredCompany.check();
+		} ).toPass();
+		await expect( requiredCompany ).toBeChecked();
+		await expect( shippingCompanyInput ).toHaveAttribute( 'required' );
 		await editor.saveSiteEditorEntities();
-	} );
 
-	test.describe( 'Attributes', () => {
-		test.beforeEach( async ( { editor } ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.selectBlocks( blockSelectorInEditor );
+		await admin.visitSiteEditor( {
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
+			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-
-		test( 'can enable dark mode inputs', async ( { editor, page } ) => {
-			const toggleLabel = page.getByLabel( 'Dark mode inputs' );
-			await toggleLabel.check();
-
-			const shippingAddressBlock = await editor.getBlockByName(
-				'woocommerce/checkout'
-			);
-
-			const darkControls = shippingAddressBlock.locator(
-				'.wc-block-checkout.has-dark-controls'
-			);
-			await expect( darkControls ).toBeVisible();
-			await toggleLabel.uncheck();
-			await expect( darkControls ).toBeHidden();
-		} );
-
-		test.describe( 'Shipping and billing addresses', () => {
-			test.beforeEach( async ( { editor } ) => {
-				await editor.openDocumentSettingsSidebar();
-				await editor.selectBlocks( blockSelectorInEditor );
-			} );
-
-			test( 'Company input visibility and optional and required can be toggled', async ( {
-				editor,
-			} ) => {
-				await editor.selectBlocks(
-					blockSelectorInEditor +
-						'  [data-type="woocommerce/checkout-shipping-address-block"]'
-				);
-
-				const shippingAddressBlock = await editor.getBlockByName(
-					'woocommerce/checkout-shipping-address-block'
-				);
-
-				const shippingCompanyInput =
-					shippingAddressBlock.getByLabel( 'Company' );
-
-				const shippingCompanyToggle = editor.page.getByRole(
-					'checkbox',
-					{
-						name: 'Company',
-						exact: true,
-					}
-				);
-
-				const shippingCompanyOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-company-field >> text="Optional"'
-				);
-
-				const shippingCompanyRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-company-field >> text="Required"'
-				);
-
-				// Verify that the company field is hidden by default.
-				await expect( shippingCompanyInput ).toBeHidden();
-
-				// Enable the company field.
-				await expect( async () => {
-					await shippingCompanyToggle.check();
-				} ).toPass();
-
-				// Verify that the company field is visible and the field is optional.
-				await expect( shippingCompanyInput ).toBeVisible();
-				await expect( shippingCompanyOptionalToggle ).toBeChecked();
-				await expect( shippingCompanyInput ).not.toHaveAttribute(
-					'required'
-				);
-
-				// Make the company field required.
-				await expect( async () => {
-					await shippingCompanyRequiredToggle.check();
-				} ).toPass();
-
-				// Verify that the company field is required.
-				await expect( shippingCompanyRequiredToggle ).toBeChecked();
-
-				// Disable the company field.
-				await expect( async () => {
-					await shippingCompanyToggle.uncheck();
-				} ).toPass();
-
-				// Verify that the company field is hidden.
-				await expect( shippingCompanyInput ).toBeHidden();
-
-				// Display the billing address form.
-				await editor.canvas
-					.getByLabel( 'Use same address for billing' )
-					.uncheck();
-
-				await editor.selectBlocks(
-					blockSelectorInEditor +
-						'  [data-type="woocommerce/checkout-billing-address-block"]'
-				);
-
-				const billingAddressBlock = await editor.getBlockByName(
-					'woocommerce/checkout-billing-address-block'
-				);
-
-				const billingCompanyInput =
-					billingAddressBlock.getByLabel( 'Company' );
-
-				const billingCompanyToggle = editor.page.getByRole(
-					'checkbox',
-					{
-						name: 'Company',
-						exact: true,
-					}
-				);
-
-				// Verify the company field on the billing address has the correct state from the shipping address.
-				await expect( billingCompanyToggle ).not.toBeChecked();
-				await expect( billingCompanyInput ).toBeHidden();
-			} );
-
-			test( 'Apartment input visibility and optional and required can be toggled', async ( {
-				editor,
-			} ) => {
-				await editor.selectBlocks(
-					blockSelectorInEditor +
-						'  [data-type="woocommerce/checkout-shipping-address-block"]'
-				);
-
-				const shippingAddressBlock = await editor.getBlockByName(
-					'woocommerce/checkout-shipping-address-block'
-				);
-
-				const shippingApartmentInput = shippingAddressBlock.getByLabel(
-					'Apartment, suite, etc.'
-				);
-
-				const shippingApartmentLink = shippingAddressBlock.getByRole(
-					'button',
-					{
-						name: '+ Add apartment, suite, etc.',
-					}
-				);
-
-				const shippingApartmentToggle = editor.page.getByRole(
-					'checkbox',
-					{
-						name: 'Address line 2',
-						exact: true,
-					}
-				);
-
-				const shippingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-address_2-field >> text="Optional"'
-				);
-
-				const shippingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-address_2-field >> text="Required"'
-				);
-
-				// Verify that the apartment link is visible by default.
-				await expect( shippingApartmentLink ).toBeVisible();
-
-				// Verify that the apartment field is hidden by default and the field is optional.
-				await expect( shippingApartmentInput ).not.toBeInViewport();
-				await expect( shippingApartmentOptionalToggle ).toBeChecked();
-
-				// Make the apartment number required.
-				await expect( async () => {
-					await shippingApartmentRequiredToggle.check();
-				} ).toPass();
-
-				// Verify that the apartment field is required.
-				await expect( shippingApartmentRequiredToggle ).toBeChecked();
-				await expect( shippingApartmentInput ).toHaveAttribute(
-					'required'
-				);
-
-				// Disable the apartment field.
-				await expect( async () => {
-					await shippingApartmentToggle.uncheck();
-				} ).toPass();
-
-				// Verify that the apartment link and the apartment field are hidden.
-				await expect( shippingApartmentLink ).toBeHidden();
-				await expect( shippingApartmentInput ).not.toBeInViewport();
-
-				// Display the billing address form.
-				await editor.canvas
-					.getByLabel( 'Use same address for billing' )
-					.uncheck();
-
-				await editor.selectBlocks(
-					blockSelectorInEditor +
-						'  [data-type="woocommerce/checkout-billing-address-block"]'
-				);
-
-				const billingAddressBlock = await editor.getBlockByName(
-					'woocommerce/checkout-billing-address-block'
-				);
-
-				const billingApartmentInput = billingAddressBlock.getByLabel(
-					'Apartment, suite, etc.'
-				);
-
-				const billingApartmentLink = billingAddressBlock.getByRole(
-					'button',
-					{
-						name: '+ Add apartment, suite, etc.',
-					}
-				);
-
-				const billingApartmentToggle = editor.page.getByRole(
-					'checkbox',
-					{
-						name: 'Address line 2',
-						exact: true,
-					}
-				);
-
-				// Verify the apartment field on the billing address has the correct state from the shipping address.
-				await expect( billingApartmentToggle ).not.toBeChecked();
-				await expect( billingApartmentLink ).toBeHidden();
-				await expect( billingApartmentInput ).not.toBeInViewport();
-			} );
-
-			test( 'Phone input visibility and optional and required can be toggled', async ( {
-				editor,
-			} ) => {
-				await editor.selectBlocks(
-					blockSelectorInEditor +
-						'  [data-type="woocommerce/checkout-shipping-address-block"]'
-				);
-
-				const shippingAddressBlock = await editor.getBlockByName(
-					'woocommerce/checkout-shipping-address-block'
-				);
-
-				const shippingPhoneInput =
-					shippingAddressBlock.getByLabel( 'Phone' );
-
-				const shippingPhoneToggle = editor.page.getByRole( 'checkbox', {
-					name: 'Phone',
-					exact: true,
-				} );
-
-				const shippingPhoneOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-phone-field >> text="Optional"'
-				);
-
-				const shippingPhoneRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-phone-field >> text="Required"'
-				);
-
-				// Verify that the phone field is visible by default and the field is optional.
-				await expect( shippingPhoneInput ).toBeVisible();
-				await expect( shippingPhoneOptionalToggle ).toBeChecked();
-				await expect( shippingPhoneInput ).not.toHaveAttribute(
-					'required'
-				);
-
-				// Make the phone number required.
-				await expect( async () => {
-					await shippingPhoneRequiredToggle.check();
-				} ).toPass();
-
-				// Verify that the phone field is required.
-				await expect( shippingPhoneRequiredToggle ).toBeChecked();
-				await expect( shippingPhoneInput ).toHaveAttribute(
-					'required'
-				);
-
-				// Disable the phone field.
-				await expect( async () => {
-					await shippingPhoneToggle.uncheck();
-				} ).toPass();
-
-				// Verify that the phone field is hidden.
-				await expect( shippingPhoneInput ).toBeHidden();
-
-				// Display the billing address form.
-				await editor.canvas
-					.getByLabel( 'Use same address for billing' )
-					.uncheck();
-
-				await editor.selectBlocks(
-					blockSelectorInEditor +
-						'  [data-type="woocommerce/checkout-billing-address-block"]'
-				);
-
-				const billingAddressBlock = await editor.getBlockByName(
-					'woocommerce/checkout-billing-address-block'
-				);
-
-				const billingPhoneInput =
-					billingAddressBlock.getByLabel( 'Phone' );
-
-				const billingPhoneToggle = editor.page.getByRole( 'checkbox', {
-					name: 'Phone',
-					exact: true,
-				} );
-
-				// Verify the phone field on the billing address has the correct state from the shipping address.
-				await expect( billingPhoneToggle ).not.toBeChecked();
-				await expect( billingPhoneInput ).toBeHidden();
-			} );
-		} );
-	} );
-
-	test.describe( 'Checkout actions', () => {
-		test.beforeEach( async ( { editor } ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.selectBlocks( blockSelectorInEditor );
-		} );
-
-		test( 'Return to cart link is visible and can be toggled', async ( {
-			editor,
-		} ) => {
-			await editor.selectBlocks(
-				`${ blockSelectorInEditor } .wp-block-woocommerce-checkout-actions-block`
-			);
-
-			// Turn on return to cart link and check it's visible in the block.
-			const returnToCartLinkToggle = editor.page.getByLabel(
-				'Show a "Return to Cart" link',
-				{ exact: true }
-			);
-			await returnToCartLinkToggle.check();
-			const shippingAddressBlock = await editor.getBlockByName(
-				'woocommerce/checkout-actions-block'
-			);
-
-			// Turn on return to cart link and check it shows in the block.
-			const returnToCartLink = shippingAddressBlock.getByText(
-				'Return to Cart',
-				{ exact: true }
-			);
-
-			// Turn off return to cart link and check it's not visible in the block.
-			await expect( returnToCartLink ).toBeVisible();
-
-			await returnToCartLinkToggle.uncheck();
-
-			await expect( returnToCartLink ).toBeHidden();
-		} );
+		await editor.openDocumentSettingsSidebar();
+		await editor.selectBlocks(
+			blockSelectorInEditor +
+				'  [data-type="woocommerce/checkout-shipping-address-block"]'
+		);
+		await expect(
+			editor.page
+				.locator( '.wc-block-components-require-company-field' )
+				.getByRole( 'radio', { name: 'Required' } )
+		).toBeChecked();
+
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
+
+		const shippingCompany = frontendUtils.page
+			.getByRole( 'group', { name: 'Shipping address' } )
+			.getByLabel( 'Company' );
+		await expect( shippingCompany ).toBeVisible();
+		await expect( shippingCompany ).toHaveAttribute( 'required' );
+
+		await frontendUtils.page
+			.getByLabel( 'Use same address for billing' )
+			.uncheck();
+		const billingCompany = frontendUtils.page
+			.getByRole( 'group', { name: 'Billing address' } )
+			.getByLabel( 'Company' );
+		await expect( billingCompany ).toBeVisible();
+		await expect( billingCompany ).toHaveAttribute( 'required' );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Checkout block merchant spec ran eight browser titles. Five of them toggled one inspector control each and read the result back in the Site Editor canvas:

- the dark mode inputs toggle;
- the Return to Cart link toggle;
- the visibility and requirement controls for Company, Address line 2, and Phone.

Each of those controls turns a click into a block attribute or a site setting inside a small component, and Jest reaches that mapping directly. This PR adds Jest suites for those components, strengthens the Terms frontend suite, and cuts the spec from 8 tests to 3.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `Merchant can see T&S and Privacy Policy links without checkbox` | `checkout-terms-block/test/frontend.js` › `FrontendBlock` › `Renders the default Terms and Privacy links without a checkbox` | the storefront showing the Terms text with the store's real terms and privacy permalinks. The Jest test checks the links against mocked URL constants. Other retained titles still place orders with the default Terms block, which has no checkbox |
| `Merchant can see T&S and Privacy Policy links with checkbox` | rewritten in place as the retained `Merchant must accept T&S before checkout` | none. The old test also unchecked the requirement at the end; the new one leaves that to the suite's per-test database restore |
| `can enable dark mode inputs` | `block-settings/test/index.tsx` › `maps hasDarkControls=false to true` and `maps hasDarkControls=true to false`; `checkout/test/edit.tsx` › `omits the dark controls class when hasDarkControls is false` and `adds the dark controls class when hasDarkControls is true` | toggling the real control in the Site Editor and seeing the class in the canvas. After this PR no browser title covers the dark mode control |
| `Company input visibility and optional and required can be toggled` | `checkout/test/address-field-controls.tsx` › `Company address field control` (4 cases); `checkout/test/edit.tsx` › `maps company=hidden`, `=optional`, and `=required from the root-site record into the real form`; the retained `Merchant can persist a required Company field` | the editor's billing address block showing the same Company state as the shipping block. The storefront's billing Company field is still checked by the retained title |
| `Apartment input visibility and optional and required can be toggled` | `address-field-controls.tsx` › `Address line 2 address field control` (4 cases); `edit.tsx` › the three `maps address_2=…` cases | the editor's billing block showing the same state, and the round trip inside the editor, from the sidebar control to the canvas, for Address line 2 |
| `Phone input visibility and optional and required can be toggled` | `address-field-controls.tsx` › `Phone address field control` (4 cases); `edit.tsx` › the three `maps phone=…` cases | the editor's billing block showing the same state, and the round trip inside the editor, from the sidebar control to the canvas, for Phone |
| `Return to cart link is visible and can be toggled` | `checkout-actions-block/tests/edit.test.tsx` › `maps showReturnToCart=false to true and previews the current state` and `maps showReturnToCart=true to false and previews the current state` | the link's visibility inside the real Checkout block. After this PR no browser title covers the Return to Cart control |

#### Relocated to Jest

- `cart-checkout-shared/block-settings/test/index.tsx` is new. It checks that the shared dark mode toggle flips `hasDarkControls` in both directions.
- `checkout/inner-blocks/checkout-actions-block/tests/edit.test.tsx` is new. It checks the Return to Cart toggle's state, its preview, and the attribute it sets.
- `checkout/test/address-field-controls.tsx` is new. For Company, Address line 2, and Phone, it checks that showing a hidden field makes it optional, that hiding an optional field works, and that the Optional and Required choices make the right edit to the site setting. It checks the edit, not a saved record.
- `checkout/test/edit.tsx` is new. It checks the dark controls class, and that each of the three fields' hidden, optional, and required site settings become the right field defaults, which the real form then renders. The link from the editor's data to the form is mocked, so only the Company browser title covers that step end to end.
- `checkout/inner-blocks/checkout-terms-block/test/frontend.js` gains `Renders the default Terms and Privacy links without a checkbox`. `Clears any validation errors when the checkbox is checked` now checks both clear calls, not just the last one.

#### The retained wiring tests

Three browser titles stay:

- `renders without crashing and can only be inserted once`, unchanged.
- `Merchant must accept T&S before checkout`: the terms requirement turned on in the editor blocks checkout until the shopper accepts.
- `Merchant can persist a required Company field`: the Company requirement survives a reload of the editor, and the storefront's shipping and billing forms both render the field as required.

Four controls lose all browser coverage: the dark mode toggle, the Return to Cart toggle, and the Address line 2 and Phone field controls. Company is the only field that keeps a browser round trip. The Checkout block itself keeps three real titles, so it still has a canary. The Jest suites above are what now guard those four controls.

Both retained journeys that reach checkout add a product through trunk's `frontendUtils` helpers. On the #68046 branch they also passed under a cart request tracker that is not landing, so this draft's CI run is the load check for them. They pass locally on trunk's helpers (see below).

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suites and confirm they pass: `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath assets/js/blocks/cart-checkout-shared/block-settings/test/index.tsx assets/js/blocks/checkout/inner-blocks/checkout-actions-block/tests/edit.test.tsx assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/frontend.js assets/js/blocks/checkout/test/address-field-controls.tsx assets/js/blocks/checkout/test/edit.tsx`
3. Confirm the Return to Cart suite guards the toggle. In `plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx`, change `showReturnToCart: ! showReturnToCart` to `showReturnToCart`. Re-run `assets/js/blocks/checkout/inner-blocks/checkout-actions-block/tests/edit.test.tsx` and confirm `maps showReturnToCart=false to true and previews the current state` fails. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/checkout/checkout-block.merchant.block_theme.spec.ts`. Confirm all three titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. The E2E store was checked first: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 34 distinct focused commands for these files, 32 Jest and 2 Playwright, and all 34 exit 0.
- **Retained titles.** `--list` shows the three titles, and the spec passes with `--retries=0 --workers=1`.
- **Mutation re-check.** For each behavior family, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0414` | the dark mode toggle keeps `hasDarkControls` as it was instead of flipping it | `maps hasDarkControls=false to true` |
| `0417` | the Return to Cart toggle keeps `showReturnToCart` as it was | `maps showReturnToCart=false to true and previews the current state` |
| `0424` | the Terms block always renders a checkbox | `Renders the default Terms and Privacy links without a checkbox`: the consent text isn't found |
| `0428` | Company's Optional and Required choice saves the opposite value | `Company address field control makes an optional field required` |
| `1286` | the same, for Address line 2 | `Address line 2 address field control makes an optional field required` |
| `1287` | the same, for Phone | `Phone address field control makes an optional field required` |
| `0429` | showing a hidden Company field makes it required instead of optional | `Company address field control shows a hidden field as optional` |
| `1288` | the same, for Address line 2 | `Address line 2 address field control shows a hidden field as optional` |
| `1289` | the same, for Phone | `Phone address field control shows a hidden field as optional` |
| `0432` | the Checkout editor always adds the dark controls class | `omits the dark controls class when hasDarkControls is false` |
| `0600` | the Terms checkbox never reports its error (Blocks rebuilt) | the retained `Merchant must accept T&S before checkout`: the checkbox's error attribute stays `false` |
| `0601` | the storefront ignores the Company requirement set in the editor (Blocks rebuilt) | the retained `Merchant can persist a required Company field`: the Company input has no `required` attribute |

- **Lint.**
    - Prettier is clean, and ESLint reports nothing on lines this PR changes. Its 2 warnings sit on trunk lines: `no-unnecessary-act` at `frontend.js:124`, and `rules-of-hooks` on the spec's `use( pageObject )` fixture.
    - oxlint finds nothing new, `verify-staged` exits 0, and `lint:changes:branch` exits 0. There is no PHP in this PR.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Reviews.** Two independent agent reviews read the branch and the evidence. Both came back clean, and their non-blocking wording findings are applied. Neither is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-checkout-block-editor-controls` and `plugins/woocommerce/client/blocks/changelog/testops-234-checkout-block-editor-controls`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



