### PR TITLE
[tests] Reduce Checkout block shopper E2E tests from 13 to 5

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-checkout-block-shopper
+++ b/plugins/woocommerce/changelog/testops-234-checkout-block-shopper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce Checkout block shopper E2E tests from 13 to 5; a Jest suite and a Checkout block PHPUnit test own the shipping-topology guard.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/test/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/test/frontend.tsx
@@ -1,0 +1,172 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useShippingData } from '@woocommerce/base-context/hooks';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
+import FrontendBlock from '../frontend';
+
+let mockNeedsShipping = true;
+
+jest.mock( '@woocommerce/block-settings', () => {
+	const settings = {
+		shippingEnabled: true,
+		shippingMethodsExist: true,
+	};
+	(
+		globalThis as typeof globalThis & {
+			checkoutShippingMethodTestSettings: typeof settings;
+		}
+	 ).checkoutShippingMethodTestSettings = settings;
+
+	return {
+		...jest.requireActual( '@woocommerce/block-settings' ),
+		get SHIPPING_ENABLED() {
+			return settings.shippingEnabled;
+		},
+		get SHIPPING_METHODS_EXIST() {
+			return settings.shippingMethodsExist;
+		},
+		LOCAL_PICKUP_ENABLED: true,
+	};
+} );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getSetting: jest.fn( ( key, defaultValue ) =>
+		key === 'collectableMethodIds' ? [ 'pickup_location' ] : defaultValue
+	),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	useShippingData: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/blocks/checkout/context', () => ( {
+	useCheckoutBlockContext: jest.fn(),
+} ) );
+
+const shippingRates = [
+	{
+		shipping_rates: [
+			{
+				method_id: 'flat_rate',
+				price: '500',
+				taxes: '0',
+			},
+			{
+				method_id: 'pickup_location',
+				price: '0',
+				taxes: '0',
+			},
+		],
+	},
+];
+
+const getBlockSettings = () =>
+	(
+		globalThis as typeof globalThis & {
+			checkoutShippingMethodTestSettings: {
+				shippingEnabled: boolean;
+				shippingMethodsExist: boolean;
+			};
+		}
+	 ).checkoutShippingMethodTestSettings;
+
+const renderFrontendBlock = () =>
+	render(
+		<FrontendBlock
+			title="Delivery"
+			description=""
+			showPrice={ false }
+			showIcon={ false }
+			shippingText="Ship"
+			localPickupText="Pickup"
+		>
+			<div />
+		</FrontendBlock>
+	);
+
+describe( 'Checkout shipping method FrontendBlock', () => {
+	beforeEach( () => {
+		getBlockSettings().shippingEnabled = true;
+		getBlockSettings().shippingMethodsExist = true;
+		mockNeedsShipping = true;
+
+		( useCheckoutBlockContext as jest.Mock ).mockReturnValue( {
+			showFormStepNumbers: false,
+		} );
+		( useShippingData as jest.Mock ).mockImplementation( () => ( {
+			needsShipping: mockNeedsShipping,
+			isCollectable: true,
+			shippingRates,
+		} ) );
+		( useSelect as jest.Mock ).mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				isProcessing: () => false,
+				prefersCollection: () => false,
+				getShippingRates: () => shippingRates,
+			} ) )
+		);
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			setPrefersCollection: jest.fn(),
+			selectShippingRate: jest.fn(),
+			setValidationErrors: jest.fn(),
+			clearValidationError: jest.fn(),
+		} );
+	} );
+
+	it( 'renders the Ship and Pickup choices when every topology guard passes', () => {
+		renderFrontendBlock();
+
+		expect(
+			screen.getByRole( 'radiogroup', { name: 'Shipping method' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'radio', { name: 'Ship' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'radio', { name: 'Pickup' } )
+		).toBeInTheDocument();
+	} );
+
+	it.each( [
+		[
+			'ordinary shipping methods do not exist',
+			() => {
+				getBlockSettings().shippingMethodsExist = false;
+			},
+		],
+		[
+			'store shipping is disabled',
+			() => {
+				getBlockSettings().shippingEnabled = false;
+			},
+		],
+		[
+			'the cart does not need shipping',
+			() => {
+				mockNeedsShipping = false;
+			},
+		],
+	] )( 'does not render when %s', ( _, disableGuard ) => {
+		disableGuard();
+
+		renderFrontendBlock();
+
+		expect(
+			screen.queryByRole( 'radiogroup', { name: 'Shipping method' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-checkout-block-shopper
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-checkout-block-shopper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce Checkout block shopper E2E tests from 13 to 5; a Jest suite and a Checkout block PHPUnit test own the shipping-topology guard.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -6,21 +6,17 @@ import {
 	test as base,
 	customerFile,
 	guestFile,
-	BlockData,
-	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
  */
 import {
-	REGULAR_PRICED_PRODUCT_NAME,
 	SIMPLE_PHYSICAL_PRODUCT_NAME,
 	FREE_SHIPPING_NAME,
 	FREE_SHIPPING_PRICE,
 	FLAT_RATE_SHIPPING_NAME,
 	FLAT_RATE_SHIPPING_PRICE,
-	SIMPLE_VIRTUAL_PRODUCT_NAME,
 } from './constants';
 import { CheckoutPage } from './checkout.page';
 
@@ -34,142 +30,19 @@ const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
 	},
 } );
 
-const blockData: BlockData = {
-	name: 'Checkout',
-	slug: 'woocommerce/checkout',
-	mainClass: '.wp-block-woocommerce-checkout',
-	selectors: {
-		editor: {
-			block: '.wp-block-woocommerce-checkout',
-			insertButton: "//button//span[text()='Checkout']",
-		},
-		frontend: {},
-	},
-};
-
-test.describe( 'Shopper → Account (guest user)', () => {
-	test.use( { storageState: guestFile } );
-
-	test.beforeEach( async ( { requestUtils, frontendUtils } ) => {
-		await requestUtils.rest( {
-			method: 'PUT',
-			path: 'wc/v3/settings/account/woocommerce_enable_guest_checkout',
-			data: { value: 'yes' },
-		} );
-		await requestUtils.rest( {
-			method: 'PUT',
-			path: 'wc/v3/settings/account/woocommerce_enable_checkout_login_reminder',
-			data: { value: 'yes' },
-		} );
-
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-	} );
-
-	// eslint-disable-next-line playwright/no-skipped-test -- This will be rewritten as a unit/integration test - WOOPLUG-4303
-	test.skip( 'Shopper can log in to an existing account and can create an account', async ( {
-		requestUtils,
-		checkoutPageObject,
-		page,
-		baseURL,
-	} ) => {
-		//Get the login link from checkout page.
-		const loginLink = page.getByRole( 'link', { name: 'Log in' } );
-
-		await expect( loginLink ).toHaveAttribute(
-			'href',
-			baseURL +
-				'/my-account/?redirect_to=' +
-				encodeURIComponent( baseURL + '/checkout/' )
-		);
-
-		await requestUtils.rest( {
-			method: 'PUT',
-			path: 'wc/v3/settings/account/woocommerce_enable_signup_and_login_from_checkout',
-			data: { value: 'yes' },
-		} );
-		await requestUtils.rest( {
-			method: 'PUT',
-			path: 'wc/v3/settings/account/woocommerce_registration_generate_password',
-			data: { value: 'yes' },
-		} );
-
-		await page.reload();
-
-		const createAccount = page.getByLabel( 'Create an account' );
-		await createAccount.check();
-
-		const testEmail = `test-${ Date.now() }@example.com`;
-		await checkoutPageObject.fillInCheckoutWithTestData( {
-			email: testEmail,
-		} );
-		await checkoutPageObject.placeOrder();
-
-		// Get users from API with same email used when purchasing.
-		await requestUtils
-			.rest( {
-				method: 'GET',
-				path: `wc/v3/customers?email=${ testEmail }`,
-			} )
-			.then( ( response ) => {
-				expect( response[ 0 ].email ).toBe( testEmail );
-			} );
-	} );
-} );
-
 test.describe( 'Shopper → Local pickup', () => {
-	test.beforeEach( async ( { admin } ) => {
-		// Enable local pickup.
-		await admin.visitAdminPage(
-			'admin.php',
-			'page=wc-settings&tab=shipping&section=pickup_location'
-		);
-		await admin.page.getByLabel( 'Enable local pickup' ).check();
-		await admin.page
-			.getByRole( 'button', { name: 'Add pickup location' } )
-			.click();
-		await admin.page.getByLabel( 'Location name' ).fill( 'Testing' );
-		await admin.page.getByPlaceholder( 'Address' ).fill( 'Test Address' );
-		await admin.page.getByPlaceholder( 'City' ).fill( 'Test City' );
-		await admin.page.getByPlaceholder( 'Postcode / ZIP' ).fill( '90210' );
-		await admin.page
-			.getByLabel( 'Pickup details' )
-			.fill( 'Pickup method.' );
-		await admin.page.getByRole( 'button', { name: 'Done' } ).click();
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
-		await admin.page.waitForResponse( ( response ) => {
-			return response.url().includes( 'wp-json/wc/v3/pickup-locations' );
+	test.beforeEach( async ( { localPickupUtils } ) => {
+		await localPickupUtils.enableLocalPickup();
+		await localPickupUtils.addPickupLocation( {
+			location: {
+				name: 'Testing',
+				address: 'Test Address',
+				city: 'Test City',
+				postcode: '90210',
+				state: 'US:CA',
+				details: 'Pickup method.',
+			},
 		} );
-	} );
-
-	test( 'The shopper can choose a local pickup option', async ( {
-		page,
-		frontendUtils,
-		checkoutPageObject,
-	} ) => {
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-
-		await checkoutPageObject.selectDeliveryOption( 'Pickup' );
-		await expect( page.getByLabel( 'Testing' ).last() ).toBeVisible();
-		await page.getByLabel( 'Testing' ).last().check();
-
-		await checkoutPageObject.fillInCheckoutWithTestData();
-		await checkoutPageObject.placeOrder();
-
-		await expect(
-			page.getByText( 'Thank you. Your order has been received.' )
-		).toBeVisible();
-
-		await expect(
-			// The regex pattern matches "Collection from Testing" followed by any characters (.*)
-			page.getByRole( 'cell', { name: /Collection from Testing.*/ } )
-		).toBeVisible();
-		await checkoutPageObject.verifyBillingDetails();
 	} );
 
 	test( 'Switching between local pickup and shipping does not affect the address and is used for the order', async ( {
@@ -221,152 +94,6 @@ test.describe( 'Shopper → Local pickup', () => {
 		).toBeVisible();
 		await checkoutPageObject.verifyBillingDetails();
 	} );
-
-	test( 'Delivery/pickup toggle is not shown when shipping methods are disabled', async ( {
-		admin,
-		page,
-		frontendUtils,
-		checkoutPageObject,
-	} ) => {
-		// Disable hide rates until address is entered.
-		await admin.visitAdminPage(
-			'admin.php',
-			'page=wc-settings&tab=shipping&section=options'
-		);
-
-		await admin.page
-			.getByLabel( 'Hide shipping costs until an address is entered' )
-			.uncheck();
-
-		let saveButton = admin.page.getByRole( 'button', {
-			name: 'Save changes',
-		} );
-
-		if ( await saveButton.isEnabled() ) {
-			await saveButton.click();
-		}
-
-		// Disable all other shipping methods.
-		await admin.visitAdminPage(
-			'admin.php',
-			'page=wc-settings&tab=shipping&zone_id=0'
-		);
-
-		// There are 2 shipping methods and 2 toggles with our test data. Disable both.
-		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
-		await admin.page.getByRole( 'link', { name: 'Yes' } ).last().click();
-
-		saveButton = admin.page.getByRole( 'button', {
-			name: 'Save changes',
-		} );
-
-		await saveButton.click();
-
-		// Go to checkout.
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-
-		await expect(
-			page.getByRole( 'radio', { name: 'Pickup', exact: true } )
-		).toBeHidden();
-
-		await expect(
-			page.getByRole( 'radio', { name: 'Ship', exact: true } )
-		).toBeHidden();
-
-		await expect( page.getByLabel( 'Testing' ).last() ).toBeVisible();
-		await page.getByLabel( 'Testing' ).last().check();
-
-		await checkoutPageObject.fillInCheckoutWithTestData();
-		await checkoutPageObject.placeOrder();
-
-		await expect(
-			page.getByText( 'Thank you. Your order has been received.' )
-		).toBeVisible();
-
-		await expect(
-			// The regex pattern matches "Collection from Testing" followed by any characters (.*)
-			page.getByRole( 'cell', { name: /Collection from Testing.*/ } )
-		).toBeVisible();
-		await checkoutPageObject.verifyBillingDetails();
-	} );
-} );
-
-test.describe( 'Shopper → Shipping and Billing Addresses', () => {
-	const billingTestData = {
-		firstname: 'John',
-		lastname: 'Doe',
-		company: 'Automattic',
-		addressfirstline: '123 Main Road',
-		addresssecondline: 'Unit 23',
-		city: 'San Francisco',
-		state: 'California',
-		country: 'United Kingdom',
-		countryKey: 'GB',
-		postcode: 'SW1 1AA',
-		phone: '123456789',
-		email: 'john.doe@example.com',
-	};
-	const shippingTestData = {
-		firstname: 'Jane',
-		lastname: 'Doe',
-		company: 'WooCommerce',
-		addressfirstline: '123 Main Avenue',
-		addresssecondline: 'Unit 42',
-		city: 'Los Angeles',
-		phone: '987654321',
-		country: 'Albania',
-		countryKey: 'AL',
-		state: 'Berat',
-		postcode: '1234',
-	};
-	// `as string` is safe here because we know the variable is a string, it is defined above.
-	const blockSelectorInEditor = blockData.selectors.editor.block as string;
-
-	test.beforeEach( async ( { admin, editor, page } ) => {
-		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		await editor.openDocumentSettingsSidebar();
-		await editor.selectBlocks(
-			blockSelectorInEditor +
-				'  [data-type="woocommerce/checkout-shipping-address-block"]'
-		);
-		const checkbox = page.getByRole( 'checkbox', {
-			name: 'Company',
-			exact: true,
-		} );
-		await checkbox.click();
-		await expect( checkbox ).toBeChecked();
-		await expect(
-			editor.canvas.locator(
-				'div.wc-block-components-address-form__company'
-			)
-		).toBeVisible();
-		await editor.saveSiteEditorEntities();
-	} );
-
-	test( 'User can add postcodes for different countries', async ( {
-		frontendUtils,
-		page,
-		checkoutPageObject,
-	} ) => {
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-
-		await page.getByLabel( 'Use same address for billing' ).uncheck();
-
-		await checkoutPageObject.fillShippingDetails( shippingTestData );
-		await checkoutPageObject.fillBillingDetails( billingTestData );
-		await expect(
-			page.getByText( 'Please enter a valid postcode' )
-		).toBeHidden();
-	} );
 } );
 
 test.describe( 'Shopper → Shipping (customer user)', () => {
@@ -414,9 +141,10 @@ test.describe( 'Shopper → Shipping (customer user)', () => {
 			name: 'Billing address',
 		} );
 
-		expect( shippingForm.getByLabel( 'Phone' ).inputValue ).toEqual(
-			billingForm.getByLabel( 'Phone' ).inputValue
-		);
+		const shippingPhone = shippingForm.getByLabel( 'Phone' );
+		const billingPhone = billingForm.getByLabel( 'Phone' );
+		await expect( shippingPhone ).toHaveValue( '0987654322' );
+		await expect( billingPhone ).toHaveValue( '0987654322' );
 
 		await checkoutPageObject.fillInCheckoutWithTestData();
 		const overrideBillingDetails = {
@@ -432,6 +160,12 @@ test.describe( 'Shopper → Shipping (customer user)', () => {
 			email: 'juan.perez@test.com',
 		};
 		await checkoutPageObject.fillBillingDetails( overrideBillingDetails );
+		await expect( billingPhone ).toHaveValue(
+			overrideBillingDetails.phone
+		);
+		await expect( shippingPhone ).not.toHaveValue(
+			overrideBillingDetails.phone
+		);
 		await checkoutPageObject.placeOrder();
 		await checkoutPageObject.verifyAddressDetails(
 			'billing',
@@ -441,32 +175,7 @@ test.describe( 'Shopper → Shipping (customer user)', () => {
 	} );
 } );
 
-test.describe( 'Shopper → Place Guest Order', () => {
-	test.use( { storageState: guestFile } );
-
-	test( 'Guest user can place order', async ( {
-		checkoutPageObject,
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-		expect(
-			await checkoutPageObject.selectAndVerifyShippingOption(
-				FREE_SHIPPING_NAME,
-				FREE_SHIPPING_PRICE
-			)
-		).toBe( true );
-		await checkoutPageObject.fillInCheckoutWithTestData();
-		await checkoutPageObject.placeOrder();
-		await expect(
-			page.getByText( 'Your order has been received.' )
-		).toBeVisible();
-	} );
-} );
-
-test.describe( 'Shopper → Place Virtual Order', () => {
+test.describe( 'Shopper → Store shipping disabled', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.rest( {
 			method: 'PUT',
@@ -475,44 +184,7 @@ test.describe( 'Shopper → Place Virtual Order', () => {
 		} );
 	} );
 
-	test( 'Does not see shipping options for digital orders when shipping is enabled', async ( {
-		checkoutPageObject,
-		frontendUtils,
-		localPickupUtils,
-		page,
-		requestUtils,
-	} ) => {
-		await requestUtils.rest( {
-			method: 'PUT',
-			path: 'wc/v3/settings/general/woocommerce_ship_to_countries',
-			data: { value: 'all' },
-		} );
-		await localPickupUtils.enableLocalPickup();
-
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );
-		await frontendUtils.goToCart();
-
-		await expect(
-			page.getByText( 'Delivery', { exact: true } )
-		).toBeHidden();
-
-		await frontendUtils.goToCheckout();
-
-		await expect( page.getByText( 'Ship', { exact: true } ) ).toBeHidden();
-		await expect(
-			page.getByText( 'Pickup', { exact: true } )
-		).toBeHidden();
-
-		await checkoutPageObject.fillInCheckoutWithTestData();
-		await checkoutPageObject.placeOrder();
-
-		await expect(
-			page.getByText( 'Thank you. Your order has been received.' )
-		).toBeVisible();
-	} );
-
-	test( 'can place a digital order when shipping is disabled', async ( {
+	test( 'can place a physical order when store shipping is disabled', async ( {
 		checkoutPageObject,
 		frontendUtils,
 		localPickupUtils,
@@ -522,45 +194,6 @@ test.describe( 'Shopper → Place Virtual Order', () => {
 
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCart();
-
-		await expect(
-			page.getByText( 'Delivery', { exact: true } )
-		).toBeHidden();
-
-		await frontendUtils.goToCheckout();
-
-		// Delivery total in the sidebar.
-		await expect(
-			page.getByText( 'Delivery', { exact: true } )
-		).toBeHidden();
-
-		// Ship/Pickup method selector.
-		await expect( page.getByText( 'Ship', { exact: true } ) ).toBeHidden();
-		await expect(
-			page.getByText( 'Pickup', { exact: true } )
-		).toBeHidden();
-
-		await checkoutPageObject.fillInCheckoutWithTestData();
-		await checkoutPageObject.placeOrder();
-
-		await expect(
-			page.getByText( 'Thank you. Your order has been received.' )
-		).toBeVisible();
-
-		await localPickupUtils.enableLocalPickup();
-	} );
-
-	test( 'can place a digital order when shipping is disabled, but Local Pickup is still enabled', async ( {
-		checkoutPageObject,
-		frontendUtils,
-		localPickupUtils,
-		page,
-	} ) => {
-		await localPickupUtils.enableLocalPickup();
-
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await frontendUtils.goToCart();
 
 		await expect(
@@ -624,38 +257,11 @@ test.describe( 'Shopper → Checkout Form Errors (guest user)', () => {
 		await expect(
 			page.getByText( 'Please enter a valid zip code' )
 		).toBeVisible();
+		await expect( page.getByLabel( 'Email address' ) ).toBeFocused();
 	} );
 } );
 
 test.describe( 'Billing Address Form', () => {
-	const blockSelectorInEditor = blockData.selectors.editor.block as string;
-
-	test( 'Enable company field', async ( { page, admin, editor } ) => {
-		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		await editor.openDocumentSettingsSidebar();
-
-		await editor.selectBlocks(
-			blockSelectorInEditor +
-				'  [data-type="woocommerce/checkout-shipping-address-block"]'
-		);
-
-		const companyCheckbox = page.getByLabel( 'Company', {
-			exact: true,
-		} );
-		await companyCheckbox.click();
-		await expect( companyCheckbox ).toBeChecked();
-
-		const companyInput = editor.canvas.getByLabel( 'Company (optional)' );
-		await expect( companyInput ).toBeVisible();
-
-		await editor.saveSiteEditorEntities();
-	} );
-
 	test.describe( 'Guest user', () => {
 		test.use( { storageState: guestFile } );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
@@ -38,6 +38,13 @@ class Checkout extends \WP_UnitTestCase {
 	private $mock_logger;
 
 	/**
+	 * Sequence for unique Checkout mock block names.
+	 *
+	 * @var int
+	 */
+	private $checkout_mock_sequence = 0;
+
+	/**
 	 * Set up the test. Creates a AssetDataRegistryMock.
 	 *
 	 * @return void
@@ -133,6 +140,135 @@ class Checkout extends \WP_UnitTestCase {
 		$data_from_registry = $this->registry->get();
 		$this->assertEquals( 'Changed pickup', $data_from_registry['localPickupText'] );
 		wp_delete_post( $page_id );
+	}
+
+	/**
+	 * @testdox Exposes whether store shipping and ordinary shipping methods are available.
+	 */
+	public function test_enqueue_data_exposes_shipping_topology(): void {
+		global $wpdb;
+
+		$original_ship_to_countries = get_option( 'woocommerce_ship_to_countries', false );
+		$original_pickup_settings   = get_option( 'woocommerce_pickup_location_settings', false );
+		$original_method_states     = $wpdb->get_results(
+			"SELECT instance_id, is_enabled FROM {$wpdb->prefix}woocommerce_shipping_zone_methods",
+			ARRAY_A
+		);
+		$shipping_zone              = new \WC_Shipping_Zone();
+
+		try {
+			foreach ( $original_method_states as $method_state ) {
+				$wpdb->update(
+					"{$wpdb->prefix}woocommerce_shipping_zone_methods",
+					array( 'is_enabled' => '0' ),
+					array( 'instance_id' => $method_state['instance_id'] )
+				);
+			}
+
+			update_option( 'woocommerce_ship_to_countries', 'all' );
+			update_option(
+				'woocommerce_pickup_location_settings',
+				array(
+					'enabled'    => 'yes',
+					'title'      => 'Pickup',
+					'cost'       => '',
+					'tax_status' => 'taxable',
+				)
+			);
+
+			$shipping_zone->set_zone_name( 'Checkout asset-data test' );
+			$shipping_zone->save();
+			$shipping_zone->add_shipping_method( 'flat_rate' );
+			$this->flush_shipping_method_cache();
+
+			$data = $this->get_checkout_asset_data();
+			$this->assertFalse(
+				\WP_Block_Type_Registry::get_instance()->is_registered( 'woocommerce/checkout-shipping-topology-1' ),
+				'The generated Checkout mock block should be unregistered after collecting asset data.'
+			);
+			$this->assertTrue( $data['shippingMethodsExist'], 'An enabled ordinary shipping method should be exposed.' );
+			$this->assertTrue( $data['shippingEnabled'], 'Shipping should be exposed as enabled when the store ships.' );
+
+			$shipping_zone->delete( true );
+			$this->flush_shipping_method_cache();
+
+			$data = $this->get_checkout_asset_data();
+			$this->assertFalse(
+				\WP_Block_Type_Registry::get_instance()->is_registered( 'woocommerce/checkout-shipping-topology-2' ),
+				'The generated Checkout mock block should be unregistered after collecting asset data.'
+			);
+			$this->assertFalse( $data['shippingMethodsExist'], 'Local pickup without an ordinary shipping method should not count as ordinary shipping.' );
+			$this->assertTrue( $data['shippingEnabled'], 'Store shipping remains enabled for the pickup-only topology.' );
+
+			update_option( 'woocommerce_ship_to_countries', 'disabled' );
+			$this->flush_shipping_method_cache();
+
+			$data = $this->get_checkout_asset_data();
+			$this->assertFalse(
+				\WP_Block_Type_Registry::get_instance()->is_registered( 'woocommerce/checkout-shipping-topology-3' ),
+				'The generated Checkout mock block should be unregistered after collecting asset data.'
+			);
+			$this->assertFalse( $data['shippingMethodsExist'], 'No ordinary shipping method should be exposed when none is configured.' );
+			$this->assertFalse( $data['shippingEnabled'], 'Globally disabled store shipping should be exposed.' );
+		} finally {
+			if ( $shipping_zone->get_id() ) {
+				$shipping_zone->delete( true );
+			}
+
+			foreach ( $original_method_states as $method_state ) {
+				$wpdb->update(
+					"{$wpdb->prefix}woocommerce_shipping_zone_methods",
+					array( 'is_enabled' => $method_state['is_enabled'] ),
+					array( 'instance_id' => $method_state['instance_id'] )
+				);
+			}
+
+			false === $original_ship_to_countries
+				? delete_option( 'woocommerce_ship_to_countries' )
+				: update_option( 'woocommerce_ship_to_countries', $original_ship_to_countries );
+			false === $original_pickup_settings
+				? delete_option( 'woocommerce_pickup_location_settings' )
+				: update_option( 'woocommerce_pickup_location_settings', $original_pickup_settings );
+			$this->flush_shipping_method_cache();
+		}
+	}
+
+	/**
+	 * Get data registered by a fresh Checkout block instance.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_checkout_asset_data(): array {
+		$registry            = new AssetDataRegistryMock( $this->asset_api );
+		$block_type_registry = \WP_Block_Type_Registry::get_instance();
+		++$this->checkout_mock_sequence;
+		$block_name      = 'checkout-shipping-topology-' . $this->checkout_mock_sequence;
+		$full_block_name = 'woocommerce/' . $block_name;
+
+		try {
+			$checkout = new CheckoutMock(
+				$this->asset_api,
+				$registry,
+				$this->integration_registry,
+				$block_name
+			);
+			$checkout->mock_enqueue_data();
+
+			return $registry->get();
+		} finally {
+			if ( $block_type_registry->is_registered( $full_block_name ) ) {
+				$block_type_registry->unregister( $full_block_name );
+			}
+		}
+	}
+
+	/**
+	 * Flush cached shipping-method state after changing topology.
+	 */
+	private function flush_shipping_method_cache(): void {
+		\WC_Cache_Helper::get_transient_version( 'shipping', true );
+		delete_transient( 'wc_shipping_method_count' );
+		WC()->shipping()->load_shipping_methods();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Checkout block shopper spec ran twelve browser titles, plus one skipped title. Several repeated journeys that other titles already walk. One checked a shipping-topology guard, whether the Ship and Pickup choice renders at all. This PR moves that guard to a Jest test and a PHPUnit test, and cuts the spec from 13 tests (one of them skipped) to 5.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `Shopper can log in to an existing account and can create an account` (skipped) | `tests/php/src/Blocks/StoreApi/Routes/Checkout.php` › `test_checkout_create_account`, `test_checkout_force_create_account`, `test_checkout_deny_guest_checkout` | the login link's `href` (`/my-account/?redirect_to=…`). The title was skipped, so it ran nothing |
| `The shopper can choose a local pickup option` | the retained `Switching between local pickup and shipping does not affect the address and is used for the order`, which shows `Pickup (Testing)`, selects pickup, places the order, and checks `Collection from Testing`; and trunk's `checkout-pickup-options-block/test/block.tsx` and `local-pickup-select/test/index.tsx`, which check the pickup options render and report a changed selection | filling in the form while Pickup is selected. The retained title fills it in while Ship is selected, then switches |
| `Delivery/pickup toggle is not shown when shipping methods are disabled` | the new `checkout-shipping-method-block/test/frontend.tsx` › `does not render when ordinary shipping methods do not exist`, and the new `tests/php/src/Blocks/BlockTypes/Checkout.php` › `test_enqueue_data_exposes_shipping_topology` | placing an order through to the confirmation page when ordinary methods are off but pickup is on. The retained pickup and shipping-disabled titles place orders in neighbouring setups, not this one |
| `User can add postcodes for different countries` | trunk's `packages/public-api/blocks-checkout/utils/validation/test/is-postcode.ts` › `isPostcode`, the client check behind the "Please enter a valid postcode" message, which has valid and invalid GB cases like the removed title's billing postcode | the Albanian shipping postcode (`1234`) the removed title entered, which goes through the `postcode-validator` package and has no test case; and the form running the postcode check with each address form's own country. The retained form-errors title shows a different message ("Please enter a valid zip code") from another code path |
| `Guest user can place order` | on trunk, `tests/e2e/tests/blocks/checkout/order-confirmation.block_theme.spec.ts` › `Shopper (guest) → Order Confirmation` › `Place order`, which places the same guest order. Another batch in the #68046 split folds that journey into the `Delayed account creation flows` setup, and its own PR covers that change | none |
| `Does not see shipping options for digital orders when shipping is enabled` | the new Jest `checkout-shipping-method-block/test/frontend.tsx` › `does not render when the cart does not need shipping`; and `tests/php/src/Blocks/StoreApi/Routes/Checkout.php` › `test_shipping_address_is_ignored_when_cart_does_not_need_shipping` and `test_virtual_product_post_data` | Ship, Pickup, and Delivery staying hidden on the real Cart and Checkout pages for a virtual product while store shipping is on. The Jest test checks the Ship and Pickup choice with a mocked cart |
| `can place a digital order when shipping is disabled` | kept and retitled `can place a physical order when store shipping is disabled`. The old title said "digital", but the test already added a physical product, so the new title only describes it correctly | none. It checks the same end state: no Delivery, Ship, or Pickup, and a placed order |
| `can place a digital order when shipping is disabled, but Local Pickup is still enabled` | the new Jest `does not render when the cart does not need shipping`, the client check for a virtual cart; `tests/php/src/Blocks/StoreApi/Routes/Cart.php` › `test_update_customer_virtual_cart`; `tests/php/src/Blocks/StoreApi/Routes/Checkout.php` › `test_shipping_address_is_ignored_when_cart_does_not_need_shipping`; the retitled shipping-disabled title | a real virtual cart showing no pickup choice in the browser while Local Pickup stays enabled. The Jest test checks the component with a mocked cart |
| `Enable company field` | on trunk, `checkout-block.merchant.block_theme.spec.ts` › `Company input visibility and optional and required can be toggled`. Another batch in the #68046 split replaces it with `Merchant can persist a required Company field` | none. The merchant title toggles the same Site Editor control and checks more |

#### Relocated to Jest and PHPUnit

- `checkout-shipping-method-block/test/frontend.tsx` is new. It checks that the Ship and Pickup choice renders when every topology condition holds, and that it is absent when ordinary shipping methods don't exist, when store shipping is off, or when the cart doesn't need shipping. The suite keeps Local Pickup enabled and the cart collectable throughout.
- `tests/php/src/Blocks/BlockTypes/Checkout.php` gains `test_enqueue_data_exposes_shipping_topology`. It checks that the Checkout block's `enqueue_data` exposes `shippingMethodsExist` and `shippingEnabled` from the store's real shipping setup, as that setup changes.

#### The retained wiring tests

Five browser titles stay:

- `Switching between local pickup and shipping does not affect the address and is used for the order`
- `Shopper can choose free shipping, flat rate shipping, and can have different billing and shipping addresses`
- `can place a physical order when store shipping is disabled`
- `can see errors when form is incomplete`
- `Ensure billing is empty and shipping address is filled`

Changed in the retained titles, compared with trunk:

- **The phone check now can fail.** In the shipping title, trunk compared `shippingForm.getByLabel( 'Phone' ).inputValue` with `billingForm.getByLabel( 'Phone' ).inputValue`: two references to the same method, so it passed whatever the fields held. The branch checks the real values: both phones after syncing, then billing against the override phone, and that shipping no longer matches it.
- `can see errors when form is incomplete` also checks that focus lands on `Email address`.
- The Local pickup setup moves into the shared `localPickupUtils` helpers. They click through the same settings screen, also set the location's state to `US:CA`, and wait for the saved notice.
- The shipping-disabled title no longer turns Local Pickup back on at the end. The per-test database restore puts back the baseline, where Local Pickup is off, so that step changed nothing the next test sees.

These journeys add products to the cart through trunk's `frontendUtils` helpers. On the #68046 branch they also passed under a cart request tracker that is not landing, so this draft's CI run is the load check for them. They pass locally on trunk's helpers (see below).

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suite and confirm it passes: `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/test/frontend.tsx`
3. Start the PHPUnit environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test`, then run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_enqueue_data_exposes_shipping_topology|test_local_pickup_title_change'` and confirm both tests pass.
4. Confirm the PHP test guards the topology data. In `plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php`, change `CartCheckoutUtils::shipping_methods_exist()` to `false`. Re-run the command from step 3 and confirm `test_enqueue_data_exposes_shipping_topology` fails. Revert the change.
5. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
6. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts`. Confirm all five titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. The E2E store was checked first: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 9 distinct focused commands for these files, 2 PHPUnit, 4 Jest, and 3 Playwright, and all 9 exit 0.
- **Retained titles.** `--list` shows the five titles, and the spec passes with `--retries=0 --workers=1`.
- **Mutation re-check.** For each behavior family, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0419` | the shipping method block always treats shipping as disabled | `renders the Ship and Pickup choices when every topology guard passes`: no "Shipping method" radio group |
| `0013` | the Checkout block always reports that no shipping methods exist | `test_enqueue_data_exposes_shipping_topology` |
| `0012` | saving the Local Pickup title stores an empty title | `test_local_pickup_title_change` |
| `0602` | billing stops copying the shipping phone after a change (Blocks rebuilt) | the retained `Shopper can choose free shipping, flat rate shipping, and can have different billing and shipping addresses`: the billing phone stays `01234567890` |
| `0603` | the shipping-disabled title's setup turns shipping back on | the retained `can place a physical order when store shipping is disabled`: `Delivery` is visible |
| `0604` | the checkout moves focus to the second invalid field (Blocks rebuilt) | the retained `can see errors when form is incomplete`: `Email address` isn't focused |

- **Lint.**
    - PHPCS reports nothing on `Checkout.php`, and Prettier is clean.
    - ESLint reports nothing on lines this PR changes. Its one warning sits on a trunk line: `rules-of-hooks` on the spec's `use( pageObject )` fixture.
    - oxlint finds nothing new, `verify-staged` exits 0, and `lint:changes:branch` exits 0.
    - PHPStan doesn't analyse `tests/` in this repository's config, so it isn't a gate for `Checkout.php`. A direct run is kept as a record.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Change on top of the #68046 state.** The retained shipping title compared phone numbers by reading `inputValue()` into plain `expect` calls, which the Playwright lint rules flag. Those four checks are now web-first `toHaveValue` assertions that check the same values, and mutation `0602` still fails at the billing phone check.
- **Reviews.** Three rounds of independent agent review read the branch and the evidence. The first two rounds found wording errors, all in this description and the commit message, and they are fixed; the third round was clean. None of them is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-checkout-block-shopper` and `plugins/woocommerce/client/blocks/changelog/testops-234-checkout-block-shopper`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


