### PR TITLE
[tests] Move order confirmation policy from 6 E2E tests to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-order-confirmation-blocks
+++ b/plugins/woocommerce/changelog/testops-234-order-confirmation-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move order confirmation policy from 6 E2E tests to PHPUnit; the Order Confirmation block spec keeps 3 browser titles.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/order-confirmation.block_theme.spec.ts
@@ -42,7 +42,7 @@ test.describe( 'Shopper (logged-in) → Order Confirmation', () => {
 		await editor.transformIntoBlocks();
 	} );
 
-	test( 'Place order', async ( {
+	test( 'Known shopper details require owner and key unless the filter opts out', async ( {
 		frontendUtils,
 		checkoutPageObject,
 		page,
@@ -61,103 +61,33 @@ test.describe( 'Shopper (logged-in) → Order Confirmation', () => {
 		await checkoutPageObject.fillInCheckoutWithTestData( TEST_ADDRESS );
 		await checkoutPageObject.placeOrder();
 
-		// Confirm Order Confirmation Block sections are visible when logged in
-		// order data are visible and correct
 		await checkoutPageObject.verifyOrderConfirmationDetails();
 
-		// Store order received URL to use later
 		const orderReceivedURL = page.url();
-
-		// Confirm downloads section is visible when logged in
-		// Open order we created
-		const orderId = checkoutPageObject.getOrderId();
-		await page.goto( `wp-admin/post.php?post=${ orderId }&action=edit` );
-		// Update order status to 'Processing'
-		await page.locator( '#order_status' ).selectOption( 'wc-processing' );
-		await page.locator( 'button.save_order' ).click();
-		// Go back to order received page
-		await page.goto( orderReceivedURL );
-		// Confirm downloads section is visible
-		const DownloadSection = page.locator(
-			'[data-block-name="woocommerce/order-confirmation-downloads"]'
-		);
-		await expect( DownloadSection ).toBeVisible();
-
-		// Access page without order key (test visibility of default message, no order details)
-		const urlObj = new URL( orderReceivedURL );
-		urlObj.searchParams.delete( 'key' );
-		await page.goto( urlObj.toString() );
-		// Confirm default message is visible
-		await expect(
-			page.getByText(
-				'Great news! Your order has been received, and a confirmation will be sent to your email address. Have an account with us?'
-			)
-		).toBeVisible();
-		// Confirm order details are not visible
-		await checkoutPageObject.verifyOrderConfirmationDetails( false );
-
-		// Access page without order ID or key (test visibility of default message)
-		await page.goto( '/checkout/order-received' );
-		// Confirm default message is visible
-		await expect(
-			page.getByText(
-				"If you've just placed an order, give your email a quick check for the confirmation. Have an account with us?"
-			)
-		).toBeVisible();
-		// Confirm order details are not visible
-		await checkoutPageObject.verifyOrderConfirmationDetails( false );
-
-		await test.step( 'Logout the user and revisit the order received page to verify that details are displayed when woocommerce_order_received_verify_known_shoppers is disabled', async () => {
-			await requestUtils.activatePlugin(
-				'woocommerce-blocks-test-order-confirmation-filters'
-			);
-			await page.goto( '/my-account' );
-			await page
-				.locator(
-					'li.woocommerce-MyAccount-navigation-link--customer-logout a'
-				)
-				.click();
-			await expect(
-				page.getByRole( 'button', { name: 'Log in' } )
-			).toBeVisible();
-			await page.goto( orderReceivedURL );
-			await checkoutPageObject.verifyOrderConfirmationDetails();
-		} );
-	} );
-} );
-
-test.describe( 'Shopper (guest) → Order Confirmation', () => {
-	test.use( { storageState: guestFile } );
-
-	test( 'Place order', async ( {
-		frontendUtils,
-		checkoutPageObject,
-		page,
-	} ) => {
+		await page.context().clearCookies();
 		await page.goto( '/my-account' );
-
 		await expect(
-			page.getByRole( 'heading', { name: 'Login' } ),
-			'User is not logged out'
+			page.getByRole( 'button', { name: 'Log in' } )
 		).toBeVisible();
 
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
+		await page.goto( orderReceivedURL );
+		await checkoutPageObject.verifyOrderConfirmationDetails( false );
 
-		expect(
-			await checkoutPageObject.selectAndVerifyShippingOption(
-				FREE_SHIPPING_NAME,
-				FREE_SHIPPING_PRICE
-			)
-		).toBe( true );
+		const missingKeyURL = new URL( orderReceivedURL );
+		missingKeyURL.searchParams.delete( 'key' );
+		await page.goto( missingKeyURL.toString() );
+		await checkoutPageObject.verifyOrderConfirmationDetails( false );
 
-		await checkoutPageObject.fillInCheckoutWithTestData( TEST_ADDRESS );
-		await checkoutPageObject.placeOrder();
+		const wrongKeyURL = new URL( orderReceivedURL );
+		wrongKeyURL.searchParams.set( 'key', 'wc_order_wrong' );
+		await page.goto( wrongKeyURL.toString() );
+		await checkoutPageObject.verifyOrderConfirmationDetails( false );
 
-		await expect(
-			page.getByText( 'Thank you. Your order has been received.' )
-		).toBeVisible();
+		await requestUtils.activatePlugin(
+			'woocommerce-blocks-test-order-confirmation-filters'
+		);
+		await page.goto( orderReceivedURL );
+		await checkoutPageObject.verifyOrderConfirmationDetails();
 	} );
 } );
 
@@ -236,55 +166,6 @@ test.describe( 'Shopper (guest) → Order Confirmation → Create Account', () =
 	} );
 } );
 
-test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
-	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
-		checkoutPageObject,
-		frontendUtils,
-		admin,
-	} ) => {
-		await admin.visitAdminPage(
-			'admin.php',
-			'page=wc-settings&tab=shipping&section=pickup_location'
-		);
-		await admin.page.getByLabel( 'Enable local pickup' ).uncheck();
-		await admin.page.getByLabel( 'Enable local pickup' ).check();
-		await admin.page
-			.getByRole( 'button', { name: 'Add pickup location' } )
-			.click();
-		await admin.page.getByLabel( 'Location name' ).fill( 'Testing' );
-		await admin.page.getByPlaceholder( 'Address' ).fill( 'Test Address' );
-		await admin.page.getByPlaceholder( 'City' ).fill( 'Test City' );
-		await admin.page.getByPlaceholder( 'Postcode / ZIP' ).fill( '90210' );
-		await admin.page
-			.getByLabel( 'Pickup details' )
-			.fill( 'Pickup method.' );
-		await admin.page.getByRole( 'button', { name: 'Done' } ).click();
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
-		await admin.page
-			.getByRole( 'button', { name: 'Dismiss this notice' } )
-			.click();
-		await frontendUtils.emptyCart();
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-		await checkoutPageObject.selectDeliveryOption( 'Pickup' );
-		await checkoutPageObject.fillInCheckoutWithTestData();
-		await checkoutPageObject.placeOrder();
-		await expect(
-			checkoutPageObject.page.getByRole( 'heading', {
-				name: 'Shipping address',
-			} )
-		).toBeHidden();
-		await expect(
-			checkoutPageObject.page.getByRole( 'heading', {
-				name: 'Billing address',
-			} )
-		).toBeVisible();
-	} );
-} );
-
 test.describe( 'Shopper → Order Confirmation → Downloadable Products', () => {
 	let confirmationPageUrl: string;
 
@@ -297,22 +178,7 @@ test.describe( 'Shopper → Order Confirmation → Downloadable Products', () =>
 		confirmationPageUrl = checkoutPageObject.page.url();
 	} );
 
-	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
-		checkoutPageObject,
-	} ) => {
-		await expect(
-			checkoutPageObject.page.getByRole( 'heading', {
-				name: 'Shipping address',
-			} )
-		).toBeHidden();
-		await expect(
-			checkoutPageObject.page.getByRole( 'heading', {
-				name: 'Billing address',
-			} )
-		).toBeVisible();
-	} );
-
-	test( 'Confirm order downloads are visible', async ( {
+	test( 'Completed downloadable order exposes named entitlement links', async ( {
 		checkoutPageObject,
 		admin,
 	} ) => {
@@ -343,5 +209,17 @@ test.describe( 'Shopper → Order Confirmation → Downloadable Products', () =>
 				name: 'Downloads',
 			} )
 		).toBeVisible();
+
+		const downloadsSection = checkoutPageObject.page.locator(
+			'[data-block-name="woocommerce/order-confirmation-downloads"]'
+		);
+		for ( const downloadName of [ 'Single 1', 'Single 2' ] ) {
+			const downloadLink = downloadsSection.getByRole( 'link', {
+				name: downloadName,
+				exact: true,
+			} );
+			await expect( downloadLink ).toBeVisible();
+			await expect( downloadLink ).toHaveAttribute( 'href', /.+/ );
+		}
 	} );
 } );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlockTest.php
@@ -1,0 +1,208 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\AbstractOrderConfirmationBlock;
+use WC_Order;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for order-confirmation permission decisions.
+ */
+final class AbstractOrderConfirmationBlockTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var AbstractOrderConfirmationBlock
+	 */
+	private $sut;
+
+	/**
+	 * Set up the test proxy.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new class() extends AbstractOrderConfirmationBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function get_view_order_permissions_proxy( ?WC_Order $order ) {
+				return $this->get_view_order_permissions( $order );
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function email_verification_permitted_proxy( WC_Order $order ): bool {
+				return $this->email_verification_permitted( $order );
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			protected function render_content( $order, $permission = false, $attributes = array(), $content = '' ) {
+				return '';
+			}
+		};
+	}
+
+	/**
+	 * @testdox Order details require the correct key and the appropriate owner, session, grace-period, or verified-email context.
+	 * @dataProvider view_permission_cases
+	 *
+	 * @param string       $scenario Scenario to arrange.
+	 * @param string|false $expected Expected permission.
+	 */
+	public function test_get_view_order_permissions( string $scenario, $expected ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Request globals are restored fixture state.
+		$original_get = $_GET;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Request globals are restored fixture state.
+		$original_post        = $_POST;
+		$original_user_id     = get_current_user_id();
+		$original_draft_order = WC()->session->get( 'store_api_draft_order' );
+		$order                = null;
+		$filter_added         = false;
+
+		try {
+			$_GET  = array();
+			$_POST = array();
+			wp_set_current_user( 0 );
+			WC()->session->set( 'store_api_draft_order', null );
+
+			if ( 'null order' !== $scenario ) {
+				$is_customer_order = in_array(
+					$scenario,
+					array( 'owner valid key', 'owner missing key', 'owner wrong key', 'wrong logged-in user', 'known shopper logged out', 'known shopper filter disabled' ),
+					true
+				);
+				$customer_id       = $is_customer_order ? self::factory()->user->create( array( 'role' => 'customer' ) ) : 0;
+				$order             = $this->create_order( $customer_id, ! in_array( $scenario, array( 'guest draft session', 'guest expired', 'guest verified email' ), true ) );
+				$_GET['key']       = $order->get_order_key();
+
+				switch ( $scenario ) {
+					case 'owner valid key':
+						wp_set_current_user( $customer_id );
+						break;
+					case 'owner missing key':
+						wp_set_current_user( $customer_id );
+						unset( $_GET['key'] );
+						break;
+					case 'owner wrong key':
+						wp_set_current_user( $customer_id );
+						$_GET['key'] = 'wc_order_wrong';
+						break;
+					case 'wrong logged-in user':
+						wp_set_current_user( self::factory()->user->create( array( 'role' => 'customer' ) ) );
+						break;
+					case 'known shopper filter disabled':
+						add_filter( 'woocommerce_order_received_verify_known_shoppers', '__return_false' );
+						$filter_added = true;
+						break;
+					case 'guest draft session':
+						WC()->session->set( 'store_api_draft_order', $order->get_id() );
+						break;
+					case 'guest verified email':
+						$_POST['email']    = $order->get_billing_email();
+						$_POST['_wpnonce'] = wp_create_nonce( 'wc_verify_email' );
+						break;
+				}
+			}
+
+			$this->assertSame( $expected, $this->sut->get_view_order_permissions_proxy( $order ) );
+		} finally {
+			if ( $filter_added ) {
+				remove_filter( 'woocommerce_order_received_verify_known_shoppers', '__return_false' );
+			}
+			if ( $order instanceof WC_Order ) {
+				$order->delete( true );
+			}
+			WC()->session->set( 'store_api_draft_order', $original_draft_order );
+			wp_set_current_user( $original_user_id );
+			$_GET  = $original_get;
+			$_POST = $original_post;
+		}
+	}
+
+	/**
+	 * Named order permission cases.
+	 *
+	 * @return array<string, array{string, string|false}>
+	 */
+	public static function view_permission_cases(): array {
+		return array(
+			'null order'                    => array( 'null order', false ),
+			'owner with valid key'          => array( 'owner valid key', 'full' ),
+			'owner without key'             => array( 'owner missing key', false ),
+			'owner with wrong key'          => array( 'owner wrong key', false ),
+			'different logged-in customer'  => array( 'wrong logged-in user', false ),
+			'known shopper logged out'      => array( 'known shopper logged out', false ),
+			'known shopper filter disabled' => array( 'known shopper filter disabled', 'full' ),
+			'guest Store API draft session' => array( 'guest draft session', 'full' ),
+			'guest within grace period'     => array( 'guest grace period', 'full' ),
+			'guest after grace period'      => array( 'guest expired', false ),
+			'guest with verified email'     => array( 'guest verified email', 'full' ),
+		);
+	}
+
+	/**
+	 * @testdox Email verification is offered only to guest orders with guest checkout enabled and a valid key.
+	 * @dataProvider email_verification_permission_cases
+	 *
+	 * @param bool $guest_checkout_enabled Whether guest checkout is enabled.
+	 * @param bool $customer_order Whether the order belongs to a customer.
+	 * @param bool $valid_key Whether the request has the order key.
+	 * @param bool $expected Expected result.
+	 */
+	public function test_email_verification_permitted( bool $guest_checkout_enabled, bool $customer_order, bool $valid_key, bool $expected ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Request globals are restored fixture state.
+		$original_get    = $_GET;
+		$original_option = get_option( 'woocommerce_enable_guest_checkout', null );
+		$customer_id     = $customer_order ? self::factory()->user->create( array( 'role' => 'customer' ) ) : 0;
+		$order           = $this->create_order( $customer_id );
+
+		try {
+			update_option( 'woocommerce_enable_guest_checkout', $guest_checkout_enabled ? 'yes' : 'no' );
+			$_GET        = array();
+			$_GET['key'] = $valid_key ? $order->get_order_key() : 'wc_order_wrong';
+
+			$this->assertSame( $expected, $this->sut->email_verification_permitted_proxy( $order ) );
+		} finally {
+			$order->delete( true );
+			$_GET = $original_get;
+			if ( null === $original_option ) {
+				delete_option( 'woocommerce_enable_guest_checkout' );
+			} else {
+				update_option( 'woocommerce_enable_guest_checkout', $original_option );
+			}
+		}
+	}
+
+	/**
+	 * Named email-verification eligibility cases.
+	 *
+	 * @return array<string, array{bool, bool, bool, bool}>
+	 */
+	public static function email_verification_permission_cases(): array {
+		return array(
+			'guest checkout and valid key'      => array( true, false, true, true ),
+			'guest checkout disabled'           => array( false, false, true, false ),
+			'guest order with wrong key'        => array( true, false, false, false ),
+			'known customer order with key'     => array( true, true, true, false ),
+			'known customer without guest mode' => array( false, true, false, false ),
+		);
+	}
+
+	/**
+	 * Create a persisted order for a guest or registered customer.
+	 *
+	 * @param int  $customer_id Customer ID, or zero for a guest.
+	 * @param bool $within_grace_period Whether the order is recent.
+	 * @return WC_Order
+	 */
+	private function create_order( int $customer_id, bool $within_grace_period = true ): WC_Order {
+		$order = wc_create_order( array( 'customer_id' => $customer_id ) );
+		$order->set_billing_email( 'shopper-' . $order->get_id() . '@example.com' );
+		if ( ! $within_grace_period ) {
+			$order->set_date_created( time() - ( 20 * MINUTE_IN_SECONDS ) );
+		}
+		$order->save();
+
+		return $order;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/BillingAddress.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/BillingAddress.php
@@ -61,6 +61,52 @@ final class BillingAddress extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Billing details follow view permission but remain present for shipped, pickup, and virtual orders.
+	 * @dataProvider billing_address_topology_cases
+	 *
+	 * @param string       $topology Order fulfillment topology.
+	 * @param string|false $permission View permission.
+	 * @param bool         $expected_visible Whether billing content should render.
+	 */
+	public function test_billing_address_topology( string $topology, $permission, bool $expected_visible ): void {
+		$original_shipping_option = get_option( 'woocommerce_calc_shipping', null );
+		list( $order, $product )  = $this->create_topology_order( $topology );
+
+		try {
+			update_option( 'woocommerce_calc_shipping', 'yes' );
+			$content = $this->render( $order, $permission );
+
+			if ( $expected_visible ) {
+				$this->assertStringContainsString( 'Billing Marker', $content, 'Billing details should be non-empty for an authorized order.' );
+			} else {
+				$this->assertSame( '', $content, 'Billing details should be empty without view permission.' );
+			}
+		} finally {
+			$order->delete( true );
+			$product->delete( true );
+			if ( null === $original_shipping_option ) {
+				delete_option( 'woocommerce_calc_shipping' );
+			} else {
+				update_option( 'woocommerce_calc_shipping', $original_shipping_option );
+			}
+		}
+	}
+
+	/**
+	 * Named billing-address topology cases.
+	 *
+	 * @return array<string, array{string, string|false, bool}>
+	 */
+	public static function billing_address_topology_cases(): array {
+		return array(
+			'physical order'     => array( 'physical', 'full', true ),
+			'local pickup order' => array( 'local-pickup', 'full', true ),
+			'virtual order'      => array( 'virtual', 'full', true ),
+			'no view permission' => array( 'physical', false, false ),
+		);
+	}
+
+	/**
 	 * Create an order placed via the Store API with a value persisted for the billing group of the test field.
 	 *
 	 * @param string $value Field value.
@@ -78,10 +124,11 @@ final class BillingAddress extends \WP_UnitTestCase {
 	/**
 	 * Render the billing address block content for the given order with full view permissions.
 	 *
-	 * @param \WC_Order $order Order object.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission View permission.
 	 * @return string
 	 */
-	private function render( \WC_Order $order ): string {
+	private function render( \WC_Order $order, $permission = 'full' ): string {
 		$proxy = new class() extends BillingAddressBlock {
 			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function __construct() {
@@ -92,6 +139,48 @@ final class BillingAddress extends \WP_UnitTestCase {
 			}
 		};
 
-		return $proxy->render_content_proxy( $order, 'full' );
+		return $proxy->render_content_proxy( $order, $permission );
+	}
+
+	/**
+	 * Create an order with billing data and a representative fulfillment topology.
+	 *
+	 * @param string $topology Order fulfillment topology.
+	 * @return array{\WC_Order, \WC_Product}
+	 */
+	private function create_topology_order( string $topology ): array {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'downloadable' => 'virtual' === $topology,
+				'virtual'      => 'virtual' === $topology,
+			)
+		);
+		$product->set_virtual( 'virtual' === $topology );
+		$product->save();
+
+		$order = wc_create_order( array( 'customer_id' => 0 ) );
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
+		$order->set_billing_first_name( 'Billing' );
+		$order->set_billing_last_name( 'Marker' );
+		$order->set_billing_address_1( '500 Billing Avenue' );
+		$order->set_billing_city( 'San Francisco' );
+		$order->set_billing_state( 'CA' );
+		$order->set_billing_postcode( '94105' );
+		$order->set_billing_country( 'US' );
+
+		if ( 'virtual' !== $topology ) {
+			$shipping_item = new \WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( 'local-pickup' === $topology ? 'Local pickup' : 'Free shipping' );
+			$shipping_item->set_method_id( 'local-pickup' === $topology ? 'local_pickup' : 'free_shipping' );
+			$order->add_item( $shipping_item );
+		}
+
+		$order->save();
+
+		return array( $order, $product );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/BillingWrapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/BillingWrapperTest.php
@@ -1,0 +1,125 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\BillingWrapper as BillingWrapperBlock;
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Order_Item_Shipping;
+use WC_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the order-confirmation billing wrapper.
+ */
+final class BillingWrapperTest extends WC_Unit_Test_Case {
+	/**
+	 * @testdox Billing wrapper headings and content require an address and permission across fulfillment topologies.
+	 * @dataProvider billing_wrapper_cases
+	 *
+	 * @param string       $topology Order fulfillment topology.
+	 * @param string|false $permission View permission.
+	 * @param bool         $has_address Whether the order has a billing address.
+	 * @param bool         $expected_visible Whether wrapper content should render.
+	 */
+	public function test_billing_wrapper_topology( string $topology, $permission, bool $has_address, bool $expected_visible ): void {
+		list( $order, $product ) = $this->create_order( $topology, $has_address );
+		$content                 = '<h2>Billing address</h2><p>Billing wrapper marker</p>';
+
+		try {
+			$rendered = $this->render( $order, $permission, $content );
+
+			if ( $expected_visible ) {
+				$this->assertSame( $content, $rendered, 'An authorized order with billing data should preserve the wrapper heading and content.' );
+				$this->assertStringContainsString( 'Billing address', $rendered );
+				$this->assertStringContainsString( 'Billing wrapper marker', $rendered );
+			} else {
+				$this->assertSame( '', $rendered, 'The billing wrapper should be empty without permission or an address.' );
+			}
+		} finally {
+			$order->delete( true );
+			$product->delete( true );
+		}
+	}
+
+	/**
+	 * Named billing-wrapper cases.
+	 *
+	 * @return array<string, array{string, string|false, bool, bool}>
+	 */
+	public static function billing_wrapper_cases(): array {
+		return array(
+			'physical free-shipping order' => array( 'physical', 'full', true, true ),
+			'local pickup order'           => array( 'local-pickup', 'full', true, true ),
+			'virtual downloadable order'   => array( 'virtual', 'full', true, true ),
+			'no view permission'           => array( 'physical', false, true, false ),
+			'no billing address'           => array( 'physical', 'full', false, false ),
+		);
+	}
+
+	/**
+	 * Render wrapper content through a public proxy.
+	 *
+	 * @param WC_Order     $order Order object.
+	 * @param string|false $permission View permission.
+	 * @param string       $content Wrapper content.
+	 * @return string
+	 */
+	private function render( WC_Order $order, $permission, string $content ): string {
+		$proxy = new class() extends BillingWrapperBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission, $content ) {
+				return $this->render_content( $order, $permission, array(), $content );
+			}
+		};
+
+		return $proxy->render_content_proxy( $order, $permission, $content );
+	}
+
+	/**
+	 * Create a persisted order for one fulfillment topology.
+	 *
+	 * @param string $topology Order fulfillment topology.
+	 * @param bool   $has_address Whether to add billing data.
+	 * @return array{WC_Order, WC_Product}
+	 */
+	private function create_order( string $topology, bool $has_address ): array {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'downloadable' => 'virtual' === $topology,
+				'virtual'      => 'virtual' === $topology,
+			)
+		);
+		$order   = wc_create_order( array( 'customer_id' => 0 ) );
+		$item    = new WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
+
+		if ( $has_address ) {
+			$order->set_billing_first_name( 'Billing' );
+			$order->set_billing_last_name( 'Marker' );
+			$order->set_billing_address_1( '500 Billing Avenue' );
+			$order->set_billing_city( 'San Francisco' );
+			$order->set_billing_state( 'CA' );
+			$order->set_billing_postcode( '94105' );
+			$order->set_billing_country( 'US' );
+		}
+
+		if ( 'virtual' !== $topology ) {
+			$shipping_item = new WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( 'local-pickup' === $topology ? 'Local pickup' : 'Free shipping' );
+			$shipping_item->set_method_id( 'local-pickup' === $topology ? 'local_pickup' : 'free_shipping' );
+			$order->add_item( $shipping_item );
+		}
+
+		$order->save();
+
+		return array( $order, $product );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsTest.php
@@ -1,0 +1,191 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\Downloads as DownloadsBlock;
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
+use WC_Customer_Download;
+use WC_Data_Store;
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the order-confirmation downloads table.
+ */
+final class DownloadsTest extends WC_Unit_Test_Case {
+	/**
+	 * @testdox Download rows render for authorized processing and completed orders with the exact names, URLs, and table classes.
+	 */
+	public function test_download_table_requires_entitlement_and_permission(): void {
+		$download_directories  = wc_get_container()->get( Download_Directories::class );
+		$original_mode_option  = get_option( 'wc_downloads_approved_directories_mode', null );
+		$original_grant_option = get_option( 'woocommerce_downloads_grant_access_after_payment', null );
+		$product               = null;
+		$order                 = null;
+		$file_exists           = static function (): bool {
+			return true;
+		};
+		$download_directories->set_mode( Download_Directories::MODE_DISABLED );
+		update_option( 'woocommerce_downloads_grant_access_after_payment', 'yes' );
+		add_filter( 'woocommerce_downloadable_file_exists', $file_exists );
+
+		try {
+			$product = \WC_Helper_Product::create_downloadable_product(
+				array(
+					array(
+						'name' => 'Single 1',
+						'file' => 'https://example.com/single-1.txt',
+					),
+					array(
+						'name' => 'Single 2',
+						'file' => 'https://example.com/single-2.txt',
+					),
+				)
+			);
+			$order   = $this->create_order( $product );
+
+			$this->assertSame( '', $this->render( $order, 'full' ), 'Pending orders should not render a downloads table.' );
+
+			$order->set_status( 'processing' );
+			$order->save();
+			wc_downloadable_product_permissions( $order->get_id(), true );
+			$order = $this->reload_order( $order );
+
+			$this->assert_download_table( $order, 'processing' );
+
+			$order->set_status( 'completed' );
+			$order->save();
+			$order = $this->reload_order( $order );
+
+			$this->assert_download_table( $order, 'completed' );
+
+			$this->assertSame( '', $this->render( $order, false ), 'Order details permission is required even after entitlement is granted.' );
+		} finally {
+			if ( $order instanceof WC_Order ) {
+				$this->delete_download_permissions( $order );
+				$order->delete( true );
+			}
+			if ( $product instanceof WC_Product ) {
+				$product->delete( true );
+			}
+			remove_filter( 'woocommerce_downloadable_file_exists', $file_exists );
+			if ( null === $original_mode_option ) {
+				delete_option( 'wc_downloads_approved_directories_mode' );
+			} else {
+				update_option( 'wc_downloads_approved_directories_mode', $original_mode_option );
+			}
+			wp_cache_delete( 'wc_downloads_approved_directories_mode', 'options' );
+			if ( null === $original_grant_option ) {
+				delete_option( 'woocommerce_downloads_grant_access_after_payment' );
+			} else {
+				update_option( 'woocommerce_downloads_grant_access_after_payment', $original_grant_option );
+			}
+		}
+	}
+
+	/**
+	 * Assert the rendered download table for one entitled order status.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @param string   $status Expected order status.
+	 */
+	private function assert_download_table( WC_Order $order, string $status ): void {
+		$downloads      = $order->get_downloadable_items();
+		$download_names = array_column( $downloads, 'download_name' );
+		sort( $download_names );
+
+		$this->assertSame( $status, $order->get_status() );
+		$this->assertCount( 2, $downloads, 'The real order should expose both granted download entitlements.' );
+		$this->assertSame( array( 'Single 1', 'Single 2' ), $download_names, 'The exact two unique fixture download names should be granted.' );
+
+		foreach ( $downloads as $download ) {
+			$this->assertNotSame( '', $download['download_url'], 'A granted entitlement must have a non-empty URL.' );
+		}
+
+		$content = $this->render( $order, 'full' );
+
+		$this->assertStringContainsString( 'wc-block-order-confirmation-downloads__table', $content );
+		$this->assertSame( 3, substr_count( $content, '<tr>' ), 'The table should contain one header row and two entitlement rows.' );
+		$this->assertSame( 2, substr_count( $content, '<td class="download-file"' ), 'Each entitlement should render a file cell.' );
+		$this->assertSame( 2, substr_count( $content, 'class="woocommerce-MyAccount-downloads-file button alt"' ), 'Each entitlement should render the expected download-link classes.' );
+
+		foreach ( $downloads as $download ) {
+			$escaped_download_url = esc_url( $download['download_url'] );
+
+			$this->assertNotSame( '', $escaped_download_url, 'A granted entitlement must retain a non-empty URL after escaping.' );
+			$this->assertStringContainsString( esc_html( $download['download_name'] ), $content );
+			$this->assertStringContainsString( $escaped_download_url, $content );
+		}
+	}
+
+	/**
+	 * Reload an order from persistence.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return WC_Order
+	 */
+	private function reload_order( WC_Order $order ): WC_Order {
+		$reloaded_order = wc_get_order( $order->get_id() );
+		$this->assertInstanceOf( WC_Order::class, $reloaded_order );
+
+		return $reloaded_order;
+	}
+
+	/**
+	 * Render the downloads table through a public proxy.
+	 *
+	 * @param WC_Order     $order Order object.
+	 * @param string|false $permission View permission.
+	 * @return string
+	 */
+	private function render( WC_Order $order, $permission ): string {
+		$proxy = new class() extends DownloadsBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission ) {
+				return $this->render_content( $order, $permission );
+			}
+		};
+
+		return $proxy->render_content_proxy( $order, $permission );
+	}
+
+	/**
+	 * Create a guest order containing the downloadable product.
+	 *
+	 * @param WC_Product $product Product object.
+	 * @return WC_Order
+	 */
+	private function create_order( WC_Product $product ): WC_Order {
+		$order = wc_create_order( array( 'customer_id' => 0 ) );
+		$item  = new WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
+		$order->set_billing_email( 'downloads-shopper@example.com' );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Delete every download grant associated with the fixture order.
+	 *
+	 * @param WC_Order $order Order object.
+	 */
+	private function delete_download_permissions( WC_Order $order ): void {
+		$download_store = WC_Data_Store::load( 'customer-download' );
+		$downloads      = $download_store->get_downloads( array( 'order_id' => $order->get_id() ) );
+
+		foreach ( $downloads as $download ) {
+			if ( $download instanceof WC_Customer_Download ) {
+				$download->delete( true );
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\DownloadsWrapper as DownloadsWrapperClass;
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 
 /**
  * Test DownloadsWrapper class.
@@ -116,5 +117,106 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 
 		\WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
 		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
+	}
+
+	/**
+	 * @testdox Runtime wrapper content requires permission, a downloadable order item, and a download-permitted status.
+	 */
+	public function test_runtime_render_requires_download_permission(): void {
+		$download_directories = wc_get_container()->get( Download_Directories::class );
+		$original_mode_option = get_option( 'wc_downloads_approved_directories_mode', null );
+		$downloadable_product = null;
+		$plain_product        = null;
+		$downloadable_order   = null;
+		$plain_order          = null;
+		$file_exists          = static function (): bool {
+			return true;
+		};
+		$download_directories->set_mode( Download_Directories::MODE_DISABLED );
+		add_filter( 'woocommerce_downloadable_file_exists', $file_exists );
+
+		try {
+			$downloadable_product = \WC_Helper_Product::create_downloadable_product(
+				array(
+					array(
+						'name' => 'Wrapper download',
+						'file' => 'https://example.com/wrapper-download.txt',
+					),
+				)
+			);
+			$plain_product        = \WC_Helper_Product::create_simple_product();
+			$downloadable_order   = $this->create_order_with_product( $downloadable_product );
+			$plain_order          = $this->create_order_with_product( $plain_product );
+
+			$this->assertSame( '', $this->render( $downloadable_order, 'full' ), 'A pending order should not expose downloads.' );
+
+			$plain_order->set_status( 'completed' );
+			$plain_order->save();
+			$this->assertSame( '', $this->render( $plain_order, 'full' ), 'An order without a downloadable item should not render the wrapper.' );
+
+			$downloadable_order->set_status( 'completed' );
+			$downloadable_order->save();
+			$this->assertSame( '', $this->render( $downloadable_order, false ), 'View permission is required.' );
+			$this->assertSame( '<p>Download marker</p>', $this->render( $downloadable_order, 'full' ), 'A completed downloadable order should render non-empty wrapper content.' );
+		} finally {
+			if ( $downloadable_order instanceof \WC_Order ) {
+				$downloadable_order->delete( true );
+			}
+			if ( $plain_order instanceof \WC_Order ) {
+				$plain_order->delete( true );
+			}
+			if ( $downloadable_product instanceof \WC_Product ) {
+				$downloadable_product->delete( true );
+			}
+			if ( $plain_product instanceof \WC_Product ) {
+				$plain_product->delete( true );
+			}
+			remove_filter( 'woocommerce_downloadable_file_exists', $file_exists );
+			if ( null === $original_mode_option ) {
+				delete_option( 'wc_downloads_approved_directories_mode' );
+			} else {
+				update_option( 'wc_downloads_approved_directories_mode', $original_mode_option );
+			}
+			wp_cache_delete( 'wc_downloads_approved_directories_mode', 'options' );
+		}
+	}
+
+	/**
+	 * Render runtime wrapper content through a public proxy.
+	 *
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission View permission.
+	 * @return string
+	 */
+	private function render( \WC_Order $order, $permission ): string {
+		$proxy = new class() extends DownloadsWrapperClass {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission, $content ) {
+				return $this->render_content( $order, $permission, array(), $content );
+			}
+		};
+
+		return $proxy->render_content_proxy( $order, $permission, '<p>Download marker</p>' );
+	}
+
+	/**
+	 * Create a persisted order containing one product.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return \WC_Order
+	 */
+	private function create_order_with_product( \WC_Product $product ): \WC_Order {
+		$order = wc_create_order( array( 'customer_id' => 0 ) );
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
+		$order->set_billing_email( 'wrapper-shopper@example.com' );
+		$order->save();
+
+		return $order;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/ShippingAddress.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/ShippingAddress.php
@@ -61,6 +61,57 @@ final class ShippingAddress extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Shipping details render only for authorized orders that require a shipping address.
+	 * @dataProvider shipping_address_topology_cases
+	 *
+	 * @param string       $topology Order fulfillment topology.
+	 * @param string|false $permission View permission.
+	 * @param bool         $expected_visible Whether shipping content should render.
+	 */
+	public function test_shipping_address_topology( string $topology, $permission, bool $expected_visible ): void {
+		$original_shipping_option = get_option( 'woocommerce_calc_shipping', null );
+		list( $order, $product )  = $this->create_topology_order( $topology );
+
+		try {
+			update_option( 'woocommerce_calc_shipping', 'yes' );
+			$content = $this->render( $order, $permission );
+			if ( 'physical' === $topology ) {
+				$this->assertTrue( $order->needs_shipping_address(), 'A free-shipping order should require a shipping address.' );
+			} else {
+				$this->assertFalse( $order->needs_shipping_address(), 'Pickup and virtual orders should not require a shipping address.' );
+			}
+
+			if ( $expected_visible ) {
+				$this->assertStringContainsString( 'Shipping Marker', $content, 'Shipping details should be non-empty for a shipped order.' );
+			} else {
+				$this->assertSame( '', $content, 'Shipping details should be empty for this topology or permission.' );
+			}
+		} finally {
+			$order->delete( true );
+			$product->delete( true );
+			if ( null === $original_shipping_option ) {
+				delete_option( 'woocommerce_calc_shipping' );
+			} else {
+				update_option( 'woocommerce_calc_shipping', $original_shipping_option );
+			}
+		}
+	}
+
+	/**
+	 * Named shipping-address topology cases.
+	 *
+	 * @return array<string, array{string, string|false, bool}>
+	 */
+	public static function shipping_address_topology_cases(): array {
+		return array(
+			'physical free-shipping order' => array( 'physical', 'full', true ),
+			'local pickup order'           => array( 'local-pickup', 'full', false ),
+			'virtual downloadable order'   => array( 'virtual', 'full', false ),
+			'no view permission'           => array( 'physical', false, false ),
+		);
+	}
+
+	/**
 	 * Create an order placed via the Store API, with a shipping address and a value persisted for the shipping group of the test field.
 	 *
 	 * @param string $value Field value.
@@ -85,10 +136,11 @@ final class ShippingAddress extends \WP_UnitTestCase {
 	/**
 	 * Render the shipping address block content for the given order with full view permissions.
 	 *
-	 * @param \WC_Order $order Order object.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission View permission.
 	 * @return string
 	 */
-	private function render( \WC_Order $order ): string {
+	private function render( \WC_Order $order, $permission = 'full' ): string {
 		$proxy = new class() extends ShippingAddressBlock {
 			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function __construct() {
@@ -99,6 +151,48 @@ final class ShippingAddress extends \WP_UnitTestCase {
 			}
 		};
 
-		return $proxy->render_content_proxy( $order, 'full' );
+		return $proxy->render_content_proxy( $order, $permission );
+	}
+
+	/**
+	 * Create an order with a persisted shipping address and fulfillment topology.
+	 *
+	 * @param string $topology Order fulfillment topology.
+	 * @return array{\WC_Order, \WC_Product}
+	 */
+	private function create_topology_order( string $topology ): array {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'downloadable' => 'virtual' === $topology,
+				'virtual'      => 'virtual' === $topology,
+			)
+		);
+		$product->set_virtual( 'virtual' === $topology );
+		$product->save();
+
+		$order = wc_create_order( array( 'customer_id' => 0 ) );
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
+		$order->set_shipping_first_name( 'Shipping' );
+		$order->set_shipping_last_name( 'Marker' );
+		$order->set_shipping_address_1( '500 Shipping Avenue' );
+		$order->set_shipping_city( 'San Francisco' );
+		$order->set_shipping_state( 'CA' );
+		$order->set_shipping_postcode( '94105' );
+		$order->set_shipping_country( 'US' );
+
+		if ( 'virtual' !== $topology ) {
+			$shipping_item = new \WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( 'local-pickup' === $topology ? 'Local pickup' : 'Free shipping' );
+			$shipping_item->set_method_id( 'local-pickup' === $topology ? 'local_pickup' : 'free_shipping' );
+			$order->add_item( $shipping_item );
+		}
+
+		$order->save();
+
+		return array( $order, $product );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/ShippingWrapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/ShippingWrapperTest.php
@@ -1,0 +1,138 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\ShippingWrapper as ShippingWrapperBlock;
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Order_Item_Shipping;
+use WC_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the order-confirmation shipping wrapper.
+ */
+final class ShippingWrapperTest extends WC_Unit_Test_Case {
+	/**
+	 * @testdox Shipping wrapper headings and content render only for an authorized shipped order.
+	 * @dataProvider shipping_wrapper_cases
+	 *
+	 * @param string       $topology Order fulfillment topology.
+	 * @param string|false $permission View permission.
+	 * @param bool         $has_address Whether the order has a shipping address.
+	 * @param bool         $expected_visible Whether wrapper content should render.
+	 */
+	public function test_shipping_wrapper_topology( string $topology, $permission, bool $has_address, bool $expected_visible ): void {
+		$original_shipping_option = get_option( 'woocommerce_calc_shipping', null );
+		list( $order, $product )  = $this->create_order( $topology, $has_address );
+		$content                  = '<h2>Shipping address</h2><p>Shipping wrapper marker</p>';
+
+		try {
+			update_option( 'woocommerce_calc_shipping', 'yes' );
+			$rendered = $this->render( $order, $permission, $content );
+
+			if ( 'physical' === $topology ) {
+				$this->assertTrue( $order->needs_shipping_address(), 'A free-shipping order should require a shipping address.' );
+			} else {
+				$this->assertFalse( $order->needs_shipping_address(), 'Pickup and virtual orders should not require a shipping address.' );
+			}
+
+			if ( $expected_visible ) {
+				$this->assertSame( $content, $rendered, 'An authorized shipped order should preserve the wrapper heading and content.' );
+				$this->assertStringContainsString( 'Shipping address', $rendered );
+				$this->assertStringContainsString( 'Shipping wrapper marker', $rendered );
+			} else {
+				$this->assertSame( '', $rendered, 'The shipping wrapper should be empty for pickup, virtual, missing-address, or unauthorized orders.' );
+			}
+		} finally {
+			$order->delete( true );
+			$product->delete( true );
+			if ( null === $original_shipping_option ) {
+				delete_option( 'woocommerce_calc_shipping' );
+			} else {
+				update_option( 'woocommerce_calc_shipping', $original_shipping_option );
+			}
+		}
+	}
+
+	/**
+	 * Named shipping-wrapper cases.
+	 *
+	 * @return array<string, array{string, string|false, bool, bool}>
+	 */
+	public static function shipping_wrapper_cases(): array {
+		return array(
+			'physical free-shipping order' => array( 'physical', 'full', true, true ),
+			'local pickup order'           => array( 'local-pickup', 'full', true, false ),
+			'virtual downloadable order'   => array( 'virtual', 'full', true, false ),
+			'no view permission'           => array( 'physical', false, true, false ),
+			'no shipping address'          => array( 'physical', 'full', false, false ),
+		);
+	}
+
+	/**
+	 * Render wrapper content through a public proxy.
+	 *
+	 * @param WC_Order     $order Order object.
+	 * @param string|false $permission View permission.
+	 * @param string       $content Wrapper content.
+	 * @return string
+	 */
+	private function render( WC_Order $order, $permission, string $content ): string {
+		$proxy = new class() extends ShippingWrapperBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission, $content ) {
+				return $this->render_content( $order, $permission, array(), $content );
+			}
+		};
+
+		return $proxy->render_content_proxy( $order, $permission, $content );
+	}
+
+	/**
+	 * Create a persisted order for one fulfillment topology.
+	 *
+	 * @param string $topology Order fulfillment topology.
+	 * @param bool   $has_address Whether to add shipping data.
+	 * @return array{WC_Order, WC_Product}
+	 */
+	private function create_order( string $topology, bool $has_address ): array {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'downloadable' => 'virtual' === $topology,
+				'virtual'      => 'virtual' === $topology,
+			)
+		);
+		$order   = wc_create_order( array( 'customer_id' => 0 ) );
+		$item    = new WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
+
+		if ( $has_address ) {
+			$order->set_shipping_first_name( 'Shipping' );
+			$order->set_shipping_last_name( 'Marker' );
+			$order->set_shipping_address_1( '500 Shipping Avenue' );
+			$order->set_shipping_city( 'San Francisco' );
+			$order->set_shipping_state( 'CA' );
+			$order->set_shipping_postcode( '94105' );
+			$order->set_shipping_country( 'US' );
+		}
+
+		if ( 'virtual' !== $topology ) {
+			$shipping_item = new WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( 'local-pickup' === $topology ? 'Local pickup' : 'Free shipping' );
+			$shipping_item->set_method_id( 'local-pickup' === $topology ? 'local_pickup' : 'free_shipping' );
+			$order->add_item( $shipping_item );
+		}
+
+		$order->save();
+
+		return array( $order, $product );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/StatusTest.php
@@ -272,4 +272,119 @@ class StatusTest extends WC_Unit_Test_Case {
 
 		return $sut->render_content_proxy( $order, 'full' );
 	}
+
+	/**
+	 * @testdox A missing order directs the shopper to email and account confirmation paths.
+	 */
+	public function test_missing_order_notice(): void {
+		$my_account_url = wc_get_page_permalink( 'myaccount' );
+		$content        = $this->render_confirmation_notice( null );
+
+		$this->assertNotSame( '', $my_account_url, 'The fixture must expose the My account login destination.' );
+		$this->assertStringContainsString( 'If you&#039;ve just placed an order, give your email a quick check for the confirmation.', $content );
+		$this->assertStringContainsString( 'Have an account with us?', $content );
+		$this->assertStringContainsString( 'Log in here to view your order details', $content );
+		$this->assertStringContainsString( 'href="' . esc_url( $my_account_url ) . '"', $content );
+	}
+
+	/**
+	 * @testdox An existing customer order without a valid key directs the shopper to email and account confirmation paths.
+	 * @dataProvider invalid_order_key_cases
+	 *
+	 * @param string $key_mode Missing or invalid key mode.
+	 */
+	public function test_invalid_key_notice_uses_real_permission_result( string $key_mode ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Request globals are restored fixture state.
+		$original_get     = $_GET;
+		$original_user_id = get_current_user_id();
+		$customer_id      = 0;
+		$order            = null;
+
+		try {
+			$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+			$order       = wc_create_order( array( 'customer_id' => $customer_id ) );
+			$order->set_billing_email( 'status-shopper@example.com' );
+			$order->save();
+			wp_set_current_user( $customer_id );
+			$_GET = array();
+
+			if ( 'wrong' === $key_mode ) {
+				$_GET['key'] = 'wc_order_wrong';
+			}
+
+			$permission     = $this->get_view_order_permissions( $order );
+			$content        = $this->render_confirmation_notice( $order );
+			$my_account_url = wc_get_page_permalink( 'myaccount' );
+
+			$this->assertFalse( $permission, 'The real permission decision must reject a missing or invalid order key.' );
+			$this->assertNotSame( '', $my_account_url, 'The fixture must expose the My account login destination.' );
+			$this->assertStringContainsString( 'Great news! Your order has been received, and a confirmation will be sent to your email address.', $content );
+			$this->assertStringContainsString( 'Have an account with us?', $content );
+			$this->assertStringContainsString( 'Log in here', $content );
+			$this->assertStringContainsString( 'to view your order.', $content );
+			$this->assertStringContainsString( 'href="' . esc_url( $my_account_url ) . '"', $content );
+		} finally {
+			if ( $order instanceof WC_Order ) {
+				$order->delete( true );
+			}
+			wp_set_current_user( $original_user_id );
+			$_GET = $original_get;
+			if ( $customer_id ) {
+				wp_delete_user( $customer_id );
+			}
+		}
+	}
+
+	/**
+	 * Named invalid-key cases.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public static function invalid_order_key_cases(): array {
+		return array(
+			'missing order key' => array( 'missing' ),
+			'wrong order key'   => array( 'wrong' ),
+		);
+	}
+
+	/**
+	 * Render a status notice through the real Status block owner.
+	 *
+	 * @param WC_Order|null $order Order object, or null when none exists.
+	 * @return string
+	 */
+	private function render_confirmation_notice( ?WC_Order $order ): string {
+		return $this->create_proxy()->render_confirmation_notice_proxy( $order );
+	}
+
+	/**
+	 * Resolve view permission through the real Status block owner.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return string|false
+	 */
+	private function get_view_order_permissions( WC_Order $order ) {
+		return $this->create_proxy()->get_view_order_permissions_proxy( $order );
+	}
+
+	/**
+	 * Create a public proxy over the Status block's protected owners.
+	 *
+	 * @return StatusBlock
+	 */
+	private function create_proxy(): StatusBlock {
+		return new class() extends StatusBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_confirmation_notice_proxy( ?WC_Order $order ): string {
+				return $this->render_confirmation_notice( $order );
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function get_view_order_permissions_proxy( WC_Order $order ) {
+				return $this->get_view_order_permissions( $order );
+			}
+		};
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Order Confirmation block spec ran six browser titles. Most of what they checked is decided on the server before any HTML reaches the browser:

- who may see an order's details;
- which notice a missing key or a missing order gets;
- whether the address blocks render for a pickup or virtual order;
- when downloads appear.

This PR adds PHPUnit tests for that policy and output, built on real orders, and cuts the spec from 6 tests to 3.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| Logged in › `Place order` (rewritten as the retained `Known shopper details require owner and key unless the filter opts out`) | the retained title keeps the mixed order's confirmation check and the filter opt-out. Its missing-key and wrong-key visits now run after logging out, where the known-shopper check already hides the details, so the key check itself is owned by the PHP "owner without key" and "owner with wrong key" cases and by `StatusTest`. Also `DownloadsTest.php` › `test_download_table_requires_entitlement_and_permission` (the processing phase), `DownloadsWrapper.php` › `test_runtime_render_requires_download_permission`, `StatusTest.php` › `test_invalid_key_notice_uses_real_permission_result` and `test_missing_order_notice`, and `AbstractOrderConfirmationBlockTest.php` › `test_get_view_order_permissions` (the "owner without key", "null order", and "known shopper filter disabled" cases) | the logged-in owner's missing-key visit in the browser; the Downloads block appearing in the browser after an admin moves a mixed order to Processing (the retained downloads title covers Completed, and `DownloadsTest` covers the table at Processing, but no test at any layer checks the downloads wrapper for a Processing order); the rendered copy of the missing-key and no-order notices; loading `/checkout/order-received` with no order; and clicking My Account's logout link, which the retained title replaces with clearing cookies |
| Guest › `Place order` | `AbstractOrderConfirmationBlockTest.php` › `test_get_view_order_permissions` (the "guest Store API draft session" and "guest within grace period" cases). The retained `Delayed account creation flows` still places a guest order in its setup, and the retained known-shopper title still checks the success copy | a logged-out guest seeing "Thank you. Your order has been received." right after checkout |
| Local Pickup › `Confirm shipping address section is hidden, but billing is visible` | the "local pickup order" cases of `ShippingWrapperTest.php` › `test_shipping_wrapper_topology`, `ShippingAddress.php` › `test_shipping_address_topology`, `BillingWrapperTest.php` › `test_billing_wrapper_topology`, and `BillingAddress.php` › `test_billing_address_topology` | the merchant setting up Local Pickup and the shopper choosing Pickup at checkout. The PHP tests build an order with the classic `local_pickup` shipping line, not the Blocks `pickup_location` one, so no test proves that the order-received page hides the shipping address for a real `pickup_location` order |
| Downloadable Products › `Confirm shipping address section is hidden, but billing is visible` | the virtual-order cases of the same four topology tests | checking out the seeded virtual product and reading the confirmation headings in the browser |

#### Relocated to PHPUnit

All under `tests/php/src/Blocks/BlockTypes/OrderConfirmation/`:

- `AbstractOrderConfirmationBlockTest.php` is new. It covers the shared permission gate:
    - `test_get_view_order_permissions` has 11 cases:
        - a missing order;
        - an owner with a valid key, without a key, and with a wrong key;
        - a different logged-in customer;
        - a known shopper after logging out, and with the filter opt-out;
        - a guest in a Store API draft session;
        - a guest within and after the grace period, and a guest with a verified email.
    - `test_email_verification_permitted` covers when a guest may verify by email.
- `BillingAddress.php` and `BillingWrapperTest.php` (new) check that the billing address block and its wrapper render for physical, pickup, and virtual orders, and stay empty for a visitor without permission. The wrapper also stays empty when there is no billing address.
- `ShippingAddress.php` and `ShippingWrapperTest.php` (new) check that the shipping address block and its wrapper render for a physical order, and stay empty for a pickup order, a virtual order, and a visitor without permission. The wrapper also stays empty when there is no shipping address.
- `DownloadsTest.php` is new. It checks the downloads table against real download grants as the order moves from pending to processing to completed, and that it stays empty without permission. `DownloadsWrapper.php` gains `test_runtime_render_requires_download_permission`, which checks the wrapper for a pending order, a completed order with no downloadable item, a visitor without permission, and a completed downloadable order.
- `StatusTest.php` gains `test_missing_order_notice` and `test_invalid_key_notice_uses_real_permission_result`. Trunk already has a `StatusTest` class at this path, so the two tests, their data provider, and their helpers are added to it; all of trunk's tests stay.

#### The retained wiring tests

Three browser titles stay:

- `Known shopper details require owner and key unless the filter opts out`: a logged-in shopper's order shows its details; after logging out, a visit with the valid key, a missing key, or a wrong key hides them; and with the filter opt-out, the valid-key visit shows them again.
- `Delayed account creation flows`, unchanged.
- `Completed downloadable order exposes named entitlement links`, renamed from `Confirm order downloads are visible`. Downloads stay hidden while the order is on hold, then appear after an admin completes it. It now also checks each download's name and link.

Every Order Confirmation block type the removed titles covered keeps a browser title through these three. The additional fields and additional information blocks had no browser title before this PR either. Several checks lose their only browser coverage, all listed in the table above: the logged-in owner's missing-key visit, the shipping wrapper staying hidden for pickup and virtual orders, the notice copy, and downloads at Processing.

All three journeys add products to the cart through trunk's `frontendUtils` helpers. On the #68046 branch they also passed under a cart request tracker that is not landing, so this draft's CI run is the load check for them. They pass locally on trunk's helpers (see below).

#### Where this differs from the TESTOPS-234 audit

The TESTOPS-234 audit leaves this spec out of its movable list, so its per-test pass keeps all six titles in the browser. The spec is also on the list of files where the audit and this branch reached different conclusions. The audit counts all six titles as browser tests, and it deferred splitting tests that bundle editor and front-end checks to a later phase. On this spec the branch also disagrees on layer: it treats the pickup and virtual address checks and the notice copy as server-rendered output.

This branch keeps the seams only a browser proves: a revisit without cookies but with a real order key, the filter test plugin, the delayed account form, and an admin completing an order before named download links appear. It moves the permission policy and the server-rendered output to PHPUnit tests that build real orders.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test`, then run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'OrderConfirmation'` and confirm it passes.
3. Confirm the permission gate test guards the invalid-order case. In `plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php`, change `return false; // Always disallow access to invalid orders and those without a valid key.` to `return 'full';`. Re-run the command from step 2 and confirm `test_get_view_order_permissions` fails for the "null order" case. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/checkout/order-confirmation.block_theme.spec.ts`. Confirm all three titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. Before the run, the Blocks assets were rebuilt from this branch's trunk base, and the E2E store was checked: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 30 distinct focused commands for these files, 28 PHPUnit and 2 Playwright, and all 30 exit 0.
- **Retained titles.** `--list` shows the three titles, and the spec passes with `--retries=0 --workers=1`.
- **`StatusTest.php`.** It keeps all 8 of trunk's tests, adds the batch's 2, and has no duplicate methods. The whole merged class passes with `OK (11 tests, 40 assertions)`, and this PR's step 2 command (`--filter 'OrderConfirmation'`) passes with `OK (56 tests, 143 assertions)`.
- **Mutation re-check.** For each of the 23 behavior families, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored. The table lists the code each mutation changed, the test that caught it, and the first failure it reported:

| Mutation | Code changed | What fails |
| --- | --- | --- |
| `1096` | `WC_Order::get_downloadable_items` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that actual size 1 matches expected size 2. |
| `1083` | `WC_Order::is_download_permitted` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that actual size 0 matches expected size 2. |
| `1091` | `wc_get_account_downloads_columns` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that 0 is identical to 2. |
| `1079` | `AbstractOrderConfirmationBlock::allow_guest_checkout` | `test_email_verification_permitted with data set guest checkout and valid key`: Failed asserting that false is identical to true. |
| `1082` | `AbstractOrderConfirmationBlock::email_verification_permitted` | `test_email_verification_permitted with data set known customer without guest mode`: Failed asserting that true is identical to false. |
| `1074` | `AbstractOrderConfirmationBlock::email_verification_required` | `test_get_view_order_permissions with data set guest Store API draft session`: Failed asserting that false is identical to 'full'. |
| `0112` | `AbstractOrderConfirmationBlock::get_view_order_permissions` | `test_get_view_order_permissions with data set null order`: Failed asserting that 'full' is identical to false. |
| `1077` | `AbstractOrderConfirmationBlock::is_email_verified` | `test_get_view_order_permissions with data set guest with verified email`: Failed asserting that false is identical to 'full'. |
| `1075` | `AbstractOrderConfirmationBlock::is_within_grace_period` | `test_get_view_order_permissions with data set guest within grace period`: Failed asserting that false is identical to 'full'. |
| `0017` | `BillingAddress::render_content` | `BillingAddress::test_billing_address_topology`: Failed asserting that '' contains "Billing Marker". |
| `0018` | `BillingWrapper::render_content` | `BillingWrapperTest::test_billing_wrapper_topology`: Failed asserting that two strings are identical. |
| `1086` | `Downloads::render_content` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that two strings are identical. |
| `0113` | `Downloads::render_order_downloads` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that 1 is identical to 3. |
| `0825` | `DownloadsWrapper::render_content` | `test_runtime_render_requires_download_permission`: Failed asserting that two strings are identical. |
| `0020` | `DownloadsWrapper::store_has_downloadable_products` | `test_store_has_downloadable_products_via_cache`: Failed asserting that true is false. |
| `0023` | `ShippingAddress::render_content` | `test_shipping_address_topology`: Failed asserting that '' contains "Shipping Marker". |
| `0024` | `ShippingWrapper::render_content` | `test_shipping_wrapper_topology`: Failed asserting that two strings are identical. |
| `0832` | `Status::render_confirmation_notice` | `test_missing_order_notice`: the notice reads `Great news! Your order has been received. …` and doesn't contain `If you've just placed an order, give your email a quick check …` |
| `0016` | `CheckoutFields::filter_fields_for_order_confirmation` | `BillingAddress::test_shows_field_when_show_in_order_confirmation_is_true`: the rendered billing address doesn't contain `visible value` |
| `0606` | `Downloads::render_order_download_row download-file href` | `Completed downloadable order exposes named entitlement links`: Error: expect(locator).toHaveAttribute(expected) failed |
| `1085` | `WC_Order::has_downloadable_item` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that '' contains "wc-block-order-confirmation-downloads__table". |
| `1092` | `Downloads::render_order_download_row` | `test_download_table_requires_entitlement_and_permission`: Failed asserting that 0 is identical to 2. |
| `0605` | `get_view_order_permissions known-shopper filter opt-out branch` | `Known shopper details require owner and key unless the filter opts out`: Error: expect(locator).toBeVisible() failed |

- **Lint.**
    - PHPCS finds nothing new in any of the 8 PHP test files compared with trunk, and Prettier is clean.
    - ESLint reports nothing on lines this PR changes. Its 2 warnings sit on trunk lines: `rules-of-hooks` on the spec's fixture, and `prefer-locator` on an `admin.page.click(` call.
    - oxlint finds nothing new, `verify-staged` exits 0, and `lint:changes:branch` exits 0.
    - PHPStan doesn't analyse `tests/` in this repository's config, so it isn't a gate for these files. Direct runs are kept as records.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Reviews.** Two independent agent reviews read the branch and the evidence, and their findings are applied or answered in writing. A fresh reviewer then checked the fixes. None of them is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-order-confirmation-blocks`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


