### PR TITLE
[tests] Reduce On-Sale Badge E2E tests from 6 to 1

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-on-sale-badge
+++ b/plugins/woocommerce/changelog/testops-234-on-sale-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce On-Sale Badge E2E tests from 6 to 1; PHPUnit owns the sale check and the alignment classes.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
@@ -1,93 +1,57 @@
 /**
  * External dependencies
  */
-import {
-	test as base,
-	expect,
-	Editor,
-	FrontendUtils,
-	BLOCK_THEME_SLUG,
-} from '@woocommerce/e2e-utils';
-
-/**
- * Internal dependencies
- */
-import { ProductGalleryPage } from '../product-gallery/product-gallery.page';
+import type { FrameLocator, Page } from '@playwright/test';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 const blockData = {
 	name: 'woocommerce/product-sale-badge',
-	mainClass: '.wp-block-woocommerce-product-sale-badge',
-	selectors: {
-		frontend: {
-			badge: '.wc-block-components-product-sale-badge',
-			badgeContainer: '.wp-block-woocommerce-product-sale-badge',
-		},
-		editor: {
-			badge: '.wc-block-components-product-sale-badge',
-			badgeContainer: '.wp-block-woocommerce-product-sale-badge',
-		},
-	},
 	slug: 'single-product',
 	productPage: '/product/hoodie/',
-	productPageNotOnSale: '/product/album/',
 };
 
-class BlockUtils {
-	editor: Editor;
-	frontendUtils: FrontendUtils;
+const badgeSelector = '.wc-block-components-product-sale-badge';
+const badgeContainerSelector = '.wp-block-woocommerce-product-sale-badge';
 
-	constructor( {
-		editor,
-		frontendUtils,
-	}: {
-		editor: Editor;
-		frontendUtils: FrontendUtils;
-	} ) {
-		this.editor = editor;
-		this.frontendUtils = frontendUtils;
-	}
+type SaleBadgeAlignment = 'left' | 'center' | 'right';
 
-	async getSaleBadgeBoundingClientRect( isFrontend: boolean ): Promise< {
-		badge: DOMRect;
-		badgeContainer: DOMRect;
-	} > {
-		const page = isFrontend ? this.frontendUtils.page : this.editor.canvas;
-		return {
-			badge: await page
-				.locator(
-					blockData.selectors[ isFrontend ? 'frontend' : 'editor' ]
-						.badge
-				)
-				.first()
-				.evaluate( ( el ) => el.getBoundingClientRect() ),
-			badgeContainer: await page
-				.locator(
-					blockData.selectors[ isFrontend ? 'frontend' : 'editor' ]
-						.badgeContainer
-				)
-				.first()
-				.evaluate( ( el ) => el.getBoundingClientRect() ),
-		};
-	}
-}
+const getAlignmentDelta = async (
+	root: Page | FrameLocator,
+	alignment: SaleBadgeAlignment
+): Promise< number > =>
+	root
+		.locator( badgeContainerSelector )
+		.first()
+		.evaluate(
+			( container, evaluation ) => {
+				const badge = container.querySelector(
+					evaluation.badgeSelector
+				);
 
-const test = base.extend< {
-	pageObject: ProductGalleryPage;
-	blockUtils: BlockUtils;
-} >( {
-	pageObject: async ( { page, editor, frontendUtils }, use ) => {
-		await use(
-			new ProductGalleryPage( {
-				page,
-				editor,
-				frontendUtils,
-			} )
+				if ( ! badge ) {
+					return Number.POSITIVE_INFINITY;
+				}
+
+				const badgeRect = badge.getBoundingClientRect();
+				const containerRect = container.getBoundingClientRect();
+
+				if ( evaluation.alignment === 'left' ) {
+					return Math.abs( badgeRect.left - containerRect.left );
+				}
+
+				if ( evaluation.alignment === 'center' ) {
+					const badgeMidpoint =
+						( badgeRect.left + badgeRect.right ) / 2;
+					const containerMidpoint =
+						( containerRect.left + containerRect.right ) / 2;
+
+					return Math.abs( badgeMidpoint - containerMidpoint );
+				}
+
+				return Math.abs( containerRect.right - badgeRect.right );
+			},
+			{ alignment, badgeSelector }
 		);
-	},
-	blockUtils: async ( { editor, frontendUtils }, use ) => {
-		await use( new BlockUtils( { editor, frontendUtils } ) );
-	},
-} );
 
 test.describe( `${ blockData.name }`, () => {
 	test.describe( `On the Single Product Template`, () => {
@@ -100,195 +64,80 @@ test.describe( `${ blockData.name }`, () => {
 			await editor.setContent( '' );
 		} );
 
-		test( 'should be rendered on the editor side', async ( { editor } ) => {
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
-
-			const block = await editor.getBlockByName( blockData.name );
-
-			await expect( block ).toBeVisible();
-		} );
-
-		test( 'should be rendered on the frontend side', async ( {
-			frontendUtils,
+		test( 'renders and aligns the sale badge in editor and frontend', async ( {
 			editor,
 			page,
-			pageObject,
 		} ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
+			const context = page.context();
+			const baselinePageCount = context.pages().length;
+			const frontendPage = await context.newPage();
 
-			await pageObject.toggleFullScreenOnClickSetting( false );
+			try {
+				expect( context.pages() ).toHaveLength( baselinePageCount + 1 );
 
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
+				await editor.openDocumentSettingsSidebar();
+				await editor.insertBlock( {
+					name: 'woocommerce/product-gallery',
+				} );
+				await page
+					.getByRole( 'checkbox', {
+						name: 'Open pop-up when clicked',
+						exact: true,
+					} )
+					.uncheck();
 
-			await page.goto( blockData.productPage );
+				let block = await editor.getBlockByName( blockData.name );
+				await expect( block ).toBeVisible();
+				await expect
+					.poll( () => getAlignmentDelta( editor.canvas, 'right' ) )
+					.toBeLessThanOrEqual( 1 );
 
-			const block = await frontendUtils.getBlockByName( blockData.name );
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 
-			await expect( block.first() ).toBeVisible();
-		} );
+				await frontendPage.goto( blockData.productPage );
+				await expect(
+					frontendPage.locator( badgeSelector ).first()
+				).toBeVisible();
+				await expect
+					.poll( () => getAlignmentDelta( frontendPage, 'right' ) )
+					.toBeLessThanOrEqual( 1 );
 
-		test( `should not render on the frontend when the product is not on sale`, async ( {
-			frontendUtils,
-			editor,
-			page,
-			pageObject,
-		} ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
+				for ( const alignment of [ 'left', 'center' ] as const ) {
+					block = await editor.getBlockByName( blockData.name );
+					await block.click();
+					await page.getByRole( 'button', { name: 'Align' } ).click();
+					await page
+						.getByRole( 'menuitemradio', {
+							name: new RegExp( `Align ${ alignment }`, 'i' ),
+						} )
+						.click();
 
-			await pageObject.toggleFullScreenOnClickSetting( false );
+					await expect
+						.poll( () =>
+							getAlignmentDelta( editor.canvas, alignment )
+						)
+						.toBeLessThanOrEqual( 1 );
 
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
 
-			await page.goto( blockData.productPageNotOnSale );
-
-			const block = await frontendUtils.getBlockByName( blockData.name );
-
-			await expect( block ).toBeHidden();
-		} );
-
-		test( 'should be aligned to the left', async ( {
-			editor,
-			page,
-			pageObject,
-			blockUtils,
-		} ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
-
-			await pageObject.toggleFullScreenOnClickSetting( false );
-
-			const block = await editor.getBlockByName( blockData.name );
-
-			await block.click();
-
-			await page.locator( "button[aria-label='Align']" ).click();
-			await page.getByText( 'Align Left' ).click();
-
-			await expect
-				.poll( async () => {
-					const { badge, badgeContainer } =
-						await blockUtils.getSaleBadgeBoundingClientRect(
-							false
-						);
-
-					return badge.x - badgeContainer.x;
-				} )
-				.toEqual( 0 );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
-
-			await page.goto( blockData.productPage );
-
-			await expect
-				.poll( async () => {
-					const { badge, badgeContainer } =
-						await blockUtils.getSaleBadgeBoundingClientRect( true );
-
-					return badge.x - badgeContainer.x;
-				} )
-				.toEqual( 0 );
-		} );
-
-		test( 'should be aligned to the center', async ( {
-			editor,
-			page,
-			pageObject,
-			blockUtils,
-		} ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
-
-			await pageObject.toggleFullScreenOnClickSetting( false );
-
-			const block = await editor.getBlockByName( blockData.name );
-
-			await block.click();
-
-			await page.locator( "button[aria-label='Align']" ).click();
-			await page.getByText( 'Align Center' ).click();
-
-			await expect
-				.poll( async () => {
-					const { badge, badgeContainer } =
-						await blockUtils.getSaleBadgeBoundingClientRect(
-							false
-						);
-
-					return badge.right < badgeContainer.right;
-				} )
-				.toBe( true );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
-
-			await page.goto( blockData.productPage );
-
-			await expect
-				.poll( async () => {
-					const { badge, badgeContainer } =
-						await blockUtils.getSaleBadgeBoundingClientRect( true );
-
-					return badge.right < badgeContainer.right;
-				} )
-				.toBe( true );
-		} );
-
-		test( 'should be aligned to the right by default', async ( {
-			editor,
-			page,
-			pageObject,
-			blockUtils,
-		} ) => {
-			await editor.openDocumentSettingsSidebar();
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
-			await pageObject.toggleFullScreenOnClickSetting( false );
-
-			await expect
-				.poll( async () => {
-					const { badge, badgeContainer } =
-						await blockUtils.getSaleBadgeBoundingClientRect(
-							false
-						);
-
-					return badgeContainer.right - badge.right;
-				} )
-				.toEqual( 0 );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
-
-			await page.goto( blockData.productPage );
-
-			await expect
-				.poll( async () => {
-					const { badge, badgeContainer } =
-						await blockUtils.getSaleBadgeBoundingClientRect( true );
-
-					return badgeContainer.right - badge.right;
-				} )
-				.toEqual( 0 );
+					await frontendPage.goto( blockData.productPage );
+					await expect(
+						frontendPage.locator( badgeSelector ).first()
+					).toBeVisible();
+					await expect
+						.poll( () =>
+							getAlignmentDelta( frontendPage, alignment )
+						)
+						.toBeLessThanOrEqual( 1 );
+				}
+			} finally {
+				await frontendPage.close();
+				expect( context.pages() ).toHaveLength( baselinePageCount );
+			}
 		} );
 	} );
 } );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
@@ -10,6 +10,95 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 class ProductSaleBadge extends \WP_UnitTestCase {
 
 	/**
+	 * @testdox Product Sale Badge does not render for a regular-price product.
+	 */
+	public function test_product_sale_badge_does_not_render_for_regular_price(): void {
+		global $product;
+
+		$had_product      = array_key_exists( 'product', $GLOBALS );
+		$original_product = $had_product ? $product : null;
+		$product          = new \WC_Product_Simple();
+
+		try {
+			$product->set_name( 'Regular Product' );
+			$product->set_regular_price( '10' );
+			$product_id = $product->save();
+
+			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sale-badge /--><!-- /wp:woocommerce/single-product -->' );
+
+			$this->assertStringNotContainsString( 'wp-block-woocommerce-product-sale-badge', $markup, 'The outer Sale Badge block should be omitted.' );
+			$this->assertStringNotContainsString( 'wc-block-components-product-sale-badge', $markup, 'The Sale Badge component should be omitted.' );
+			$this->assertStringNotContainsString( 'Sale', $markup, 'Sale text should be omitted.' );
+		} finally {
+			if ( $product->get_id() ) {
+				$product->delete( true );
+			}
+
+			if ( $had_product ) {
+				$product = $original_product;
+			} else {
+				unset( $GLOBALS['product'] );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Product Sale Badge renders the $align alignment class.
+	 *
+	 * @dataProvider provider_product_sale_badge_alignment
+	 * @param string $align Alignment value.
+	 */
+	public function test_product_sale_badge_renders_alignment_class( string $align ): void {
+		global $product;
+
+		$had_product      = array_key_exists( 'product', $GLOBALS );
+		$original_product = $had_product ? $product : null;
+		$product          = new \WC_Product_Simple();
+
+		try {
+			$product->set_name( 'Sale Product' );
+			$product->set_regular_price( '10' );
+			$product->set_sale_price( '5' );
+			$product_id = $product->save();
+
+			$markup         = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sale-badge {"align":"' . $align . '"} /--><!-- /wp:woocommerce/single-product -->' );
+			$expected_class = 'wc-block-components-product-sale-badge--align-' . $align;
+
+			$this->assertStringContainsString( $expected_class, $markup );
+			foreach ( array_diff( array( 'left', 'center', 'right' ), array( $align ) ) as $other_align ) {
+				$this->assertStringNotContainsString(
+					'wc-block-components-product-sale-badge--align-' . $other_align,
+					$markup,
+					'The Sale Badge should contain only its requested alignment class.'
+				);
+			}
+		} finally {
+			if ( $product->get_id() ) {
+				$product->delete( true );
+			}
+
+			if ( $had_product ) {
+				$product = $original_product;
+			} else {
+				unset( $GLOBALS['product'] );
+			}
+		}
+	}
+
+	/**
+	 * Alignment values for the Sale Badge.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function provider_product_sale_badge_alignment(): array {
+		return array(
+			'left'   => array( 'left' ),
+			'center' => array( 'center' ),
+			'right'  => array( 'right' ),
+		);
+	}
+
+	/**
 	 * Tests that the Product Sale Badge block is rendered correctly on the Single Product Block
 	 */
 	public function test_product_sale_badge_render_single_product_block() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The On-Sale Badge spec ran six browser titles on the Single Product template:

- two checked that the badge renders;
- one checked that it is absent for a product that isn't on sale;
- three checked its left, center, and right alignment, each saving the template again.

Whether the badge renders, and which alignment class it gets, are both decided on the frontend in `ProductSaleBadge::render`. This PR adds PHPUnit tests for those decisions and folds the browser checks into one title. The spec goes from 6 tests to 1, and `ProductSaleBadge.php` goes from 3 test methods to 5.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `should be rendered on the editor side` | the retained title, which inserts the Product Gallery and checks that the badge is visible in the editor | only its isolation (see below the table). It checks the same block in the same template editor |
| `should be rendered on the frontend side` | the retained title, which checks that the badge is visible on `/product/hoodie/` after saving; and the existing `ProductSaleBadge.php` › `test_product_sale_badge_render_single_product_block` | the frontend check now looks for the badge's component class, not the block's `data-block-name` attribute, and it loads the product page in a second tab |
| `should not render on the frontend when the product is not on sale` | the new `ProductSaleBadge.php` › `test_product_sale_badge_does_not_render_for_regular_price`, which checks that the wrapper, the component, and the `Sale` text are all absent | the browser check on a real product that isn't on sale (`/product/album/`), rendered through the saved template and the Product Gallery. The PHP test renders a regular-price product it creates |
| `should be aligned to the left` | the retained title's left step, which checks the badge's position in the editor and on the product page; and the new `test_product_sale_badge_renders_alignment_class` left case | an exact 0 px offset, now within 1 px. Left also no longer runs on its own: it follows the other steps in one title |
| `should be aligned to the center` | the retained title's center step, which checks that the badge's midpoint matches its container's; and the center case | rejecting a badge as wide as its container. The old check failed a full-width badge; the midpoint check passes it, and so do the left and right checks. Center also no longer runs on its own |
| `should be aligned to the right by default` | the retained title's first checks, made before any alignment is chosen; and the right case | an exact 0 px offset, now within 1 px. The PHP right case only covers an explicit attribute, so the default right alignment is proven only in the browser |

The editor and frontend render checks lose their isolation too. The editor check now runs after the Product Gallery's pop-up setting is unchecked, and the frontend check runs after the editor's right-alignment check.

#### Relocated to PHPUnit

`tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php` gains two methods:

- `test_product_sale_badge_does_not_render_for_regular_price` checks that nothing renders for a product at its regular price.
- `test_product_sale_badge_renders_alignment_class` runs for left, center, and right. Each case checks that the badge gets its own alignment class and neither of the others.

#### The retained wiring test

`renders and aligns the sale badge in editor and frontend` stays as the only title. It inserts the badge through the Product Gallery, saves the template, and measures the badge's position in the editor and on the product page for right (the default), left, and center. Only a browser can check this: the position comes from the badge stylesheet's flex layout, the editor badge is rendered by the block's JavaScript, and the right default comes from the Product Gallery's editor template. The badge's frontend output is also asserted by Product Collection's `Renders correctly with all Product Elements › In a post`.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test`, then run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter test_product_sale_badge` and confirm it passes.
3. Confirm the new test guards the sale check. In `plugins/woocommerce/src/Blocks/BlockTypes/ProductSaleBadge.php`, change `if ( ! $is_on_sale ) {` to `if ( false ) {`. Re-run the command from step 2 and confirm `test_product_sale_badge_does_not_render_for_regular_price` fails. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts`. Confirm the title passes. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. The E2E store was checked first: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 5 distinct focused commands for these files, 4 PHPUnit and 1 Playwright, and all 5 exit 0.
- **Retained titles.** `--list` shows the one title, and the spec passes with `--retries=0 --workers=1`.
- **Mutation re-check.** For each behavior, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0047` | `ProductSaleBadge::render` always treats the product as on sale | `test_product_sale_badge_does_not_render_for_regular_price`: the regular-price output still contains `wp-block-woocommerce-product-sale-badge` |
| `0048` | `ProductSaleBadge::render` ignores the chosen alignment and uses `invalid` | `test_product_sale_badge_renders_alignment_class` (left): the output lacks `wc-block-components-product-sale-badge--align-left` |
| `0617` | `ProductSaleBadge::render` forces left alignment | the retained `renders and aligns the sale badge in editor and frontend`: on the product page, the badge's right edge sits 937.375 px inside its container's right edge instead of within 1 px |

- **Lint.**
    - PHPCS finds nothing new in `ProductSaleBadge.php` compared with trunk, and Prettier is clean.
    - ESLint reports nothing on lines this PR changes.
    - oxlint finds nothing new, `verify-staged` exits 0, and `lint:changes:branch` exits 0.
    - PHPStan doesn't analyse `tests/` in this repository's config, so it isn't a gate for the PHP test. A direct run is kept as a record.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Reviews.** Two independent agent reviews read the branch and the evidence. The one blocking finding, that the center row overstated the new check, is fixed in this description, and a fresh reviewer checked the fix. Non-blocking findings about carried test code are left for follow-ups. None of them is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-on-sale-badge`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


