### PR TITLE
[tests] Reduce Local Pickup settings E2E tests from 7 to 2

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-local-pickup-settings
+++ b/plugins/woocommerce/changelog/testops-234-local-pickup-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce Local Pickup settings E2E tests from 7 to 2; three Jest suites own the settings screen's logic.
+

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/general-settings.tsx
@@ -1,0 +1,230 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import GeneralSettings from '../general-settings';
+import { useSettingsContext } from '../settings-context';
+import type { SettingsContextType } from '../types';
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children }: { children: ReactNode } ) => (
+		<button type="button">{ children }</button>
+	),
+	Card: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	CardBody: ( { children }: { children: ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	CheckboxControl: ( {
+		checked,
+		label,
+		onChange,
+	}: {
+		checked: boolean;
+		label: string;
+		onChange: ( checked: boolean ) => void;
+	} ) => {
+		const id = `checkbox-${ label.toLowerCase().replace( /\W+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="checkbox"
+					checked={ checked }
+					onChange={ ( event ) => onChange( event.target.checked ) }
+				/>
+			</>
+		);
+	},
+	ExternalLink: ( {
+		children,
+		href,
+	}: {
+		children: ReactNode;
+		href: string;
+	} ) => <a href={ href }>{ children }</a>,
+	Notice: ( { children }: { children: ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	Modal: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	SelectControl: ( {
+		label,
+		onChange,
+		options,
+		value,
+	}: {
+		label: string;
+		onChange: ( value: string ) => void;
+		options: { label: string; value: string }[];
+		value: string;
+	} ) => {
+		const id = `select-${ label.toLowerCase().replace( /\W+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<select
+					id={ id }
+					value={ value }
+					onChange={ ( event ) => onChange( event.target.value ) }
+				>
+					{ options.map( ( option ) => (
+						<option key={ option.value } value={ option.value }>
+							{ option.label }
+						</option>
+					) ) }
+				</select>
+			</>
+		);
+	},
+	TextControl: ( {
+		label,
+		onChange,
+		placeholder,
+		type = 'text',
+		value,
+	}: {
+		label: string;
+		onChange: ( value: string ) => void;
+		placeholder?: string;
+		type?: string;
+		value: string;
+	} ) => {
+		const id = `text-${ label.toLowerCase().replace( /\W+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type={ type }
+					placeholder={ placeholder }
+					value={ value }
+					onChange={ ( event ) => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
+	ToggleControl: () => <input type="checkbox" readOnly />,
+} ) );
+
+jest.mock( '../settings-context', () => ( {
+	useSettingsContext: jest.fn(),
+} ) );
+
+const mockUseSettingsContext = useSettingsContext as jest.MockedFunction<
+	typeof useSettingsContext
+>;
+
+const getContext = (
+	overrides: Partial< SettingsContextType > = {}
+): SettingsContextType => ( {
+	settings: {
+		enabled: true,
+		title: '',
+		tax_status: 'taxable',
+		cost: '',
+	},
+	readOnlySettings: {
+		hasLegacyPickup: false,
+		storeCountry: 'US',
+		storeState: 'CA',
+	},
+	setSettingField: jest.fn( () => jest.fn() ),
+	pickupLocations: [],
+	setPickupLocations: jest.fn(),
+	toggleLocation: jest.fn(),
+	updateLocation: jest.fn(),
+	isSaving: false,
+	save: jest.fn(),
+	isDirty: false,
+	...overrides,
+} );
+
+describe( 'GeneralSettings', () => {
+	it( 'delegates enablement and title changes to their setting fields', async () => {
+		const user = userEvent.setup();
+		const enabledChanged = jest.fn();
+		const titleChanged = jest.fn();
+		const setSettingField = jest.fn( ( field ) => {
+			return field === 'enabled' ? enabledChanged : titleChanged;
+		} );
+		mockUseSettingsContext.mockReturnValue(
+			getContext( { setSettingField } )
+		);
+
+		render( <GeneralSettings /> );
+
+		await user.click(
+			screen.getByRole( 'checkbox', { name: 'Enable local pickup' } )
+		);
+		const title = screen.getByRole( 'textbox', { name: 'Title' } );
+		await user.type( title, 'C' );
+
+		expect( setSettingField ).toHaveBeenCalledWith( 'enabled' );
+		expect( setSettingField ).toHaveBeenCalledWith( 'title' );
+		expect( enabledChanged ).toHaveBeenCalledWith( false );
+		expect( titleChanged ).toHaveBeenLastCalledWith( 'C' );
+	} );
+
+	it( 'shows price controls and clears cost whenever price visibility changes', async () => {
+		const user = userEvent.setup();
+		const costChanged = jest.fn();
+		const taxStatusChanged = jest.fn();
+		const setSettingField = jest.fn( ( field ) => {
+			if ( field === 'cost' ) {
+				return costChanged;
+			}
+			if ( field === 'tax_status' ) {
+				return taxStatusChanged;
+			}
+			return jest.fn();
+		} );
+		mockUseSettingsContext.mockReturnValue(
+			getContext( { setSettingField } )
+		);
+
+		render( <GeneralSettings /> );
+
+		const showPrice = screen.getByRole( 'checkbox', {
+			name: 'Add a price for customers who choose local pickup',
+		} );
+		expect(
+			screen.queryByRole( 'spinbutton', { name: 'Cost' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Taxes' } )
+		).not.toBeInTheDocument();
+
+		await act( async () => {
+			await user.click( showPrice );
+		} );
+
+		const cost = screen.getByRole( 'spinbutton', { name: 'Cost' } );
+		const taxes = screen.getByRole( 'combobox', { name: 'Taxes' } );
+		await user.type( cost, '7' );
+		await user.selectOptions( taxes, 'none' );
+
+		expect( setSettingField ).toHaveBeenCalledWith( 'cost' );
+		expect( setSettingField ).toHaveBeenCalledWith( 'tax_status' );
+		expect( costChanged ).toHaveBeenCalledWith( '' );
+		expect( costChanged ).toHaveBeenLastCalledWith( '7' );
+		expect( taxStatusChanged ).toHaveBeenCalledWith( 'none' );
+
+		await act( async () => {
+			await user.click( showPrice );
+		} );
+
+		expect( costChanged ).toHaveBeenLastCalledWith( '' );
+		expect(
+			screen.queryByRole( 'spinbutton', { name: 'Cost' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Taxes' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/location-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/location-settings.tsx
@@ -1,0 +1,329 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import LocationSettings from '../location-settings';
+import { useSettingsContext } from '../settings-context';
+import type { SettingsContextType, SortablePickupLocation } from '../types';
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		onClick,
+	}: {
+		children: ReactNode;
+		onClick: () => void;
+	} ) => (
+		<button type="button" onClick={ onClick }>
+			{ children }
+		</button>
+	),
+	Card: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	CardBody: ( { children }: { children: ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	ExternalLink: ( {
+		children,
+		href,
+	}: {
+		children: ReactNode;
+		href: string;
+	} ) => <a href={ href }>{ children }</a>,
+	Modal: ( { children, title }: { children: ReactNode; title: string } ) => (
+		<div role="dialog" aria-label={ title }>
+			{ children }
+		</div>
+	),
+	SelectControl: ( {
+		children,
+		label,
+		onChange,
+		value,
+	}: {
+		children: ReactNode;
+		label: string;
+		onChange: ( value: string ) => void;
+		value: string;
+	} ) => {
+		const id = `select-${ label.toLowerCase().replace( /\W+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<select
+					id={ id }
+					value={ value }
+					onChange={ ( event ) => onChange( event.target.value ) }
+				>
+					{ children }
+				</select>
+			</>
+		);
+	},
+	TextControl: ( {
+		label,
+		onChange,
+		placeholder,
+		required,
+		value,
+	}: {
+		label?: string;
+		onChange: ( value: string ) => void;
+		placeholder?: string;
+		required?: boolean;
+		value: string;
+	} ) => {
+		const accessibleLabel = label || placeholder || 'Text field';
+		const id = `text-${ accessibleLabel
+			.toLowerCase()
+			.replace( /\W+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ accessibleLabel }</label>
+				<input
+					id={ id }
+					required={ required }
+					value={ value }
+					onChange={ ( event ) => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
+	ToggleControl: ( {
+		checked,
+		onChange,
+	}: {
+		checked: boolean;
+		onChange: () => void;
+	} ) => (
+		<>
+			<label htmlFor="toggle-location">Toggle location</label>
+			<input
+				id="toggle-location"
+				type="checkbox"
+				checked={ checked }
+				onChange={ onChange }
+			/>
+		</>
+	),
+} ) );
+
+jest.mock( '../settings-context', () => ( {
+	useSettingsContext: jest.fn(),
+} ) );
+
+jest.mock( '../utils', () => ( {
+	getUserFriendlyAddress: jest.fn( ( address: Record< string, string > ) =>
+		Object.values( address ).filter( Boolean ).join( ', ' )
+	),
+	states: {
+		US: { CA: 'California' },
+		GB: {},
+	},
+	countryStateOptions: {
+		options: [
+			{
+				label: 'United States',
+				options: [
+					{ value: 'US:CA', label: 'United States — California' },
+				],
+			},
+			{
+				options: [ { value: 'GB', label: 'United Kingdom' } ],
+			},
+		],
+	},
+} ) );
+
+const mockUseSettingsContext = useSettingsContext as jest.MockedFunction<
+	typeof useSettingsContext
+>;
+
+const location: SortablePickupLocation = {
+	id: 'warehouse-0',
+	name: 'Warehouse',
+	details: 'Rear entrance',
+	enabled: true,
+	address: {
+		address_1: '60 29th Street',
+		city: 'San Francisco',
+		state: 'CA',
+		postcode: '94110',
+		country: 'US',
+	},
+};
+
+const getContext = (
+	overrides: Partial< SettingsContextType > = {}
+): SettingsContextType => ( {
+	settings: {
+		enabled: true,
+		title: 'Pickup',
+		tax_status: 'taxable',
+		cost: '',
+	},
+	readOnlySettings: {
+		hasLegacyPickup: false,
+		storeCountry: 'US',
+		storeState: 'CA',
+	},
+	setSettingField: jest.fn( () => jest.fn() ),
+	pickupLocations: [ location ],
+	setPickupLocations: jest.fn(),
+	toggleLocation: jest.fn(),
+	updateLocation: jest.fn(),
+	isSaving: false,
+	save: jest.fn(),
+	isDirty: false,
+	...overrides,
+} );
+
+describe( 'LocationSettings', () => {
+	it( 'adds a location with the dialog field values', async () => {
+		const user = userEvent.setup();
+		const updateLocation = jest.fn();
+		mockUseSettingsContext.mockReturnValue(
+			getContext( { pickupLocations: [], updateLocation } )
+		);
+		render( <LocationSettings /> );
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add pickup location' } )
+			);
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByRole( 'textbox', { name: /Location name/ } ),
+				'Downtown'
+			);
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByRole( 'textbox', { name: 'Address' } ),
+				'10 Market Street'
+			);
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByRole( 'textbox', { name: 'City' } ),
+				'San Francisco'
+			);
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByRole( 'textbox', { name: 'Postcode / ZIP' } ),
+				'94105'
+			);
+		} );
+		await act( async () => {
+			await user.selectOptions(
+				screen.getByRole( 'combobox', { name: 'Country / State' } ),
+				'US:CA'
+			);
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByRole( 'textbox', { name: 'Pickup details' } ),
+				'Ask at reception'
+			);
+		} );
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Done' } ) );
+		} );
+
+		expect( updateLocation ).toHaveBeenCalledWith( 'new', {
+			name: 'Downtown',
+			details: 'Ask at reception',
+			enabled: true,
+			address: {
+				address_1: '10 Market Street',
+				city: 'San Francisco',
+				state: 'CA',
+				postcode: '94105',
+				country: 'US',
+			},
+		} );
+	} );
+
+	it( 'edits a location using its existing ID and dialog payload', async () => {
+		const user = userEvent.setup();
+		const updateLocation = jest.fn();
+		mockUseSettingsContext.mockReturnValue(
+			getContext( { updateLocation } )
+		);
+		render( <LocationSettings /> );
+
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Edit' } ) );
+		} );
+		const name = screen.getByRole( 'textbox', {
+			name: /Location name/,
+		} );
+		await act( async () => {
+			await user.clear( name );
+		} );
+		await act( async () => {
+			await user.type( name, 'London office' );
+		} );
+		await act( async () => {
+			await user.selectOptions(
+				screen.getByRole( 'combobox', { name: 'Country / State' } ),
+				'GB'
+			);
+		} );
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Done' } ) );
+		} );
+
+		expect( updateLocation ).toHaveBeenCalledWith( 'warehouse-0', {
+			...location,
+			name: 'London office',
+			address: {
+				...location.address,
+				state: '',
+				country: 'GB',
+			},
+		} );
+	} );
+
+	it( 'deletes a location using its existing ID', async () => {
+		const user = userEvent.setup();
+		const updateLocation = jest.fn();
+		mockUseSettingsContext.mockReturnValue(
+			getContext( { updateLocation } )
+		);
+		render( <LocationSettings /> );
+
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Edit' } ) );
+		} );
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Delete location' } )
+			);
+		} );
+
+		expect( updateLocation ).toHaveBeenCalledWith( 'warehouse-0', null );
+	} );
+
+	it( 'toggles a location using its existing ID', async () => {
+		const user = userEvent.setup();
+		const toggleLocation = jest.fn();
+		mockUseSettingsContext.mockReturnValue(
+			getContext( { toggleLocation } )
+		);
+		render( <LocationSettings /> );
+
+		await user.click(
+			screen.getByRole( 'checkbox', { name: 'Toggle location' } )
+		);
+
+		expect( toggleLocation ).toHaveBeenCalledWith( 'warehouse-0' );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/settings-context.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/settings-context.tsx
@@ -1,0 +1,362 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsProvider, useSettingsContext } from '../settings-context';
+import type { SortablePickupLocation } from '../types';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	dispatch: jest.fn(),
+} ) );
+
+jest.mock( '../utils', () => ( {
+	defaultSettings: {
+		enabled: false,
+		title: 'Pickup',
+		tax_status: 'taxable',
+		cost: '',
+	},
+	defaultReadyOnlySettings: {
+		hasLegacyPickup: false,
+		storeCountry: 'US',
+		storeState: 'CA',
+	},
+	readOnlySettings: {
+		hasLegacyPickup: false,
+		storeCountry: 'US',
+		storeState: 'CA',
+	},
+	getInitialSettings: jest.fn( () => ( {
+		enabled: false,
+		title: 'Pickup',
+		tax_status: 'none',
+		cost: '',
+	} ) ),
+	getInitialPickupLocations: jest.fn( () => [
+		{
+			id: 'warehouse-0',
+			name: 'Warehouse',
+			details: 'Rear entrance',
+			enabled: true,
+			address: {
+				address_1: '60 29th Street',
+				city: 'San Francisco',
+				state: 'CA',
+				postcode: '94110',
+				country: 'US',
+			},
+		},
+	] ),
+} ) );
+
+const mockApiFetch = apiFetch as jest.Mock;
+const mockDispatch = dispatch as jest.Mock;
+const createSuccessNotice = jest.fn();
+const createErrorNotice = jest.fn();
+
+const annex: SortablePickupLocation = {
+	id: '',
+	name: 'Annex',
+	details: 'Front desk',
+	enabled: true,
+	address: {
+		address_1: '10 Market Street',
+		city: 'San Francisco',
+		state: 'CA',
+		postcode: '94105',
+		country: 'US',
+	},
+};
+
+const replacement: SortablePickupLocation = {
+	id: 'warehouse-0',
+	name: 'Main warehouse',
+	details: 'Loading bay',
+	enabled: false,
+	address: {
+		address_1: '100 New Bridge Street',
+		city: 'London',
+		state: '',
+		postcode: 'EC4V 6JA',
+		country: 'GB',
+	},
+};
+
+const initialWarehouse: SortablePickupLocation = {
+	id: 'warehouse-0',
+	name: 'Warehouse',
+	details: 'Rear entrance',
+	enabled: true,
+	address: {
+		address_1: '60 29th Street',
+		city: 'San Francisco',
+		state: 'CA',
+		postcode: '94110',
+		country: 'US',
+	},
+};
+
+const addedAnnex: SortablePickupLocation = {
+	...annex,
+	id: 'annex-1',
+};
+
+const ContextConsumer = () => {
+	const context = useSettingsContext();
+	return (
+		<>
+			<output aria-label="Settings state">
+				{ JSON.stringify( context.settings ) }
+			</output>
+			<output aria-label="Pickup locations state">
+				{ JSON.stringify( context.pickupLocations ) }
+			</output>
+			<output aria-label="Dirty state">
+				{ String( context.isDirty ) }
+			</output>
+			<output aria-label="Saving state">
+				{ String( context.isSaving ) }
+			</output>
+			<button
+				type="button"
+				onClick={ () => context.updateLocation( 'new', annex ) }
+			>
+				Add annex
+			</button>
+			<button
+				type="button"
+				onClick={ () =>
+					context.updateLocation( 'warehouse-0', replacement )
+				}
+			>
+				Replace warehouse
+			</button>
+			<button
+				type="button"
+				onClick={ () => context.toggleLocation( 'warehouse-0' ) }
+			>
+				Toggle warehouse
+			</button>
+			<button
+				type="button"
+				onClick={ () => context.updateLocation( 'annex-1', null ) }
+			>
+				Delete annex
+			</button>
+			<button
+				type="button"
+				onClick={ () => {
+					context.setSettingField( 'enabled' )( true );
+					context.setSettingField( 'title' )( 'Curbside pickup' );
+					context.setSettingField( 'tax_status' )( 'unsupported' );
+					context.setSettingField( 'cost' )( '7.50' );
+				} }
+			>
+				Change settings
+			</button>
+			<button type="button" onClick={ context.save }>
+				Save
+			</button>
+		</>
+	);
+};
+
+const getOutput = ( name: string ) => screen.getByRole( 'status', { name } );
+
+const getPickupLocations = (): SortablePickupLocation[] =>
+	JSON.parse(
+		getOutput( 'Pickup locations state' ).textContent ?? '[]'
+	) as SortablePickupLocation[];
+
+describe( 'SettingsProvider', () => {
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockDispatch.mockReset();
+		createSuccessNotice.mockReset();
+		createErrorNotice.mockReset();
+		mockDispatch.mockReturnValue( {
+			createSuccessNotice,
+			createErrorNotice,
+		} );
+	} );
+
+	it( 'adds, replaces, toggles, and deletes locations while marking changes dirty', async () => {
+		const user = userEvent.setup();
+		render(
+			<SettingsProvider>
+				<ContextConsumer />
+			</SettingsProvider>
+		);
+
+		expect( getOutput( 'Dirty state' ) ).toHaveTextContent( 'false' );
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add annex' } )
+			);
+		} );
+		expect( getPickupLocations() ).toEqual( [
+			initialWarehouse,
+			addedAnnex,
+		] );
+		expect( getOutput( 'Dirty state' ) ).toHaveTextContent( 'true' );
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Replace warehouse' } )
+			);
+		} );
+		expect( getPickupLocations() ).toEqual( [ replacement, addedAnnex ] );
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle warehouse' } )
+			);
+		} );
+		const enabledReplacement = { ...replacement, enabled: true };
+		expect( getPickupLocations() ).toEqual( [
+			enabledReplacement,
+			addedAnnex,
+		] );
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Delete annex' } )
+			);
+		} );
+		expect( getPickupLocations() ).toEqual( [ enabledReplacement ] );
+	} );
+
+	it( 'normalizes settings and locations in a successful save request', async () => {
+		const user = userEvent.setup();
+		let resolveRequest: () => void;
+		mockApiFetch.mockImplementation(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveRequest = () => resolve( {} );
+				} )
+		);
+		render(
+			<SettingsProvider>
+				<ContextConsumer />
+			</SettingsProvider>
+		);
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Change settings' } )
+			);
+		} );
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add annex' } )
+			);
+		} );
+		expect( getOutput( 'Dirty state' ) ).toHaveTextContent( 'true' );
+
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/wc/v3/pickup-locations',
+			method: 'POST',
+			data: {
+				pickup_location_settings: {
+					enabled: 'yes',
+					title: 'Curbside pickup',
+					tax_status: 'taxable',
+					cost: '7.50',
+				},
+				pickup_locations: [
+					{
+						name: 'Warehouse',
+						address: {
+							address_1: '60 29th Street',
+							city: 'San Francisco',
+							state: 'CA',
+							postcode: '94110',
+							country: 'US',
+						},
+						details: 'Rear entrance',
+						enabled: true,
+					},
+					{
+						name: 'Annex',
+						address: annex.address,
+						details: 'Front desk',
+						enabled: true,
+					},
+				],
+			},
+		} );
+		expect( getOutput( 'Saving state' ) ).toHaveTextContent( 'true' );
+		expect( getOutput( 'Dirty state' ) ).toHaveTextContent( 'false' );
+
+		await act( async () => {
+			resolveRequest();
+		} );
+
+		await waitFor( () => {
+			expect( getOutput( 'Saving state' ) ).toHaveTextContent( 'false' );
+		} );
+		expect( createSuccessNotice ).toHaveBeenCalledWith(
+			'Local Pickup settings have been saved.'
+		);
+		expect( createErrorNotice ).not.toHaveBeenCalled();
+		expect( mockDispatch ).toHaveBeenCalledWith( noticesStore );
+	} );
+
+	it( 'restores dirty state and reports a rejected save', async () => {
+		const user = userEvent.setup();
+		let rejectRequest: ( reason: Error ) => void;
+		mockApiFetch.mockImplementation(
+			() =>
+				new Promise( ( resolve, reject ) => {
+					void resolve;
+					rejectRequest = reject;
+				} )
+		);
+		render(
+			<SettingsProvider>
+				<ContextConsumer />
+			</SettingsProvider>
+		);
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Change settings' } )
+			);
+		} );
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		} );
+		expect( getOutput( 'Saving state' ) ).toHaveTextContent( 'true' );
+		expect( getOutput( 'Dirty state' ) ).toHaveTextContent( 'false' );
+
+		await act( async () => {
+			rejectRequest( new Error( 'Request failed' ) );
+		} );
+
+		await waitFor( () => {
+			expect( getOutput( 'Saving state' ) ).toHaveTextContent( 'false' );
+		} );
+		expect( getOutput( 'Dirty state' ) ).toHaveTextContent( 'true' );
+		expect( createErrorNotice ).toHaveBeenCalledWith(
+			'There was an error saving your Local Pickup settings. Please try again.'
+		);
+		expect( createSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockDispatch ).toHaveBeenCalledWith( noticesStore );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-local-pickup-settings
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-local-pickup-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce Local Pickup settings E2E tests from 7 to 2; three Jest suites own the settings screen's logic.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/local-pickup/local-pickup.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/local-pickup/local-pickup.merchant.block_theme.spec.ts
@@ -2,180 +2,171 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-utils';
+import type { Page } from '@playwright/test';
+
+const saveLocalPickupSettings = async ( page: Page ) => {
+	const saveButton = page.getByRole( 'button', { name: 'Save changes' } );
+	const [ response ] = await Promise.all( [
+		page.waitForResponse(
+			( candidate ) =>
+				candidate.request().method() === 'POST' &&
+				candidate.url().includes( '/wc/v3/pickup-locations' )
+		),
+		saveButton.click(),
+	] );
+
+	expect( response.ok() ).toBeTruthy();
+	await expect( saveButton ).toBeDisabled();
+};
 
 test.describe( 'Merchant → Local Pickup Settings', () => {
-	test.beforeEach( async ( { localPickupUtils } ) => {
+	test.beforeEach( async ( { page, localPickupUtils } ) => {
 		await localPickupUtils.disableLocalPickupCosts();
 		await localPickupUtils.enableLocalPickup();
+		if (
+			( await page
+				.getByRole( 'textbox', { name: 'Title' } )
+				.inputValue() ) !== 'Pickup'
+		) {
+			await localPickupUtils.setLocalPickupTitle( 'Pickup' );
+		}
 	} );
 
-	test( 'user can toggle the enabled state', async ( {
+	test( 'Merchant can configure Local Pickup general settings', async ( {
 		page,
-		localPickupUtils,
 	} ) => {
-		await expect( page.getByLabel( 'Enable local pickup' ) ).toBeChecked();
+		await test.step( 'Configure and save the general settings', async () => {
+			const enabled = page.getByRole( 'checkbox', {
+				name: 'Enable local pickup',
+			} );
+			const title = page.getByRole( 'textbox', { name: 'Title' } );
+			const showPrice = page.getByRole( 'checkbox', {
+				name: 'Add a price for customers who choose local pickup',
+			} );
 
-		await localPickupUtils.disableLocalPickup();
+			await expect( enabled ).toBeChecked();
+			await expect( title ).toHaveValue( 'Pickup' );
+			await expect( showPrice ).not.toBeChecked();
+			await expect(
+				page.getByRole( 'spinbutton', { name: 'Cost' } )
+			).toBeHidden();
 
-		await expect(
-			page.getByLabel( 'Enable local pickup' )
-		).not.toBeChecked();
-	} );
+			await enabled.uncheck();
+			await title.fill( 'Curbside pickup' );
+			await showPrice.check();
 
-	test( 'user can change the title', async ( { page, localPickupUtils } ) => {
-		await page.getByPlaceholder( 'Pickup' ).fill( 'Local Pickup Test #1' );
+			const cost = page.getByRole( 'spinbutton', { name: 'Cost' } );
+			const taxes = page.getByRole( 'combobox', { name: 'Taxes' } );
+			await expect( cost ).toBeVisible();
+			await expect( taxes ).toBeVisible();
+			await cost.fill( '20' );
+			await taxes.selectOption( 'none' );
 
-		await localPickupUtils.saveLocalPickupSettings();
-
-		await expect( page.getByPlaceholder( 'Pickup' ) ).toHaveValue(
-			'Local Pickup Test #1'
-		);
-
-		await page.getByPlaceholder( 'Pickup' ).fill( 'Local Pickup Test #2' );
-
-		await localPickupUtils.saveLocalPickupSettings();
-
-		await expect( page.getByPlaceholder( 'Pickup' ) ).toHaveValue(
-			'Local Pickup Test #2'
-		);
-	} );
-
-	test( 'user can toggle the price field state', async ( {
-		page,
-		localPickupUtils,
-	} ) => {
-		await localPickupUtils.enableLocalPickupCosts();
-
-		await expect(
-			page.getByLabel(
-				'Add a price for customers who choose local pickup'
-			)
-		).toBeChecked();
-
-		await localPickupUtils.disableLocalPickupCosts();
-
-		await expect(
-			page.getByLabel(
-				'Add a price for customers who choose local pickup'
-			)
-		).not.toBeChecked();
-	} );
-
-	test( 'user can edit costs and tax status', async ( {
-		page,
-		localPickupUtils,
-	} ) => {
-		await localPickupUtils.enableLocalPickupCosts();
-
-		await expect(
-			page.getByLabel(
-				'Add a price for customers who choose local pickup'
-			)
-		).toBeChecked();
-
-		await page.getByPlaceholder( 'Free' ).fill( '20' );
-		await page.getByLabel( 'Taxes' ).selectOption( 'none' );
-
-		await localPickupUtils.saveLocalPickupSettings();
-
-		await expect( page.getByPlaceholder( 'Free' ) ).toHaveValue( '20' );
-		await expect( page.getByLabel( 'Taxes' ) ).toHaveValue( 'none' );
-
-		await page.getByPlaceholder( 'Free' ).fill( '' );
-		await page.getByLabel( 'Taxes' ).selectOption( 'taxable' );
-
-		await localPickupUtils.saveLocalPickupSettings();
-
-		await expect( page.getByPlaceholder( 'Free' ) ).toHaveValue( '' );
-		await expect( page.getByLabel( 'Taxes' ) ).toHaveValue( 'taxable' );
-	} );
-
-	test( 'user can add a new location', async ( {
-		page,
-		localPickupUtils,
-	} ) => {
-		await localPickupUtils.addPickupLocation( {
-			location: {
-				name: 'Automattic, Inc.',
-				address: '60 29th Street, Suite 343',
-				city: 'San Francisco',
-				postcode: '94110',
-				state: 'US:CA',
-				details: 'American entity',
-			},
+			await saveLocalPickupSettings( page );
 		} );
 
-		await expect(
-			page.getByRole( 'cell', {
-				name: 'Automattic, Inc.60 29th Street, Suite 343, San Francisco, California, 94110, United States (US)',
-			} )
-		).toBeVisible();
+		await test.step( 'Reload and confirm the settings persisted', async () => {
+			await page.reload();
+
+			await expect(
+				page.getByRole( 'checkbox', { name: 'Enable local pickup' } )
+			).not.toBeChecked();
+			await expect(
+				page.getByRole( 'textbox', { name: 'Title' } )
+			).toHaveValue( 'Curbside pickup' );
+			await expect(
+				page.getByRole( 'checkbox', {
+					name: 'Add a price for customers who choose local pickup',
+				} )
+			).toBeChecked();
+			await expect(
+				page.getByRole( 'spinbutton', { name: 'Cost' } )
+			).toHaveValue( '20' );
+			await expect(
+				page.getByRole( 'combobox', { name: 'Taxes' } )
+			).toHaveValue( 'none' );
+		} );
 	} );
 
-	test( 'user can edit a location', async ( { page, localPickupUtils } ) => {
-		await localPickupUtils.addPickupLocation( {
-			location: {
-				name: 'Automattic, Inc.',
-				address: '60 29th Street, Suite 343',
-				city: 'San Francisco',
-				postcode: '94110',
-				state: 'US:CA',
-				details: 'American entity',
-			},
-		} );
-
-		await expect(
-			page.getByRole( 'cell', {
-				name: 'Automattic, Inc.60 29th Street, Suite 343, San Francisco, California, 94110, United States (US)',
-			} )
-		).toBeVisible();
-
-		await localPickupUtils.editPickupLocation( {
-			location: {
-				name: 'Ministry of Automattic Limited',
-				address: '100 New Bridge Street',
-				city: 'London',
-				postcode: 'EC4V 6JA',
-				state: 'GB',
-				details: 'British entity',
-			},
-		} );
-
-		await expect(
-			page.getByRole( 'cell', {
-				name: 'Ministry of Automattic Limited100 New Bridge Street, London, EC4V 6JA, United Kingdom (UK)',
-			} )
-		).toBeVisible();
-	} );
-
-	test( 'user can delete a location', async ( {
+	test( 'Merchant can manage a Local Pickup location lifecycle', async ( {
 		page,
-		localPickupUtils,
 	} ) => {
-		await localPickupUtils.addPickupLocation( {
-			location: {
-				name: 'Ausomattic Pty Ltd',
-				address:
-					'c/o Baker And Mckenzie Level 19 Cbw, 181 William Street',
-				city: 'Melbourne',
-				postcode: '300',
-				state: 'AU:VIC',
-				details: 'Australian entity',
-			},
+		const sanFranciscoLocation = page.getByRole( 'cell', {
+			name: 'Automattic, Inc.60 29th Street, Suite 343, San Francisco, California, 94110, United States (US)',
+		} );
+		const londonLocation = page.getByRole( 'cell', {
+			name: 'Ministry of Automattic Limited100 New Bridge Street, London, EC4V 6JA, United Kingdom (UK)',
+		} );
+		const emptyLocations = page.getByRole( 'cell', {
+			name: 'When you add a pickup location, it will appear here.',
 		} );
 
-		await expect(
-			page.getByRole( 'cell', {
-				name: 'Ausomattic Pty Ltdc/o Baker And Mckenzie Level 19 Cbw, 181 William Street, Melbourne, Victoria, 300, Australia',
-			} )
-		).toBeVisible();
+		await test.step( 'Add, save, and reload a pickup location', async () => {
+			await expect( emptyLocations ).toBeVisible();
+			await page
+				.getByRole( 'button', { name: 'Add pickup location' } )
+				.click();
+			await page.getByLabel( 'Location name' ).fill( 'Automattic, Inc.' );
+			await page
+				.getByRole( 'textbox', { name: 'Address' } )
+				.fill( '60 29th Street, Suite 343' );
+			await page
+				.getByRole( 'textbox', { name: 'City' } )
+				.fill( 'San Francisco' );
+			await page
+				.getByRole( 'textbox', { name: 'Postcode / ZIP' } )
+				.fill( '94110' );
+			await page
+				.getByRole( 'combobox', { name: 'Country / State' } )
+				.selectOption( 'US:CA' );
+			await page
+				.getByRole( 'textbox', { name: 'Pickup details' } )
+				.fill( 'American entity' );
+			await page.getByRole( 'button', { name: 'Done' } ).click();
 
-		await localPickupUtils.deletePickupLocation();
+			await saveLocalPickupSettings( page );
+			await page.reload();
+			await expect( sanFranciscoLocation ).toBeVisible();
+		} );
 
-		await expect(
-			page.getByRole( 'cell', {
-				name: 'When you add a pickup location, it will appear here.',
-			} )
-		).toBeVisible();
+		await test.step( 'Edit, save, and reload the pickup location', async () => {
+			await page.getByRole( 'button', { name: 'Edit' } ).click();
+			await page
+				.getByLabel( 'Location name' )
+				.fill( 'Ministry of Automattic Limited' );
+			await page
+				.getByRole( 'textbox', { name: 'Address' } )
+				.fill( '100 New Bridge Street' );
+			await page
+				.getByRole( 'textbox', { name: 'City' } )
+				.fill( 'London' );
+			await page
+				.getByRole( 'textbox', { name: 'Postcode / ZIP' } )
+				.fill( 'EC4V 6JA' );
+			await page
+				.getByRole( 'combobox', { name: 'Country / State' } )
+				.selectOption( 'GB' );
+			await page
+				.getByRole( 'textbox', { name: 'Pickup details' } )
+				.fill( 'British entity' );
+			await page.getByRole( 'button', { name: 'Done' } ).click();
+
+			await saveLocalPickupSettings( page );
+			await page.reload();
+			await expect( londonLocation ).toBeVisible();
+			await expect( sanFranciscoLocation ).toBeHidden();
+		} );
+
+		await test.step( 'Delete, save, and reload the pickup location', async () => {
+			await page.getByRole( 'button', { name: 'Edit' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Delete location' } )
+				.click();
+
+			await saveLocalPickupSettings( page );
+			await page.reload();
+			await expect( emptyLocations ).toBeVisible();
+			await expect( londonLocation ).toBeHidden();
+		} );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Local Pickup merchant spec ran seven browser titles, one per setting or location action: the enabled toggle, the title, the price toggle, cost and tax status, and adding, editing, and deleting a location. Most of them changed a control and read it back on the same page without reloading, so they never proved that anything was saved.

This PR adds Jest suites for the settings screen's three modules. It replaces the seven titles with two journeys that save and reload. The spec goes from 7 tests to 2, and the three new Jest suites add 9 tests.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `user can toggle the enabled state` | the retained general settings journey, which unchecks the setting, saves, reloads, and checks it stays unchecked; `general-settings.tsx` › `delegates enablement and title changes to their setting fields`; `settings-context.tsx` › `normalizes settings and locations in a successful save request` | the browser waiting for the "Local Pickup settings have been saved." notice. The journey checks the save request's response and the disabled Save button instead, and the Jest provider test checks the notice call |
| `user can change the title` | the general settings journey, which saves a new title and checks it after a reload; `general-settings.tsx` › `delegates enablement and title changes to their setting fields`; `settings-context.tsx` › `normalizes settings and locations in a successful save request`; `PickupLocationsRestControllerTest.php` › `test_update_settings_sanitizes_html_in_title` | a second edit and save on the same page after a completed save. No test checks that the form becomes editable and savable again after a successful save |
| `user can toggle the price field state` | `general-settings.tsx` › `shows price controls and clears cost whenever price visibility changes`; the general settings journey, which turns pricing on and checks that it persists | none. The old test's "disable" half never ran the uncheck path: the `disableLocalPickupCosts()` helper it called midway reloads the page, and the checkbox starts unchecked for an empty cost |
| `user can edit costs and tax status` | the general settings journey, which saves a cost of `20` and a tax status of `none` and checks both after a reload; `general-settings.tsx` › `shows price controls and clears cost whenever price visibility changes`; `settings-context.tsx` › `normalizes settings and locations in a successful save request`; `PickupLocationsRestControllerTest.php` › `test_update_settings_saves_method_settings` and `test_update_settings_preserves_cost_formula` | clearing the cost and switching the tax status back to `taxable` in a second save in the browser. The REST tests still cover saving `taxable` with an empty cost |
| `user can add a new location` | the location journey's first step, which adds the same San Francisco location and checks its row after a reload; `location-settings.tsx` › `adds a location with the dialog field values`; `settings-context.tsx` › `adds, replaces, toggles, and deletes locations while marking changes dirty`; `PickupLocationsRestControllerTest.php` › `test_update_settings_saves_pickup_locations` | none. The same add and row check run, now after a reload |
| `user can edit a location` | the location journey's second step, which edits the location to London, checks the new row, and checks the old one is gone after a reload; `location-settings.tsx` › `edits a location using its existing ID and dialog payload`; `settings-context.tsx` › `adds, replaces, toggles, and deletes locations while marking changes dirty` | none. The same edit runs, now after a reload |
| `user can delete a location` | the location journey's third step, which deletes the location and checks the empty placeholder after a reload; `location-settings.tsx` › `deletes a location using its existing ID`; `settings-context.tsx` › `adds, replaces, toggles, and deletes locations while marking changes dirty` | the Australian location (`AU:VIC`) and its rendered address, `…, Melbourne, Victoria, 300, Australia`. No test renders a non-US state's address, because the location table's Jest suite mocks the address formatter. The US state (`California`) is still checked in the location journey |

#### Relocated to Jest

All under `client/blocks/assets/js/extensions/shipping-methods/pickup-location/test/`:

- `general-settings.tsx` checks that the enabled and title controls update their settings, and that turning pricing on or off shows or hides the cost and tax controls and clears the cost.
- `location-settings.tsx` checks that adding sends the dialog values under `new`, editing and deleting send the location's own ID with the new values or `null`, and toggling sends the row's ID. Adding, editing, and deleting go through the edit dialog, with its WordPress UI parts stubbed; toggling doesn't open it.
- `settings-context.tsx` uses the real settings provider. It checks the location list as locations are added, replaced, toggled, and deleted, the unsaved-changes flag after the add, and the save request it sends. It also checks the success notice, and that a failed save keeps the changes unsaved and reports the error.

#### The retained wiring tests

Two browser titles stay, and both save and then reload before checking:

- `Merchant can configure Local Pickup general settings`: disabling the method, a new title, and pricing with a cost of `20` and a tax status of `none`.
- `Merchant can manage a Local Pickup location lifecycle`: adding a location, editing it, and deleting it, with the location table checked after each reload.

They are also the only tests that catch two server-side faults the mutation matrix records. One is the pickup settings endpoint turning a submitted `none` tax status into `taxable`. The other is the endpoint ignoring an empty location list, so a deleted location stays stored. No PHPUnit test checks either case: `test_omitted_params_are_not_overwritten` submits an empty location list but checks only the method settings.

Like trunk's version, the spec doesn't delete stored locations before each test. It relies on the suite's per-test database restore, which the location journey's first check (an empty table) depends on.

#### Where this differs from the TESTOPS-234 audit

This spec is one of the files where the TESTOPS-234 audit's own lists disagree, and the branch agrees with neither:

- The audit's "Start here" list includes this file, meaning all seven tests can move below Playwright.
- The audit's later per-test pass leaves this file out of its movable list, meaning all seven stay in the browser.
- This branch moves the settings logic to three Jest suites and keeps two browser journeys for what only a browser proves: the settings screen saving through the REST endpoint and the saved values coming back after a reload.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suites and confirm they pass: `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath assets/js/extensions/shipping-methods/pickup-location/test/general-settings.tsx assets/js/extensions/shipping-methods/pickup-location/test/location-settings.tsx assets/js/extensions/shipping-methods/pickup-location/test/settings-context.tsx`
3. Confirm the location suite guards the location ID. In `plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx`, change `onChange={ () => toggleLocation( row.id ) }` to `onChange={ () => toggleLocation( 0 ) }`. Re-run `assets/js/extensions/shipping-methods/pickup-location/test/location-settings.tsx` and confirm `toggles a location using its existing ID` fails. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/local-pickup/local-pickup.merchant.block_theme.spec.ts`. Confirm both titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. The E2E store was checked first: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 11 distinct focused commands for these files, 9 Jest and 2 Playwright, and all 11 exit 0.
- **Retained titles.** `--list` shows the two titles, and the spec passes with `--retries=0 --workers=1`.
- **Mutation re-check.** For each of the 10 behavior families, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored. Rows `0610` and `0611` change the pickup settings endpoint, and only the retained browser titles catch them:

| Mutation | Code changed | What fails |
| --- | --- | --- |
| `0544` | `GeneralSettings::price-visibility CheckboxControl.onChange` | `GeneralSettings shows price controls and clears cost whenever price visibility changes`: expected a call with `""`, received calls with `"1"` and `"7"` |
| `0545` | `GeneralSettings::title TextControl.onChange` | `GeneralSettings delegates enablement and title changes to their setting fields`: `Expected: "title"; Received: "enabled"` |
| `1332` | `GeneralSettings::enabled CheckboxControl.onChange` | `GeneralSettings delegates enablement and title changes to their setting fields`: `Expected: "enabled"; Received: "title"` |
| `0549` | `LocationSettings` | `LocationSettings toggles a location using its existing ID`: `Expected: "warehouse-0"; Received: 0` |
| `0551` | `SettingsProvider::save pickupLocations.map` | `SettingsProvider normalizes settings and locations in a successful save request`: the saved locations have `"enabled": false` instead of `true` |
| `0610` | `sanitize_pickup_location_settings tax_status valid-value branch` | `Merchant can configure Local Pickup general settings`: `Error: expect(locator).toHaveValue(expected) failed; Expected: "none"` |
| `0611` | `update_settings empty pickup_locations persistence` | `Merchant can manage a Local Pickup location lifecycle`: `Error: expect(locator).toBeVisible() failed; Expected: visible` |
| `0547` | `LocationSettings::EditLocation.onSave` | `LocationSettings edits a location using its existing ID and dialog payload`: the edit is saved under ID `"new"` instead of `"warehouse-0"` |
| `0550` | `SettingsProvider::updateLocation setPickupLocations updater` | `SettingsProvider adds, replaces, toggles, and deletes locations while marking changes dirty`: the dirty state reads `false` after the add instead of `true` |
| `0552` | `SettingsProvider::save apiFetch.catch` | `SettingsProvider restores dirty state and reports a rejected save`: the dirty state reads `false` after the rejected save instead of `true` |

- **Lint.**
    - Prettier and oxlint are clean, `verify-staged` exits 0, and `lint:changes:branch` exits 0.
    - ESLint reports 26 `testing-library/no-unnecessary-act` warnings in the three new Jest suites, and they are kept as the #68046 branch has them. Removing the `act` wrappers was tried, and 7 of the 11 focused commands then failed: React's act() warnings become test failures under `@wordpress/jest-console`. The wrappers are needed because `@testing-library/user-event` and React Testing Library resolve different copies of `@testing-library/dom` here, so the library's own `act` wrapping doesn't cover the user events. The warnings stay visible, with no suppression comment.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Reviews.** Two independent agent reviews read the branch and the evidence. Their findings were about this description and the recorded lint evidence, and they are fixed; a fresh reviewer then checked the fixes. Non-blocking findings about carried test code are left for follow-ups. None of them is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-local-pickup-settings` and `plugins/woocommerce/client/blocks/changelog/testops-234-local-pickup-settings`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

