### PR TITLE
[tests] Reduce Product Gallery E2E tests from 12 to 8

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-product-gallery
+++ b/plugins/woocommerce/changelog/testops-234-product-gallery
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce Product Gallery E2E tests from 12 to 8; Jest owns the block's registered defaults and its Single Product ancestry.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/test/block.ts
@@ -3,7 +3,7 @@
  */
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockType } from '@wordpress/blocks';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
@@ -152,6 +152,21 @@ async function setup( attributes = {} ) {
 }
 
 describe( 'Product Gallery Block', () => {
+	it( 'uses the registered default gallery settings', () => {
+		const productGalleryBlock = createBlock( blockJson.name );
+
+		expect( productGalleryBlock.attributes ).toMatchObject( {
+			hoverZoom: true,
+			fullScreenOnClick: true,
+		} );
+	} );
+
+	it( 'restricts registration to Single Product descendants', () => {
+		expect( getBlockType( blockJson.name )?.ancestor ).toEqual( [
+			'woocommerce/single-product',
+		] );
+	} );
+
 	it( 'should render the block in the editor with correct structure', async () => {
 		await setup();
 

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-product-gallery
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-product-gallery
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce Product Gallery E2E tests from 12 to 8; Jest owns the block's registered defaults and its Single Product ancestry.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.block_theme.spec.ts
@@ -86,7 +86,7 @@ test.describe( `${ blockData.name }`, () => {
 	} );
 
 	test.describe( 'with thumbnails', () => {
-		test( 'should have as first thumbnail, the same image that it is visible in the product block', async ( {
+		test( 'selects thumbnails and keeps the active viewer in sync', async ( {
 			page,
 			editor,
 			pageObject,
@@ -99,55 +99,39 @@ test.describe( `${ blockData.name }`, () => {
 
 			await page.goto( blockData.productPage );
 
-			const viewerImageId = await pageObject.getViewerImageId();
-
+			const thumbnailsBlock = await pageObject.getThumbnailsBlock( {
+				page: 'frontend',
+			} );
+			const initialViewerImageId = await pageObject.getViewerImageId();
 			const firstImageThumbnailId = await getThumbnailImageIdByNth(
 				0,
-				await pageObject.getThumbnailsBlock( {
-					page: 'frontend',
-				} )
+				thumbnailsBlock
 			);
-
-			expect( viewerImageId ).toBe( firstImageThumbnailId );
-		} );
-
-		test( 'should change the image when the user click on a thumbnail image', async ( {
-			page,
-			editor,
-			pageObject,
-		} ) => {
-			await pageObject.addProductGalleryBlock( { cleanContent: true } );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
-
-			await page.goto( blockData.productPage );
-
-			const viewerImageId = await pageObject.getViewerImageId();
+			const initialActiveThumbnailId =
+				await pageObject.getActiveThumbnailImageId();
 
 			const secondImageThumbnailId = await getThumbnailImageIdByNth(
 				1,
-				await pageObject.getThumbnailsBlock( {
-					page: 'frontend',
-				} )
+				thumbnailsBlock
 			);
 
-			expect( viewerImageId ).not.toBe( secondImageThumbnailId );
+			expect( initialViewerImageId ).not.toBeNull();
+			expect( firstImageThumbnailId ).not.toBeNull();
+			expect( initialActiveThumbnailId ).not.toBeNull();
+			expect( initialViewerImageId ).toBe( firstImageThumbnailId );
+			expect( initialActiveThumbnailId ).toBe( firstImageThumbnailId );
+			expect( secondImageThumbnailId ).not.toBeNull();
+			expect( initialViewerImageId ).not.toBe( secondImageThumbnailId );
 
-			await (
-				await pageObject.getThumbnailsBlock( {
-					page: 'frontend',
-				} )
-			)
-				.locator( 'img' )
-				.nth( 1 )
-				.click();
+			await thumbnailsBlock.locator( 'img' ).nth( 1 ).click();
 
 			await expect( async () => {
 				const newViewerImageId = await pageObject.getViewerImageId();
+				const newActiveThumbnailId =
+					await pageObject.getActiveThumbnailImageId();
 
 				expect( newViewerImageId ).toBe( secondImageThumbnailId );
+				expect( newActiveThumbnailId ).toBe( secondImageThumbnailId );
 			} ).toPass( { timeout: 1_000 } );
 		} );
 	} );
@@ -175,19 +159,34 @@ test.describe( `${ blockData.name }`, () => {
 				} )
 			);
 
+			expect( initialViewerImageId ).not.toBeNull();
+			expect( secondImageThumbnailId ).not.toBeNull();
 			expect( initialViewerImageId ).not.toBe( secondImageThumbnailId );
+			expect( await pageObject.getActiveThumbnailImageId() ).toBe(
+				initialViewerImageId
+			);
 
 			await pageObject.clickNextButton();
 
-			const nextImageId = await pageObject.getViewerImageId();
-
-			expect( nextImageId ).toBe( secondImageThumbnailId );
+			await expect( async () => {
+				expect( await pageObject.getViewerImageId() ).toBe(
+					secondImageThumbnailId
+				);
+				expect( await pageObject.getActiveThumbnailImageId() ).toBe(
+					secondImageThumbnailId
+				);
+			} ).toPass( { timeout: 1_000 } );
 
 			await pageObject.clickPreviousButton();
 
-			const previousImageId = await pageObject.getViewerImageId();
-
-			expect( previousImageId ).toBe( initialViewerImageId );
+			await expect( async () => {
+				expect( await pageObject.getViewerImageId() ).toBe(
+					initialViewerImageId
+				);
+				expect( await pageObject.getActiveThumbnailImageId() ).toBe(
+					initialViewerImageId
+				);
+			} ).toPass( { timeout: 1_000 } );
 		} );
 	} );
 
@@ -216,13 +215,20 @@ test.describe( `${ blockData.name }`, () => {
 				} )
 			);
 
+			expect( initialViewerImageId ).not.toBeNull();
+			expect( secondImageThumbnailId ).not.toBeNull();
 			expect( initialViewerImageId ).not.toBe( secondImageThumbnailId );
 
 			await pageObject.clickNextButton();
 
-			const nextImageId = await pageObject.getViewerImageId();
-
-			expect( nextImageId ).toBe( secondImageThumbnailId );
+			await expect( async () => {
+				expect( await pageObject.getViewerImageId() ).toBe(
+					secondImageThumbnailId
+				);
+				expect( await pageObject.getActiveThumbnailImageId() ).toBe(
+					secondImageThumbnailId
+				);
+			} ).toPass( { timeout: 1_000 } );
 
 			const viewerBlock = await pageObject.getViewerBlock( {
 				page: 'frontend',
@@ -231,40 +237,35 @@ test.describe( `${ blockData.name }`, () => {
 
 			const dialogImage = page
 				.getByRole( 'dialog' )
-				.locator( `img[data-image-id='${ nextImageId }']` );
+				.locator( `img[data-image-id='${ secondImageThumbnailId }']` );
 
 			// The image should be in the viewport but it simply doesn't fit fully.
 			await expect( dialogImage ).toBeInViewport( { ratio: 0.7 } );
 
-			const closePopUpButton = page.locator(
-				'.wc-block-product-gallery-dialog__close-button'
-			);
-			await closePopUpButton.click();
+			await page.getByRole( 'button', { name: 'Close dialog' } ).click();
 
-			const singleProductImageId = await pageObject.getViewerImageId();
-
-			expect( singleProductImageId ).toBe( nextImageId );
+			await expect( async () => {
+				expect( await pageObject.getViewerImageId() ).toBe(
+					secondImageThumbnailId
+				);
+				expect( await pageObject.getActiveThumbnailImageId() ).toBe(
+					secondImageThumbnailId
+				);
+			} ).toPass( { timeout: 1_000 } );
 		} );
 	} );
 
 	test.describe( 'open pop-up when clicked option', () => {
-		test( 'should be enabled by default', async ( {
-			pageObject,
-			editor,
-		} ) => {
-			await pageObject.addProductGalleryBlock( { cleanContent: true } );
-			await editor.openDocumentSettingsSidebar();
-			const fullScreenOption = pageObject.getFullScreenOnClickSetting();
-
-			await expect( fullScreenOption ).toBeChecked();
-		} );
-
-		test( 'should open dialog on the frontend', async ( {
+		test( 'enables pop-up by default and opens it on the frontend', async ( {
 			pageObject,
 			page,
 			editor,
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
+			await editor.openDocumentSettingsSidebar();
+			await expect(
+				pageObject.getFullScreenOnClickSetting()
+			).toBeChecked();
 			await editor.saveSiteEditorEntities( {
 				isOnlyCurrentEntityDirty: true,
 			} );
@@ -309,38 +310,27 @@ test.describe( `${ blockData.name }`, () => {
 	} );
 
 	test.describe( 'block availability', () => {
-		test( 'should be available on the Single Product Template', async ( {
+		test( 'is available only in supported Single Product contexts', async ( {
+			admin,
 			page,
 			editor,
 		} ) => {
 			await editor.openGlobalBlockInserter();
 			await page.getByRole( 'tab', { name: 'Blocks' } ).click();
-			const productGalleryBlockOption = page
+			let productGalleryBlockOption = page
 				.getByRole( 'listbox', { name: 'WooCommerce' } )
 				.getByRole( 'option', { name: blockData.title } );
 
 			await expect( productGalleryBlockOption ).toBeVisible();
-		} );
 
-		test( 'should be hidden on the post editor globally', async ( {
-			admin,
-			page,
-			editor,
-		} ) => {
 			await admin.createNewPost();
 			await editor.openGlobalBlockInserter();
-			const productGalleryBlockOption = page
+			productGalleryBlockOption = page
 				.getByRole( 'listbox', { name: 'WooCommerce' } )
 				.getByRole( 'option', { name: blockData.title } );
 
 			await expect( productGalleryBlockOption ).toBeHidden();
-		} );
 
-		test( 'on the post editor, block should be in Single Product by default and is visible in inserter', async ( {
-			admin,
-			editor,
-		} ) => {
-			await admin.createNewPost();
 			await editor.insertBlockUsingGlobalInserter( 'Product' );
 			await editor.canvas.getByText( 'Album' ).click();
 			await editor.canvas.getByText( 'Done' ).click();

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.page.ts
@@ -250,18 +250,12 @@ export class ProductGalleryPage {
 
 	async clickNextButton() {
 		await this.page.getByRole( 'button', { name: 'Next image' } ).click();
-		// Wait for the transition to change
-		// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
-		await this.page.waitForTimeout( 400 );
 	}
 
 	async clickPreviousButton() {
 		await this.page
 			.getByRole( 'button', { name: 'Previous image' } )
 			.click();
-		// Wait for the transition to change
-		// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
-		await this.page.waitForTimeout( 400 );
 	}
 
 	async getBlock( { page }: { page: 'frontend' | 'editor' } ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Product Gallery spec ran twelve browser titles. Seven of them repeated the same setup to check one step each of three journeys:

- the first thumbnail, and a thumbnail click;
- the pop-up setting's default, and the pop-up opening;
- the block's availability in three editor contexts.

This PR folds those seven into three titles that each walk the journey once, and moves the block's registered defaults and its Single Product ancestry to Jest. The spec goes from 12 tests to 8, and the Jest suite `client/blocks/assets/js/blocks/product-gallery/test/block.ts` goes from 2 tests to 4.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `with thumbnails` › `should have as first thumbnail, the same image that it is visible in the product block` | the retained `selects thumbnails and keeps the active viewer in sync`, which checks the viewer, the first thumbnail, and the active thumbnail are the same image, and that none is missing | none. The retained check is stricter: the old one would also have passed if both IDs were missing |
| `with thumbnails` › `should change the image when the user click on a thumbnail image` | the same retained title, which clicks the second thumbnail and waits until both the viewer and the active thumbnail show it | none. It also checks the active thumbnail |
| `open pop-up when clicked option` › `should be enabled by default` | the retained `enables pop-up by default and opens it on the frontend`, which checks the same setting is on in the editor; and Jest `client/blocks/assets/js/blocks/product-gallery/test/block.ts` › `uses the registered default gallery settings` | separate reporting: if the setting check fails, the frontend pop-up check in the same title doesn't run |
| `open pop-up when clicked option` › `should open dialog on the frontend` | the same retained title, which saves, opens the product page, and checks that clicking the image opens the pop-up | none beyond the separate reporting above |
| `block availability` › `should be available on the Single Product Template` | the retained `is available only in supported Single Product contexts`, whose first check is this one | separate reporting: the three availability checks now run in one title, so the first failure hides the others |
| `block availability` › `should be hidden on the post editor globally` | the same retained title | the same separate reporting |
| `block availability` › `on the post editor, block should be in Single Product by default and is visible in inserter` | the same retained title; and Jest `test/block.ts` › `restricts registration to Single Product descendants` | the same separate reporting |

#### Relocated to Jest

`client/blocks/assets/js/blocks/product-gallery/test/block.ts` gains two tests:

- `uses the registered default gallery settings` checks that a new gallery block has zoom on hover and the pop-up on click turned on.
- `restricts registration to Single Product descendants` checks that, outside the Site Editor's Single Product template, the block registers with Single Product as its required ancestor.

#### The retained wiring tests

Eight browser titles stay: the three combined titles above, plus the previous and next buttons, the pop-up showing the selected image, the pop-up staying closed when its setting is off, the block persisting after navigating back to the template, and the layout on mobile.

Two retained titles are stricter than before, one change affects timing, and one changes a locator:

- The previous and next buttons title, and the pop-up title, now check that the image IDs they compare exist, and that the active thumbnail follows the viewer.
- After clicking next or previous, and after closing the pop-up, they wait for the change by polling for up to 1 second (`toPass`). Before, next and previous slept a fixed 400 ms and read once, and the close step read once with no wait. The page object's two fixed sleeps are removed. That is the same 1 second polling the trunk version of the thumbnail title already uses. The 1 second cap is below this repo's 10 s assertion timeout (20 s on CI); without a cap, `toPass` would keep polling until the test times out. The diff changes no retries and no other timeouts.
- The pop-up's close button is found by its accessible name, "Close dialog", instead of its CSS class. The class was only used to find the button, never checked.

The spec needs the seeded product images on disk; the E2E setup provides them.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suite and confirm it passes: `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js --runTestsByPath assets/js/blocks/product-gallery/test/block.ts`
3. Confirm the ancestry test guards the registration. In `plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts`, change `ancestor: shouldRemoveAncestor ? undefined : ancestor,` to `ancestor: undefined,`. Re-run the command from step 2 and confirm `restricts registration to Single Product descendants` fails. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/product-gallery/product-gallery.block_theme.spec.ts`. Confirm all eight titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. The E2E store was checked first: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 7 distinct focused commands for these files, 2 Jest and 5 Playwright, and all 7 exit 0.
- **Retained titles.** `--list` shows the eight titles, and the spec passes with `--retries=0 --workers=1`.
- **Mutation re-check.** For each of the 8 behavior families, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0498` | the block's registered `hoverZoom` attribute loses its default | Jest `uses the registered default gallery settings`: the zoom default is missing |
| `1323` | the registered `fullScreenOnClick` attribute loses its default | the same Jest test: the pop-up default is missing |
| `0499` | product block registration drops the ancestor restriction | Jest `restricts registration to Single Product descendants`: `ancestor` is `undefined` instead of `["woocommerce/single-product"]` |
| `0649` | the gallery marks the first image's thumbnail active instead of the selected image's (Blocks rebuilt) | the retained `selects thumbnails and keeps the active viewer in sync`: the viewer moves to the second image (`37`), but the active thumbnail stays on the first (`39`) |
| `0650` | the previous button scrolls to the image without selecting it (Blocks rebuilt) | the retained previous and next buttons title: after clicking previous, the IDs disagree (`37` against `39`) |
| `0651` | closing the pop-up changes the selected image (Blocks rebuilt) | the retained `should display the same selected image when the pop-up is opened`: the IDs disagree (`39` against `37`) |
| `0652` | clicking the large image runs another action instead of opening the pop-up | the retained `enables pop-up by default and opens it on the frontend`: the `dialog` stays hidden |
| `0653` | the block's `ancestor` points to the large image block instead of Single Product (Blocks rebuilt) | the retained `is available only in supported Single Product contexts`: the editor shows 1 gallery block instead of 2 |

- **Lint.**
    - Prettier is clean, and ESLint reports nothing on lines this PR changes. Its one warning is on a trunk line: `rules-of-hooks` on the spec's `use( pageObject )` fixture, which `lint:changes:branch` also prints as a warning.
    - oxlint finds nothing new, `verify-staged` exits 0, and `lint:changes:branch` exits 0. There are no PHP changes.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Timing.** The diff adds four `toPass( { timeout: 1_000 } )` polls: after Next and after Previous in the previous and next title, and after Next and after closing the pop-up in the pop-up title. The first three replace a fixed 400 ms sleep followed by one read; the fourth replaces one read that had no wait. The page object's two sleeps are removed. Mutations `0650` and `0651` fail inside the after-Previous and after-close polls; `0649` fails inside the thumbnail title's poll, which trunk already has at 1 s.
- **Reviews.** Two independent agent reviews read the branch and the evidence, and a fresh reviewer then checked the fixes. Their findings were about this description, mainly how it counted the polls, and they are fixed; the last round was clean. None of them is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-product-gallery` and `plugins/woocommerce/client/blocks/changelog/testops-234-product-gallery`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

