### PR TITLE
Replace the variation gallery Manage link with an inline add tile

### DIFF
--- a/plugins/woocommerce/changelog/68582-variation-gallery-add-tile
+++ b/plugins/woocommerce/changelog/68582-variation-gallery-add-tile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Replace the variation gallery "Manage" link in the classic product editor with an inline "+" tile, and move the reorder hint into a help tip next to the label.

--- a/plugins/woocommerce/client/legacy/css/variation-gallery-admin.scss
+++ b/plugins/woocommerce/client/legacy/css/variation-gallery-admin.scss
@@ -32,7 +32,6 @@
 
 	/* Colors (WP admin palette). */
 	--wc-vg-link: #2271b1;
-	--wc-vg-link-hover: #135e96;
 	--wc-vg-surface: #f0f0f1;
 	--wc-vg-surface-hover: #f6f7f7;
 	--wc-vg-surface-strong: #1d2327;
@@ -43,7 +42,6 @@
 	--wc-vg-border-hover: #8c8f94;
 	--wc-vg-text-strong: #1d2327;
 	--wc-vg-text-muted: #50575e;
-	--wc-vg-text-subtle: #787c82;
 	--wc-vg-text-placeholder: #a7aaad;
 	--wc-vg-focus-ring: rgba(34, 113, 177, 0.4);
 
@@ -56,7 +54,7 @@
 	--wc-vg-space-6: 24px;
 
 	/* Sizing tokens. */
-	--wc-vg-thumb-size: 40px;
+	--wc-vg-thumbs-per-row: 4;
 	--wc-vg-icon-sm: 14px;
 	--wc-vg-icon-md: 20px;
 	--wc-vg-icon-lg: 28px;
@@ -77,6 +75,7 @@
 	/* Typography. */
 	--wc-vg-font-size-xs: 12px;
 	--wc-vg-font-size-sm: 13px;
+	--wc-vg-font-weight-regular: 400;
 	--wc-vg-font-weight-medium: 500;
 	--wc-vg-font-weight-semibold: 600;
 
@@ -127,54 +126,35 @@
 	width: 100%;
 	box-sizing: border-box;
 
+	/* Mirrors the 1em top margin of the next form row so the gallery has
+	 * the same breathing room below as above. */
+	margin-block-end: 1em;
+
+	/* Matches the <p class="form-row"><label> rendered by
+	 * woocommerce_wp_text_input() in the neighbouring SKU column (1em top
+	 * margin, 1.5 line-height), so the two row headings line up. */
 	.wc-variation-gallery-field__header {
 		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: var(--wc-vg-space-4);
-	}
+		align-items: center;
+		gap: var(--wc-vg-space-1);
+		margin-block-start: 1em;
+		line-height: 1.5;
 
-	.wc-variation-gallery-field__title-block {
-		display: flex;
-		align-items: baseline;
-		gap: var(--wc-vg-space-2);
-		flex-wrap: wrap;
+		.woocommerce-help-tip {
+			float: none;
+			margin: 0;
+		}
 	}
 
 	.wc-variation-gallery-field__title {
 		font-size: var(--wc-vg-font-size-sm);
-		font-weight: var(--wc-vg-font-weight-semibold);
+		font-weight: var(--wc-vg-font-weight-regular);
 		margin: 0;
-	}
-
-	.wc-variation-gallery-field__count {
-		color: var(--wc-vg-text-subtle);
-		font-size: var(--wc-vg-font-size-xs);
-
-		&::before {
-			content: "·";
-			margin-right: var(--wc-vg-space-1);
-		}
-	}
-
-	.wc-variation-gallery-manage {
-		color: var(--wc-vg-link);
-		background: transparent;
-		border: none;
-		padding: 0;
-		cursor: pointer;
-		font-size: var(--wc-vg-font-size-sm);
-		text-decoration: none;
-
-		&:hover,
-		&:focus {
-			color: var(--wc-vg-link-hover);
-			text-decoration: underline;
-		}
 	}
 
 	.wc-variation-gallery-field__hero {
 		position: relative;
+		box-sizing: border-box;
 		width: 100%;
 		aspect-ratio: 1 / 1;
 		border-radius: var(--wc-vg-radius-md);
@@ -285,9 +265,11 @@
 		}
 	}
 
+	/* Fixed column count so every row spans the same width as the hero
+	 * image above it; the add tile wraps with the thumbnails. */
 	.wc-variation-gallery-field__thumbs {
-		display: flex;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: repeat(var(--wc-vg-thumbs-per-row), minmax(0, 1fr));
 		gap: var(--wc-vg-space-3);
 		margin: 0;
 		padding: 0;
@@ -295,9 +277,11 @@
 		min-height: 0;
 
 		.wc-variation-gallery-thumb,
+		.wc-variation-gallery-add,
 		.wc-metabox-sortable-placeholder {
-			width: var(--wc-vg-thumb-size);
-			height: var(--wc-vg-thumb-size);
+			width: auto;
+			height: auto;
+			aspect-ratio: 1 / 1;
 			margin: 0;
 			padding: 0;
 			list-style: none;
@@ -305,20 +289,65 @@
 			box-sizing: border-box;
 		}
 
+		.wc-variation-gallery-thumb__remove {
+			position: absolute;
+			top: -4px;
+			right: -4px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 18px;
+			height: 18px;
+			padding: 0;
+			border: 0;
+			border-radius: 50%;
+			background: var(--wc-vg-surface-strong);
+			color: var(--wc-vg-on-surface);
+			cursor: pointer;
+			opacity: 0;
+			transition: opacity var(--wc-vg-transition-fast), background-color var(--wc-vg-transition-fast), box-shadow var(--wc-vg-transition-fast);
+
+			/* Same hover/focus treatment as the hero's Replace button. */
+			&:hover,
+			&:focus-visible {
+				background: var(--wc-vg-surface-strongest);
+				box-shadow: var(--wc-vg-elevation-3-hover);
+				outline: none;
+			}
+
+			.dashicons {
+				font-size: 14px;
+				width: 14px;
+				height: 14px;
+				line-height: 1;
+			}
+
+			@media (hover: none) {
+				opacity: 1;
+			}
+
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
+		}
+
+		/* The active/hover ring is an inset outline rather than a border: it
+		 * follows the radius and paints over the image, so there is a single
+		 * curve with no inner-radius mismatch or anti-aliased gap. */
 		.wc-variation-gallery-thumb {
 			position: relative;
-			border: 2px solid transparent;
+			border: 0;
+			outline: 2px solid transparent;
+			outline-offset: -2px;
 			cursor: grab;
-			transition:
-				border-color var(--wc-vg-transition-fast),
-				box-shadow var(--wc-vg-transition-fast);
+			transition: outline-color var(--wc-vg-transition-fast);
 
 			&.is-active {
-				border-color: var(--wc-vg-link);
+				outline-color: var(--wc-vg-link);
 			}
 
 			&:not(.is-active):hover {
-				border-color: var(--wc-vg-border-hover);
+				outline-color: var(--wc-vg-border-hover);
 			}
 
 			&.is-dragging {
@@ -334,7 +363,6 @@
 			&.is-broken {
 
 				@include center-content;
-				background: var(--wc-vg-surface);
 				color: var(--wc-vg-text-placeholder);
 			}
 
@@ -344,6 +372,7 @@
 			}
 		}
 
+		/* Clipped to the thumb's radius so image corners follow it. */
 		.wc-variation-gallery-thumb__button {
 			display: block;
 			width: 100%;
@@ -351,6 +380,8 @@
 			padding: 0;
 			margin: 0;
 			border: 0;
+			border-radius: var(--wc-vg-radius-sm);
+			overflow: hidden;
 			background: var(--wc-vg-surface);
 			cursor: inherit;
 
@@ -370,41 +401,43 @@
 			height: var(--wc-vg-icon-md);
 		}
 
-		.wc-variation-gallery-thumb__remove {
-			position: absolute;
-			top: -4px;
-			right: -4px;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			width: 18px;
-			height: 18px;
-			border-radius: 50%;
-			background: var(--wc-vg-surface-strong);
-			color: var(--wc-vg-on-surface);
-			cursor: pointer;
-			opacity: 0;
-			transition: opacity var(--wc-vg-transition-fast), background-color var(--wc-vg-transition-fast);
+		.wc-metabox-sortable-placeholder {
+			border: 2px dashed var(--wc-vg-border-dashed);
+			background: transparent;
+		}
 
-			.dashicons {
-				font-size: 14px;
-				width: 14px;
-				height: 14px;
-				line-height: 1;
+		.wc-variation-gallery-add__button {
+
+			@include center-content;
+			width: 100%;
+			height: 100%;
+			padding: 0;
+			margin: 0;
+			background: transparent;
+			border: 2px dashed var(--wc-vg-border-dashed);
+			border-radius: var(--wc-vg-radius-sm);
+			color: var(--wc-vg-text-muted);
+			cursor: pointer;
+			transition: background-color var(--wc-vg-transition-fast), border-color var(--wc-vg-transition-fast), color var(--wc-vg-transition-fast);
+
+			&:hover,
+			&:focus-visible {
+				background: var(--wc-vg-surface-hover);
+				border-color: var(--wc-vg-link);
+				color: var(--wc-vg-link);
+				outline: none;
 			}
 
-			@media (hover: none) {
-				opacity: 1;
+			.dashicons {
+				font-size: var(--wc-vg-icon-md);
+				width: var(--wc-vg-icon-md);
+				height: var(--wc-vg-icon-md);
+				line-height: 1;
 			}
 
 			@media (prefers-reduced-motion: reduce) {
 				transition: none;
 			}
-		}
-
-		.wc-metabox-sortable-placeholder {
-			border: 2px dashed var(--wc-vg-border-dashed);
-			background: transparent;
 		}
 
 		&.is-sorting .wc-variation-gallery-thumb:hover .wc-variation-gallery-thumb__remove,
@@ -414,18 +447,13 @@
 		}
 	}
 
+	/* The empty-state CTA draws its own dashed border, so drop the hero's
+	 * solid one to avoid a double outline. */
+	&.is-empty .wc-variation-gallery-field__hero {
+		border-color: transparent;
+	}
+
 	&.is-empty .wc-variation-gallery-field__thumbs {
-		display: none;
-	}
-
-	.wc-variation-gallery-field__hint {
-		margin: 0;
-		color: var(--wc-vg-text-muted);
-		font-size: var(--wc-vg-font-size-xs);
-		line-height: 1.4;
-	}
-
-	&.is-empty .wc-variation-gallery-field__hint {
 		display: none;
 	}
 }

--- a/plugins/woocommerce/client/legacy/js/admin/variation-gallery.js
+++ b/plugins/woocommerce/client/legacy/js/admin/variation-gallery.js
@@ -18,10 +18,9 @@ jQuery( function ( $ ) {
 		fieldHeroImg: '.wc-variation-gallery-field__hero-img',
 		fieldHeroBroken: '.wc-variation-gallery-field__hero-broken',
 		fieldHeroEmptyCta: '.wc-variation-gallery-field__empty-cta',
-		fieldHint: '.wc-variation-gallery-field__hint',
-		fieldCount: '.wc-variation-gallery-field__count',
 		fieldImageIdsInput: '.wc-variation-gallery-image-ids',
 		thumb: '.wc-variation-gallery-thumb',
+		addTile: '.wc-variation-gallery-add',
 		thumbButton: '.wc-variation-gallery-thumb__button',
 		thumbRemove: '.wc-variation-gallery-thumb__remove',
 		manageTrigger: '.wc-variation-gallery-manage',
@@ -84,22 +83,6 @@ jQuery( function ( $ ) {
 			attachmentJson.url ||
 			''
 		);
-	};
-
-	/**
-	 * Map an image count to the i18n template key used to label the field.
-	 *
-	 * @param {number} count
-	 * @return {string}
-	 */
-	const getCountTemplateKey = ( count ) => {
-		if ( count === 0 ) {
-			return 'countZero';
-		}
-		if ( count === 1 ) {
-			return 'countSingular';
-		}
-		return 'countPlural';
 	};
 
 	/**
@@ -212,6 +195,7 @@ jQuery( function ( $ ) {
 					stop( _event, ui ) {
 						ui.item.removeClass( 'is-dragging' );
 						$list.removeClass( 'is-sorting' );
+						variationGallery.ensureAddTileLast( $list );
 					},
 					update() {
 						const wasPrimary =
@@ -283,9 +267,9 @@ jQuery( function ( $ ) {
 		},
 
 		/**
-		 * "Manage" button: open the WP media frame in multi-select mode,
-		 * preselect the variation's current gallery, and rewrite the
-		 * gallery from whatever the merchant selects.
+		 * Add tile (or the empty-state CTA): open the WP media frame in
+		 * multi-select mode, preselect the variation's current gallery, and
+		 * rewrite the gallery from whatever the merchant selects.
 		 *
 		 * @param {jQuery.Event} event
 		 */
@@ -539,16 +523,64 @@ jQuery( function ( $ ) {
 				)
 			);
 
-			$list.empty();
+			$list.find( SELECTORS.thumb ).remove();
 
 			ids.forEach( ( id, index ) => {
-				$list.append(
-					this.buildThumbMarkup( id, urls[ index ], index === 0 )
+				this.buildThumbMarkup( id, urls[ index ], index === 0 ).insertBefore(
+					this.getOrCreateAddTile( $list )
 				);
 			} );
 
+			this.ensureAddTileLast( $list );
+
 			if ( $list.data( 'wc-variation-gallery-sortable' ) ) {
 				$list.sortable( 'refresh' );
+			}
+		},
+
+		/**
+		 * Return the list's trailing add tile, creating it when the
+		 * server-rendered one is missing.
+		 *
+		 * @param {jQuery} $list
+		 * @return {jQuery}
+		 */
+		getOrCreateAddTile( $list ) {
+			const $existing = $list.find( SELECTORS.addTile );
+			if ( $existing.length ) {
+				return $existing;
+			}
+
+			const $icon = $( '<span></span>' )
+				.addClass( 'dashicons dashicons-plus-alt2' )
+				.attr( 'aria-hidden', 'true' );
+			const $button = $( '<button type="button"></button>' )
+				.addClass(
+					'wc-variation-gallery-add__button wc-variation-gallery-manage'
+				)
+				.attr(
+					'aria-label',
+					l10n.addTileLabel || 'Add images to variation gallery'
+				)
+				.append( $icon );
+			const $tile = $( '<li></li>' )
+				.addClass( 'wc-variation-gallery-add' )
+				.append( $button );
+
+			$list.append( $tile );
+			return $tile;
+		},
+
+		/**
+		 * Keep the add tile as the last item in the list, after any
+		 * thumbnails that were appended or reordered.
+		 *
+		 * @param {jQuery} $list
+		 */
+		ensureAddTileLast( $list ) {
+			const $tile = this.getOrCreateAddTile( $list );
+			if ( ! $tile.is( ':last-child' ) ) {
+				$list.append( $tile );
 			}
 		},
 
@@ -918,9 +950,8 @@ jQuery( function ( $ ) {
 		},
 
 		/**
-		 * Refresh the count label, the empty-state class, and the hint
-		 * visibility from the field's current image count. Pass an
-		 * explicit count to skip the DOM lookup.
+		 * Refresh the empty-state class from the field's current image
+		 * count. Pass an explicit count to skip the DOM lookup.
 		 *
 		 * @param {jQuery}      $field
 		 * @param {number|null} [precomputedCount=null]
@@ -930,12 +961,8 @@ jQuery( function ( $ ) {
 				precomputedCount === null
 					? this.getFieldIds( $field ).length
 					: precomputedCount;
-			const template = l10n[ getCountTemplateKey( count ) ] || '%d';
-			const label = template.replace( '%d', count );
 
 			$field.toggleClass( CLASSES.isEmpty, count === 0 );
-			$field.find( SELECTORS.fieldCount ).text( label );
-			$field.find( SELECTORS.fieldHint ).prop( 'hidden', count === 0 );
 		},
 
 		restoreMediaPostId() {

--- a/plugins/woocommerce/src/Internal/VariationGallery/ClassicVariationGalleryAdmin.php
+++ b/plugins/woocommerce/src/Internal/VariationGallery/ClassicVariationGalleryAdmin.php
@@ -75,11 +75,7 @@ class ClassicVariationGalleryAdmin implements RegisterHooksInterface {
 				'announceReorder'  => __( 'Variation gallery order updated.', 'woocommerce' ),
 				'announcePrimary'  => __( 'New primary image set.', 'woocommerce' ),
 				'removeLabel'      => __( 'Remove image', 'woocommerce' ),
-				'countZero'        => __( 'No images yet', 'woocommerce' ),
-				/* translators: %d: number of variation gallery images */
-				'countSingular'    => __( '%d image', 'woocommerce' ),
-				/* translators: %d: number of variation gallery images */
-				'countPlural'      => __( '%d images', 'woocommerce' ),
+				'addTileLabel'     => __( 'Add images to variation gallery', 'woocommerce' ),
 				'primaryLabel'     => __( 'Primary', 'woocommerce' ),
 				/* translators: %d: gallery image position */
 				'thumbLabel'       => __( 'Show gallery image %d', 'woocommerce' ),
@@ -120,21 +116,10 @@ class ClassicVariationGalleryAdmin implements RegisterHooksInterface {
 			data-variation-id="<?php echo esc_attr( (string) $variation->ID ); ?>"
 		>
 			<div class="wc-variation-gallery-field__header">
-				<div class="wc-variation-gallery-field__title-block">
-					<strong class="wc-variation-gallery-field__title">
-						<?php esc_html_e( 'Variation gallery', 'woocommerce' ); ?>
-					</strong>
-					<span class="wc-variation-gallery-field__count" aria-live="polite">
-						<?php echo esc_html( $this->get_count_text( $count ) ); ?>
-					</span>
-				</div>
-				<button
-					type="button"
-					class="button-link wc-variation-gallery-manage"
-					aria-label="<?php esc_attr_e( 'Manage variation gallery images', 'woocommerce' ); ?>"
-				>
-					<?php esc_html_e( 'Manage', 'woocommerce' ); ?>
-				</button>
+				<span class="wc-variation-gallery-field__title">
+					<?php esc_html_e( 'Variation gallery', 'woocommerce' ); ?>
+				</span>
+				<?php echo wc_help_tip( __( 'First image is used as the primary. Drag to reorder.', 'woocommerce' ) ); ?>
 			</div>
 
 			<div class="wc-variation-gallery-field__hero" data-active-index="0">
@@ -159,11 +144,8 @@ class ClassicVariationGalleryAdmin implements RegisterHooksInterface {
 				<?php foreach ( $image_ids as $index => $image_id ) : ?>
 					<?php $this->render_thumbnail( $image_id, 0 === $index ); ?>
 				<?php endforeach; ?>
+				<?php $this->render_add_tile(); ?>
 			</ul>
-
-			<p class="wc-variation-gallery-field__hint"<?php echo 0 === $count ? ' hidden' : ''; ?>>
-				<?php esc_html_e( 'First image is used as the primary. Drag to reorder.', 'woocommerce' ); ?>
-			</p>
 
 			<input
 				type="hidden"
@@ -339,21 +321,25 @@ class ClassicVariationGalleryAdmin implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Get the image count label shown beside the field title.
+	 * Render the trailing "add images" tile in the thumbnail list.
 	 *
-	 * @param int $count Number of images.
-	 * @return string
+	 * Shares the `wc-variation-gallery-manage` class with the empty-state
+	 * CTA so the same delegated click handler opens the media picker.
+	 *
+	 * @return void
 	 */
-	private function get_count_text( int $count ): string {
-		if ( 0 === $count ) {
-			return __( 'No images yet', 'woocommerce' );
-		}
-
-		return sprintf(
-			/* translators: %d number of variation gallery images */
-			_n( '%d image', '%d images', $count, 'woocommerce' ),
-			$count
-		);
+	private function render_add_tile(): void {
+		?>
+		<li class="wc-variation-gallery-add">
+			<button
+				type="button"
+				class="wc-variation-gallery-add__button wc-variation-gallery-manage"
+				aria-label="<?php esc_attr_e( 'Add images to variation gallery', 'woocommerce' ); ?>"
+			>
+				<span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
+			</button>
+		</li>
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/VariationGallery/ClassicVariationGalleryAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/VariationGallery/ClassicVariationGalleryAdminTest.php
@@ -147,12 +147,14 @@ class ClassicVariationGalleryAdminTest extends \WC_Unit_Test_Case {
 
 		$output = $this->render_variation_gallery_field( $variation );
 
-		$this->assertMatchesRegularExpression(
-			'/data-attachment_id="' . $second . '".*<li class="wc-variation-gallery-add">\s*<button\s+type="button"\s+class="wc-variation-gallery-add__button wc-variation-gallery-manage"/s',
-			$output,
-			'Add tile should be rendered after the last thumbnail.'
-		);
+		$last_thumbnail = strpos( $output, 'data-attachment_id="' . $second . '"' );
+		$add_tile       = strpos( $output, '<li class="wc-variation-gallery-add">' );
+
+		$this->assertIsInt( $last_thumbnail );
+		$this->assertIsInt( $add_tile );
+		$this->assertGreaterThan( $last_thumbnail, $add_tile, 'Add tile should be rendered after the last thumbnail.' );
 		$this->assertSame( 1, substr_count( $output, 'wc-variation-gallery-add__button' ) );
+		$this->assertStringContainsString( 'class="wc-variation-gallery-add__button wc-variation-gallery-manage"', $output );
 		$this->assertStringContainsString( 'aria-label="Add images to variation gallery"', $output );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/VariationGallery/ClassicVariationGalleryAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/VariationGallery/ClassicVariationGalleryAdminTest.php
@@ -114,6 +114,61 @@ class ClassicVariationGalleryAdminTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The gallery header renders a label with a help tip instead of a Manage link, count, or hint paragraph.
+	 */
+	public function test_render_variation_gallery_field_renders_label_and_help_tip_without_manage_link() {
+		$variation = $this->create_variation();
+		$image_id  = $this->create_attachment( 'Header test image' );
+
+		$variation->set_gallery_image_ids( array( $image_id ) );
+		$variation->save();
+
+		$output = $this->render_variation_gallery_field( $variation );
+
+		$this->assertStringContainsString( 'class="wc-variation-gallery-field__title"', $output );
+		$this->assertStringContainsString( 'class="woocommerce-help-tip"', $output );
+		$this->assertStringContainsString( 'First image is used as the primary. Drag to reorder.', $output );
+		$this->assertStringNotContainsString( 'wc-variation-gallery-field__count', $output );
+		$this->assertStringNotContainsString( 'wc-variation-gallery-field__hint', $output );
+		$this->assertStringNotContainsString( 'button-link wc-variation-gallery-manage', $output );
+		$this->assertStringNotContainsString( '>Manage<', $output );
+	}
+
+	/**
+	 * @testdox The add tile renders last in the thumbnail list and opens the same picker as the empty-state CTA.
+	 */
+	public function test_render_variation_gallery_field_renders_add_tile_after_thumbnails() {
+		$variation = $this->create_variation();
+		$first     = $this->create_attachment( 'Tile test image 1' );
+		$second    = $this->create_attachment( 'Tile test image 2' );
+
+		$variation->set_gallery_image_ids( array( $first, $second ) );
+		$variation->save();
+
+		$output = $this->render_variation_gallery_field( $variation );
+
+		$this->assertMatchesRegularExpression(
+			'/data-attachment_id="' . $second . '".*<li class="wc-variation-gallery-add">\s*<button\s+type="button"\s+class="wc-variation-gallery-add__button wc-variation-gallery-manage"/s',
+			$output,
+			'Add tile should be rendered after the last thumbnail.'
+		);
+		$this->assertSame( 1, substr_count( $output, 'wc-variation-gallery-add__button' ) );
+		$this->assertStringContainsString( 'aria-label="Add images to variation gallery"', $output );
+	}
+
+	/**
+	 * @testdox Empty galleries keep the hero CTA as the only add affordance and hide the tile with the thumbnail list.
+	 */
+	public function test_render_variation_gallery_field_empty_state_keeps_hero_cta() {
+		$variation = $this->create_variation();
+		$output    = $this->render_variation_gallery_field( $variation );
+
+		$this->assertStringContainsString( 'wc-variation-gallery-field is-empty', $output );
+		$this->assertStringContainsString( 'wc-variation-gallery-field__empty-cta wc-variation-gallery-manage', $output );
+		$this->assertStringContainsString( 'wc-variation-gallery-add__button', $output );
+	}
+
+	/**
 	 * @testdox Saving an empty variation gallery clears featured + gallery and disables the legacy fallback.
 	 */
 	public function test_saving_empty_variation_gallery_disables_legacy_fallback() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The variation gallery's only add action was a "Manage" text link in the field header, and people kept missing it. This moves adding inline with the thumbnails.

- Replace the "Manage" link with a dashed "+" tile after the thumbnails. It opens the same picker and stays last after reordering.
- Drop the image count and the hint paragraph. The hint moves into a help tip next to the label.
- Restyle the label to match the SKU label, and lay the thumbnails out as a 4-column grid that matches the hero width.
- Tidy a few pre-existing CSS nits: bevelled remove buttons, a double border on the empty state, thumbnail corners clipping past the rounded ring, and no hover/focus ring on the remove buttons.

No hooks, handles, or public signatures change. The count keys in `wcVariationGalleryL10n` are gone (only this feature's script read them).

Closes #68582.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="700" alt="Before: Manage link in the header, image count, hint paragraph below the thumbnails" src="https://github.com/user-attachments/assets/71d7ec90-fddf-4485-a964-cacdb17d8e66" /> | <img width="700" alt="After: label with help tip, thumbnails spanning the hero width, dashed + tile after the thumbnails" src="https://github.com/user-attachments/assets/312ff8fc-49fa-438e-8423-2e7212fcd8bb" /> |

### How to test the changes in this Pull Request:

1. Edit a variable product, open the Variations tab, and expand a variation that has images.
2. Check the label sits level with "SKU" with a "?" tip, there's no Manage link, count, or hint text, and the thumb row is the same width as the primary image.
3. Click "+" and add an image: the thumbnail appears and "+" stays last. Drag a thumbnail to reorder: "+" still stays last.
4. Remove every image: the "Add variation images" CTA comes back. Use it to add one again.
5. Save and reload: images and order persist.

### Testing that has already taken place:

Manual run of the steps above in wp-env. `ClassicVariationGalleryAdminTest` passes with 3 new cases. phpcs, PHPStan, and ESLint clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually.

https://claude.ai/code/session_01GihBXKV7a75pP3fYEycXMJ
