### PR TITLE
Resolve blocks webpack entry paths with POSIX separators

### DIFF
--- a/plugins/woocommerce/changelog/fix-blocks-windows-glob-entry-paths
+++ b/plugins/woocommerce/changelog/fix-blocks-windows-glob-entry-paths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Resolve blocks webpack entry paths with POSIX separators so the build works on Windows.

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -276,7 +276,7 @@ const getBlockEntries = ( relativePath, blockEntries = blocks ) => {
 				const filePaths = glob.sync(
 					`./assets/js/blocks/${ config.customDir || blockCode }/` +
 						relativePath,
-					{ dotRelative: true }
+					{ dotRelative: true, posix: true }
 				);
 				if ( filePaths.length > 0 ) {
 					return [ blockCode, filePaths ];
@@ -343,6 +343,7 @@ const entries = {
 			'./packages/public-api/{price-format,blocks-components,blocks-checkout}/**/index.{t,j}s',
 			{
 				dotRelative: true,
+				posix: true,
 			}
 		),
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The blocks build does not complete on Windows. `bin/webpack-entries.js` collects entry files with `glob.sync( ..., { dotRelative: true } )`, and glob returns platform-native paths, so on Windows the styling entries come out as:

```
.\packages\public-api\price-format\utils\index.js
```

webpack only treats a request as relative when it starts with `./`, so it tries to resolve those as module requests and fails:

```
ERROR in wc-block-library-style-source
Module not found: Error: Can't resolve '.\packages\public-api\price-format\utils\index.js'
Did you mean './.\packages\public-api\price-format\utils\index.js'?
```

glob's `posix: true` option makes it return `/`-separated paths on every platform. It is a no-op on Linux and macOS, where the separator is already `/`, so CI output is unchanged.

Both `glob.sync` calls in the file take `dotRelative`, so both get the option.

### Backward compatibility:

No impact. Build tooling only, and the emitted bundles are byte-identical on POSIX platforms since `posix: true` changes nothing where the separator is already `/`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

On Linux or macOS (regression check):

1. `pnpm --filter='@woocommerce/plugin-woocommerce' build`
2. Confirm it succeeds and the blocks bundle is unchanged.

On Windows (the actual fix):

1. Check out `trunk` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`. Confirm the blocks build fails with the `Can't resolve '.\packages\...'` error above.
2. Check out this branch and run it again. Confirm the whole build completes.

<!-- End testing instructions -->

### Testing that has already taken place:

Reproduced and fixed on Windows 11, Node 24.21.0, pnpm 10.33.0, glob 10.5.0.

Before: the blocks build failed with `Can't resolve '.\packages\public-api\price-format\utils\index.js'`.

After: `pnpm --filter='@woocommerce/plugin-woocommerce' build` completes with exit code 0 and zero `ERROR in` lines across every sub-build (blocks, admin, classic-assets, packages, translations), and `plugins/woocommerce/assets/client/blocks/` is populated.

Confirmed the option does what is claimed:

```js
glob.sync( './packages/public-api/price-format/**/index.{t,j}s', { dotRelative: true } )
// .\packages\public-api\price-format\index.js
glob.sync( './packages/public-api/price-format/**/index.{t,j}s', { dotRelative: true, posix: true } )
// ./packages/public-api/price-format/index.js
```

I have not run the build on Linux or macOS, so the no-op claim there rests on glob's documented behaviour rather than my own run. Worth a reviewer confirming on CI.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
