### PR TITLE
[tests] Move 9 Product Collection compatibility hook checks to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-product-collection-compatibility
+++ b/plugins/woocommerce/changelog/testops-234-product-collection-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move 9 collection compatibility hook checks to PHPUnit; the spec keeps two rendered-order browser titles.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/compatibility-layer.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/compatibility-layer.block_theme.spec.ts
@@ -8,73 +8,6 @@ import { test as base, expect } from '@woocommerce/e2e-utils';
  */
 import ProductCollectionPage from './product-collection.page';
 
-type Scenario = {
-	title: string;
-	dataTestId: string;
-	content: string;
-	amount: number;
-};
-
-const singleOccurrenceScenarios: Scenario[] = [
-	{
-		title: 'Before Main Content',
-		dataTestId: 'woocommerce_before_main_content',
-		content: 'Hook: woocommerce_before_main_content',
-		amount: 1,
-	},
-	{
-		title: 'After Main Content',
-		dataTestId: 'woocommerce_after_main_content',
-		content: 'Hook: woocommerce_after_main_content',
-		amount: 1,
-	},
-	{
-		title: 'Before Shop Loop',
-		dataTestId: 'woocommerce_before_shop_loop',
-		content: 'Hook: woocommerce_before_shop_loop',
-		amount: 1,
-	},
-	{
-		title: 'After Shop Loop',
-		dataTestId: 'woocommerce_after_shop_loop',
-		content: 'Hook: woocommerce_after_shop_loop',
-		amount: 1,
-	},
-];
-
-const multipleOccurrenceScenarios: Scenario[] = [
-	{
-		title: 'Before Shop Loop Item Title',
-		dataTestId: 'woocommerce_before_shop_loop_item_title',
-		content: 'Hook: woocommerce_before_shop_loop_item_title',
-		amount: 16,
-	},
-	{
-		title: 'Shop Loop Item Title',
-		dataTestId: 'woocommerce_shop_loop_item_title',
-		content: 'Hook: woocommerce_shop_loop_item_title',
-		amount: 16,
-	},
-	{
-		title: 'After Shop Loop Item Title',
-		dataTestId: 'woocommerce_after_shop_loop_item_title',
-		content: 'Hook: woocommerce_after_shop_loop_item_title',
-		amount: 16,
-	},
-	{
-		title: 'Before Shop Loop Item',
-		dataTestId: 'woocommerce_before_shop_loop_item',
-		content: 'Hook: woocommerce_before_shop_loop_item',
-		amount: 16,
-	},
-	{
-		title: 'After Shop Loop Item',
-		dataTestId: 'woocommerce_after_shop_loop_item',
-		content: 'Hook: woocommerce_after_shop_loop_item',
-		amount: 16,
-	},
-];
-
 const test = base.extend< { pageObject: ProductCollectionPage } >( {
 	pageObject: async ( { page, admin, editor }, use ) => {
 		const pageObject = new ProductCollectionPage( {
@@ -94,25 +27,112 @@ test.describe( 'Product Collection: Compatibility Layer', () => {
 		await pageObject.goToProductCatalogFrontend();
 	} );
 
-	for ( const scenario of singleOccurrenceScenarios ) {
-		test( `${ scenario.title } is attached to the page`, async ( {
-			pageObject,
-		} ) => {
-			const hooks = pageObject.locateByTestId( scenario.dataTestId );
+	test( 'renders global compatibility hooks around the inherited collection and loop', async ( {
+		page,
+		pageObject,
+	} ) => {
+		const globalHooks = [
+			'woocommerce_before_main_content',
+			'woocommerce_before_shop_loop',
+			'woocommerce_after_shop_loop',
+			'woocommerce_after_main_content',
+		];
 
-			await expect( hooks ).toHaveCount( scenario.amount );
-			await expect( hooks ).toHaveText( scenario.content );
-		} );
-	}
+		for ( const hookName of globalHooks ) {
+			const hook = pageObject.locateByTestId( hookName );
+			await expect( hook ).toHaveCount( 1 );
+			await expect( hook ).toHaveText( `Hook: ${ hookName }` );
+		}
 
-	for ( const scenario of multipleOccurrenceScenarios ) {
-		test( `${ scenario.title } is attached to the page`, async ( {
-			pageObject,
-		} ) => {
-			const hooks = pageObject.locateByTestId( scenario.dataTestId );
+		await expect(
+			page.locator( '.wp-block-woocommerce-product-collection' )
+		).toHaveCount( 1 );
+		await expect( pageObject.productTemplate ).toHaveCount( 1 );
+		await expect( pageObject.products.first() ).toBeVisible();
 
-			await expect( hooks ).toHaveCount( scenario.amount );
-			await expect( hooks.first() ).toHaveText( scenario.content );
-		} );
-	}
+		const structureSelector = [
+			'[data-testid="woocommerce_before_main_content"]',
+			'.wp-block-woocommerce-product-collection',
+			'[data-testid="woocommerce_before_shop_loop"]',
+			'.wc-block-product-template',
+			'[data-testid="woocommerce_after_shop_loop"]',
+			'[data-testid="woocommerce_after_main_content"]',
+		].join( ', ' );
+		const structure = await page
+			.locator( structureSelector )
+			.evaluateAll( ( nodes ) =>
+				nodes.map( ( node ) => {
+					const testId = node.getAttribute( 'data-testid' );
+					if ( testId ) {
+						return testId;
+					}
+
+					return node.classList.contains(
+						'wp-block-woocommerce-product-collection'
+					)
+						? 'product-collection'
+						: 'product-template';
+				} )
+			);
+
+		expect( structure ).toEqual( [
+			'woocommerce_before_main_content',
+			'product-collection',
+			'woocommerce_before_shop_loop',
+			'product-template',
+			'woocommerce_after_shop_loop',
+			'woocommerce_after_main_content',
+		] );
+	} );
+
+	test( 'renders compatibility hooks in order for every product', async ( {
+		pageObject,
+	} ) => {
+		await expect( pageObject.products.first() ).toBeVisible();
+		const productCount = await pageObject.products.count();
+		expect( productCount ).toBeGreaterThan( 0 );
+
+		const itemHooks = [
+			'woocommerce_before_shop_loop_item',
+			'woocommerce_before_shop_loop_item_title',
+			'woocommerce_shop_loop_item_title',
+			'woocommerce_after_shop_loop_item_title',
+			'woocommerce_after_shop_loop_item',
+		];
+
+		for ( const hookName of itemHooks ) {
+			const hooks = pageObject.locateByTestId( hookName );
+			await expect( hooks ).toHaveCount( productCount );
+			await expect( hooks ).toHaveText(
+				Array( productCount ).fill( `Hook: ${ hookName }` )
+			);
+		}
+
+		const productSequences = await pageObject.products.evaluateAll(
+			( products ) =>
+				products.map( ( product ) =>
+					Array.from(
+						product.querySelectorAll(
+							'[data-testid="woocommerce_before_shop_loop_item"], [data-testid="woocommerce_before_shop_loop_item_title"], .wp-block-post-title, [data-testid="woocommerce_shop_loop_item_title"], [data-testid="woocommerce_after_shop_loop_item_title"], [data-testid="woocommerce_after_shop_loop_item"]'
+						)
+					).map(
+						( node ) =>
+							node.getAttribute( 'data-testid' ) ??
+							'product-title'
+					)
+				)
+		);
+		const expectedSequence = [
+			'woocommerce_before_shop_loop_item',
+			'woocommerce_before_shop_loop_item_title',
+			'product-title',
+			'woocommerce_shop_loop_item_title',
+			'woocommerce_after_shop_loop_item_title',
+			'woocommerce_after_shop_loop_item',
+		];
+
+		expect( productSequences ).toEqual(
+			Array.from( { length: productCount }, () => expectedSequence )
+		);
+	} );
 } );

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/ArchiveProductTemplatesCompatibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/ArchiveProductTemplatesCompatibilityTest.php
@@ -1,0 +1,343 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Templates;
+
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
+use WC_Unit_Test_Case;
+use WP_Hook;
+
+/**
+ * Tests for the archive Product Collection hook compatibility layer.
+ */
+class ArchiveProductTemplatesCompatibilityTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Hooks whose state the compatibility layer can change.
+	 *
+	 * @var string[]
+	 */
+	private const COMPATIBILITY_HOOKS = array(
+		'woocommerce_before_main_content',
+		'woocommerce_after_main_content',
+		'woocommerce_before_shop_loop_item_title',
+		'woocommerce_shop_loop_item_title',
+		'woocommerce_after_shop_loop_item_title',
+		'woocommerce_before_shop_loop_item',
+		'woocommerce_after_shop_loop_item',
+		'woocommerce_before_shop_loop',
+		'woocommerce_after_shop_loop',
+		'woocommerce_no_products_found',
+		'woocommerce_archive_description',
+		'template_include',
+		'render_block_data',
+		'render_block',
+		'woocommerce_disable_compatibility_layer',
+	);
+
+	/**
+	 * Hook stacks captured before each test.
+	 *
+	 * @var array<string, WP_Hook|null>
+	 */
+	private $hook_snapshots = array();
+
+	/**
+	 * Action counts captured before each test.
+	 *
+	 * @var array<string, int|null>
+	 */
+	private $action_snapshots = array();
+
+	/**
+	 * Query globals captured before each test.
+	 *
+	 * @var array<string, array{exists: bool, value: mixed}>
+	 */
+	private $query_snapshots = array();
+
+	/**
+	 * Shop page option captured before each test.
+	 *
+	 * @var mixed
+	 */
+	private $original_shop_page_id;
+
+	/**
+	 * Shop page created for the archive request.
+	 *
+	 * @var int
+	 */
+	private $shop_page_id = 0;
+
+	/**
+	 * @inheritdoc
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_shop_page_id = get_option( 'woocommerce_shop_page_id' );
+
+		foreach ( self::COMPATIBILITY_HOOKS as $hook_name ) {
+			$this->hook_snapshots[ $hook_name ] = isset( $GLOBALS['wp_filter'][ $hook_name ] ) && $GLOBALS['wp_filter'][ $hook_name ] instanceof WP_Hook
+				? clone $GLOBALS['wp_filter'][ $hook_name ]
+				: null;
+		}
+
+		foreach ( array_slice( self::COMPATIBILITY_HOOKS, 0, 11 ) as $hook_name ) {
+			$this->action_snapshots[ $hook_name ] = array_key_exists( $hook_name, $GLOBALS['wp_actions'] ) ? $GLOBALS['wp_actions'][ $hook_name ] : null;
+		}
+
+		foreach ( array( 'wp_query', 'wp_the_query' ) as $global_name ) {
+			$this->query_snapshots[ $global_name ] = array(
+				'exists' => array_key_exists( $global_name, $GLOBALS ),
+				'value'  => $GLOBALS[ $global_name ] ?? null,
+			);
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function tearDown(): void {
+		foreach ( $this->hook_snapshots as $hook_name => $snapshot ) {
+			if ( $snapshot instanceof WP_Hook ) {
+				$GLOBALS['wp_filter'][ $hook_name ] = clone $snapshot; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the exact pre-test hook stack.
+			} else {
+				unset( $GLOBALS['wp_filter'][ $hook_name ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Remove callbacks installed by the compatibility layer or test.
+			}
+		}
+
+		foreach ( $this->action_snapshots as $hook_name => $snapshot ) {
+			if ( null === $snapshot ) {
+				unset( $GLOBALS['wp_actions'][ $hook_name ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore prior absence of the action counter.
+			} else {
+				$GLOBALS['wp_actions'][ $hook_name ] = $snapshot; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the exact pre-test action count.
+			}
+		}
+
+		foreach ( $this->query_snapshots as $global_name => $snapshot ) {
+			if ( $snapshot['exists'] ) {
+				$GLOBALS[ $global_name ] = $snapshot['value']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the exact pre-test query global.
+			} else {
+				unset( $GLOBALS[ $global_name ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore prior absence of the query global.
+			}
+		}
+
+		if ( false === $this->original_shop_page_id ) {
+			delete_option( 'woocommerce_shop_page_id' );
+		} else {
+			update_option( 'woocommerce_shop_page_id', $this->original_shop_page_id );
+		}
+		if ( $this->shop_page_id ) {
+			wp_delete_post( $this->shop_page_id, true );
+			$this->shop_page_id = 0;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Injects $hook_name $position the inherited $block_name block
+	 * @dataProvider supported_hook_provider
+	 *
+	 * @param string $hook_name Hook to exercise.
+	 * @param string $block_name Target block name.
+	 * @param string $position Expected marker position relative to the block.
+	 */
+	public function test_injects_supported_hook_at_declared_position( string $hook_name, string $block_name, string $position ): void {
+		$sut    = $this->initialize_archive_compatibility();
+		$target = $this->get_marked_target_block( $sut, $block_name );
+
+		add_action(
+			$hook_name,
+			static function () {
+				echo esc_html( '__HOOK_MARKER__' );
+			}
+		);
+
+		$rendered = $sut->inject_hooks( '__BLOCK_SENTINEL__', $target );
+
+		$this->assertSame( 1, substr_count( $rendered, '__HOOK_MARKER__' ), 'The selected public hook should render exactly once.' );
+		$this->assertSame( 1, substr_count( $rendered, '__BLOCK_SENTINEL__' ), 'The inherited block sentinel should render exactly once.' );
+
+		$marker_position = strpos( $rendered, '__HOOK_MARKER__' );
+		$block_position  = strpos( $rendered, '__BLOCK_SENTINEL__' );
+		$this->assertIsInt( $marker_position );
+		$this->assertIsInt( $block_position );
+
+		if ( 'before' === $position ) {
+			$this->assertLessThan( $block_position, $marker_position, "{$hook_name} should render before {$block_name}." );
+		} else {
+			$this->assertGreaterThan( $block_position, $marker_position, "{$hook_name} should render after {$block_name}." );
+		}
+	}
+
+	/**
+	 * Supported public hook and block positions.
+	 *
+	 * @return array<string, array{string, string, string}>
+	 */
+	public function supported_hook_provider(): array {
+		return array(
+			'before main content'         => array( 'woocommerce_before_main_content', 'woocommerce/product-collection', 'before' ),
+			'after main content'          => array( 'woocommerce_after_main_content', 'woocommerce/product-collection', 'after' ),
+			'before shop loop'            => array( 'woocommerce_before_shop_loop', 'woocommerce/product-template', 'before' ),
+			'after shop loop'             => array( 'woocommerce_after_shop_loop', 'woocommerce/product-template', 'after' ),
+			'before shop loop item title' => array( 'woocommerce_before_shop_loop_item_title', 'core/post-title', 'before' ),
+			'shop loop item title'        => array( 'woocommerce_shop_loop_item_title', 'core/post-title', 'after' ),
+			'after shop loop item title'  => array( 'woocommerce_after_shop_loop_item_title', 'core/post-title', 'after' ),
+			'before shop loop item'       => array( 'woocommerce_before_shop_loop_item', 'core/null', 'before' ),
+			'after shop loop item'        => array( 'woocommerce_after_shop_loop_item', 'core/null', 'after' ),
+		);
+	}
+
+	/**
+	 * @testdox Marks an inherited Product Collection and all descendants
+	 */
+	public function test_marks_inherited_product_collection_tree(): void {
+		$sut  = $this->initialize_archive_compatibility();
+		$tree = array(
+			'blockName'   => 'woocommerce/product-collection',
+			'attrs'       => array( 'query' => array( 'inherit' => true ) ),
+			'innerBlocks' => array(
+				array(
+					'blockName'   => 'woocommerce/product-template',
+					'attrs'       => array(),
+					'innerBlocks' => array(
+						array(
+							'blockName'   => 'core/null',
+							'attrs'       => array(),
+							'innerBlocks' => array(
+								array(
+									'blockName'   => 'core/post-title',
+									'attrs'       => array(),
+									'innerBlocks' => array(),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$marked = $sut->update_render_block_data( $tree, $tree, null );
+
+		$this->assertSame( 1, $marked['attrs']['isInherited'] );
+		$this->assertSame( 1, $marked['innerBlocks'][0]['attrs']['isInherited'] );
+		$this->assertSame( 1, $marked['innerBlocks'][0]['innerBlocks'][0]['attrs']['isInherited'] );
+		$this->assertSame( 1, $marked['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['isInherited'] );
+	}
+
+	/**
+	 * @testdox Skips blocks outside the supported inherited archive contexts
+	 */
+	public function test_skips_unsupported_context(): void {
+		$sut = $this->initialize_archive_compatibility();
+		add_action(
+			'woocommerce_before_main_content',
+			static function () {
+				echo esc_html( '__HOOK_MARKER__' );
+			}
+		);
+		add_action(
+			'woocommerce_before_shop_loop',
+			static function () {
+				echo esc_html( '__HOOK_MARKER__' );
+			}
+		);
+
+		$this->go_to( home_url( '/' ) );
+		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Keep the conditional query globals aligned for the non-archive control.
+
+		$non_archive = array(
+			'blockName'   => 'woocommerce/product-collection',
+			'attrs'       => array( 'query' => array( 'inherit' => true ) ),
+			'innerBlocks' => array(),
+		);
+		$this->assertSame( $non_archive, $sut->update_render_block_data( $non_archive, $non_archive, null ) );
+		$this->assertSame( '__BLOCK_SENTINEL__', $sut->inject_hooks( '__BLOCK_SENTINEL__', $non_archive ) );
+
+		$this->establish_shop_query();
+		$supported_not_inherited = array(
+			'blockName' => 'woocommerce/product-collection',
+			'attrs'     => array(),
+		);
+		$this->assertSame( '__BLOCK_SENTINEL__', $sut->inject_hooks( '__BLOCK_SENTINEL__', $supported_not_inherited ) );
+
+		$unsupported_inherited = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array( 'isInherited' => 1 ),
+		);
+		$this->assertSame( '__BLOCK_SENTINEL__', $sut->inject_hooks( '__BLOCK_SENTINEL__', $unsupported_inherited ) );
+
+		$empty_product_template = array(
+			'blockName' => 'woocommerce/product-template',
+			'attrs'     => array( 'isInherited' => 1 ),
+		);
+		$this->assertSame( '', $sut->inject_hooks( '', $empty_product_template ) );
+	}
+
+	/**
+	 * Initializes the real compatibility layer in a Shop request.
+	 */
+	private function initialize_archive_compatibility(): ArchiveProductTemplatesCompatibility {
+		$this->establish_shop_query();
+		$sut = new ArchiveProductTemplatesCompatibility();
+		$sut->init();
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- WordPress owns this hook; the test applies the real callback registered by init().
+		apply_filters( 'template_include', 'index.php' );
+
+		return $sut;
+	}
+
+	/**
+	 * Establishes and verifies the real Shop main query.
+	 */
+	private function establish_shop_query(): void {
+		if ( ! $this->shop_page_id ) {
+			$this->shop_page_id = self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+					'post_title'  => 'Compatibility Layer Shop',
+					'post_name'   => 'compatibility-layer-shop',
+				)
+			);
+			update_option( 'woocommerce_shop_page_id', $this->shop_page_id );
+		}
+
+		$this->go_to( get_permalink( $this->shop_page_id ) );
+		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Product archive conditionals read the main query global.
+		$this->assertTrue( is_shop(), 'The compatibility contract must run under a real Shop main query.' );
+	}
+
+	/**
+	 * Marks an inherited tree and returns the requested target block.
+	 *
+	 * @param ArchiveProductTemplatesCompatibility $sut        Compatibility layer.
+	 * @param string                               $block_name Target block name.
+	 * @return array<string, mixed>
+	 */
+	private function get_marked_target_block( ArchiveProductTemplatesCompatibility $sut, string $block_name ): array {
+		$target = array(
+			'blockName'   => $block_name,
+			'attrs'       => array(),
+			'innerBlocks' => array(),
+		);
+
+		if ( 'woocommerce/product-collection' === $block_name ) {
+			$tree                   = $target;
+			$tree['attrs']['query'] = array( 'inherit' => true );
+		} else {
+			$tree = array(
+				'blockName'   => 'woocommerce/product-collection',
+				'attrs'       => array( 'query' => array( 'inherit' => true ) ),
+				'innerBlocks' => array( $target ),
+			);
+		}
+
+		$marked = $sut->update_render_block_data( $tree, $tree, null );
+
+		return 'woocommerce/product-collection' === $block_name ? $marked : $marked['innerBlocks'][0];
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Product Collection compatibility layer spec ran nine browser titles, one per hook position. Each one loaded the shop archive with a test plugin and checked a single hook's element count and text. Which position each hook takes is a declaration in the layer's own hook data, and placing that hook's buffer before or after the block it belongs to is a PHP decision. A browser is not needed to see it.

This PR adds a PHPUnit test for that decision and keeps two browser titles for the rendered order, which is what a browser does prove. The spec goes from 9 tests to 2, and the new `ArchiveProductTemplatesCompatibilityTest.php` has 3 test methods, one of which runs the nine hook positions these templates use.

Refs TESTOPS-234

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `Before Main Content is attached to the page` | `ArchiveProductTemplatesCompatibilityTest.php` › `test_injects_supported_hook_at_declared_position` ("before main content"); and the retained `renders global compatibility hooks around the inherited collection and loop`, whose structure check requires this hook first | none. The retained title loops over the global hooks and checks each one's count and text, then requires this hook first in the page's structure |
| `After Main Content is attached to the page` | the same provider case ("after main content"); the same retained title, whose loop checks this hook's count and text and whose structure check requires it last | none |
| `Before Shop Loop is attached to the page` | the provider case ("before shop loop"); the retained global title, which checks this hook's count and text and its place in the structure | none |
| `After Shop Loop is attached to the page` | the provider case ("after shop loop"); the same retained title | none |
| `Before Shop Loop Item Title is attached to the page` | the provider case ("before shop loop item title"); the retained `renders compatibility hooks in order for every product`, which checks the hook's count against the product count, its text, and its place in every product's sequence | the fixed count of 16. The retained title compares the hook count against the number of products on the page instead of a hard-coded number, so a page that renders fewer products than expected would still pass |
| `Shop Loop Item Title is attached to the page` | the provider case ("shop loop item title"); the same retained title | the fixed count of 16, as in the row above |
| `After Shop Loop Item Title is attached to the page` | the provider case ("after shop loop item title"); the same retained title | the fixed count of 16, as in the row above |
| `Before Shop Loop Item is attached to the page` | the provider case ("before shop loop item"); the same retained title | the fixed count of 16, as in the row above |
| `After Shop Loop Item is attached to the page` | the provider case ("after shop loop item"); the same retained title | the fixed count of 16, as in the row above |

The nine titles each loaded the page on their own, so one failure left the other eight reported. They now run as two journeys, and a failure inside a journey hides the checks after it.

#### Relocated to PHPUnit

`tests/php/src/Blocks/Templates/ArchiveProductTemplatesCompatibilityTest.php` is new, with three tests:

- `test_injects_supported_hook_at_declared_position` runs the nine hook positions the removed titles covered. For each one it checks that the hook's buffer is injected at the declared position, before or after the block it belongs to. The layer declares two more hooks, `woocommerce_no_products_found` and `woocommerce_archive_description`, which no test in this PR covers and none covered before it.
- `test_marks_inherited_product_collection_tree` checks that an inherited Product Collection and every block inside it are marked as inherited.
- `test_skips_unsupported_context` checks four guards: a block outside an archive template, a block that isn't inherited, an unsupported block name, and an inherited product template with no content all pass through untouched.

#### The retained wiring tests

Two browser titles stay, both on the shop archive with the compatibility test plugin active:

- `renders global compatibility hooks around the inherited collection and loop`: each global hook's count and text, then the page's structure, which must be exactly the before-main hook, the collection, the before-loop hook, the product template, the after-loop hook, and the after-main hook.
- `renders compatibility hooks in order for every product`: each per-item hook's count against the number of products and its text, then every product's inner sequence, which must be the same expected order for all of them.

The compatibility layer keeps no other browser coverage in the suite: this spec is the only one that renders its hooks. The single-product compatibility layer is a different class, covered by its own unchanged spec.

#### Where this differs from the TESTOPS-234 audit

The TESTOPS-234 audit puts this spec on its start-here list, so its pass moves all nine titles below the browser.

This branch moves the nine hook positions to PHPUnit, which decides them, and keeps two browser titles for what PHPUnit can't see: the order of the rendered hooks around the collection and inside each product.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test`, then run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter ArchiveProductTemplatesCompatibilityTest` and confirm it passes.
3. Confirm the new test guards the injection point. In `plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php`, change `$data['position'] === $position` to `$data['position'] !== $position`. Re-run the command from step 2 and confirm `test_injects_supported_hook_at_declared_position` fails. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build` (the E2E README's build step; the Blocks bundle needs scripts the admin build registers), then start the E2E environment with the Blocks seed: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/product-collection/compatibility-layer.block_theme.spec.ts`. Confirm both titles pass. Playwright runs the `blocks setup` project first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled. The E2E store was checked first: 22 attachments with none missing on disk.

- **Focused commands.** The mutation matrix records 13 distinct focused commands for these files, 11 PHPUnit and 2 Playwright, and all 13 exit 0.
- **Retained titles.** `--list` shows the two titles, and the spec passes with `--retries=0 --workers=1`.
- **PHPUnit.** This PR's step 2 command runs the whole class and passes with `OK (11 tests, 66 assertions)`: the nine provider cases and the two other tests.
- **Mutation re-check.** For each of the 6 behavior families, a script applied one hand-written mutation from the matrix, ran its test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0081` | the hook buffer goes to every position except the one it declares | `test_injects_supported_hook_at_declared_position` ("before main content"): the hook no longer sits before its block |
| `0082` | an inherited Product Collection is marked as not inherited | `test_marks_inherited_product_collection_tree`: the root's flag is `0` instead of `1` |
| `0083` | blocks outside an archive template come back changed | `test_skips_unsupported_context`: the untouched block no longer matches |
| `0960` | block content outside an archive template is replaced | the same test: the returned content no longer matches |
| `0629` | the before-shop-loop hook declares that it renders after the loop | the retained `renders global compatibility hooks around the inherited collection and loop`: the hook appears in the wrong place in the page's structure |
| `0630` | the shop-loop item title hook declares that it renders before the title | the retained `renders compatibility hooks in order for every product`: the hook appears in the wrong place in every product's sequence |

- **Lint.**
    - PHPCS finds nothing in the new PHP test, and Prettier is clean.
    - ESLint reports nothing on lines this PR changes.
    - oxlint finds nothing new, `verify-staged` exits 0, and `lint:changes:branch` exits 0.
    - PHPStan doesn't analyse `tests/` in this repository's config, so it isn't a gate for the PHP test.
- **Deleted files.** None, so no dangling-reference sweep was needed.
- **Reviews.** Two independent agent reviews read the branch and the evidence, and a fresh reviewer then checked the fixes. One asked for a change in the test code, a fixture page renamed to say what it is, and the PHPUnit commands and mutations that use it were re-run. The rest were claims in this description: it said two hooks lost their rendered count and text check when the retained title still makes it, it described the layer as deciding a hook's position while the block tree is parsed when the placement happens as the block renders, and it left out one of the four guards the new test asserts. All are fixed. Two suggestions about the moved test's own style were declined, because this PR carries that file unchanged apart from the rename; they are recorded as follow-ups. None of these is a human review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-product-collection-compatibility`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

