### PR TITLE
[tests] Reduce admin smoke E2E tests from 27 to 6

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-admin-smoke
+++ b/plugins/woocommerce/changelog/testops-288-admin-smoke
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Reduce admin smoke E2E tests from 27 titles to 6; PHPUnit owns the customer redirect policy and the 24 admin destinations become four menu journeys with named steps.
+

--- a/plugins/woocommerce/tests/e2e/tests/basic/dashboard-access.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/basic/dashboard-access.spec.ts
@@ -13,7 +13,6 @@ test.describe( 'Customer-role users are blocked from accessing the WP Dashboard.
 
 	const dashboardScreens = {
 		'WP Admin home': 'wp-admin',
-		'WP Admin profile page': 'wp-admin/profile.php',
 		'WP Admin using ajax query param': 'wp-admin?wc-ajax=1',
 	};
 

--- a/plugins/woocommerce/tests/e2e/tests/basic/page-loads.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/basic/page-loads.spec.ts
@@ -187,7 +187,8 @@ const wcPages = [
 ];
 
 const product = getFakeProduct();
-let orderId: number;
+let productId: number | undefined;
+let orderId: number | undefined;
 
 test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -202,104 +203,90 @@ test.beforeAll( async ( { restApi } ) => {
 
 	expect( response.status ).toEqual( 200 );
 
-	// create a simple product
-	await restApi
-		.post( `${ WC_API_PATH }/products`, product )
-		.then( ( r ) => {
-			product.id = r.data.id;
-		} )
-		.catch( ( e ) => {
-			console.error(
-				`Failed to create product ${
-					e.data ? JSON.stringify( e.data ) : ''
-				}`
-			);
-			throw e;
-		} );
+	const productResponse = await restApi.post(
+		`${ WC_API_PATH }/products`,
+		product
+	);
+	const createdProductId: number = productResponse.data.id;
+	productId = createdProductId;
 
-	// create an order
-	await restApi
-		.post( `${ WC_API_PATH }/orders`, {
-			line_items: [
-				{
-					product_id: product.id,
-					quantity: 1,
-				},
-			],
-		} )
-		.then( ( r ) => {
-			orderId = r.data.id;
-		} )
-		.catch( ( e ) => {
-			console.error(
-				`Failed to create order ${
-					e.data ? JSON.stringify( e.data ) : ''
-				}`
-			);
-			throw e;
-		} );
+	const orderResponse = await restApi.post( `${ WC_API_PATH }/orders`, {
+		line_items: [
+			{
+				product_id: createdProductId,
+				quantity: 1,
+			},
+		],
+	} );
+	orderId = orderResponse.data.id;
 } );
 
 test.afterAll( async ( { restApi } ) => {
-	await restApi
-		.delete( `${ WC_API_PATH }/orders/${ orderId }`, {
-			force: true,
-		} )
-		.catch( ( e ) => {
-			console.error(
-				`Failed to delete order ${
-					e.data ? JSON.stringify( e.data ) : ''
-				}`
-			);
-			throw e;
-		} );
-	await restApi
-		.delete( `${ WC_API_PATH }/products/${ product.id }`, {
-			force: true,
-		} )
-		.catch( ( e ) => {
-			console.error(
-				`Failed to delete product ${
-					e.data ? JSON.stringify( e.data ) : ''
-				}`
-			);
-			throw e;
-		} );
+	const cleanupErrors: unknown[] = [];
+
+	if ( orderId !== undefined ) {
+		try {
+			await restApi.delete( `${ WC_API_PATH }/orders/${ orderId }`, {
+				force: true,
+			} );
+		} catch ( error ) {
+			cleanupErrors.push( error );
+		}
+	}
+
+	if ( productId !== undefined ) {
+		try {
+			await restApi.delete( `${ WC_API_PATH }/products/${ productId }`, {
+				force: true,
+			} );
+		} catch ( error ) {
+			cleanupErrors.push( error );
+		}
+	}
+
+	if ( cleanupErrors.length > 0 ) {
+		throw new AggregateError(
+			cleanupErrors,
+			'Failed to clean up page-load test fixtures.'
+		);
+	}
 } );
 
 for ( const currentPage of wcPages ) {
-	for ( let i = 0; i < currentPage.subpages.length; i++ ) {
-		test( `can load ${ currentPage.name } > ${ currentPage.subpages[ i ].name } page`, async ( {
-			page,
-		} ) => {
-			await page.goto( currentPage.url );
+	test( `can load ${ currentPage.name } pages`, async ( { page } ) => {
+		await page.goto( currentPage.url );
 
-			// needs a Regexp on link name to match exact text and also match the possible counter
-			// E.g. should match "Orders 3" or "Orders", but should not match "Quick Orders"
-			await page
-				.locator( 'li.wp-menu-open > ul.wp-submenu' )
-				.getByRole( 'link', {
-					name: new RegExp(
-						`^${ currentPage.subpages[ i ].name }( \\d+)?$`
-					),
-				} )
-				.click();
+		for ( const currentSubpage of currentPage.subpages ) {
+			await test.step( currentSubpage.name, async () => {
+				// needs a Regexp on link name to match exact text and also match the possible counter
+				// E.g. should match "Orders 3" or "Orders", but should not match "Quick Orders"
+				const subpageLink = page
+					.locator( 'li.wp-menu-open > ul.wp-submenu' )
+					.getByRole( 'link', {
+						name: new RegExp(
+							`^${ currentSubpage.name }( \\d+)?$`
+						),
+					} );
 
-			await expect(
-				page
-					.getByRole( 'heading', {
-						name: currentPage.subpages[ i ].heading,
-					} )
-					.first()
-			).toBeVisible();
+				await expect( subpageLink ).toBeVisible();
+				await subpageLink.click();
 
-			await expect(
-				page.locator( currentPage.subpages[ i ].element ).first()
-			).toBeVisible();
+				await expect(
+					page
+						.getByRole( 'heading', {
+							name: currentSubpage.heading,
+						} )
+						.first()
+				).toBeVisible();
 
-			await expect(
-				page.locator( currentPage.subpages[ i ].element )
-			).toContainText( currentPage.subpages[ i ].text );
-		} );
-	}
+				await expect(
+					page.locator( currentSubpage.element ).first()
+				).toBeVisible();
+
+				await expect(
+					page.locator( currentSubpage.element )
+				).toContainText( currentSubpage.text );
+			} );
+		}
+	} );
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-test.php
@@ -27,12 +27,56 @@ class WC_Admin_Test extends WC_Unit_Test_Case {
 	private array $original_get = array();
 
 	/**
+	 * Original $_SERVER.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private array $original_server = array();
+
+	/**
+	 * Original current user ID.
+	 *
+	 * @var int
+	 */
+	private int $original_current_user_id = 0;
+
+	/**
+	 * The My Account page this test creates, so the redirect target is a real page.
+	 *
+	 * @var int
+	 */
+	private int $myaccount_page_id = 0;
+
+	/**
+	 * The site's My Account page id before this test replaced it.
+	 *
+	 * @var mixed
+	 */
+	private $original_myaccount_page_id = null;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->sut          = new WC_Admin();
-		$this->original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->sut                      = new WC_Admin();
+		$this->original_get             = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->original_server          = $_SERVER;
+		$this->original_current_user_id = get_current_user_id();
+
+		// Without a real My Account page, wc_get_page_permalink() falls back to the home URL and
+		// the redirect assertions cannot tell My Account from the site root.
+		$this->original_myaccount_page_id = get_option( 'woocommerce_myaccount_page_id' );
+		$this->myaccount_page_id          = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'My Account',
+				'post_name'   => 'my-account',
+			)
+		);
+		update_option( 'woocommerce_myaccount_page_id', $this->myaccount_page_id );
+
 		add_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
 	}
 
@@ -41,8 +85,11 @@ class WC_Admin_Test extends WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		remove_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
-		$_GET = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		wp_set_current_user( 0 );
+		update_option( 'woocommerce_myaccount_page_id', $this->original_myaccount_page_id );
+		wp_delete_post( $this->myaccount_page_id, true );
+		$_GET    = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$_SERVER = $this->original_server;
+		wp_set_current_user( $this->original_current_user_id );
 		parent::tearDown();
 	}
 
@@ -100,5 +147,185 @@ class WC_Admin_Test extends WC_Unit_Test_Case {
 			$this->assertStringContainsString( 'action=install-plugin', $e->getMessage() );
 			$this->assertStringContainsString( 'plugin=woocommerce-gateway-stripe', $e->getMessage() );
 		}
+	}
+
+	/**
+	 * @testdox Customers are redirected from non-exempt admin scripts.
+	 * @dataProvider customer_non_exempt_admin_scripts_provider
+	 *
+	 * @param string              $script_filename Script filename.
+	 * @param array<string,mixed> $get             Request query parameters.
+	 */
+	public function test_prevent_admin_access_redirects_customer_from_non_exempt_script( string $script_filename, array $get ): void {
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+
+		$this->assertSame(
+			get_permalink( $this->myaccount_page_id ),
+			$this->invoke_prevent_admin_access( $customer_id, $script_filename, $get ),
+			'Customers should be redirected to My Account from non-exempt admin scripts.'
+		);
+	}
+
+	/**
+	 * Provides customer request shapes that are not exempt from admin access prevention.
+	 *
+	 * @return array<string,array{string,array<string,mixed>}>
+	 */
+	public function customer_non_exempt_admin_scripts_provider(): array {
+		return array(
+			'customer ordinary wp-admin index script' => array( '/var/www/html/wp-admin/index.php', array() ),
+			'customer wp-admin profile script'        => array( '/var/www/html/wp-admin/profile.php', array() ),
+			'customer ordinary script with wc-ajax query parameter' => array( '/var/www/html/wp-admin/index.php', array( 'wc-ajax' => '1' ) ),
+		);
+	}
+
+	/**
+	 * @testdox Customers are not redirected from exempt or incomplete admin request shapes.
+	 * @dataProvider customer_exempt_or_incomplete_admin_request_provider
+	 *
+	 * @param string|null $script_filename Script filename, if present.
+	 */
+	public function test_prevent_admin_access_does_not_redirect_customer_from_exempt_or_incomplete_request( ?string $script_filename ): void {
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+
+		$this->assertSame(
+			null,
+			$this->invoke_prevent_admin_access( $customer_id, $script_filename ),
+			'Exempt or incomplete admin request shapes should not redirect customers.'
+		);
+	}
+
+	/**
+	 * Provides customer request shapes that are exempt from admin access prevention.
+	 *
+	 * @return array<string,array{string|null}>
+	 */
+	public function customer_exempt_or_incomplete_admin_request_provider(): array {
+		return array(
+			'customer admin-post script'              => array( '/var/www/html/wp-admin/admin-post.php' ),
+			'customer admin-ajax script'              => array( '/var/www/html/wp-admin/admin-ajax.php' ),
+			'customer missing SCRIPT_FILENAME server' => array( null ),
+		);
+	}
+
+	/**
+	 * @testdox Users with an admin access capability are not redirected.
+	 * @dataProvider admin_access_capabilities_provider
+	 *
+	 * @param string $capability Capability granted to the user.
+	 */
+	public function test_prevent_admin_access_does_not_redirect_user_with_admin_access_capability( string $capability ): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		$user    = get_user_by( 'id', $user_id );
+		if ( ! $user instanceof WP_User ) {
+			throw new RuntimeException( 'Factory-created user could not be loaded.' );
+		}
+		$user->add_cap( $capability );
+
+		$this->assertSame(
+			null,
+			$this->invoke_prevent_admin_access( $user_id, '/var/www/html/wp-admin/index.php' ),
+			"Users granted {$capability} should not be redirected from an ordinary admin script."
+		);
+	}
+
+	/**
+	 * Provides capabilities that allow access to the admin.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public function admin_access_capabilities_provider(): array {
+		return array(
+			'user granted edit_posts'           => array( 'edit_posts' ),
+			'user granted manage_woocommerce'   => array( 'manage_woocommerce' ),
+			'user granted view_admin_dashboard' => array( 'view_admin_dashboard' ),
+		);
+	}
+
+	/**
+	 * @testdox The disable-admin-bar filter receives true and can suppress customer redirects.
+	 */
+	public function test_prevent_admin_access_disable_admin_bar_filter_can_suppress_customer_redirect(): void {
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		$received    = null;
+		$callback    = static function ( $disabled ) use ( &$received ) {
+			$received = $disabled;
+			return false;
+		};
+		add_filter( 'woocommerce_disable_admin_bar', $callback );
+
+		try {
+			$this->assertSame( null, $this->invoke_prevent_admin_access( $customer_id, '/var/www/html/wp-admin/index.php' ), 'The disable-admin-bar filter should suppress the customer redirect.' );
+			$this->assertSame( true, $received, 'The disable-admin-bar filter should receive its default true value.' );
+		} finally {
+			remove_filter( 'woocommerce_disable_admin_bar', $callback );
+		}
+	}
+
+	/**
+	 * @testdox The prevent-admin-access filter receives computed customer denial and can suppress it.
+	 */
+	public function test_prevent_admin_access_filter_can_suppress_computed_customer_denial(): void {
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		$received    = null;
+		$callback    = static function ( $prevent_access ) use ( &$received ) {
+			$received = $prevent_access;
+			return false;
+		};
+		add_filter( 'woocommerce_prevent_admin_access', $callback );
+
+		try {
+			$this->assertSame( null, $this->invoke_prevent_admin_access( $customer_id, '/var/www/html/wp-admin/index.php' ), 'The prevent-admin-access filter should suppress the computed customer denial.' );
+			$this->assertSame( true, $received, 'The prevent-admin-access filter should receive the computed customer denial.' );
+		} finally {
+			remove_filter( 'woocommerce_prevent_admin_access', $callback );
+		}
+	}
+
+	/**
+	 * @testdox The prevent-admin-access filter can force a redirect from an exempt request.
+	 */
+	public function test_prevent_admin_access_filter_can_force_redirect_from_exempt_request(): void {
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		$received    = null;
+		$callback    = static function ( $prevent_access ) use ( &$received ) {
+			$received = $prevent_access;
+			return true;
+		};
+		add_filter( 'woocommerce_prevent_admin_access', $callback );
+
+		try {
+			$this->assertSame( get_permalink( $this->myaccount_page_id ), $this->invoke_prevent_admin_access( $customer_id, '/var/www/html/wp-admin/admin-ajax.php' ), 'The prevent-admin-access filter should force an exact My Account redirect from an exempt request.' );
+			$this->assertSame( false, $received, 'The prevent-admin-access filter should receive false for an exempt request.' );
+		} finally {
+			remove_filter( 'woocommerce_prevent_admin_access', $callback );
+		}
+	}
+
+	/**
+	 * Invokes prevent_admin_access() with a synthetic request and returns its redirect location.
+	 *
+	 * @param int                 $user_id         Current user ID.
+	 * @param string|null         $script_filename Script filename, if present.
+	 * @param array<string,mixed> $get             Request query parameters.
+	 * @return string|null Redirect location, or null when no redirect occurred.
+	 */
+	private function invoke_prevent_admin_access( int $user_id, ?string $script_filename, array $get = array() ): ?string {
+		wp_set_current_user( $user_id );
+		$_GET = $get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( null === $script_filename ) {
+			unset( $_SERVER['SCRIPT_FILENAME'] );
+		} else {
+			$_SERVER['SCRIPT_FILENAME'] = $script_filename;
+		}
+
+		try {
+			$this->sut->prevent_admin_access();
+		} catch ( RuntimeException $e ) {
+			return $e->getMessage();
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The two specs in `tests/e2e/tests/basic` ran 27 browser titles over the WooCommerce admin's entry surface. Twenty-four of them opened one admin destination each, in a test of its own, with its own page load. The other three checked that a customer is redirected away from the WP Dashboard.

The twenty-four destinations become four titles, one per top-level menu, each walking its own submenu as named steps. Nothing is demoted there: every click, heading, sentinel and sentinel text is kept, and every destination gains an assertion it did not have, that the submenu link is visible before it is clicked.

Which requests a customer is redirected away from is decided in PHP, so `class-wc-admin-test.php` goes from one test to seven, and the spec keeps two browser titles for the redirect itself. `page-loads.spec.ts` goes from 24 titles to 4, `dashboard-access.spec.ts` from 3 to 2.

Refs TESTOPS-288

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `can load WooCommerce > Home`, `> Orders`, `> Customers`, `> Reports`, `> Settings`, `> Status` | the retained `can load WooCommerce pages`, which walks the same six destinations as named steps, with the same click, heading, sentinel and sentinel-text assertions, plus a new visibility assertion on each submenu link | six independent tests. A step that fails ends its journey, so one broken destination now hides the later ones in the same menu |
| `can load Products > All Products`, `> Add new product`, `> Categories`, `> Tags`, `> Attributes` | the retained `can load Products pages`, the same way | five independent tests, and the same masking |
| `can load Analytics > Overview`, `> Products`, `> Revenue`, `> Orders`, `> Variations`, `> Categories`, `> Coupons`, `> Taxes`, `> Downloads`, `> Stock`, `> Settings` | the retained `can load Analytics pages`, the same way | eleven independent tests. This is where the masking costs most: a failure at Overview hides ten destinations |
| `can load Marketing > Overview`, `> Coupons` | the retained `can load Marketing pages`, the same way | two independent tests |
| `Customer is redirected from WP Admin profile page back to the My Account page.` | `class-wc-admin-test.php` › `test_prevent_admin_access_redirects_customer_from_non_exempt_script`, data set `customer wp-admin profile script`, which requires the redirect target to equal the permalink of a My Account page the test creates, where the browser title only checked the URL contained `/my-account/` | the browser no longer loads a real `wp-admin/profile.php` request as a customer. The PHP owner calls the method directly and intercepts the redirect, so it proves the policy but not the wiring; the two retained titles keep that, through `wp-admin` and through `wp-admin?wc-ajax=1` |

Three more things the consolidation costs, stated plainly:

- **A fresh landing before every destination.** The removed titles each loaded the top-level page before clicking. A journey navigates once per menu and then clicks the next submenu from wherever the last destination left the browser. A destination that only works when reached from a freshly loaded page is no longer proven.
- **Retry granularity.** On CI the root config retries once. A retry now re-runs a journey of up to eleven destinations instead of one.
- **Order is part of the contract.** Each destination now runs after the ones before it in the same menu, so a change to that order changes what a failure means.
- **`--grep` no longer selects one destination.** Step names are not matched by `--grep`, so the smallest thing anyone can run is a whole menu's journey.
- **A shared container weakens one assertion.** The eleven Analytics destinations render inside the same `#woocommerce-layout__primary` element, which stays mounted between steps, so its visibility no longer proves that the new destination rendered. The heading assertion in each step is what carries that.

Two things get stronger in exchange: every submenu link is asserted visible before the click, so a route that stops registering fails on the link rather than timing out inside a click; and the cleanup now attempts both deletions and reports them together instead of throwing on the first and leaking a product.

#### Relocated to PHPUnit

`tests/php/includes/admin/class-wc-admin-test.php` goes from one test to seven. Beyond the redirect the browser title covered, the new ones cover what nothing covered before:

- The class now creates a real My Account page in `setUp` and restores the site's own setting afterwards, and the redirect assertions compare against that page's permalink rather than against `wc_get_page_permalink( 'myaccount' )`. Without both, the expected value came from the same helper the code under test uses, and in the PHPUnit environment it was the site root, so the assertion could not tell My Account from home.
- `test_prevent_admin_access_redirects_customer_from_non_exempt_script`, over three requests: `wp-admin/index.php`, `wp-admin/profile.php`, and `index.php` with `wc-ajax=1` in the query. The third is the case the browser could only approximate: a `wc-ajax` query parameter does not make a request exempt, because the exemption is keyed on the script name.
- `test_prevent_admin_access_does_not_redirect_customer_from_exempt_or_incomplete_request`, over `admin-post.php`, `admin-ajax.php`, and a request with no script name at all.
- `test_prevent_admin_access_does_not_redirect_user_with_admin_access_capability`, one data set per capability in the allow list.
- Three tests for the two public filters, `woocommerce_disable_admin_bar` and `woocommerce_prevent_admin_access`: that each is called, what value it receives, and that returning the opposite changes the outcome. Both are documented `@since 3.6.0` hooks, and nothing proved either was still called.

#### The retained wiring tests

Six browser titles stay, all in the `core-parallel` project:

- `can load WooCommerce pages`, `can load Products pages`, `can load Analytics pages` and `can load Marketing pages`, each walking one top-level menu's destinations as named steps.
- `Customer is redirected from WP Admin home back to the My Account page.` and `Customer is redirected from WP Admin using ajax query param back to the My Account page.`, which keep the proof that the policy is still wired to a real admin request and that the browser follows the redirect.

The TESTOPS-234 audit lists only Blocks specs, so it takes no position on either of these files.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test`, then run the PHP class and confirm it passes: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'WC_Admin_Test::'`
3. Confirm the PHP tests guard the policy. In `plugins/woocommerce/includes/admin/class-wc-admin.php`, in `prevent_admin_access`, replace `apply_filters( 'woocommerce_disable_admin_bar', true )` with `true`. Re-run the command from step 2 and confirm `test_prevent_admin_access_disable_admin_bar_filter_can_suppress_customer_redirect` fails. Revert the change.
4. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build`, then start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
5. Run both specs with retries disabled and confirm 4 and 2 titles pass: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/basic/page-loads.spec.ts tests/e2e/tests/basic/dashboard-access.spec.ts`. Playwright runs the site setup, authentication and install projects first.
6. Confirm a journey catches a missing destination. In `plugins/woocommerce/includes/admin/class-wc-admin-menus.php`, in `status_menu`, replace the `add_submenu_page` callback `array( $this, 'status_page' )` with `'__return_empty_string'`. Re-run the command from step 5 and confirm `can load WooCommerce pages` fails at its `Status` step. Revert the change.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled.

- **Focused commands.** The mutation matrix records 10 distinct focused commands for these files, 6 PHPUnit and 4 Playwright, and all 10 exit 0.
- **Retained titles.** `--list` shows 4 and 2 titles, and both specs pass with `--retries=0 --workers=1`.
- **Whole class.** This PR's step 2 command runs the PHP class and passes with `OK (13 tests, 19 assertions)`.
- **Mutation re-check.** For each of the 23 behavior families, a script applied one hand-written mutation from the matrix, ran only that family's test, and restored the code. Every mutation fails its test at the intended step, and the test passes again once the code is restored. No mutation needs a build: twenty edit PHP, which the site reads on the next request, and three edit the observer itself.
- **One re-run, disclosed.** The `0748` cycle's restore run failed the first time. Its output was overwritten by the re-run, so all that survives is the non-zero exit the run recorded. The whole spec passes on the restored tree, and the cycle was then run again end to end: red at the Overview step, clean restore, green.

| Mutation | Change | What fails |
| --- | --- | --- |
| `0137` | the disable-admin-bar filter is bypassed | `test_prevent_admin_access_disable_admin_bar_filter_can_suppress_customer_redirect`: the redirect happens even though the filter returned false |
| `0737` | the Home submenu is registered at a route that does not exist | `can load WooCommerce pages` at its `Home` step: the submenu link is never visible |
| `0738`, `0740`, `0741`, `0742` | the Orders, Reports, Settings and Status submenu callbacks are replaced by an empty page | the same title, each at its own step |
| `0739` | the Customers report points at the overview instead | the same title at its `Customers` step |
| `0743`, `0745` | a controlled `href` override sends the All Products and Categories submenu links to a different admin page | `can load Products pages` at those steps. These two stand in for the submenu `href` WordPress core generates, which WooCommerce does not own |
| `0747` | the Attributes submenu callback is replaced by an empty page | the same title at its `Attributes` step |
| `0748` | the Analytics overview submenu points at the Products report instead | `can load Analytics pages` at its `Overview` step |
| `0749`–`0751`, `0753`–`0758` | each remaining Analytics report is registered at a route that does not exist, one mutation per report | the same title, each at its own step |
| `0752` | the Variations report is registered at a route that does not exist | the same title at its `Variations` step, where the submenu entry never becomes clickable |
| `0759` | the Marketing overview is registered at the Analytics products route instead | `can load Marketing pages` at its `Overview` step |
| `0760` | a controlled `href` override sends the Coupons submenu link to a different admin page | the same title at its `Coupons` step |

- **Lint.**
    - PHPCS finds nothing on the changed PHP lines, and Prettier is clean.
    - ESLint reports nothing on lines this PR changes.
    - oxlint finds nothing new, and `lint:changes:branch` exits 0.
    - PHPStan doesn't analyse `tests/` in this repository's config, so it isn't a gate for the PHP test; the raw run is kept as a record.
- **Deleted files.** None, so no dangling-reference sweep was needed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-admin-smoke`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

