### PR TITLE
[tests] Move command palette registration below E2E

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-command-palette
+++ b/plugins/woocommerce/changelog/testops-288-command-palette
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move command palette command registration below E2E: Jest owns each command's name, label, icon, tracking event and target URL, and the spec keeps two browser titles.
+

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/command-palette-analytics/__tests__/index.test.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/command-palette-analytics/__tests__/index.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { queueRecordEvent } from '@woocommerce/tracks';
+// eslint-disable-next-line import/no-unresolved -- Provided by WordPress in the wp-admin runtime.
+import { store as commandsStore } from '@wordpress/commands';
+import { dispatch } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+import { chartBar } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+
+jest.mock( '@woocommerce/tracks', () => ( { queueRecordEvent: jest.fn() } ) );
+jest.mock( '@wordpress/commands', () => ( { store: 'commands-store' } ) );
+jest.mock( '@wordpress/data', () => ( { dispatch: jest.fn() } ) );
+jest.mock( '@wordpress/dom-ready', () => jest.fn() );
+jest.mock( '@wordpress/icons', () => ( { chartBar: 'chart-bar-icon' } ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) => value,
+	sprintf: ( format, value ) => format.replace( '%s', value ),
+} ) );
+jest.mock( '@wordpress/url', () => ( {
+	addQueryArgs: jest.fn(
+		( base, args ) => `#${ base }-${ JSON.stringify( args ) }`
+	),
+} ) );
+
+const registerWithReports = ( analytics ) => {
+	const commands = [];
+	dispatch.mockReturnValue( {
+		registerCommand: ( command ) => commands.push( command ),
+	} );
+	if ( analytics === undefined ) {
+		delete window.wcCommandPaletteAnalytics;
+	} else {
+		window.wcCommandPaletteAnalytics = analytics;
+	}
+	jest.isolateModules( () => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- Load after each injected report state is installed.
+		require( '../index' );
+	} );
+	domReady.mock.calls[ 0 ][ 0 ]();
+	return commands;
+};
+
+describe( 'Analytics Command Palette', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it.each( [
+		{ caseName: 'missing global', analytics: undefined },
+		{ caseName: 'missing reports', analytics: {} },
+		{ caseName: 'non-array reports', analytics: { reports: {} } },
+		{ caseName: 'empty reports', analytics: { reports: [] } },
+	] )(
+		'does not register commands for an invalid injected report state: $caseName',
+		( { analytics } ) => {
+			expect( registerWithReports( analytics ) ).toEqual( [] );
+			expect( dispatch ).not.toHaveBeenCalled();
+		}
+	);
+
+	it( 'registers injected Analytics reports with exact destinations and tracking', () => {
+		const commands = registerWithReports( {
+			reports: [
+				{ title: 'Revenue', path: '/analytics/revenue' },
+				{ title: 'Orders', path: '/analytics/orders' },
+			],
+		} );
+
+		expect( dispatch ).toHaveBeenCalledWith( commandsStore );
+		expect(
+			commands.map( ( command ) => ( {
+				name: command.name,
+				label: command.label,
+				icon: command.icon,
+			} ) )
+		).toEqual( [
+			{
+				name: 'woocommerce/analytics/revenue',
+				label: 'WooCommerce Analytics: Revenue',
+				icon: chartBar,
+			},
+			{
+				name: 'woocommerce/analytics/orders',
+				label: 'WooCommerce Analytics: Orders',
+				icon: chartBar,
+			},
+		] );
+
+		commands.forEach( ( command, index ) => {
+			command.callback();
+			expect( decodeURIComponent( window.location.hash ) ).toBe(
+				addQueryArgs.mock.results[ index ].value
+			);
+		} );
+		expect( addQueryArgs.mock.calls ).toEqual( [
+			[ 'admin.php', { page: 'wc-admin', path: '/analytics/revenue' } ],
+			[ 'admin.php', { page: 'wc-admin', path: '/analytics/orders' } ],
+		] );
+		expect( queueRecordEvent.mock.calls ).toEqual(
+			commands.map( ( command ) => [
+				'woocommerce_command_palette_submit',
+				{ name: command.name, origin: undefined },
+			] )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/command-palette/__tests__/index.test.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/command-palette/__tests__/index.test.js
@@ -1,0 +1,262 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+import { queueRecordEvent, recordEvent } from '@woocommerce/tracks';
+// eslint-disable-next-line import/no-unresolved -- Provided by WordPress in the wp-admin runtime.
+import { store as commandsStore } from '@wordpress/commands';
+import { dispatch, useSelect } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+import { box, plus } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { registerCommandWithTracking } from '../register-command-with-tracking';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	queueRecordEvent: jest.fn(),
+	recordEvent: jest.fn(),
+} ) );
+jest.mock( '@wordpress/commands', () => ( { store: 'commands-store' } ) );
+jest.mock( '@wordpress/core-data', () => ( { store: 'core-store' } ) );
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+jest.mock( '@wordpress/dom-ready', () => jest.fn() );
+jest.mock( '@wordpress/html-entities', () => ( {
+	decodeEntities: ( value ) => value.replace( '&amp;', '&' ),
+} ) );
+jest.mock( '@wordpress/i18n', () => ( { __: ( value ) => value } ) );
+jest.mock( '@wordpress/icons', () => ( {
+	box: 'box-icon',
+	plus: 'plus-icon',
+} ) );
+jest.mock( '@wordpress/url', () => ( {
+	addQueryArgs: jest.fn(
+		( base, args ) => `#${ base }-${ JSON.stringify( args ) }`
+	),
+} ) );
+
+describe( 'registerCommandWithTracking', () => {
+	it( 'forwards callback arguments exactly once', () => {
+		jest.clearAllMocks();
+		const registerCommand = jest.fn();
+		dispatch.mockReturnValue( { registerCommand } );
+		const callback = jest.fn();
+		const firstArgument = { sentinel: 'first' };
+		const secondArgument = { sentinel: 'second' };
+
+		registerCommandWithTracking( {
+			name: 'woocommerce/test-command',
+			label: 'Test command',
+			icon: 'test-icon',
+			callback,
+		} );
+
+		const registeredCallback =
+			registerCommand.mock.calls[ 0 ][ 0 ].callback;
+		registeredCallback( firstArgument, secondArgument );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+		expect( callback ).toHaveBeenCalledWith(
+			firstArgument,
+			secondArgument
+		);
+	} );
+} );
+
+describe( 'Command Palette', () => {
+	let registeredCommands;
+	let registeredLoader;
+	let startEntry;
+
+	const runEntry = () => {
+		const commandDispatcher = {
+			registerCommand: ( command ) => registeredCommands.push( command ),
+			registerCommandLoader: ( loader ) => {
+				registeredLoader = loader;
+			},
+		};
+		dispatch.mockReturnValue( commandDispatcher );
+		startEntry();
+	};
+
+	beforeAll( () => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- Load only after the entry-point mocks are installed.
+		require( '../index' );
+		startEntry = domReady.mock.calls[ 0 ][ 0 ];
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		registeredCommands = [];
+		registeredLoader = undefined;
+		runEntry();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'registers static commands and product loader with exact behavior', () => {
+		expect( dispatch ).toHaveBeenLastCalledWith( commandsStore );
+		expect(
+			registeredCommands.map( ( command ) => ( {
+				name: command.name,
+				label: command.label,
+				icon: command.icon,
+			} ) )
+		).toEqual( [
+			{
+				name: 'woocommerce/add-new-product',
+				label: 'Add new product',
+				icon: plus,
+			},
+			{
+				name: 'woocommerce/add-new-order',
+				label: 'Add new order',
+				icon: plus,
+			},
+			{
+				name: 'woocommerce/view-products',
+				label: 'Products',
+				icon: box,
+			},
+			{
+				name: 'woocommerce/view-orders',
+				label: 'Orders',
+				icon: box,
+			},
+		] );
+		expect( registeredLoader.name ).toBe( 'woocommerce/product' );
+
+		const destinations = [
+			[ 'post-new.php', { post_type: 'product' } ],
+			[ 'admin.php', { page: 'wc-orders', action: 'new' } ],
+			[ 'edit.php', { post_type: 'product' } ],
+			[ 'admin.php', { page: 'wc-orders' } ],
+		];
+		registeredCommands.forEach( ( command, index ) => {
+			command.callback();
+			expect( decodeURIComponent( window.location.hash ) ).toBe(
+				addQueryArgs.mock.results[ index ].value
+			);
+		} );
+
+		expect( addQueryArgs.mock.calls ).toEqual( destinations );
+		expect( queueRecordEvent.mock.calls ).toEqual(
+			registeredCommands.map( ( command ) => [
+				'woocommerce_command_palette_submit',
+				{ name: command.name, origin: undefined },
+			] )
+		);
+	} );
+
+	it( 'loads products, tracks searches, and navigates through product commands', () => {
+		jest.useFakeTimers();
+		const state = { records: undefined, isLoading: true };
+		const getEntityRecords = jest.fn( () => state.records );
+		const hasFinishedResolution = jest.fn( () => ! state.isLoading );
+		useSelect.mockImplementation( ( callback ) =>
+			callback( () => ( { getEntityRecords, hasFinishedResolution } ) )
+		);
+
+		const { result, rerender, unmount } = renderHook(
+			( { search } ) => registeredLoader.hook( { search } ),
+			{ initialProps: { search: '' } }
+		);
+
+		expect( getEntityRecords ).toHaveBeenLastCalledWith(
+			'postType',
+			'product',
+			{
+				search: undefined,
+				per_page: 10,
+				orderby: 'date',
+				status: [ 'publish', 'future', 'draft', 'pending', 'private' ],
+			}
+		);
+		expect( result.current ).toEqual( { commands: [], isLoading: true } );
+
+		state.records = [
+			{ id: 12, title: { rendered: 'Bread &amp; Butter' } },
+			{ id: 13, title: {} },
+		];
+		state.isLoading = false;
+		rerender( { search: 'bread' } );
+
+		expect( getEntityRecords ).toHaveBeenLastCalledWith(
+			'postType',
+			'product',
+			{
+				search: 'bread',
+				per_page: 10,
+				orderby: 'relevance',
+				status: [ 'publish', 'future', 'draft', 'pending', 'private' ],
+			}
+		);
+		expect( result.current ).toMatchObject( {
+			isLoading: false,
+			commands: [
+				{
+					name: 'product-12',
+					searchLabel: 'Bread &amp; Butter 12',
+					label: 'Bread & Butter',
+					icon: box,
+				},
+				{
+					name: 'product-13',
+					searchLabel: 'undefined 13',
+					label: '(no title)',
+					icon: box,
+				},
+			],
+		} );
+
+		const close = jest.fn();
+		result.current.commands[ 0 ].callback( { close } );
+		expect( addQueryArgs ).toHaveBeenLastCalledWith( 'post.php', {
+			post: 12,
+			action: 'edit',
+		} );
+		expect( decodeURIComponent( window.location.hash ) ).toBe(
+			addQueryArgs.mock.results.at( -1 ).value
+		);
+		expect( close ).toHaveBeenCalledTimes( 1 );
+		expect( queueRecordEvent ).toHaveBeenLastCalledWith(
+			'woocommerce_command_palette_submit',
+			{ name: 'woocommerce/product' }
+		);
+
+		jest.advanceTimersByTime( 300 );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'woocommerce_command_palette_search',
+			{ value: 'bread' }
+		);
+
+		rerender( { search: 'butter' } );
+		expect( jest.getTimerCount() ).toBe( 1 );
+		unmount();
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+
+	it( 'does not track a product search after unmount', () => {
+		jest.useFakeTimers();
+		const getEntityRecords = jest.fn( () => [] );
+		const hasFinishedResolution = jest.fn( () => true );
+		useSelect.mockImplementation( ( callback ) =>
+			callback( () => ( { getEntityRecords, hasFinishedResolution } ) )
+		);
+
+		const { unmount } = renderHook( () =>
+			registeredLoader.hook( { search: 'bread' } )
+		);
+
+		unmount();
+		jest.advanceTimersByTime( 300 );
+		expect( recordEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e/tests/editor/command-palette.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/editor/command-palette.spec.ts
@@ -117,42 +117,6 @@ test( 'can use the "Add new product" command', async ( { page } ) => {
 	).toBeVisible();
 } );
 
-test( 'can use the "Add new order" command', async ( { page } ) => {
-	await clickOnCommandPaletteOption( {
-		page,
-		optionName: 'Add new order',
-	} );
-
-	// Verify that the page has loaded.
-	await expect(
-		page.getByRole( 'heading', { name: 'Add new order' } )
-	).toBeVisible();
-} );
-
-test( 'can use the "Products" command', async ( { page } ) => {
-	await clickOnCommandPaletteOption( {
-		page,
-		optionName: 'Products',
-	} );
-
-	// Verify that the page has loaded.
-	await expect(
-		page.locator( 'h1' ).filter( { hasText: 'Products' } ).first()
-	).toBeVisible();
-} );
-
-test( 'can use the "Orders" command', async ( { page } ) => {
-	await clickOnCommandPaletteOption( {
-		page,
-		optionName: 'Orders',
-	} );
-
-	// Verify that the page has loaded.
-	await expect(
-		page.locator( 'h1' ).filter( { hasText: 'Orders' } ).first()
-	).toBeVisible();
-} );
-
 test( 'can use the product search command', async ( { page, product } ) => {
 	await clickOnCommandPaletteOption( {
 		page,
@@ -163,18 +127,4 @@ test( 'can use the product search command', async ( { page, product } ) => {
 	await expect( page.getByLabel( 'Product name' ) ).toHaveValue(
 		`${ product.name }`
 	);
-} );
-
-test( 'can use an analytics command', async ( { page } ) => {
-	await clickOnCommandPaletteOption( {
-		page,
-		optionName: 'WooCommerce Analytics: Products',
-	} );
-
-	// Verify that the page has loaded.
-	await expect(
-		page.locator( 'h1' ).filter( { hasText: 'Products' } )
-	).toBeVisible();
-	const pageTitle = await page.title();
-	expect( pageTitle.includes( 'Products ‹ Analytics' ) ).toBeTruthy();
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The command palette spec ran six browser titles. Four of them opened the palette, typed a command name, clicked the option, and checked the heading of the page it landed on. What each command registers — its name, its label, its icon, the tracking event it fires and the URL its callback navigates to — is decided in the admin bundle's own JavaScript.

This PR adds two Jest suites for that, one PHPUnit case for the PHP side of the analytics commands, and keeps two browser titles. The spec goes from 6 tests to 2. `command-palette/__tests__/index.test.js` is new with 4 tests, and `command-palette-analytics/__tests__/index.test.js` is new with 5.

Refs TESTOPS-288

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `can use the "Add new order" command` | `command-palette/__tests__/index.test.js` › `Command Palette registers static commands and product loader with exact behavior`, which requires the second registration's exact name, label and icon, the exact arguments its callback passes to `addQueryArgs` (`admin.php`, `page=wc-orders`, `action=new`), and the tracking event it fires | the installed path. Jest stubs the command dispatcher and the URL builder, and reads the navigation off the jsdom location, so it proves the arguments, never the destination: that the built bundle is enqueued on a wp-admin screen, that the option is findable by typing into the real palette, and that the URL resolves to a page whose heading reads `Add new order` |
| `can use the "Products" command` | the same test, for the third registration and `edit.php?post_type=product` | the same, for that destination and its heading |
| `can use the "Orders" command` | the same test, for the fourth registration and `admin.php?page=wc-orders` | the same. Also dropped: this was the only title proving the `Orders` option does not lose to `Add new order` in the real palette's fuzzy search |
| `can use an analytics command` | `command-palette-analytics/__tests__/index.test.js` › `Analytics Command Palette registers injected Analytics reports with exact destinations and tracking` for the names, labels, icons, destinations and tracking, and its four `does not register commands for an invalid injected report state` cases: missing global, missing reports, non-array reports, empty reports; and `WC_Admin_Assets_Test` › `Should localize the Analytics reports from Analytics::get_report_pages() for the command palette` for the handoff from PHP: that `enqueue_command_palette_assets()` enqueues the analytics bundle and localizes `wcCommandPaletteAnalytics` from `Analytics::get_report_pages()` as an array, with titles stripped of HTML; and the retained `can use the "Add new product" command` title, which requires `WooCommerce Analytics: Products` to be listed in the real palette | selecting an analytics command and landing on its report, where the page title reads `Products ‹ Analytics` |

At base each static command had its own page load, so one broken destination reported on its own. The two survivors now carry the shared installed path for the four static commands, which share one enqueue with the loader. The analytics commands are a second bundle with its own enqueue. Both retained titles visit wp-admin, where that bundle is enqueued too. The `Add new product` title also requires `WooCommerce Analytics: Products` in the real palette, but neither title selects an analytics command. The four removed titles also exercised the palette's fuzzy matching against the WordPress and Gutenberg commands registered on the same screen, which no Jest test can see, because the dispatcher is a stub.

#### Relocated to Jest

- `client/admin/client/wp-admin-scripts/command-palette/__tests__/index.test.js` is new. It has four tests. One registers the real module against a stubbed dispatcher and asserts the four static commands as one ordered list — name, label and icon each — then the exact `addQueryArgs` arguments each callback passes and the tracking event it fires. One asserts that the tracking wrapper forwards its callback's arguments exactly once. One drives the product loader: the debounced search telemetry, the records it maps into commands including the `(no title)` fallback, and the URL a selection navigates to, observed as the location the jsdom window ends on. One asserts that a pending search is not tracked after the component unmounts.
- `client/admin/client/wp-admin-scripts/command-palette-analytics/__tests__/index.test.js` is new. It asserts one command per injected report, with the `WooCommerce Analytics: %s` label, the icon, the destination and the tracking event, and four guard cases for an invalid injected state: no global at all, a global with no reports, reports that are not an array, and an empty array. Entry-level validation happens in PHP before the data is localized; the PHPUnit case below covers title sanitization, but not the dropping of invalid entries.

#### Added to PHPUnit

- `tests/php/includes/admin/class-wc-admin-assets-test.php` gains `Should localize the Analytics reports from Analytics::get_report_pages() for the command palette`. It feeds `Analytics::get_report_pages()` two reports through its `woocommerce_analytics_report_menu_items` filter, runs `enqueue_command_palette_assets()`, and decodes `wcCommandPaletteAnalytics`: the analytics bundle is enqueued, `reports` is an array, titles lose their HTML, and paths pass through unchanged. The CI PHPUnit jobs do not build the admin bundles, so the test writes a stub asset registry when a bundle is missing and removes it in teardown.

#### The retained wiring tests

Two browser titles stay, both in the `core-parallel` project:

- `can use the "Add new product" command` opens the palette with the platform modifier. It first searches `WooCommerce Analytics: Products` and requires that option, which proves the separate analytics bundle loaded and registered its PHP-fed reports. Then it types `Add new product`, clicks the option, and requires the `Add new product` heading. It is the proof that a registered command still reaches its destination through the real palette on a real admin screen.
- `can use the product search command` creates a product over the REST API, searches its name in the palette, clicks the result, and requires the product editor to hold that name. It is the proof of the loader's asynchronous path end to end.

The first version of this PR named one residual risk: the analytics commands are the only removed ones whose data comes from PHP, and nothing tested that handoff at any layer. The PHPUnit case above now covers it. Writing it surfaced a separate bug: with stock management off, `reports` reaches JavaScript as an object and no analytics command registers. The fix ships separately in #68753.

The TESTOPS-234 audit lists only Blocks specs, so it takes no position on this file.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the two new Jest suites and confirm all 9 tests pass: `pnpm --dir plugins/woocommerce/client/admin exec jest --config client/jest.config.js --runInBand --runTestsByPath client/wp-admin-scripts/command-palette/__tests__/index.test.js client/wp-admin-scripts/command-palette-analytics/__tests__/index.test.js`
3. Confirm the suite guards a command's destination. In `plugins/woocommerce/client/admin/client/wp-admin-scripts/command-palette/index.js`, in the `woocommerce/view-products` callback, change `addQueryArgs( 'edit.php', {` to `addQueryArgs( 'post.php', {`. Re-run the command from step 2 and confirm the static-commands test fails. Revert the change.
4. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
5. Run the admin assets tests and confirm all 9 pass: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Admin_Assets_Test`.
6. Confirm the PHPUnit case guards the handoff. In `plugins/woocommerce/includes/admin/class-wc-admin-assets.php`, in `enqueue_command_palette_assets()`, change `'wcCommandPaletteAnalytics',` to `'wcCommandPaletteAnalyticsX',`. Re-run the command from step 5 and confirm `Should localize the Analytics reports from Analytics::get_report_pages() for the command palette` fails with `wc-admin-command-palette-analytics should localize wcCommandPaletteAnalytics`. Revert the change.
7. Build the plugin with `pnpm --filter=@woocommerce/plugin-woocommerce build`. The palette is a webpack entry, so the browser step below loads the built file rather than the source.
8. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
9. Run the spec with retries disabled and confirm both titles pass: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/editor/command-palette.spec.ts`. Playwright runs the site setup and authentication projects first.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled.

- **Focused commands.** The mutation matrix records 9 distinct focused commands for these files, all Jest, and all 9 exit 0.
- **Retained titles.** `--list` shows the two titles, and the spec passes with `--retries=0 --workers=1`. With the built `command-palette-analytics.js` hidden, `can use the "Add new product" command` fails at the `WooCommerce Analytics: Products` option, and the product search title still passes.
- **Whole files.** This PR's step 2 command runs both suites and passes with 9 tests.
- **PHPUnit handoff case.** `WC_Admin_Assets_Test` passes with 9 tests. Six source mutations of `enqueue_command_palette_assets()` each fail the new case at their own assertion: the global renamed, `wp_strip_all_tags` removed, the path swapped for the title, `get_report_pages()` replaced by a literal, `reports` cast to an object, and the analytics bundle registered but not enqueued. With `assets/client/admin` hidden, as in the CI PHPUnit jobs, the class still passes and leaves no stub file behind.
- **Mutation re-check.** For each of the 38 behavior families, a script applied one hand-written mutation from the matrix, ran only that family's test, and restored the code. Every mutation fails its test at the intended assertion, and the test passes again once the code is restored. No mutation needs a build: every one of them is observed by a Jest suite that runs from source.

The 38 families are the two registration entry points, the tracking wrapper, and one family per behavior of the product loader and of each static command. Rather than list all 38, here is one per group:

| Mutation | Change | What fails |
| --- | --- | --- |
| `1181` | the analytics module registers only the first report | `Analytics Command Palette registers injected Analytics reports with exact destinations and tracking`: the command list is short |
| `1187` | the analytics commands lose their icon | the same test, at the icon assertion |
| `1180` | the tracking wrapper dispatches to a store that does not exist | the same test: the assertion on which store received the registration sees the wrong name |
| `1205` | the tracking wrapper stops forwarding to the wrapped callback | `registerCommandWithTracking › forwards callback arguments exactly once`: the wrapped callback is never called |
| `1221` | the loader's effect cleanup stops cancelling the pending search timer | `Command Palette › does not track a product search after unmount`: the pending search event fires after unmount |
| `1197` | the view-products command registers under a different name | the static-commands test, at the ordered name list |
| `0313` | the view-orders callback points at the WooCommerce admin root instead | the same test, at that callback's `addQueryArgs` arguments |
| `1211` | the loader names its commands with a slash instead of a hyphen | the loader's mapping test |
| `0315` | a product command asks the post editor for the new-post action instead of edit | `Command Palette › loads products, tracks searches, and navigates through product commands`, at the callback's arguments |

- **Lint.**
    - Prettier is clean, and ESLint reports nothing on lines this PR changes.
    - oxlint finds nothing new, and `lint:changes:branch` exits 0. Its two warnings are `react-hooks/rules-of-hooks` on the spec's own fixture parameters, both lines carried unchanged from trunk.
    - phpcs is clean on the changed PHPUnit file, and PHPStan does not analyse tests.
- **Deleted files.** None, so no dangling-reference sweep was needed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-command-palette`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



