### PR TITLE
Fix rejected coupons blocking Place Order in the Checkout block

### DIFF
--- a/plugins/woocommerce/changelog/fix-42074-coupon-error-blocks-checkout
+++ b/plugins/woocommerce/changelog/fix-42074-coupon-error-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep a rejected coupon from blocking Place Order in the Checkout block.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -3,18 +3,17 @@
  */
 import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
-import { useState, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import Button from '@woocommerce/base-components/button';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import {
-	ValidatedTextInput,
+	TextInput,
 	ValidationInputError,
-	ValidatedTextInputHandle,
 	Panel,
 	Spinner,
 } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { validationStore } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import type { MouseEvent, MouseEventHandler } from 'react';
 
 /**
@@ -36,7 +35,8 @@ export interface TotalsCouponProps {
 	 */
 	displayCouponForm?: boolean;
 	/**
-	 * Submit handler
+	 * Submit handler. Resolves true when the coupon was applied. Rejects with
+	 * an Error whose message is shown under the input when it was not.
 	 */
 	onSubmit?: ( couponValue: string ) => Promise< boolean > | undefined;
 }
@@ -48,37 +48,55 @@ export const TotalsCoupon = ( {
 	displayCouponForm = false,
 }: TotalsCouponProps ): JSX.Element => {
 	const [ couponValue, setCouponValue ] = useState( '' );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const [ isCouponFormVisible, setIsCouponFormVisible ] =
 		useState( displayCouponForm );
 	const textInputId = `wc-block-components-totals-coupon__input-${ instanceId }`;
-	const { validationErrorId } = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return {
-				validationErrorId: store.getValidationErrorId( instanceId ),
-			};
-		},
-		[ instanceId ]
+	const errorId = `wc-block-components-totals-coupon__error-${ instanceId }`;
+	const inputRef = useRef< HTMLInputElement >( null );
+	const isCheckoutIdle = useSelect(
+		( select ) => select( checkoutStore ).isIdle(),
+		[]
 	);
-	const inputRef = useRef< ValidatedTextInputHandle >( null );
+	const hasError = errorMessage !== '';
+
+	useEffect( () => {
+		if ( isCouponFormVisible ) {
+			inputRef.current?.focus();
+		}
+	}, [ isCouponFormVisible ] );
+
+	// The message only concerns this form. Drop it once the shopper places the
+	// order so a later checkout error does not read as a coupon problem.
+	useEffect( () => {
+		if ( ! isCheckoutIdle ) {
+			setErrorMessage( '' );
+		}
+	}, [ isCheckoutIdle ] );
 
 	const handleCouponSubmit: MouseEventHandler< HTMLButtonElement > = (
 		e: MouseEvent< HTMLButtonElement >
 	) => {
 		e.preventDefault();
-		if ( typeof onSubmit !== 'undefined' ) {
-			void onSubmit( couponValue )?.then( ( result ) => {
+		if ( typeof onSubmit === 'undefined' ) {
+			setCouponValue( '' );
+			setIsCouponFormVisible( true );
+			return;
+		}
+		setErrorMessage( '' );
+		void onSubmit( couponValue )
+			?.then( ( result ) => {
 				if ( result ) {
 					setCouponValue( '' );
 					setIsCouponFormVisible( false );
-				} else if ( inputRef.current?.focus ) {
-					inputRef.current.focus();
+				} else {
+					inputRef.current?.focus();
 				}
+			} )
+			.catch( ( error: Error ) => {
+				setErrorMessage( error.message );
+				inputRef.current?.focus();
 			} );
-		} else {
-			setCouponValue( '' );
-			setIsCouponFormVisible( true );
-		}
 	};
 
 	return (
@@ -100,19 +118,21 @@ export const TotalsCoupon = ( {
 						className="wc-block-components-totals-coupon__form"
 						id="wc-block-components-totals-coupon__form"
 					>
-						<ValidatedTextInput
+						<TextInput
 							id={ textInputId }
-							errorId="coupon"
-							className="wc-block-components-totals-coupon__input"
+							className={ clsx(
+								'wc-block-components-totals-coupon__input',
+								{ 'has-error': hasError }
+							) }
 							label={ __( 'Enter code', 'woocommerce' ) }
 							value={ couponValue }
-							ariaDescribedBy={ validationErrorId || '' }
+							ariaDescribedBy={ hasError ? errorId : undefined }
+							aria-invalid={ hasError }
+							aria-errormessage={ hasError ? errorId : undefined }
 							onChange={ ( newCouponValue ) => {
+								setErrorMessage( '' );
 								setCouponValue( newCouponValue );
 							} }
-							focusOnMount={ true }
-							validateOnMount={ false }
-							showError={ false }
 							ref={ inputRef }
 						/>
 						<Button
@@ -131,10 +151,12 @@ export const TotalsCoupon = ( {
 							{ __( 'Apply', 'woocommerce' ) }
 						</Button>
 					</form>
-					<ValidationInputError
-						propertyName="coupon"
-						elementId={ instanceId }
-					/>
+					{ hasError && (
+						<ValidationInputError
+							errorMessage={ errorMessage }
+							id={ errorId }
+						/>
+					) }
 				</div>
 			</LoadingMask>
 		</Panel>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/stories/index.stories.tsx
@@ -4,8 +4,6 @@
 import { useArgs } from 'storybook/preview-api';
 import type { StoryFn, Meta } from '@storybook/react-webpack5';
 import { INTERACTION_TIMEOUT } from '@woocommerce/storybook-controls';
-import { useDispatch } from '@wordpress/data';
-import { validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -20,18 +18,13 @@ export default {
 	},
 } as Meta< TotalsCouponProps >;
 
-const INVALID_COUPON_ERROR = {
-	hidden: false,
-	message: 'Invalid coupon code',
-};
-
 const Template: StoryFn< TotalsCouponProps > = ( args ) => {
 	const [ {}, setArgs ] = useArgs();
 
 	const onSubmit = ( code: string ) => {
 		args.onSubmit?.( code );
 		setArgs( { isLoading: true } );
-		return new Promise( ( resolve ) => {
+		return new Promise< boolean >( ( resolve ) => {
 			setTimeout( () => {
 				setArgs( { isLoading: false } );
 				resolve( true );
@@ -50,16 +43,15 @@ LoadingState.args = {
 	isLoading: true,
 };
 
+// Type a code and click Apply to see the error the server would return.
 export const ErrorState: StoryFn< TotalsCouponProps > = ( args ) => {
-	const { setValidationErrors } = useDispatch( validationStore );
+	const onSubmit = () => Promise.reject( new Error( 'Invalid coupon code' ) );
 
-	setValidationErrors( { coupon: INVALID_COUPON_ERROR } );
-
-	return <TotalsCoupon { ...args } />;
+	return (
+		<TotalsCoupon
+			{ ...args }
+			displayCouponForm={ true }
+			onSubmit={ onSubmit }
+		/>
+	);
 };
-
-ErrorState.decorators = [
-	( StoryComponent ) => {
-		return <StoryComponent />;
-	},
-];

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
@@ -3,55 +3,220 @@
  */
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { dispatch } from '@wordpress/data';
-import { validationStore } from '@woocommerce/block-data';
+import { dispatch, select } from '@wordpress/data';
+import { checkoutStore, validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
  */
 import { TotalsCoupon } from '..';
 
+const ERROR_ID = 'wc-block-components-totals-coupon__error-coupon';
+
 describe( 'TotalsCoupon', () => {
-	beforeEach( () => {
-		// Clear validation errors before each test
-		const { clearValidationErrors } = dispatch( validationStore );
-		act( () => {
-			clearValidationErrors();
-		} );
-	} );
-	afterAll( () => {
-		// Clear validation errors after all tests to ensure no data store state is leaked.
-		const { clearValidationErrors } = dispatch( validationStore );
-		act( () => {
-			clearValidationErrors();
-		} );
-	} );
+	describe( 'Rejected coupons', () => {
+		it( 'shows the message from a rejected submit and keeps the validation store empty', async () => {
+			const user = userEvent.setup();
+			const message =
+				'Coupon code "5fixedcheckout" has already been applied.';
+			const mockOnSubmit = jest
+				.fn()
+				.mockRejectedValue( new Error( message ) );
 
-	it( "Shows a validation error when one is in the wc/store/validation data store and doesn't show one when there isn't", async () => {
-		const user = userEvent.setup();
-		const { rerender } = render( <TotalsCoupon instanceId={ 'coupon' } /> );
+			render(
+				<TotalsCoupon
+					instanceId="coupon"
+					onSubmit={ mockOnSubmit }
+					displayCouponForm={ true }
+				/>
+			);
 
-		const openCouponFormButton = screen.getByText( 'Add coupons' );
-		expect( openCouponFormButton ).toBeInTheDocument();
-		await act( async () => {
-			await user.click( openCouponFormButton );
+			const couponInput = screen.getByLabelText( 'Enter code' );
+
+			await act( async () => {
+				await user.type( couponInput, '5fixedcheckout' );
+			} );
+			await act( async () => {
+				await user.click(
+					screen.getByRole( 'button', { name: 'Apply' } )
+				);
+			} );
+
+			expect( mockOnSubmit ).toHaveBeenCalledWith( '5fixedcheckout' );
+			expect( await screen.findByRole( 'alert' ) ).toHaveTextContent(
+				message
+			);
+
+			// The input points at the message so assistive tech can read it.
+			expect( document.getElementById( ERROR_ID ) ).toHaveTextContent(
+				message
+			);
+			expect( couponInput ).toHaveAttribute( 'aria-invalid', 'true' );
+			expect( couponInput ).toHaveAttribute(
+				'aria-describedby',
+				ERROR_ID
+			);
+			expect( couponInput ).toHaveAttribute(
+				'aria-errormessage',
+				ERROR_ID
+			);
+			expect(
+				couponInput.closest( '.wc-block-components-text-input' )
+			).toHaveClass( 'has-error' );
+
+			// The shopper can correct the code without retyping it.
+			expect( couponInput ).toHaveValue( '5fixedcheckout' );
+			expect( couponInput ).toHaveFocus();
+
+			// The failure must not enter the store that blocks checkout.
+			expect( select( validationStore ).hasValidationErrors() ).toBe(
+				false
+			);
 		} );
-		expect(
-			screen.queryByText( 'Invalid coupon code' )
-		).not.toBeInTheDocument();
 
-		const { setValidationErrors } = dispatch( validationStore );
-		act( () => {
-			setValidationErrors( {
-				coupon: {
-					hidden: false,
-					message: 'Invalid coupon code',
-				},
+		it.each( [
+			'Usage limit for coupon "limited_coupon" has been reached.',
+			'Coupons are disabled.',
+			'"nope" is an invalid coupon code.',
+		] )( 'shows the server message "%s"', async ( message ) => {
+			const user = userEvent.setup();
+			const mockOnSubmit = jest
+				.fn()
+				.mockRejectedValue( new Error( message ) );
+
+			render(
+				<TotalsCoupon
+					instanceId="coupon"
+					onSubmit={ mockOnSubmit }
+					displayCouponForm={ true }
+				/>
+			);
+
+			await act( async () => {
+				await user.type( screen.getByLabelText( 'Enter code' ), 'x' );
+			} );
+			await act( async () => {
+				await user.click(
+					screen.getByRole( 'button', { name: 'Apply' } )
+				);
+			} );
+
+			expect( await screen.findByRole( 'alert' ) ).toHaveTextContent(
+				message
+			);
+		} );
+
+		it( 'clears the message when the code is edited', async () => {
+			const user = userEvent.setup();
+			const mockOnSubmit = jest
+				.fn()
+				.mockRejectedValue( new Error( 'Invalid coupon code' ) );
+
+			render(
+				<TotalsCoupon
+					instanceId="coupon"
+					onSubmit={ mockOnSubmit }
+					displayCouponForm={ true }
+				/>
+			);
+
+			const couponInput = screen.getByLabelText( 'Enter code' );
+
+			await act( async () => {
+				await user.type( couponInput, 'bad' );
+			} );
+			await act( async () => {
+				await user.click(
+					screen.getByRole( 'button', { name: 'Apply' } )
+				);
+			} );
+			expect( await screen.findByRole( 'alert' ) ).toBeInTheDocument();
+
+			await act( async () => {
+				await user.type( couponInput, '2' );
+			} );
+
+			expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
+			expect( couponInput ).toHaveAttribute( 'aria-invalid', 'false' );
+			expect( couponInput ).not.toHaveAttribute( 'aria-describedby' );
+		} );
+
+		it( 'clears the message when a later submit succeeds', async () => {
+			const user = userEvent.setup();
+			const mockOnSubmit = jest
+				.fn()
+				.mockRejectedValueOnce( new Error( 'Invalid coupon code' ) )
+				.mockResolvedValueOnce( true );
+
+			render(
+				<TotalsCoupon
+					instanceId="coupon"
+					onSubmit={ mockOnSubmit }
+					displayCouponForm={ true }
+				/>
+			);
+
+			await act( async () => {
+				await user.type( screen.getByLabelText( 'Enter code' ), 'bad' );
+			} );
+			await act( async () => {
+				await user.click(
+					screen.getByRole( 'button', { name: 'Apply' } )
+				);
+			} );
+			expect( await screen.findByRole( 'alert' ) ).toBeInTheDocument();
+
+			await act( async () => {
+				await user.click(
+					screen.getByRole( 'button', { name: 'Apply' } )
+				);
+			} );
+
+			await waitFor( () => {
+				expect(
+					screen.queryByLabelText( 'Enter code' )
+				).not.toBeInTheDocument();
+			} );
+			expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'clears the message when the checkout leaves the idle state', async () => {
+			const user = userEvent.setup();
+			const mockOnSubmit = jest
+				.fn()
+				.mockRejectedValue( new Error( 'Invalid coupon code' ) );
+
+			render(
+				<TotalsCoupon
+					instanceId="coupon"
+					onSubmit={ mockOnSubmit }
+					displayCouponForm={ true }
+				/>
+			);
+
+			await act( async () => {
+				await user.type( screen.getByLabelText( 'Enter code' ), 'bad' );
+			} );
+			await act( async () => {
+				await user.click(
+					screen.getByRole( 'button', { name: 'Apply' } )
+				);
+			} );
+			expect( await screen.findByRole( 'alert' ) ).toBeInTheDocument();
+
+			// Placing the order moves the checkout out of idle.
+			act( () => {
+				dispatch( checkoutStore ).__internalSetProcessing();
+			} );
+
+			await waitFor( () => {
+				expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
+			} );
+
+			act( () => {
+				dispatch( checkoutStore ).__internalSetIdle();
 			} );
 		} );
-		rerender( <TotalsCoupon instanceId={ 'coupon' } /> );
-
-		expect( screen.getByText( 'Invalid coupon code' ) ).toBeInTheDocument();
 	} );
 
 	describe( 'API Response Scenarios', () => {
@@ -129,159 +294,6 @@ describe( 'TotalsCoupon', () => {
 
 			// Input should be focused for retry
 			expect( couponInput ).toHaveFocus();
-		} );
-
-		it( 'handles onSubmit that returns Promise that rejects', async () => {
-			const user = userEvent.setup();
-
-			// Create a proper promise-returning mock that catches the rejection
-			const mockOnSubmit = jest.fn().mockImplementation( () => {
-				return Promise.reject( {
-					code: 'woocommerce_rest_cart_coupon_error',
-					message: 'Coupon "expired_coupon" has already expired.',
-				} ).catch( () => {
-					// Handle the rejection internally to prevent unhandled promise
-					return false;
-				} );
-			} );
-
-			render(
-				<TotalsCoupon
-					instanceId="coupon"
-					onSubmit={ mockOnSubmit }
-					displayCouponForm={ true }
-				/>
-			);
-
-			const couponInput = screen.getByLabelText( 'Enter code' );
-			const applyButton = screen.getByRole( 'button', { name: 'Apply' } );
-
-			// Enter an expired coupon code
-			await act( async () => {
-				await user.type( couponInput, 'expired_coupon' );
-			} );
-
-			// Submit the coupon
-			await act( async () => {
-				await user.click( applyButton );
-			} );
-
-			// Verify the API was called
-			expect( mockOnSubmit ).toHaveBeenCalledWith( 'expired_coupon' );
-
-			// Component should handle the case gracefully
-			expect( couponInput ).toHaveValue( 'expired_coupon' );
-		} );
-
-		it( 'handles duplicate coupon application', async () => {
-			const user = userEvent.setup();
-			const mockOnSubmit = jest.fn().mockResolvedValue( false );
-
-			// Set up validation error as would happen from the API response
-			const { setValidationErrors } = dispatch( validationStore );
-			act( () => {
-				setValidationErrors( {
-					coupon: {
-						hidden: false,
-						message:
-							'Coupon code "5fixedcheckout" has already been applied.',
-					},
-				} );
-			} );
-
-			render(
-				<TotalsCoupon
-					instanceId="coupon"
-					onSubmit={ mockOnSubmit }
-					displayCouponForm={ true }
-				/>
-			);
-
-			// Verify error message is displayed
-			expect(
-				screen.getByText(
-					'Coupon code "5fixedcheckout" has already been applied.'
-				)
-			).toBeInTheDocument();
-
-			const couponInput = screen.getByLabelText( 'Enter code' );
-			const applyButton = screen.getByRole( 'button', { name: 'Apply' } );
-
-			// Try to apply the same coupon again
-			await act( async () => {
-				await user.type( couponInput, '5fixedcheckout' );
-			} );
-
-			await act( async () => {
-				await user.click( applyButton );
-			} );
-
-			expect( mockOnSubmit ).toHaveBeenCalledWith( '5fixedcheckout' );
-
-			// Input should retain value and stay focused on failure
-			await waitFor( () => {
-				expect( couponInput ).toHaveValue( '5fixedcheckout' );
-				expect( couponInput ).toHaveFocus();
-			} );
-		} );
-
-		it( 'handles usage limit exceeded error', async () => {
-			const mockOnSubmit = jest.fn().mockResolvedValue( false );
-
-			// Set up validation error for usage limit
-			const { setValidationErrors } = dispatch( validationStore );
-			act( () => {
-				setValidationErrors( {
-					coupon: {
-						hidden: false,
-						message:
-							'Usage limit for coupon "limited_coupon" has been reached.',
-					},
-				} );
-			} );
-
-			render(
-				<TotalsCoupon
-					instanceId="coupon"
-					onSubmit={ mockOnSubmit }
-					displayCouponForm={ true }
-				/>
-			);
-
-			// Verify error message is displayed
-			expect(
-				screen.getByText(
-					'Usage limit for coupon "limited_coupon" has been reached.'
-				)
-			).toBeInTheDocument();
-		} );
-
-		it( 'handles coupons disabled error', async () => {
-			const mockOnSubmit = jest.fn().mockResolvedValue( false );
-
-			// Set up validation error for disabled coupons
-			const { setValidationErrors } = dispatch( validationStore );
-			act( () => {
-				setValidationErrors( {
-					coupon: {
-						hidden: false,
-						message: 'Coupons are disabled.',
-					},
-				} );
-			} );
-
-			render(
-				<TotalsCoupon
-					instanceId="coupon"
-					onSubmit={ mockOnSubmit }
-					displayCouponForm={ true }
-				/>
-			);
-
-			// Verify error message is displayed
-			expect(
-				screen.getByText( 'Coupons are disabled.' )
-			).toBeInTheDocument();
 		} );
 	} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/test/use-store-cart-coupons.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/test/use-store-cart-coupons.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { renderHook, act } from '@testing-library/react';
+import { select } from '@wordpress/data';
+import { validationStore } from '@woocommerce/block-data';
 import { server, http, HttpResponse } from '@woocommerce/test-utils/msw';
 
 /**
@@ -22,6 +24,9 @@ jest.mock( '@woocommerce/block-data/cart/resolvers', () => {
 	};
 } );
 
+// The stubbed batch responses below are not complete Store API responses, so
+// applyCoupon rejects after the request has been captured. Where only the
+// request is under test, the rejection is ignored.
 type CapturedRequest = {
 	url: string;
 	method: string;
@@ -90,7 +95,9 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 
 			// Apply a coupon
 			await act( async () => {
-				await result.current.applyCoupon( 'TEST5' );
+				await result.current
+					.applyCoupon( 'TEST5' )
+					.catch( () => undefined );
 			} );
 
 			// Verify the request was made
@@ -148,7 +155,9 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			// Apply each coupon and verify API calls
 			for ( let i = 0; i < testCoupons.length; i++ ) {
 				await act( async () => {
-					await result.current.applyCoupon( testCoupons[ i ] );
+					await result.current
+						.applyCoupon( testCoupons[ i ] )
+						.catch( () => undefined );
 				} );
 
 				// Verify the API call for this coupon
@@ -184,7 +193,7 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			} );
 		} );
 
-		it( 'handles API errors correctly without breaking', async () => {
+		it( 'rejects with the server message and leaves the validation store empty', async () => {
 			// Track the request details
 			let capturedRequest: CapturedRequest = {
 				url: '',
@@ -224,11 +233,15 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 				useStoreCartCoupons( 'wc/checkout' )
 			);
 
-			// Apply invalid coupon - should not throw error
+			// The failure is reported to the caller, not to the validation store.
 			await act( async () => {
-				const success = await result.current.applyCoupon( 'INVALID' );
-				expect( success ).toBe( false );
+				await expect(
+					result.current.applyCoupon( 'INVALID' )
+				).rejects.toThrow( 'Coupon "INVALID" does not exist!' );
 			} );
+			expect( select( validationStore ).hasValidationErrors() ).toBe(
+				false
+			);
 
 			// Verify the API call was still made
 			expect( capturedRequest ).not.toBeNull();
@@ -272,7 +285,9 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			);
 
 			await act( async () => {
-				await result.current.applyCoupon( 'CACHE_TEST' );
+				await result.current
+					.applyCoupon( 'CACHE_TEST' )
+					.catch( () => undefined );
 			} );
 
 			// Verify proper headers are sent
@@ -316,7 +331,9 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			);
 
 			await act( async () => {
-				await result.current.applyCoupon( 'BATCH_TEST' );
+				await result.current
+					.applyCoupon( 'BATCH_TEST' )
+					.catch( () => undefined );
 			} );
 
 			// Parse and verify the batch request structure
@@ -415,7 +432,9 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			);
 
 			await act( async () => {
-				await result.current.applyCoupon( 'CHECKOUT_CONTEXT' );
+				await result.current
+					.applyCoupon( 'CHECKOUT_CONTEXT' )
+					.catch( () => undefined );
 			} );
 
 			// Verify API call is made regardless of context
@@ -461,11 +480,15 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			);
 
 			await act( async () => {
-				await checkoutResult.current.applyCoupon( 'CHECKOUT_COUPON' );
+				await checkoutResult.current
+					.applyCoupon( 'CHECKOUT_COUPON' )
+					.catch( () => undefined );
 			} );
 
 			await act( async () => {
-				await cartResult.current.applyCoupon( 'CART_COUPON' );
+				await cartResult.current
+					.applyCoupon( 'CART_COUPON' )
+					.catch( () => undefined );
 			} );
 
 			// Both should make the same API calls
@@ -516,7 +539,9 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 
 			const specialCoupon = 'COUPON-WITH_SPECIAL@CHARS';
 			await act( async () => {
-				await result.current.applyCoupon( specialCoupon );
+				await result.current
+					.applyCoupon( specialCoupon )
+					.catch( () => undefined );
 			} );
 
 			expect( capturedRequest ).not.toBeNull();
@@ -554,7 +579,7 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 			);
 
 			await act( async () => {
-				await result.current.applyCoupon( '' );
+				await result.current.applyCoupon( '' ).catch( () => undefined );
 			} );
 
 			expect( capturedRequest ).not.toBeNull();
@@ -590,12 +615,15 @@ describe( 'useStoreCartCoupons hook API integration', () => {
 				useStoreCartCoupons( 'wc/checkout' )
 			);
 
-			// Should not throw error even on network failure
+			// A network failure is reported the same way as a rejected coupon.
 			await act( async () => {
-				const success =
-					await result.current.applyCoupon( 'NETWORK_FAIL' );
-				expect( success ).toBe( false );
+				await expect(
+					result.current.applyCoupon( 'NETWORK_FAIL' )
+				).rejects.toThrow();
 			} );
+			expect( select( validationStore ).hasValidationErrors() ).toBe(
+				false
+			);
 
 			expect( capturedRequest ).not.toBeNull();
 			expect( capturedRequest.url ).toContain( '/wc/store/v1/batch' );

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -4,11 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import {
-	cartStore,
-	validationStore,
-	checkoutStore,
-} from '@woocommerce/block-data';
+import { cartStore, checkoutStore } from '@woocommerce/block-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import type {
 	StoreCartCoupon,
@@ -24,6 +20,12 @@ import { useStoreCart } from './use-store-cart';
 /**
  * This is a custom hook for loading the Store API /cart/coupons endpoint and an
  * action for adding a coupon _to_ the cart.
+ *
+ * applyCoupon resolves true once the coupon is applied. When the Store API
+ * rejects the coupon it rejects with an Error whose message is ready to show to
+ * the shopper. The failure is feedback for the coupon form only, so it is never
+ * written to the validation store, which would block checkout.
+ *
  * See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/RestApi/StoreApi
  */
 export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
@@ -82,14 +84,9 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 					return Promise.resolve( true );
 				} )
 				.catch( ( error ) => {
-					const errorMessage = getCouponErrorMessage( error );
-					dispatch( validationStore ).setValidationErrors( {
-						coupon: {
-							message: decodeEntities( errorMessage ),
-							hidden: false,
-						},
-					} );
-					return Promise.resolve( false );
+					throw new Error(
+						decodeEntities( getCouponErrorMessage( error ) )
+					);
 				} );
 		},
 		[ applyCoupon, getCouponErrorMessage, context ]

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.tsx
@@ -575,4 +575,112 @@ describe( 'Testing Checkout', () => {
 		// Given we're checking for invisible errors here, reaching to the data store is a good option.
 		expect( select( validationStore ).hasValidationErrors() ).toBe( false );
 	} );
+
+	it( 'Places the order after a coupon fails to apply', async () => {
+		const user = userEvent.setup();
+		const couponError =
+			'Coupon code "5fixedcheckout" has already been applied.';
+		let checkoutRequests = 0;
+
+		server.use(
+			http.post( '/wc/store/v1/batch', () =>
+				HttpResponse.json(
+					{
+						code: 'woocommerce_rest_cart_coupon_error',
+						message: couponError,
+						data: { status: 400, details: { cart: couponError } },
+					},
+					{ status: 400 }
+				)
+			),
+			http.post( '/wc/store/v1/checkout', () => {
+				checkoutRequests++;
+				return HttpResponse.json(
+					{
+						code: 'woocommerce_rest_checkout_test_stop',
+						message: 'Stop here.',
+						data: { status: 400 },
+					},
+					{ status: 400 }
+				);
+			} )
+		);
+
+		render( <CheckoutBlock /> );
+
+		await waitFor( () =>
+			expect( screen.getByText( /Place Order/i ) ).toBeVisible()
+		);
+
+		// Apply a coupon the server rejects.
+		await act( async () => {
+			await user.click( screen.getByText( 'Add coupons' ) );
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByLabelText( 'Enter code' ),
+				'5fixedcheckout'
+			);
+		} );
+		await act( async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+		} );
+		expect( await screen.findByText( couponError ) ).toBeVisible();
+
+		// Fill the rest of the form.
+		const shippingForm = screen.getByRole( 'group', {
+			name: /shipping address/i,
+		} );
+		await act( async () => {
+			await user.selectOptions(
+				within( shippingForm ).getByLabelText( /Country\/Region/i ),
+				'Spain'
+			);
+		} );
+		await act( async () => {
+			await user.type(
+				screen.getByLabelText( /Email address/i ),
+				'test@test.com'
+			);
+			await user.type(
+				within( shippingForm ).getByLabelText( /First name/i ),
+				'John'
+			);
+			await user.type(
+				within( shippingForm ).getByLabelText( /Last name/i ),
+				'Doe'
+			);
+			await user.type(
+				within( shippingForm ).getByLabelText( 'Address' ),
+				'123 Main St'
+			);
+			await user.type(
+				within( shippingForm ).getByLabelText( /City/i ),
+				'BCN'
+			);
+			await user.selectOptions(
+				within( shippingForm ).getByLabelText( /Province/i ),
+				'Barcelona'
+			);
+			await user.click(
+				screen.getByRole( 'checkbox', {
+					name: /terms and conditions/i,
+				} )
+			);
+		} );
+
+		await act( async () => {
+			await user.click(
+				screen.getByRole( 'button', { name: /Place order/i } )
+			);
+		} );
+
+		// The coupon failure must not stop the order from being sent.
+		await waitFor( () => expect( checkoutRequests ).toBe( 1 ), {
+			timeout: 3000,
+		} );
+		expect( select( validationStore ).hasValidationErrors() ).toBe( false );
+		// Placing the order drops the stale coupon message.
+		expect( screen.queryByText( couponError ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/validation-input-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/validation-input-error/index.tsx
@@ -14,12 +14,15 @@ export interface ValidationInputErrorProps {
 	errorMessage?: string;
 	propertyName?: string;
 	elementId?: string;
+	// Id for the message element. Use it when errorMessage does not come from the validation store, so an input can still reference the message.
+	id?: string;
 }
 
 export const ValidationInputError = ( {
 	errorMessage = '',
 	propertyName = '',
 	elementId = '',
+	id = '',
 }: ValidationInputErrorProps ): JSX.Element | null => {
 	const { validationError, validationErrorId } = useSelect(
 		( select ) => {
@@ -43,7 +46,7 @@ export const ValidationInputError = ( {
 
 	return (
 		<div className="wc-block-components-validation-error" role="alert">
-			<p id={ validationErrorId }>
+			<p id={ id || validationErrorId }>
 				<Icon icon={ cautionFilled } />
 				<span>{ errorMessage }</span>
 			</p>

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/validation-input-error/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/validation-input-error/test/index.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+import { dispatch } from '@wordpress/data';
+import { validationStore } from '@woocommerce/block-data';
+
+/**
+ * Internal dependencies
+ */
+import { ValidationInputError } from '..';
+
+describe( 'ValidationInputError', () => {
+	afterEach( () => {
+		act( () => {
+			dispatch( validationStore ).clearValidationErrors();
+		} );
+	} );
+
+	it( 'uses the given id for a message passed directly', () => {
+		render(
+			<ValidationInputError
+				errorMessage="Coupon rejected"
+				id="coupon-error"
+			/>
+		);
+
+		expect( screen.getByRole( 'alert' ) ).toHaveTextContent(
+			'Coupon rejected'
+		);
+		expect( document.getElementById( 'coupon-error' ) ).toHaveTextContent(
+			'Coupon rejected'
+		);
+	} );
+
+	it( 'keeps the store-derived id when no id is given', () => {
+		act( () => {
+			dispatch( validationStore ).setValidationErrors( {
+				email: { message: 'Enter a valid email', hidden: false },
+			} );
+		} );
+
+		render(
+			<ValidationInputError propertyName="email" elementId="email" />
+		);
+
+		expect(
+			document.getElementById( 'validate-error-email' )
+		).toHaveTextContent( 'Enter a valid email' );
+	} );
+
+	it( 'renders nothing without a message', () => {
+		const { container } = render(
+			<ValidationInputError propertyName="missing" />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When the Store API rejects a coupon (already applied, invalid, expired, disabled), `useStoreCartCoupons` wrote the message into the validation store under a `coupon` key. The checkout processor refuses to place an order while that store has any entry, so a shopper who applied the same coupon twice could not check out until they edited or closed the coupon field, and the block moved focus to the coupon input as if it were an invalid address field.

This change keeps coupon feedback out of the validation store. `applyCoupon` now rejects with the shopper-facing message, and `TotalsCoupon` holds that message in local state, renders it through `ValidationInputError` with an explicit id, and keeps the `has-error` class, `aria-invalid` and `aria-describedby` the input had before. `aria-errormessage` is new: trunk never set it, because the coupon form passed `showError={ false }` to `ValidatedTextInput`. The message clears when the shopper edits the code, when a later apply succeeds, or when the checkout leaves idle (Place Order clicked). Closing and reopening the coupon panel keeps the message and the red border; on trunk the unmount cleared them. The coupon input is a plain `TextInput` now; it never had validation rules.

`ValidationInputError` gains an optional `id` prop so a message that does not come from the store can still be referenced from an input. The `errorMessage` prop is already public and documented, but no component on trunk renders it without a store entry, so this is the first local-state use of the component; the validation store itself is documented as field validation, and the coupon apply path was its only writer for a server-rejected request (remove coupon and every other Store API failure go to `core/notices`).

**Backward compatibility.** `ValidationInputError` (`wc.blocksComponents`) gains an optional prop; existing calls behave the same. `useStoreCartCoupons` and `TotalsCoupon` live under `assets/js/base/` and are not exported on `window.wc`; their internal contract changes from "resolve `false` on failure" to "reject with an `Error`", and the only consumers are the two coupon-form blocks. The validation store, its selectors, the checkout processor, the cart thunks and the Store API are unchanged. No hooks, templates, PHP, persisted data or script handles change. Behaviour is the same on multisite and in any install layout.

**Not done here:** clearing the coupon input on failure. The Store API returns one error code, `woocommerce_rest_cart_coupon_error`, for every apply failure, so the client cannot clear only for "already applied" without matching translated text, and clearing on a typo would hurt. A follow-up can add a distinct error code server-side.

Not a regression from a single PR: the coupon form has written its errors to the validation store since the woocommerce-blocks era, before the 2025 monorepo merge.

Closes #42074.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. In wp-admin, Marketing → Coupons → Add coupon: code `twice`, percentage discount, amount `10`. Publish. (Or with WP-CLI: `wp wc shop_coupon create --code=twice --discount_type=percent --amount=10 --user=1`.)
2. As a shopper, add any product to the cart and open the Checkout block page.
3. Order summary → **Add coupons** → enter `twice` → **Apply**. The coupon appears in the summary and the form closes.
4. **Add coupons** again → enter `twice` → **Apply**. Expected: the message `Coupon code "twice" has already been applied.` under the coupon form, the input still contains `twice` and has focus, the input has a red border, and **Place Order** is enabled.
5. Fill in the address and choose a payment method (Cash on delivery is enough). Click **Place Order**. Expected: the order goes through to the thank-you page. Before the fix nothing is submitted and focus jumps to the coupon input.
6. Repeat steps 2–4, then clear a required address field and click **Place Order**. Expected: the usual field errors show, and the coupon message is gone (Place Order clears it).
7. Repeat step 4, then type one more character in the coupon input. Expected: the message disappears while typing.
8. Open the Cart block page, **Add coupons** → enter `nope` → **Apply**. Expected: `Coupon "nope" cannot be applied because it does not exist.` under the form; typing clears it. Proceed to checkout works.
9. With the error visible, inspect the input in DevTools. Expected: `aria-invalid="true"`, `aria-describedby="wc-block-components-totals-coupon__error-coupon"`, `aria-errormessage` with the same value, and a `<p id="wc-block-components-totals-coupon__error-coupon">` inside `div.wc-block-components-validation-error[role="alert"]`.
10. Run `pnpm --filter=@woocommerce/block-library test:js assets/js/blocks/checkout/test/block.tsx -t "coupon fails to apply"` and confirm it passes. Check out `trunk` and run it again to see it fail with `Received: 0` checkout requests.

<!-- End testing instructions -->

### Testing that has already taken place:

- Manual wp-env shopper flow: steps 1–9 above run in a local wp-env (WordPress latest, PHP 8.1, Twenty Twenty-Five, guest checkout, Cash on delivery) with the blocks built from this branch, and checked in the DOM at each step. All pass. 

**High-Impact:** This changes the Checkout block order-placement path and adds an optional prop to a public `wc.blocksComponents` component. It needs an independent human review (Checkout / Rubik). AI reviews do not satisfy that requirement.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The change and tests were authored with an AI coding agent working from a written implementation plan. A human reviewed the resulting diff before opening this PR.



