### PR TITLE
Fix percentage order fees calculated on tax-inclusive total

### DIFF
--- a/plugins/woocommerce/changelog/38830-percentage-order-fees-ex-tax
+++ b/plugins/woocommerce/changelog/38830-percentage-order-fees-ex-tax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Calculate percentage-based order fees added in admin on the net order total instead of the tax-inclusive total.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1313,11 +1313,13 @@ class WC_AJAX {
 			);
 
 			if ( strstr( $amount, '%' ) ) {
-				// We need to calculate totals first, so that $order->get_total() is correct.
+				// Refresh totals so the percentage base is current. Use the net
+				// (ex-tax) total; otherwise tax is charged again on a tax-inclusive amount.
 				$order->calculate_totals( false );
 				$formatted_amount = $amount;
 				$percent          = floatval( trim( $amount, '%' ) );
-				$amount           = $order->get_total() * ( $percent / 100 );
+				$base             = (float) $order->get_total() - (float) $order->get_total_tax();
+				$amount           = NumberUtil::round( $base * ( $percent / 100 ), wc_get_price_decimals() );
 			} else {
 				$amount           = floatval( $amount );
 				$formatted_amount = wc_price( $amount, array( 'currency' => $order->get_currency() ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -2386,6 +2386,137 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Percentage order fees added via AJAX are calculated on the net (ex-tax) order total.
+	 *
+	 * @testWith ["25%", 25.0, 5.0, 150.0]
+	 *           ["-25%", -25.0, -5.0, 90.0]
+	 *
+	 * @param string $amount          Fee amount posted to the AJAX handler.
+	 * @param float  $expected_fee    Expected fee line total (ex tax).
+	 * @param float  $expected_fee_tax Expected fee tax.
+	 * @param float  $expected_total  Expected order grand total.
+	 */
+	public function test_add_order_fee_percentage_uses_net_total( string $amount, float $expected_fee, float $expected_fee_tax, float $expected_total ): void {
+		$order = $this->create_order_for_percentage_fee_tests();
+
+		$this->_setRole( 'administrator' );
+		$_POST['security'] = wp_create_nonce( 'order-item' );
+		$_POST['order_id'] = $order->get_id();
+		$_POST['amount']   = $amount;
+
+		$response = $this->do_ajax( 'woocommerce_add_order_fee' );
+
+		$this->assertTrue( $response['success'] ?? false, 'Adding a percentage fee via AJAX should succeed.' );
+
+		$order = wc_get_order( $order->get_id() );
+		$fees  = array_values( $order->get_fees() );
+		$this->assertCount( 1, $fees, 'Exactly one fee should be added to the order.' );
+		$this->assertEquals( $expected_fee, (float) $fees[0]->get_total(), 'Fee total should be a percentage of the net order total.' );
+		$this->assertEquals( $expected_fee_tax, (float) $fees[0]->get_total_tax(), 'Fee tax should be calculated on the net fee amount.' );
+		$this->assertEquals( $expected_total, (float) $order->get_total(), 'Order total should include the net-based fee and its tax.' );
+
+		unset( $_POST['security'], $_POST['order_id'], $_POST['amount'] );
+	}
+
+	/**
+	 * @testdox Percentage fee base includes shipping under option A (net items + shipping, ex tax).
+	 */
+	public function test_add_order_fee_percentage_includes_shipping_in_net_base(): void {
+		WC_Helper_Shipping::create_simple_flat_rate();
+
+		$order = $this->create_order_for_percentage_fee_tests();
+
+		$shipping = new WC_Order_Item_Shipping();
+		$shipping->set_method_title( 'Flat rate' );
+		$shipping->set_method_id( 'flat_rate' );
+		$shipping->set_total( 10 );
+		$order->add_item( $shipping );
+		$order->calculate_totals( true );
+		$order->save();
+
+		$this->_setRole( 'administrator' );
+		$_POST['security'] = wp_create_nonce( 'order-item' );
+		$_POST['order_id'] = $order->get_id();
+		$_POST['amount']   = '10%';
+
+		$response = $this->do_ajax( 'woocommerce_add_order_fee' );
+
+		$this->assertTrue( $response['success'] ?? false, 'Adding a percentage fee via AJAX should succeed.' );
+
+		$order = wc_get_order( $order->get_id() );
+		$fees  = array_values( $order->get_fees() );
+		$this->assertCount( 1, $fees, 'Exactly one fee should be added to the order.' );
+		// Net base is items (100) + shipping (10) = 110; 10% of that is 11, not 13.20 (10% of tax-inclusive 132).
+		$this->assertEquals( 11.0, (float) $fees[0]->get_total(), 'Percentage fee should use the net total including shipping.' );
+
+		unset( $_POST['security'], $_POST['order_id'], $_POST['amount'] );
+		WC_Helper_Shipping::delete_simple_flat_rate();
+	}
+
+	/**
+	 * @testdox Fixed-amount order fees added via AJAX are unchanged.
+	 */
+	public function test_add_order_fee_fixed_amount_unchanged(): void {
+		$order = $this->create_order_for_percentage_fee_tests();
+
+		$this->_setRole( 'administrator' );
+		$_POST['security'] = wp_create_nonce( 'order-item' );
+		$_POST['order_id'] = $order->get_id();
+		$_POST['amount']   = '12.5';
+
+		$response = $this->do_ajax( 'woocommerce_add_order_fee' );
+
+		$this->assertTrue( $response['success'] ?? false, 'Adding a fixed fee via AJAX should succeed.' );
+
+		$order = wc_get_order( $order->get_id() );
+		$fees  = array_values( $order->get_fees() );
+		$this->assertCount( 1, $fees, 'Exactly one fee should be added to the order.' );
+		$this->assertEquals( 12.5, (float) $fees[0]->get_total(), 'Fixed fee amount should be stored as posted.' );
+		$this->assertEquals( 2.5, (float) $fees[0]->get_total_tax(), 'Fixed fee tax should remain 20% of the fee.' );
+		$this->assertEquals( 135.0, (float) $order->get_total(), 'Order total should include the fixed fee and its tax.' );
+
+		unset( $_POST['security'], $_POST['order_id'], $_POST['amount'] );
+	}
+
+	/**
+	 * Create a $100 order with a 20% tax line for percentage fee AJAX tests.
+	 *
+	 * @return WC_Order
+	 */
+	private function create_order_for_percentage_fee_tests(): WC_Order {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '20.0000',
+				'tax_rate_name'     => 'Tax',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product, 1 );
+		$order->calculate_totals( true );
+		$order->save();
+
+		$this->assertEquals( 20.0, (float) $order->get_total_tax(), 'Fixture order should have a $20 tax line.' );
+		$this->assertEquals( 120.0, (float) $order->get_total(), 'Fixture order should total $120 gross.' );
+
+		return $order;
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Admin percentage fees (`WC_AJAX::add_order_fee()`) were calculated on `get_total()`, which already includes tax, so a taxable fee got tax in its base and then taxed again. I'm basing the percentage on the net total (`get_total() - get_total_tax()`) and rounding with `NumberUtil::round`.

I left shipping in the net base on purpose, it's the same base as before with tax removed. If we'd rather match percent coupons and use products only, that's a one-line follow-up.

Closes #38830.

No signature or hook changes, but merchants who relied on the old gross base will see smaller percentage fees on taxed orders. Percentage fees are also stored rounded to the store's price decimals now. Touches order totals and tax, so this needs an independent human review before merge.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Local admin orders after the fix (20% tax, prices entered ex tax):

**25% fee:** $25 + $5 tax, order total $150 (was $30 / $7.50 on the gross base).
<img width="3840" height="2160" alt="step-3" src="https://github.com/user-attachments/assets/489166f0-34aa-45bf-a038-3312f0fd04c3" />

**-25% fee:** -$25 / -$5 tax, order total $90.
<img width="3840" height="2160" alt="step-4" src="https://github.com/user-attachments/assets/57d730f6-e8e1-42dd-b981-35364b3a3536" />

**10% with $10 shipping:** fee $11.00, not $13.20.
<img width="3840" height="2160" alt="step-5" src="https://github.com/user-attachments/assets/94e3651b-249c-49fa-8a22-64dd56ad1285" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable taxes with a 20% standard rate. Keep "Prices entered with tax" set to **No**.
2. Create an order in admin with a $100 product and calculate totals (order should be $120 including $20 tax).
3. Add a fee of `25%` via the order items UI. Confirm the fee is **$25** with **$5** tax, and the order total becomes **$150** (not $30 / $7.50 / $157.50).
4. On a fresh equivalent order, add a fee of `-25%`. Confirm the fee is **-$25** with **-$5** tax, and the order total becomes **$90**.
5. On an order with a $10 taxable shipping line (items $100 + shipping $10 = $110 net / $132 gross), add a `10%` fee. Confirm the fee is **$11.00**, not $13.20.
6. Add a fixed fee of `12.5` and confirm it is unchanged ($12.50 + $2.50 tax).
7. Optionally repeat a percentage-fee case with HPOS disabled (posts storage) to confirm the same totals.

<!-- End testing instructions -->

### Testing that has already taken place:

I ran the cases above on a local wp-env with this branch mounted and checked the resulting admin order totals (screenshots above).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Drafted with Cursor. I reviewed the diff and the local test results before opening.

