### PR TITLE
[tests] Add RTL coverage for the block email editor sidebar settings

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-email-editor-sidebar-settings
+++ b/plugins/woocommerce/changelog/testops-288-email-editor-sidebar-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Add RTL coverage for the block email editor's sidebar settings panel.
+

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/__tests__/sidebar-settings.test.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/__tests__/sidebar-settings.test.tsx
@@ -1,0 +1,412 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentType, JSX, ReactNode } from 'react';
+
+type WooCommerceData = Record< string, unknown >;
+type RichTextWithButtonProps = {
+	attributeName: string;
+	attributeValue: string;
+	updateProperty: ( name: string, value: string | boolean ) => void;
+	label: string;
+	placeholder: string;
+	help?: ReactNode;
+};
+type SidebarFilter = (
+	RichTextWithButton: ComponentType< RichTextWithButtonProps >,
+	tracking: {
+		recordEvent: jest.Mock;
+		debouncedRecordEvent: jest.Mock;
+	}
+) => ComponentType;
+
+const mockRegisteredPlugins = new Map<
+	string,
+	{ render: () => JSX.Element }
+>();
+const mockSidebarFilters: SidebarFilter[] = [];
+
+const mockEntityState: {
+	woocommerceData: WooCommerceData;
+	editedWooCommerceData: Record< string, unknown >;
+} = {
+	woocommerceData: {},
+	editedWooCommerceData: {},
+};
+const mockEditEntityRecord = jest.fn();
+const mockEmailEditorRecordEvent = jest.fn();
+const mockEntitySubscribers = new Set< () => void >();
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: { name: 'core' },
+	useEntityProp: () => {
+		const { useEffect, useReducer } =
+			jest.requireActual( '@wordpress/element' );
+		const [ , refresh ] = useReducer( ( count: number ) => count + 1, 0 );
+		useEffect( () => {
+			mockEntitySubscribers.add( refresh );
+			return () => mockEntitySubscribers.delete( refresh );
+		}, [ refresh ] );
+		return [ mockEntityState.woocommerceData ];
+	},
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	select: () => ( {
+		getEditedEntityRecord: () => ( {
+			woocommerce_data: mockEntityState.editedWooCommerceData,
+		} ),
+	} ),
+	dispatch: () => ( {
+		editEntityRecord: mockEditEntityRecord,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/hooks', () => ( {
+	addFilter: (
+		filterName: string,
+		_namespace: string,
+		callback: SidebarFilter
+	) => {
+		if (
+			filterName ===
+			'woocommerce_email_editor_setting_sidebar_extension_component'
+		) {
+			mockSidebarFilters.push( callback );
+		}
+	},
+} ) );
+
+jest.mock( '@wordpress/plugins', () => ( {
+	registerPlugin: ( name: string, settings: { render: () => JSX.Element } ) =>
+		mockRegisteredPlugins.set( name, settings ),
+} ) );
+
+jest.mock( '@woocommerce/email-editor', () => ( {
+	EmailActionsFill: ( { children }: { children: ReactNode } ) => children,
+	TemplateSelection: () => null,
+	recordEvent: mockEmailEditorRecordEvent,
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { modifySidebar } from '../sidebar_settings';
+
+const defaultWooCommerceData: WooCommerceData = {
+	recipient: 'merchant@example.com',
+	cc: null,
+	bcc: null,
+	preheader: 'Order update preview',
+	email_type: 'new_order',
+	subject: 'New order',
+	subject_full: null,
+	subject_partial: null,
+	default_subject: 'Default subject',
+	is_manual: false,
+	enabled: true,
+};
+
+const RichTextWithButton = ( {
+	attributeName,
+	attributeValue,
+	updateProperty,
+	label,
+}: {
+	attributeName: string;
+	attributeValue: string;
+	updateProperty: ( name: string, value: string | boolean ) => void;
+	label: string;
+} ) => (
+	<label htmlFor={ `rich-text-${ attributeName }` }>
+		{ label }
+		<input
+			id={ `rich-text-${ attributeName }` }
+			value={ attributeValue }
+			onChange={ ( event ) =>
+				updateProperty( attributeName, event.target.value )
+			}
+		/>
+	</label>
+);
+
+const renderSettings = ( {
+	recordEvent = jest.fn(),
+	debouncedRecordEvent = jest.fn(),
+}: {
+	recordEvent?: jest.Mock;
+	debouncedRecordEvent?: jest.Mock;
+} = {} ) => {
+	modifySidebar();
+
+	const SidebarSettings = mockSidebarFilters.at( -1 )!( RichTextWithButton, {
+		recordEvent,
+		debouncedRecordEvent,
+	} );
+	const EmailStatus = mockRegisteredPlugins.get(
+		'woocommerce-email-editor-email-status'
+	)!.render;
+
+	return {
+		...render(
+			<>
+				<EmailStatus />
+				<SidebarSettings />
+			</>
+		),
+		recordEvent,
+		debouncedRecordEvent,
+		SidebarSettings,
+		EmailStatus,
+	};
+};
+
+describe( 'Email editor sidebar settings', () => {
+	beforeEach( () => {
+		mockRegisteredPlugins.clear();
+		mockSidebarFilters.length = 0;
+		mockEntitySubscribers.clear();
+		mockEditEntityRecord.mockClear();
+		mockEditEntityRecord.mockImplementation(
+			(
+				_kind: string,
+				_name: string,
+				_id: string,
+				{ woocommerce_data }: { woocommerce_data: WooCommerceData }
+			) => {
+				mockEntityState.woocommerceData = woocommerce_data;
+				mockEntityState.editedWooCommerceData = woocommerce_data;
+				mockEntitySubscribers.forEach( ( refresh ) => refresh() );
+			}
+		);
+		mockEmailEditorRecordEvent.mockClear();
+		mockEntityState.woocommerceData = { ...defaultWooCommerceData };
+		mockEntityState.editedWooCommerceData = {
+			...defaultWooCommerceData,
+			unrelated_setting: 'preserved',
+		};
+		window.WooCommerceEmailEditor = {
+			current_post_id: '42',
+			current_post_type: 'woo_email',
+			email_types: [],
+			sender_settings: { from_name: '', from_address: '' },
+		};
+	} );
+
+	it( 'updates email status and tracks it', async () => {
+		const { rerender } = renderSettings();
+		const initialEditedWooCommerceData = {
+			...mockEntityState.editedWooCommerceData,
+		};
+
+		expect(
+			screen.getByRole( 'button', { name: 'Change status: Active' } )
+		).toBeEnabled();
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Change status: Active' } )
+		);
+		await userEvent.click(
+			screen.getByRole( 'radio', { name: 'Inactive' } )
+		);
+
+		expect( mockEditEntityRecord ).toHaveBeenLastCalledWith(
+			'postType',
+			'woo_email',
+			'42',
+			{
+				woocommerce_data: {
+					...initialEditedWooCommerceData,
+					unrelated_setting: 'preserved',
+					enabled: false,
+				},
+			}
+		);
+		expect( mockEmailEditorRecordEvent ).toHaveBeenLastCalledWith(
+			'email_status_changed',
+			{ status: 'inactive' }
+		);
+
+		mockEntityState.woocommerceData = {
+			...defaultWooCommerceData,
+			is_manual: true,
+		};
+		rerender(
+			<>
+				{ mockRegisteredPlugins
+					.get( 'woocommerce-email-editor-email-status' )!
+					.render() }
+			</>
+		);
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Change status: Manually sent',
+			} )
+		).toBeDisabled();
+	} );
+
+	it( 'passes subject and preheader values through the sidebar data owner', async () => {
+		renderSettings();
+		const initialEditedWooCommerceData = {
+			...mockEntityState.editedWooCommerceData,
+		};
+
+		const subject = screen.getByRole( 'textbox', { name: 'Subject' } );
+		const preheader = screen.getByRole( 'textbox', {
+			name: 'Preview text',
+		} );
+		await userEvent.clear( subject );
+		await userEvent.type( subject, 'Your order is on its way' );
+		await userEvent.clear( preheader );
+		await userEvent.type( preheader, 'Track it from your account' );
+
+		expect( mockEditEntityRecord ).toHaveBeenNthCalledWith(
+			1,
+			'postType',
+			'woo_email',
+			'42',
+			{
+				woocommerce_data: {
+					...initialEditedWooCommerceData,
+					subject: '',
+				},
+			}
+		);
+		expect( mockEditEntityRecord ).toHaveBeenLastCalledWith(
+			'postType',
+			'woo_email',
+			'42',
+			{
+				woocommerce_data: {
+					...initialEditedWooCommerceData,
+					subject: 'Your order is on its way',
+					preheader: 'Track it from your account',
+				},
+			}
+		);
+	} );
+
+	it( 'updates and clears CC and BCC recipients', async () => {
+		const recordEvent = jest.fn();
+		const debouncedRecordEvent = jest.fn();
+		mockEntityState.woocommerceData = {
+			...defaultWooCommerceData,
+			recipient: null,
+			cc: null,
+			bcc: null,
+		};
+		mockEntityState.editedWooCommerceData = {
+			...defaultWooCommerceData,
+			recipient: null,
+			cc: null,
+			bcc: null,
+			unrelated_setting: 'preserved',
+		};
+		const { rerender, SidebarSettings, EmailStatus } = renderSettings( {
+			recordEvent,
+			debouncedRecordEvent,
+		} );
+		const initialEditedWooCommerceData = {
+			...mockEntityState.editedWooCommerceData,
+		};
+
+		expect(
+			screen.getByText( 'This email is sent to Customer.' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByDisplayValue( 'merchant@example.com' )
+		).not.toBeInTheDocument();
+
+		await userEvent.click(
+			screen.getByRole( 'checkbox', { name: 'Add CC' } )
+		);
+		expect( screen.getByTestId( 'email_cc' ) ).toBeInTheDocument();
+		expect( recordEvent ).toHaveBeenCalledWith( 'email_cc_toggle_clicked', {
+			isEnabled: true,
+		} );
+
+		await userEvent.click(
+			screen.getByRole( 'checkbox', { name: 'Add BCC' } )
+		);
+		expect( screen.getByTestId( 'email_bcc' ) ).toBeInTheDocument();
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'email_bcc_toggle_clicked',
+			{ isEnabled: true }
+		);
+
+		await userEvent.type(
+			screen.getByTestId( 'email_cc' ),
+			'copy@example.com'
+		);
+		await userEvent.type(
+			screen.getByTestId( 'email_bcc' ),
+			'hidden@example.com'
+		);
+
+		expect( mockEditEntityRecord ).toHaveBeenLastCalledWith(
+			'postType',
+			'woo_email',
+			'42',
+			{
+				woocommerce_data: {
+					...initialEditedWooCommerceData,
+					cc: 'copy@example.com',
+					bcc: 'hidden@example.com',
+				},
+			}
+		);
+		expect( debouncedRecordEvent ).toHaveBeenCalledWith(
+			'email_cc_input_updated',
+			{ value: 'copy@example.com' }
+		);
+		expect( debouncedRecordEvent ).toHaveBeenLastCalledWith(
+			'email_bcc_input_updated',
+			{ value: 'hidden@example.com' }
+		);
+
+		await userEvent.click(
+			screen.getByRole( 'checkbox', { name: 'Add CC' } )
+		);
+		await userEvent.click(
+			screen.getByRole( 'checkbox', { name: 'Add BCC' } )
+		);
+
+		expect( mockEditEntityRecord ).toHaveBeenLastCalledWith(
+			'postType',
+			'woo_email',
+			'42',
+			{
+				woocommerce_data: {
+					...initialEditedWooCommerceData,
+					cc: '',
+					bcc: '',
+				},
+			}
+		);
+		expect( recordEvent ).toHaveBeenCalledWith( 'email_cc_toggle_clicked', {
+			isEnabled: false,
+		} );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'email_bcc_toggle_clicked',
+			{ isEnabled: false }
+		);
+
+		mockEntityState.woocommerceData = {
+			...defaultWooCommerceData,
+			recipient: 'team@example.com',
+		};
+		rerender(
+			<>
+				<EmailStatus />
+				<SidebarSettings />
+			</>
+		);
+		expect(
+			screen.getByDisplayValue( 'team@example.com' )
+		).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The block email editor's sidebar panel is where a merchant sets what a single email does: whether it is active, inactive or sent manually, its subject and preheader, and its CC and BCC recipients. All of that ran only in a browser, in `email-editor-settings-sidebar.spec.ts`.

This PR adds a React Testing Library suite for the panel. **It removes nothing:** that spec keeps all three of its titles and is not touched here, and no coverage moves between layers. It is the lower-layer gate the migration portfolio asks for before that spec is trimmed to one canary, which a later PR will do.

Refs TESTOPS-288

Part of the #68046 split.

| What the suite pins | How |
| --- | --- |
| The status control | that a stored `enabled` email selects the active label, a stored not-enabled one selects the inactive label, and a stored `is_manual` one selects the manual label and disables the control — none of the three hard-coded — and that a change dispatches the new value and records `email_status_changed` with `active` or `inactive` |
| The subject and preheader | that each is sent to the editor's entity store for the current post, merged into the existing `woocommerce_data` rather than replacing it, and that clearing a value sends the cleared value instead of silently keeping the old one |
| CC and BCC | that each toggle shows its field, that typing sends the value, that disabling sends the cleared value, and that each of those actions records its Tracks event with the right `isEnabled` or `value` payload — six events across the two fields. Toggling off is pinned by the cleared payload and the event, not by the field unmounting |

The suite drives the real `SidebarSettings` and `EmailStatus` components against mocked `@wordpress/core-data`, `@wordpress/data`, `@wordpress/hooks`, `@wordpress/plugins` and `@woocommerce/email-editor`. The two tracking paths differ: the status event is the `recordEvent` imported from `@woocommerce/email-editor`, so it is asserted against that mock, while the CC and BCC events arrive as the `tracking` argument the editor's filter passes in and are asserted against that. So what the suite checks is the **write** side — the payload handed to the entity store's mock — while the read side is stubbed. Nothing goes further than that spy: no real store, no request, no reload.

#### Limits worth stating

- **Personalization tags are not covered.** The suite stubs the rich text component, so it pins the subject and preheader *payloads* but not the insertion of a personalization tag into either. Whoever trims `email-editor-settings-sidebar.spec.ts` later needs that: the existing Jest owners around personalization tags test the picker, not its insertion into these two fields.
- **Three test cases carry twenty-seven behaviors.** The suite is dense by design — one case per area, each walking several actions — so a failure names the area rather than the behavior. That is the shape the migration produced; splitting the cases is a follow-up, not a blocker.
- **Nothing here proves the settings persist.** With the entity store mocked, every write ends in a spy: no save, no reload, no round trip. In `email-editor-settings-sidebar.spec.ts` it is the status title that saves, reloads and re-asserts, and that is exactly the part this suite cannot replace. Whoever trims that spec to one canary has to keep that save-and-reload assertion — and if the canary ends up being one of the other titles, the assertion has to be added to it rather than carried over.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the new suite and the rest of its directory, and confirm they pass: `pnpm --dir plugins/woocommerce/client/admin exec jest --config client/jest.config.js --runInBand client/wp-admin-scripts/email-editor-integration`. Expect 8 suites and 88 tests.
3. Confirm the suite would catch a real regression rather than passing on anything. In `plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx`, in the CC toggle's `recordEvent` call, change `isEnabled: value` to `isEnabled: true`. Re-run step 2 and confirm `updates and clears CC and BCC recipients` fails on the event payload. Revert the change.
4. Confirm the sidebar still behaves the same in a browser, since this PR changes no production code: start the environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:dev`, enable the block email editor, open **WooCommerce > Settings > Emails**, open any email in the editor, and check that the sidebar's status control, subject, preheader and the CC and BCC toggles all still work.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch's single commit against a local checkout, with no environment needed: the suite is plain Node, and this PR touches no PHP and no browser test.

- **Focused commands.** The mutation matrix records 27 behavior families for the two files this suite covers — `email-status.tsx` and `sidebar_settings.tsx` — and one focused command per family. All 27 exit 0. They resolve to the suite's three cases, so each command runs one case and skips the other two.
- **The whole directory.** `client/wp-admin-scripts/email-editor-integration` passes whole: 8 suites, 88 tests. That matters because the new suite mocks `@wordpress/core-data` and `@wordpress/data`, which three sibling suites in the same directory also mock.
- **Mutation re-check.** For each of the 27 families, a script applied one hand-written mutation from the matrix, ran only that family's case, restored the file and proved it byte-identical, then ran the case again. Every mutation fails and every restore passes, all on the first run. Every anchor was checked to occur exactly once in its file at `origin/trunk` before the run, which matters here because several of these lines appear twice — the toggle's `disabled={ isManual }`, the dispatch's `current_post_id`, and the CC and BCC `isEnabled: value` pairs are each disambiguated by the line above them.
- **Where the reds land.** Twenty-one of the 27 fail at an `expect`. Six fail at a Testing Library query instead: the CC and BCC visibility families, the recipient binding, the null-recipient branch, and two status-label families. For a rendering behavior that is the observation — the element's absence, or its accessible name, is what the test is checking — but it means the failure surfaces where the test looks for the element rather than at an assertion line, and a reader comparing against the matrix's recorded red should expect that.
- **Lint.** Prettier and ESLint are clean on the changed lines, oxlint reports nothing new against trunk, PHPCS has no PHP to look at, and `lint:changes:branch` exits 0. PHPStan does not apply: there is no PHP in this PR.
- **Trunk drift.** None. The one added file does not exist on trunk, and both production files the suite covers are byte-identical at the diff base, at the migration branch and at `origin/trunk`, so every mutation anchor still matches.

A sample, one per area:

| Mutation | Change | What fails |
| --- | --- | --- |
| `0293` | the status control reports `true` whatever the merchant picked | `updates email status and tracks it`, at the dispatched payload |
| `1232` | the status toggle is disabled for every email, not only manual ones | same case, at the enabled-state assertion |
| `0294` | the sidebar replaces `woocommerce_data` instead of merging into it | `passes subject and preheader values through the sidebar data owner`, at the first payload |
| `1237` | clearing the subject silently keeps the previous value | same case, at the cleared payload |
| `1241` | the CC field never renders | `updates and clears CC and BCC recipients`, where it looks for the field |
| `1250` | the CC toggle always reports `isEnabled: true` | same case, at the Tracks payload |

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-email-editor-sidebar-settings`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


