### PR TITLE
[tests] Trim block email rendering-source E2E tests from three to one

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-block-email-rendering-source
+++ b/plugins/woocommerce/changelog/testops-288-block-email-rendering-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Trim block email rendering-source coverage to one browser journey; two rules move to their PHPUnit owners.
+

--- a/plugins/woocommerce/tests/e2e/tests/email/order-emails-block-editor.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/order-emails-block-editor.spec.ts
@@ -15,14 +15,13 @@ import {
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { admin } from '../../test-data/data';
-import { setOption } from '../../utils/options';
+import { deleteOption, setOption } from '../../utils/options';
 import { accessTheEmailEditor, expectEmail } from '../../utils/email';
 
 /**
- * End-to-end coverage for file-first block email rendering (WOOPLUG-6171):
- * with the block email editor enabled, a transactional email renders from its
- * file template until the merchant edits AND saves it — a draft scratchpad
- * (even one carrying unsaved edits) never affects what customers receive.
+ * End-to-end coverage for the installed block-email customization seam: a
+ * merchant opens the file-backed editor, edits its scratchpad, saves it, and
+ * receives the published customization in a transactional email.
  *
  * Uses the customer "Processing order" email; delivery is asserted through the
  * WP Mail Logging inbox like the classic `order-emails.spec.ts`.
@@ -31,16 +30,13 @@ import { accessTheEmailEditor, expectEmail } from '../../utils/email';
 const EMAIL_LISTING_TITLE = 'Order confirmation';
 const EMAIL_TYPE = 'customer_processing_order';
 const SUBJECT_REGEX = /Your .+ order has been received!/;
-// Footer text unique to the `wooemailtemplate` block template — proves the
-// email was rendered through the block pipeline, not the classic one.
-const BLOCK_TEMPLATE_FOOTER = 'All Rights Reserved';
 const DRAFT_MARKER = 'WOOPLUG6171_DRAFT_ONLY_MARKER';
+const EMAIL_POST_MAPPING_OPTION =
+	'woocommerce_email_templates_customer_processing_order_post_id';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
 } );
-
-test.describe.configure( { mode: 'serial' } );
 
 const createAdminApiClient = ( baseURL: string ) =>
 	createClient( baseURL, {
@@ -75,6 +71,10 @@ test.beforeAll( async ( { baseURL } ) => {
 	);
 	// Start from a clean slate in case another spec left a post behind.
 	await deleteEmailTypePosts( baseURL );
+	// A mapping can outlive its email post and later point at an unrelated post
+	// after an environment restore reuses the numeric ID. Remove this email
+	// type's mapping so the real Edit action creates a fresh `woo_email` draft.
+	await deleteOption( request, baseURL, EMAIL_POST_MAPPING_OPTION );
 } );
 
 test.afterAll( async ( { baseURL } ) => {
@@ -87,6 +87,7 @@ test.afterAll( async ( { baseURL } ) => {
 	// Delete posts while the feature is still enabled so the
 	// `before_delete_post` hook also clears the email type → post mapping.
 	await deleteEmailTypePosts( baseURL );
+	await deleteOption( request, baseURL, EMAIL_POST_MAPPING_OPTION );
 	await setOption(
 		request,
 		baseURL,
@@ -124,26 +125,12 @@ const triggerOrderEmailAndOpenLog = async ( page, restApi ) => {
 	return modalContent.locator( 'iframe' ).contentFrame();
 };
 
-test( 'uncustomized email is sent from the file template', async ( {
+test( 'saved email is sent from the customized post', async ( {
 	page,
 	restApi,
 } ) => {
-	const emailBody = await triggerOrderEmailAndOpenLog( page, restApi );
-
-	await expect( emailBody.locator( 'body' ) ).toContainText(
-		'is now being processed'
-	);
-	await expect( emailBody.locator( 'body' ) ).toContainText(
-		BLOCK_TEMPLATE_FOOTER
-	);
-} );
-
-test( 'draft edits do not affect sent emails until saved', async ( {
-	page,
-	restApi,
-} ) => {
-	// Opening the editor lazily creates the draft scratchpad with the file
-	// template content.
+	// Opening the editor creates this email type's draft scratchpad from the
+	// canonical file template.
 	await accessTheEmailEditor( page, EMAIL_LISTING_TITLE );
 	await expect(
 		page
@@ -152,8 +139,6 @@ test( 'draft edits do not affect sent emails until saved', async ( {
 			.getByText( 'Thank you for your order' )
 	).toBeVisible();
 
-	// Write an edit into the draft via REST — a deterministic stand-in for
-	// the editor's remote autosave (which fires on a 60s interval).
 	const drafts = await restApi.get( `${ WP_API_PATH }/woo_email`, {
 		status: 'draft',
 		context: 'edit',
@@ -163,25 +148,12 @@ test( 'draft edits do not affect sent emails until saved', async ( {
 		( post.slug as string ).startsWith( EMAIL_TYPE )
 	);
 	expect( draft ).toBeTruthy();
+	expect( Number.isSafeInteger( draft.id ) && draft.id > 0 ).toBe( true );
 	await restApi.post( `${ WP_API_PATH }/woo_email/${ draft.id }`, {
 		content: `${ draft.content.raw }\n<!-- wp:paragraph --><p>${ DRAFT_MARKER }</p><!-- /wp:paragraph -->`,
 	} );
 
-	const emailBody = await triggerOrderEmailAndOpenLog( page, restApi );
-
-	await expect( emailBody.locator( 'body' ) ).toContainText(
-		BLOCK_TEMPLATE_FOOTER
-	);
-	await expect( emailBody.locator( 'body' ) ).not.toContainText(
-		DRAFT_MARKER
-	);
-} );
-
-test( 'saved email is sent from the customized post', async ( {
-	page,
-	restApi,
-} ) => {
-	// The editor reuses the edited draft (edits must survive reopening).
+	// The real listing must reopen that same edited scratchpad before Save.
 	await accessTheEmailEditor( page, EMAIL_LISTING_TITLE );
 	await expect(
 		page
@@ -191,22 +163,23 @@ test( 'saved email is sent from the customized post', async ( {
 	).toBeVisible();
 
 	// Save publishes the draft in the background, making it the rendering
-	// source.
-	await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
-
-	const drafts = await restApi.get( `${ WP_API_PATH }/woo_email`, {
-		status: 'publish,draft',
-		per_page: 100,
+	// source. Observe the exact post write and then poll the same draft ID.
+	const saveResponse = page.waitForResponse( ( response ) => {
+		const url = new URL( response.url() );
+		return (
+			url.pathname.endsWith( `/wp/v2/woo_email/${ draft.id }` ) &&
+			[ 'POST', 'PUT' ].includes( response.request().method() ) &&
+			response.ok()
+		);
 	} );
-	const post = drafts.data.find( ( item ) =>
-		( item.slug as string ).startsWith( EMAIL_TYPE )
-	);
-	expect( post ).toBeTruthy();
+	await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
+	await saveResponse;
+
 	await expect
 		.poll(
 			async () => {
 				const response = await restApi.get(
-					`${ WP_API_PATH }/woo_email/${ post.id }`,
+					`${ WP_API_PATH }/woo_email/${ draft.id }`,
 					{ context: 'edit' }
 				);
 				return response.data.status;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`order-emails-block-editor.spec.ts` ran three browser titles over a single decision: which post a sent block email renders from. Two of them sent a real mail only to observe a rule the renderer applies before any mail exists.

This PR deletes those two and keeps the one that is a journey rather than a rule — a merchant customizes an email, saves it, and the mail that goes out carries their copy. Both deleted rules already have PHPUnit owners that live on trunk today and are not touched here. Three browser titles become one.

Refs TESTOPS-288

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `uncustomized email is sent from the file template` | `BlockEmailRendererTest::testItRendersFromFileTemplateWhenNoPostMappingExists`, pre-existing and unchanged: it asserts a non-null render, the Woo content substituted, no raw placeholder left behind, and the `. All Rights Reserved.` footer that proves the file template was used | the no-mapping branch **in a sent mail**. The PHP owner calls `maybe_render_block_email()` directly, where the browser sent a real processing-order email through WP Mail Logging and read it. The send wiring itself is still walked by the retained title, and `settings-email-listing.spec.ts` › `Preview action renders the file template for emails without a saved post` still proves file-template rendering in a browser, through the preview popup rather than a sent mail |
| `draft edits do not affect sent emails until saved` | `BlockEmailRendererTest::testItFallsBackToFileTemplateWhenMappedPostIsUnpublished` (data provider: `draft`, `auto-draft`) and `…WhenMappedPostIsTrashed`; `IntegrationTest::test_editor_open_refreshes_untouched_scratchpad` and `…_leaves_edited_scratchpad_untouched` for the scratchpad lifecycle | the negative send: nothing now sends a real mail while an edited draft exists and asserts the draft's text is absent. The loss is smaller than it looks, because in the real flow the draft is never mapped: `create_draft()` writes only the `_wc_email_type` meta, the mapping is written on publish, and the renderer finds posts through the mapping alone, so the unpublished-status check never runs for that draft. Two layers keep a draft out of the mail, each with a PHPUnit owner: no mapping before publish (`WCTransactionalEmailPostsGeneratorTest::test_create_draft_does_not_write_option_mapping`, plus `WCTransactionalEmailPostsManagerTest::testGetEmailTypeFromPostIdDoesNotCacheMetaFallbackResult`, which keeps the meta lookup from passing the draft off as the mapped post), and the status check (`…WhenMappedPostIsUnpublished`). The deleted title could only have gone red if both broke at once |

#### The browser title that stays, and why it is better than it was

`saved email is sent from the customized post`, in `core-serial`. It opens the block editor for the processing-order email through the Emails listing, edits it, saves, then places an order and reads the mail that WP Mail Logging captured.

It also **absorbs the deleted draft title's setup**: it now performs the lazy-draft-on-editor-open step and the REST marker write itself. That is not cosmetic. On trunk this title cannot run on its own — selecting it alone with `--grep` fails, because the draft marker it looks for is written by the title above it in the file. After this PR it passes alone. A title that depends on its neighbour is a title that cannot be run in isolation, quarantined, or moved, and this one no longer is.

What it loses is one step that belonged to the deleted title: the pre-Save check that the sent email excludes the marker.

Four further changes come with that independence, and they are the ones a reviewer should look at rather than take on trust:

- `test.describe.configure( { mode: 'serial' } )` is gone from the file. It existed because the titles fed each other; with one title left, nothing orders anything.
- `beforeAll` and `afterAll` now delete the `woocommerce_email_templates_customer_processing_order_post_id` option. This is load-bearing, not tidying, and the file says why: a mapping can outlive its email post and end up pointing at an unrelated one after an environment restore reuses the numeric id, which would send the title's first action — the real Edit link in the Emails listing — to the wrong post.
- The post-Save wait was rewritten. It used to re-query the REST collection and match a post by slug prefix; it now waits for the response to the exact write to `/wp/v2/woo_email/<draft id>`. That is a synchronisation change, so it is the place to look first if this title ever turns flaky, though it is strictly narrower than what it replaces.
- A guard asserts the draft id is a positive safe integer before it is used in a URL.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Build the plugin: `pnpm --filter=@woocommerce/plugin-woocommerce build`. The retained title runs the block email editor, which needs the built bundles.
3. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`. It installs WP Mail Logging, which the title reads the sent mail from.
4. Confirm the file lists one title: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-serial --list tests/e2e/tests/email/order-emails-block-editor.spec.ts`.
5. Run it with retries disabled and confirm it passes: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-serial --retries=0 --workers=1 tests/e2e/tests/email/order-emails-block-editor.spec.ts`.
6. Confirm the title now stands alone, which it does not on trunk: re-run step 5 with `--grep 'saved email is sent from the customized post'` and confirm it still passes. Doing the same on trunk fails, because there the draft marker is written by the title above it.
7. Confirm the two PHPUnit owners that replace the deleted titles pass: start the PHP environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start`, then run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'BlockEmailRendererTest'` and `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'test_editor_open_refreshes_untouched_scratchpad|test_editor_open_leaves_edited_scratchpad_untouched'`. Filtering on `IntegrationTest` alone matches many unrelated classes and runs well over a hundred tests. Neither file is changed by this PR; the point is that they are the owners.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch's single commit against a local WordPress, with retries disabled. Trunk was at `adefb5f971`, and `BlockEmailRenderer.php` — the file the one mutation targets — is byte-identical at the diff base, on the migration branch and at trunk, so the recorded anchor still matches.

- **Before extracting anything, the retained title was run against unmodified trunk.** The batch's own analysis flagged a risk: trunk's #68498 made the Settings > Emails listing load on demand, and this title walks that listing through `accessTheEmailEditor`. The whole spec passes on trunk, all three titles, so the risk does not materialize. That run is kept as evidence rather than described from memory.
- **The same run exposed something better worth fixing than the risk it was looking for.** Selecting the retained title alone on trunk *fails*: it waits for a draft marker that the title above it writes. On this branch it passes alone, because it now performs that setup itself. Both runs are in the evidence.
- **Focused command.** The matrix records one behavior family for this file, and its focused command exits 0.
- **The retained title.** `--list` shows one title where trunk lists three, and the spec passes at `--retries=0 --workers=1`.
- **Mutation re-check.** `mutation-0775` makes `get_email_post_by_wc_email()` return `null` for a post it should have found, keeping the unpublished-status guard intact. The title goes red at its final assertion — the sent mail no longer carries the merchant's copy — the file is restored byte-identical, and the title passes again. Red and green on the first run.
- **Lint.** Prettier and ESLint are clean on the changed lines, oxlint reports nothing new against trunk, PHPCS has no changed PHP to look at, and `lint:changes:branch` exits 0. A search for the two deleted titles' names across the tests, the client, the packages, `.github` and both `package.json` files finds nothing, and the same log carries a positive control — the retained title, which the search does find — so an empty result cannot be confused with a broken search.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-block-email-rendering-source`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


