### PR TITLE
[tests] Make checkout payment method selectors exact in two retained E2E specs

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-checkout-shortcode-flows
+++ b/plugins/woocommerce/changelog/testops-288-checkout-shortcode-flows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Make checkout payment-method selectors exact in two retained E2E specs.
+

--- a/plugins/woocommerce/tests/e2e/tests/checkout/checkout-shortcode-custom-place-order-button.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/checkout/checkout-shortcode-custom-place-order-button.spec.ts
@@ -158,7 +158,7 @@ test.describe( 'Shortcode Checkout Custom Place Order Button', () => {
 				.fill( customer.billing.email );
 
 			// Selecting Cash on Delivery first.
-			await page.getByText( 'Cash on delivery' ).click();
+			await page.getByText( 'Cash on delivery', { exact: true } ).click();
 
 			// Ensuring the default button is visible and the custom button is not.
 			await expect( page.locator( '#place_order' ) ).toBeVisible();
@@ -184,7 +184,7 @@ test.describe( 'Shortcode Checkout Custom Place Order Button', () => {
 			await expect( page.locator( '#place_order' ) ).toBeHidden();
 
 			// Switching back to Cash on Delivery.
-			await page.getByText( 'Cash on delivery' ).click();
+			await page.getByText( 'Cash on delivery', { exact: true } ).click();
 
 			await page.waitForFunction( () => {
 				const form = document.querySelector( 'form.checkout' );
@@ -239,7 +239,6 @@ test.describe( 'Shortcode Checkout Custom Place Order Button', () => {
 			await expect(
 				page.getByTestId( 'custom-place-order-button' )
 			).toBeVisible();
-
 			await page.getByTestId( 'custom-place-order-button' ).click();
 
 			// Ensuring the order was placed successfully.

--- a/plugins/woocommerce/tests/e2e/tests/checkout/checkout.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/checkout/checkout.spec.ts
@@ -91,7 +91,7 @@ async function placeOrder( page: Page ) {
 		// this helps with flakiness on clicking the Place order button
 		await page
 			.getByPlaceholder( 'Notes about your order' )
-			.fill( 'This order was created by an end-to-end test.' );
+			.fill( 'Test note' );
 	}
 
 	await page.getByRole( 'button', { name: 'Place order' } ).click();
@@ -279,7 +279,7 @@ checkoutPages.forEach( ( { name, slug } ) => {
 			);
 			const newCustomer = getFakeCustomer();
 			await fillBillingDetails( page, newCustomer.billing, false );
-			await page.getByText( 'Cash on delivery' ).click();
+			await page.getByText( 'Cash on delivery', { exact: true } ).click();
 			await placeOrder( page );
 			await page.goto( 'my-account/' );
 			await expect( page.locator( '#username' ) ).toBeVisible();
@@ -301,7 +301,9 @@ checkoutPages.forEach( ( { name, slug } ) => {
 			);
 			const newCustomer = getFakeCustomer();
 			await fillBillingDetails( page, newCustomer.billing, true );
-			await page.getByText( 'Direct bank transfer' ).click();
+			await page
+				.getByText( 'Direct bank transfer', { exact: true } )
+				.click();
 			await placeOrder( page );
 			await page.goto( 'my-account/' );
 			await expect(
@@ -328,7 +330,9 @@ checkoutPages.forEach( ( { name, slug } ) => {
 				tax
 			);
 
-			await page.getByText( 'Direct bank transfer' ).click();
+			await page
+				.getByText( 'Direct bank transfer', { exact: true } )
+				.click();
 			await placeOrder( page );
 		}
 	);
@@ -426,7 +430,7 @@ checkoutPages.forEach( ( { name, slug } ) => {
 				await fillShippingCheckoutBlocks( page, shippingAddress );
 			}
 
-			await page.getByText( 'Cash on delivery' ).click();
+			await page.getByText( 'Cash on delivery', { exact: true } ).click();
 			await placeOrder( page );
 		}
 	);
@@ -476,7 +480,9 @@ checkoutPages.forEach( ( { name, slug } ) => {
 				} );
 			}
 
-			await page.getByText( 'Direct bank transfer' ).click();
+			await page
+				.getByText( 'Direct bank transfer', { exact: true } )
+				.click();
 			await placeOrder( page );
 		}
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Both specs pick a payment method by its visible text — `getByText( 'Cash on delivery' )` in each, and `getByText( 'Direct bank transfer' )` in `checkout.spec.ts`. That is a substring match, and a gateway's description can contain its own title — in which case the locator matches both the label and the description, and Playwright fails in strict mode before the order is placed. This PR makes the seven selectors exact.

This is not hypothetical, and it is not a style preference. The repository's own Blocks E2E seed writes descriptions of exactly that shape: `tests/e2e/bin/blocks/scripts/parallel/payment.sh` sets the Cash on delivery description to `Cash on delivery description` and the Direct bank transfer one to `Direct bank transfer description`. Against a store carrying those settings, trunk's current copy of `checkout.spec.ts` fails:

```
Error: locator.click: Error: strict mode violation: getByText('Cash on delivery') resolved to 2 elements:
    1) <label for="payment_method_cod">↵⇆⇆Cash on delivery ⇆</label> aka getByText('Cash on delivery', { exact: true })
    2) <p>Cash on delivery description</p> aka getByText('Cash on delivery description')
```

Playwright names this PR's own fix in that output: the label it wanted is `getByText('Cash on delivery', { exact: true })`.

**Corrected after this PR was opened: this state does not arise in CI, so the fix is defensive rather than a currently-red job.** The descriptions come from `tests/e2e/bin/blocks/test-env-setup.sh`, which runs `scripts/index.sh` and its `parallel/payment.sh` as part of `pnpm env:start:blocks` — the environment start for the Blocks CI jobs (`package.json:896, 951, 999, 1050`). It is not a Playwright project step: the `blocks setup` project only regenerates the attributes lookup table and handles the database snapshot. The Core E2E jobs start `env:e2e` in their own environment and never run that script, and `site.setup.ts` enables the gateways without setting any description, so CI sees the shipped defaults — `Pay with cash upon delivery.` and `Make your payment directly into our bank account...` — neither of which contains its title. Where it does bite is a long-lived local environment shared between batches, which is where the reproduction above came from.

Refs TESTOPS-288

Part of the #68046 split.

**This batch moves no coverage.** Nothing is demoted, no title is removed, and no test is added. Both specs stay in the browser with every title they have. That makes it unlike the rest of the split, and it is worth saying plainly so nobody looks for a removal table.

| File | What changes | Titles at the migration base → here |
| --- | --- | --- |
| `tests/e2e/tests/checkout/checkout.spec.ts` | five payment-method selectors become exact; the order note's text changes | 5 declarations, 10 listed titles → unchanged |
| `tests/e2e/tests/checkout/checkout-shortcode-custom-place-order-button.spec.ts` | two payment-method selectors become exact; one blank line | 3 → unchanged |

The ten listed titles come from five `test()` declarations, each generated once per checkout page. All five exact selectors sit at the top level of their test bodies — two of them follow an `isClassicCheckout` block but after its closing brace, not inside it — so every one runs on both the blocks and the classic checkout. The shortcode spec is classic by definition.

#### One deliberate departure from the migration branch

The migration branch also swapped `.check()` for `.click()` on the order-note checkbox in the shared `placeOrder()` helper, and deleted the comment recording why that step exists. This PR keeps trunk's `.check()` and its comment.

`check()` asserts the element is a checkbox and that it ends up checked, throwing if it does not, and it is a no-op when the box is already checked. `click()` asserts neither, and on an already-checked box it would uncheck it — after which the Blocks checkout stops rendering the textarea the next `fill()` targets, since it is behind `{ withOrderNotes && … }`, so that call would fail with the element not found. The `expect()` count is identical either way, which is why no count-based comparison would show the difference. No commit message explains the swap and it has nothing to do with moving a test between layers, so it is not carried. That helper step runs on the blocks checkout only.

The same hunk also shortened the order note from `This order was created by an end-to-end test.` to `Test note`, and that part **is** carried. The line between the two is whether the change removes a check: `.check()` does assert something and `.click()` does not, while neither note string is asserted anywhere. The batch dossier objected that the shorter text loses the only marker identifying test-created orders in a store database, which is a fair point for a long-lived local store and not for CI, where the store is rebuilt per run. It is called out here rather than left for a reader to notice.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Build the plugin: `pnpm --filter=@woocommerce/plugin-woocommerce build`.
3. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
4. Give the store the gateway descriptions that expose the bug, which is what the Blocks seed writes: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp option set --format=json woocommerce_cod_settings '{"enabled":"yes","title":"Cash on delivery","description":"Cash on delivery description","instructions":"Cash on delivery instructions"}'`. Running `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks` sets the same thing along with much else.
5. Confirm the bug exists on trunk. With the branch checked out, restore trunk's copy of the one spec and run a classic title: `git checkout origin/trunk -- plugins/woocommerce/tests/e2e/tests/checkout/checkout.spec.ts` then `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/checkout/checkout.spec.ts --grep 'guest can checkout paying with cash on delivery on classic checkout'`. Expect a failure reading `strict mode violation: getByText('Cash on delivery') resolved to 2 elements`.
6. Restore this branch's copy: `git checkout HEAD -- plugins/woocommerce/tests/e2e/tests/checkout/checkout.spec.ts`.
7. Run the same title again and confirm it now passes.
8. Run both specs in full with retries disabled and confirm `15 passed` and `1 skipped`: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --retries=0 --workers=1 tests/e2e/tests/checkout/checkout.spec.ts tests/e2e/tests/checkout/checkout-shortcode-custom-place-order-button.spec.ts`. The fifteen are thirteen spec titles plus the `global authentication` and `site setup` projects; the one skip is the `install wc` setup project, which skips itself when `INSTALL_WC` is unset.

If step 8 fails with the order never placed and the page still on `/classic-checkout/`, check `wp option get woocommerce_terms_page_id`. The same Blocks seed creates a `Terms` page and sets that option, and once it is set the classic checkout requires a terms checkbox that no Core spec ticks. Removing the option restores what Core's own site setup leaves. That is environment state rather than anything this PR changes, and it is called out here because it is easy to mistake for a regression.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch's single commit against a local WordPress, with retries disabled, on an environment where the terms-page option had been removed. Trunk was at `adefb5f971`. Evidence logs are stamped `12882f6a57` or `3396e28c85`, both points in this commit's amend chain, and the extraction gate against `adefb5f971`, which is trunk. The amends changed the message only: `git diff 12882f6a57 HEAD` and `git diff 3396e28c85 HEAD` are both empty, so every log applies to the current tree unchanged.

- **The bug this fixes was reproduced on trunk, not assumed.** Trunk's own unmodified copy of `checkout.spec.ts`, run in the same environment, fails with `strict mode violation: getByText('Cash on delivery') resolved to 2 elements` — the label and `<p>Cash on delivery description</p>`. `evidence/control-trunk-nonexact-selectors.log` has the run and traces the description to the Blocks seed script that writes it.
- **Focused commands.** The matrix records 12 rows for these two files, and all 12 exit 0.
- **Retained titles.** Both specs run in full at `--retries=0 --workers=1`: 15 passed, 1 skipped, no failures. Every title present at the migration base is still present.
- **Mutation re-check, five behavior families.** A family is a distinct SUT symbol; the matrix has five for these files. For each, a script applied one recorded mutation, ran only that family's test, restored the file, then ran the same test again. The harness checks the restore is byte-identical before the second run and reports it; `evidence/mutations-run.log` carries that line per mutation, and the working tree is clean at HEAD. All five go red and green back: the Store API payment method and the classic terms condition each break `Your order has been received`; the optional account branch breaks the `Log out` link; the fixture's hidden button breaks its `toBeVisible`; and the fixture gateway returning failure breaks `toHaveURL( /order-received/ )`.
- **The recorded mutation narratives for this batch are stale, and were not relied on.** Every row was gated against two trees that are not ancestors of the migration branch, when these specs still called a helper that ticked a terms box. That helper exists at neither endpoint now, so six of the twelve recorded row descriptions mention steps the shipped specs do not perform — two of them among the five families re-checked here. Each red above was matched to the *assertion* the matrix names, not to its prose.
- **Extraction.** The shortcode spec is byte-identical to the migration branch's version. `checkout.spec.ts` differs from it only by the `placeOrder()` departure described above. Neither path has a trunk commit since the diff base, so nothing had to be merged. `evidence/extraction-gate.log`.
- **Lint.** `lint:changes:branch` exits 0, Prettier is clean, and oxlint attributed against trunk reports 0 new findings (`evidence/verify-staged.log`; `evidence/lint-oxlint.log` is a raw whole-project run and supports no claim here, which it now says in its own header). ESLint reports 12 warnings across the two specs, ten in `checkout.spec.ts` and two in the shortcode spec, and all 12 are inherited: linting trunk's own copies produces the same 12 rules at the same sites, with line numbers shifted only by the lines this PR adds. A sweep for internal campaign identifiers across all three touched paths finds nothing, with a control proving the pattern catches the abbreviated spelling that slipped past an earlier batch.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-checkout-shortcode-flows`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



