### PR TITLE
[tests] Make the customer payment page gateway selector exact

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-customer-payment-page
+++ b/plugins/woocommerce/changelog/testops-288-customer-payment-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Make the customer payment page's payment-method selector exact.
+

--- a/plugins/woocommerce/tests/e2e/tests/order/customer-payment-page.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/customer-payment-page.spec.ts
@@ -124,7 +124,9 @@ test.describe(
 			} );
 			await test.step( 'Select payment method and pay for the order', async () => {
 				// explicitly select the payment method
-				await page.getByText( 'Direct bank transfer' ).click();
+				await page
+					.getByText( 'Direct bank transfer', { exact: true } )
+					.click();
 
 				// Handle notice if present
 				await page.addLocatorHandler(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The customer payment page spec picks the gateway by its visible text, with `getByText( 'Direct bank transfer' )`. That is a substring match, and a gateway's description can contain its own title — in which case the locator matches both the label and the description, and Playwright fails in strict mode before the order is paid. This PR makes that one selector exact. That narrows the failure without closing it completely — a description equal to the title exactly would still match twice, and only a `label[for=...]` locator would be immune to description text — but it matches what the migration branch shipped, and this batch is otherwise byte-identical to it.

The repository's own Blocks E2E seed writes a description of exactly that shape: `tests/e2e/bin/blocks/scripts/parallel/payment.sh` sets the Direct bank transfer description to `Direct bank transfer description`. Against a store carrying that setting, trunk's current copy of this spec fails:

```
Error: locator.click: Error: strict mode violation: getByText('Direct bank transfer') resolved to 2 elements:
    1) <label for="payment_method_bacs">↵⇆⇆Direct bank transfer ⇆</label> aka getByText('Direct bank transfer', { exact: true })
    2) <p>Direct bank transfer description</p> aka getByText('Direct bank transfer description')
```

Playwright names the fix in its own output: the label it wanted is `getByText('Direct bank transfer', { exact: true })`.

**This state does not arise in CI, and the fix is defensive rather than a currently-red job.** The description comes from `tests/e2e/bin/blocks/test-env-setup.sh`, which runs `scripts/index.sh` and its `parallel/payment.sh` as part of `pnpm env:start:blocks` — the environment start for the Blocks CI jobs. It is not a Playwright project step: the `blocks setup` project only regenerates the attributes lookup table and handles the database snapshot. The Core E2E jobs start `env:e2e` in their own environment and never run that script, and `site.setup.ts` enables BACS without setting a description, so CI sees the gateway's shipped default, `Make your payment directly into our bank account...`, which does not contain the title. What this PR buys is a locator that is correct on any store whose description names its gateway — including the long-lived local environments this suite is developed against, where the reproduction above came from.

Refs TESTOPS-288

Part of the #68046 split.

**That is the whole change — one line, plus the reflow Prettier requires.** Nothing is demoted, no title is removed, no test is added, and the spec keeps all three of its titles. Two of them carry a `@not-e2e` tag; that tag classifies rather than excludes, since nothing in the Playwright config filters on it, and `--list` shows all three in `core-parallel`.

This is the second half of a batch split because it covered two features: the campaign ships one PR per feature area, each with its own dossier and mutation matrix. #68639 carries the same fix for the two checkout specs. The two are independent and can merge in either order.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Build the plugin: `pnpm --filter=@woocommerce/plugin-woocommerce build`.
3. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
4. Confirm no terms page is set — `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp option get woocommerce_terms_page_id` should report the option does not exist. If you reached this state by running `env:start:blocks`, that seed also creates a `Terms` page and sets this option, and `templates/checkout/form-pay.php` then renders the terms field that `WC_Form_Handler::pay_action` blocks on, so steps 7 and 8 would fail with the order never placed. Delete it with `wp option delete woocommerce_terms_page_id`.
5. Give the store the gateway description that exposes the bug, which is what the Blocks seed writes: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp option set --format=json woocommerce_bacs_settings '{"enabled":"yes","title":"Direct bank transfer","description":"Direct bank transfer description","instructions":"Direct bank transfer instructions"}'`.
6. Confirm the bug exists on trunk. Restore trunk's copy of the spec — `git checkout origin/trunk -- plugins/woocommerce/tests/e2e/tests/order/customer-payment-page.spec.ts` — then run `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/order/customer-payment-page.spec.ts --grep 'can pay for the order through the customer payment page'`. Expect a failure reading `strict mode violation: getByText('Direct bank transfer') resolved to 2 elements`.
7. Restore this branch's copy: `git checkout HEAD -- plugins/woocommerce/tests/e2e/tests/order/customer-payment-page.spec.ts`.
8. Run the same title again and confirm it passes.
9. Run the whole spec with retries disabled and confirm `5 passed` and `1 skipped`: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --retries=0 --workers=1 tests/e2e/tests/order/customer-payment-page.spec.ts`. The five are the spec's three titles plus the `global authentication` and `site setup` projects; the one skip is the `install wc` setup project, which skips itself when `INSTALL_WC` is unset.

That terms-page precondition is not incidental to this spec: the pay-for-order form renders the same terms field, and it is the exact condition `mutation-0717` targets. It is environment state rather than anything this PR changes.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch's single commit against a local WordPress, with retries disabled. Trunk was at `adefb5f971`.

- **The bug this fixes was reproduced on trunk, not assumed.** Trunk's own unmodified copy of the spec, run in the same environment, fails with the strict-mode violation quoted above, naming the label and `<p>Direct bank transfer description</p>`. `evidence/control-trunk-nonexact.log`.
- **Extraction.** The file is byte-identical to the migration branch's version — this batch ships the frozen state with no divergence. The path has no trunk commit since the diff base, so nothing had to be merged. `evidence/extraction-gate.log`.
- **Retained titles.** The whole spec runs at `--retries=0 --workers=1`: 5 passed, 1 skipped, no failures. All three titles present at the migration base are still present.
- **Mutation re-check, one behavior family.** The matrix has a single row for this file, and a single SUT symbol: `WC_Form_Handler::pay_action terms condition`. Forcing that terms error on makes the paid-order confirmation never appear, and the red fails at `getByText( 'Your order has been received' )` — the assertion the matrix names.
- **The green run after that restore failed once, and it is recorded rather than hidden.** It did not fail at the mutation's assertion but at an earlier setup click, `page.locator( 'label[for=order_status] > a' )`, with a 10s timeout. That link renders only when `$order->needs_payment()` is true (`class-wc-meta-box-order-data.php:423`), so the live candidates are a rendering-timing flake and an order that came back non-payable from the REST setup; the evidence retained does not separate them. The restore was byte-identical and the tree clean. A green re-run against that same tree passed, and three further runs passed whose output was not retained. The failing run's screenshot, trace and error context were overwritten by those re-runs before they were read, which is the part of this that should have gone differently: the one artifact set that could have named the cause was produced, named in the log, and then discarded by the runs offered as reassurance. The cause is not known and is not claimed. The campaign's usual explanation, a stale PHP file in the container, is ruled out for a reason that can be checked rather than asserted: `includes/class-wc-form-handler.php` is included only by `frontend_includes()` (`class-woocommerce.php:896`, guarded to frontend, REST and post-editor requests), so it is not loaded at all on an admin order-edit screen, and no state of it can change what that screen renders. `evidence/mutations-run.log` states all of this.
- **Lint.** `lint:changes:branch` exits 0, Prettier is clean, and oxlint attributed against trunk reports 0 new findings. ESLint reports 3 warnings, all inherited: linting trunk's own copy produces the same 3 rules at the same sites, with the two after the changed line shifted by exactly the +2 lines this PR adds. A sweep for internal campaign identifiers across both touched paths finds nothing, with a control proving the pattern catches the abbreviated spelling that slipped past an earlier batch.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-customer-payment-page`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

