### PR TITLE
[tests] Demote the auto-generated shipping-class slug test to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-shipping-classes
+++ b/plugins/woocommerce/changelog/testops-288-shipping-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move the auto-generated shipping-class slug check from E2E to PHPUnit.
+

--- a/plugins/woocommerce/tests/e2e/tests/shipping/shipping-classes.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/shipping/shipping-classes.spec.ts
@@ -20,13 +20,6 @@ const uq = faker.string.alphanumeric( 5 );
 		description: `Small items that don't cost much to ship ${ uq }`,
 		testTitle: 'can add a shipping class with an unique slug',
 	},
-	{
-		name: `Poster Pack ${ uq }`,
-		slug: '',
-		expectedSlug: `poster-pack-${ uq }`,
-		description: `Posters, stickers, and other flat items ${ uq }`,
-		testTitle: 'can add a shipping class with an auto-generated slug',
-	},
 ].forEach( ( { testTitle, name, slug, expectedSlug, description } ) => {
 	const test = baseTest.extend( {
 		storageState: ADMIN_STATE_PATH,
@@ -48,7 +41,6 @@ const uq = faker.string.alphanumeric( 5 );
 		},
 	} );
 
-	// eslint-disable-next-line playwright/valid-title -- Title comes from the parametrized test data row.
 	test( testTitle, { tag: [ tags.SERVICES ] }, async ( { page } ) => {
 		await page.goto(
 			'wp-admin/admin.php?page=wc-settings&tab=shipping&section=classes'

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -143,6 +143,93 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Saving a new shipping class with a blank slug generates and returns its persisted slug.
+	 */
+	public function test_shipping_classes_save_changes_generates_slug(): void {
+		$original_post            = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test snapshots request state before installing a real nonce.
+		$original_request         = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test snapshots request state before installing a real nonce.
+		$original_user_id         = get_current_user_id();
+		$had_current_tab          = array_key_exists( 'current_tab', $GLOBALS );
+		$had_current_section      = array_key_exists( 'current_section', $GLOBALS );
+		$original_current_tab     = $GLOBALS['current_tab'] ?? null;
+		$original_current_section = $GLOBALS['current_section'] ?? null;
+		$name                     = 'Poster Pack ' . wp_unique_id();
+		$expected_slug            = sanitize_title( $name );
+		$description              = 'Posters, stickers, and other flat items.';
+		$term_id                  = 0;
+
+		try {
+			$this->_setRole( 'administrator' );
+			$_POST    = array(
+				'wc_shipping_classes_nonce' => wp_create_nonce( 'wc_shipping_classes_nonce' ),
+				'changes'                   => array(
+					'new-row' => array(
+						'newRow'      => true,
+						'name'        => $name,
+						'slug'        => '',
+						'description' => $description,
+					),
+				),
+			);
+			$_REQUEST = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test installs the real nonce immediately above.
+
+			// WC_Shipping::get_shipping_classes() memoizes into a public property that nothing
+			// resets, so a warm cache would omit the new term from the response.
+			WC_Shipping::instance()->shipping_classes = array();
+
+			$response = $this->do_ajax( 'woocommerce_shipping_classes_save_changes' );
+			$this->assertTrue( $response['success'] ?? false, 'The registered AJAX action should report success.' );
+
+			$term = get_term_by( 'slug', $expected_slug, 'product_shipping_class' );
+			$this->assertInstanceOf( WP_Term::class, $term, 'The blank-slug request should create a shipping-class term.' );
+			if ( ! $term instanceof WP_Term ) {
+				throw new RuntimeException( 'The shipping-class term could not be reloaded.' );
+			}
+			$term_id = $term->term_id;
+
+			$this->assertSame( $name, $term->name );
+			$this->assertSame( $description, $term->description );
+
+			$response_rows = $response['data']['shipping_classes'] ?? array();
+			$matching_rows = array_values(
+				array_filter(
+					$response_rows,
+					static fn ( array $row ): bool => (int) ( $row['term_id'] ?? 0 ) === $term_id
+				)
+			);
+			$this->assertCount( 1, $matching_rows, 'The AJAX response should contain the new shipping class exactly once.' );
+			$this->assertSame( $expected_slug, $matching_rows[0]['slug'] );
+			$this->assertSame( $name, $matching_rows[0]['name'] );
+			$this->assertSame( $description, $matching_rows[0]['description'] );
+		} finally {
+			WC_Shipping::instance()->shipping_classes = array();
+
+			if ( 0 === $term_id ) {
+				$created_term = get_term_by( 'slug', $expected_slug, 'product_shipping_class' );
+				$term_id      = $created_term instanceof WP_Term ? $created_term->term_id : 0;
+			}
+			if ( 0 < $term_id ) {
+				wp_delete_term( $term_id, 'product_shipping_class' );
+			}
+
+			$_POST    = $original_post;
+			$_REQUEST = $original_request;
+			wp_set_current_user( $original_user_id );
+
+			if ( $had_current_tab ) {
+				$GLOBALS['current_tab'] = $original_current_tab;
+			} else {
+				unset( $GLOBALS['current_tab'] );
+			}
+			if ( $had_current_section ) {
+				$GLOBALS['current_section'] = $original_current_section;
+			} else {
+				unset( $GLOBALS['current_section'] );
+			}
+		}
+	}
+
+	/**
 	 * Skip the current test on PHP 8.1 and higher.
 	 * TODO: Remove this method and its usages once WordPress is compatible with PHP 8.1. Please note that there are multiple copies of this method.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The shipping classes admin spec runs two browser titles from one parametrized data set: adding a class with an explicit slug, and adding one with a blank slug so the server generates it. Both drive the same screen through the same steps, and the only difference between them is whether the slug field is filled.

What the second one proves is a server decision, though the decision is WordPress core's rather than ours. `shipping_classes_save_changes` runs `array_filter()` over the new-row arguments, which drops the blank slug entirely, so `wp_insert_term()` is called without one and derives it from the name. What the test guards is that WooCommerce passes the blank through instead of substituting its own value, and that the generated slug reaches both the term and the response row. That does not need a browser. This PR moves it to PHPUnit and keeps the explicit-slug title, so the spec goes from 2 titles to 1 and `class-wc-ajax-test.php` gains one method.

Refs TESTOPS-288

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `can add a shipping class with an auto-generated slug` | the new `WC_AJAX_Test::test_shipping_classes_save_changes_generates_slug`, which posts the save-changes request with a blank slug and asserts, in eight assertions, what the browser title never separated: that the action reports success, that a `product_shipping_class` term exists under the slug generated from the name, that the term's name and description round-tripped, and that the response lists the new class exactly once with that slug, name and description | the rendered result for the blank-slug case specifically — that a *generated* slug shows up in the admin table. The retained title still asserts the rendered name, slug and description for a slug the test supplies, through the same code path and the same Backbone render, so what is lost is the pairing of "server generated it" with "the table showed it", not the rendering itself. One client-side behaviour does go unowned with it: nothing at any layer now drives the create-class modal with the slug field left empty, so a regression making the slug required — `validateFormArguments` in `client/legacy/js/admin/wc-shipping-classes.js` requires only `name` and `description` today — would not be caught |

#### The PHPUnit file is shared, and this PR takes only its own method

`class-wc-ajax-test.php` receives methods from two batches of this split. **This PR does not check that file out from the migration branch.** It starts from trunk's copy and adds only the one method its own migration commit adds. The other four methods in that file's migration delta ship in #68637.

That matters because trunk has moved four commits on this file since the migration branch was cut. A whole-file checkout would have silently deleted three merged tests and a data provider, among them `test_json_search_downloadable_products_honors_include_and_exclude`, the regression test for #68101. The evidence log lists all four by name and shows each still present here and absent from the migration branch's copy; a static-aware method-set diff against trunk reports exactly one method added and none removed.

The new method needs nothing that the other batch introduces: no new `use`, no data provider, and its only helper, `do_ajax()`, is already on trunk.

Two defects in the migrated test are fixed here rather than carried. It asserted the slug of a term it had just fetched *by that slug*, which cannot fail; that assertion is replaced by one on the response row's name, which nothing checked. And `WC_Shipping::get_shipping_classes()` memoizes into a public property that nothing resets, so a warm cache would omit the new term from the response and fail the count assertion for an unrelated reason, while a cache left warm would go on showing later tests in the same process a class the transaction has already rolled back — the test now clears it before the request and again in its teardown. The assertion count is unchanged at eight.

#### Two smaller differences from the migration branch

The spec drops an `eslint-disable` for `playwright/valid-title`. That directive is already unused on trunk — it reports *itself* as an unused directive — so removing it removes a warning rather than adding one. It sat on the single `test()` call inside the `forEach` and applied to every row equally, including the one this PR keeps, so the removal is justified by the directive being unused and not by the row change.

The migration branch named the new test's fixture `Slice 103 Poster Pack`, after an internal work item. It is renamed to `Poster Pack` here. `sanitize_title()` of that name is what produces the expected slug, so the rename changes the fixture's value and nothing about the behaviour under test.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the new test and confirm `OK (1 test, 8 assertions)`: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter '/WC_AJAX_Test::test_shipping_classes_save_changes_generates_slug/'`. Anchor the filter as shown — `--filter` is an unanchored substring match.
4. Run the whole class and confirm it passes, which is the check that matters for a file two PRs add to: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter '/WC_AJAX_Test::/'`. Expect `Tests: 86, Assertions: 335, Skipped: 2` and no failures.
5. Confirm the new test detects a real regression. In `plugins/woocommerce/includes/class-wc-ajax.php`, inside `shipping_classes_save_changes`, change `wp_insert_term( $update_args['name'], 'product_shipping_class', $update_args )` to `wp_insert_term( $update_args['name'], 'product_shipping_class', array_merge( $update_args, array( 'slug' => 'wrong-slug' ) ) )`. Re-run step 3 and expect `Failed asserting that false is an instance of class "WP_Term"` — the AJAX-success assertion still passes, and the term lookup by the generated slug fails. Revert afterwards. Nothing needs cleaning up: the test runs inside the `WP_UnitTestCase` transaction, so the term the mutated run created is rolled back with everything else.
6. Build the plugin — `pnpm --filter=@woocommerce/plugin-woocommerce build` — then start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
7. Confirm the spec now lists one title: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --list tests/e2e/tests/shipping/shipping-classes.spec.ts`. Count the `[core-parallel]` line, not the `Total:` line, which also counts the setup projects.
8. Run it with retries disabled and confirm the summary reads `1 skipped` and `3 passed`: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --retries=0 --workers=1 tests/e2e/tests/shipping/shipping-classes.spec.ts`. The three are the one retained title plus the `global authentication` and `site setup` projects; the skip is the `install wc` setup project, which skips itself when `INSTALL_WC` is unset.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch's single commit against a local WordPress, with retries disabled. Trunk was at `adefb5f971`.

- **The shared file was gated by name, not by count.** All four trunk methods a whole-file checkout would have deleted are present here and absent from the migration branch's copy, each checked individually; the static-aware method-set diff against trunk is exactly `+1 / −0`. `evidence/extraction-gate.log`. The spec, which is not shared, has zero trunk drift and is byte-identical to the migration branch's version.
- **PHPUnit.** The new method alone: `OK (1 test, 8 assertions)`. The whole merged class: `Tests: 86, Assertions: 335, Skipped: 2`, no failures. Both filters are anchored on the class; a scan of every test class in the tree confirms `/WC_AJAX_Test::/` selects only this one, with a control showing the same scan finds 567 classes under a deliberately loose pattern (`evidence/filter-scope.log`).
- **Retained title.** The spec runs at `--retries=0 --workers=1`: 3 passed, 1 skipped, no failures. `--list` shows the single `[core-parallel]` title.
- **Mutation re-check, two behavior families.** The matrix has two distinct SUT symbols for this batch, one per layer of the same AJAX action, and both were killed. Persistence, observed by the new PHPUnit test: persisting the term under `wrong-slug` fails at `Failed asserting that false is an instance of class "WP_Term"`, after its success assertion passes — the assertion the matrix names. Response rendering, observed by the retained browser title: rewriting the returned classes' slugs while leaving the persisted term alone makes `locator('text=small-items-…-slug')` absent, which is again the assertion the matrix names. Both restore byte-identical and pass again.
- **One red was not a kill on the first attempt, and was re-run rather than recorded.** The persistence mutation first produced a PHP `ParseError` in the bootstrap, before any test ran. That is a torn read — the container reading the file while the harness rewrote it — not a result, and it is the third time this campaign has hit one. The harness now writes mutations through a same-directory temp file and `rename()`, which is atomic, and the re-run produced the real red quoted above. `evidence/mutations-run.log` keeps both attempts.
- **Lint.** `lint:changes:branch` exits 0, and it is what covers the new PHP: its `phpcs-changed` run diffs against the merge base, picks up `class-wc-ajax-test.php`, and reports nothing. `lint:php:changes` also exits 0, but on a clean tree it diffs unstaged changes only, so it lints nothing here and is not evidence. The one remaining ESLint warning in the spec is inherited from trunk; removing the unused directive leaves the file with fewer warnings than trunk has — 1 against trunk's 2, both runs in `evidence/lint-eslint-attribution.log`. A sweep for internal campaign identifiers across all three touched paths finds nothing, and its control is the migration branch's own version of this method, where the same pattern does find the `Slice 103` name that was renamed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-shipping-classes`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


