### PR TITLE
Add tax settings to the System Status Report

### DIFF
--- a/plugins/woocommerce/changelog/add-system-status-tax-settings
+++ b/plugins/woocommerce/changelog/add-system-status-tax-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Tax settings section to the System Status Report.

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -33,7 +33,8 @@ $active_plugins_count   = is_countable( $active_plugins ) ? count( $active_plugi
 $inactive_plugins_count = is_countable( $inactive_plugins ) ? count( $inactive_plugins ) : 0;
 
 $additional_tax_classes_limit     = 10;
-$additional_tax_classes           = $settings['additional_tax_classes'];
+$additional_tax_classes           = $settings['additional_tax_classes'] ?? array();
+$additional_tax_classes           = is_array( $additional_tax_classes ) ? array_values( array_filter( $additional_tax_classes, 'is_string' ) ) : array();
 $displayed_additional_tax_classes = array_slice( $additional_tax_classes, 0, $additional_tax_classes_limit );
 $remaining_additional_tax_classes = max( 0, count( $additional_tax_classes ) - $additional_tax_classes_limit );
 $additional_tax_classes_display   = implode( ', ', $displayed_additional_tax_classes );

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Enums\{ DefaultCustomerAddress, TaxBasedOn, TaxDisplayMode };
 use Automattic\WooCommerce\Utilities\RestApiUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -30,6 +31,55 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Cons
 
 $active_plugins_count   = is_countable( $active_plugins ) ? count( $active_plugins ) : 0;
 $inactive_plugins_count = is_countable( $inactive_plugins ) ? count( $inactive_plugins ) : 0;
+
+$additional_tax_classes_limit     = 10;
+$additional_tax_classes           = $settings['additional_tax_classes'];
+$displayed_additional_tax_classes = array_slice( $additional_tax_classes, 0, $additional_tax_classes_limit );
+$remaining_additional_tax_classes = max( 0, count( $additional_tax_classes ) - $additional_tax_classes_limit );
+$additional_tax_classes_display   = implode( ', ', $displayed_additional_tax_classes );
+
+if ( $remaining_additional_tax_classes ) {
+	$additional_tax_classes_display .= ', ' . sprintf(
+		/* translators: %d: number of additional tax classes not shown. */
+		__( 'and %d more', 'woocommerce' ),
+		$remaining_additional_tax_classes
+	);
+}
+
+$countries                  = WC()->countries->get_countries();
+$store_base_country         = $settings['store_base_country'];
+$store_base_country_display = isset( $countries[ $store_base_country ] ) ? $countries[ $store_base_country ] . ' (' . $store_base_country . ')' : $store_base_country;
+
+$tax_based_on_labels  = array(
+	TaxBasedOn::SHIPPING => __( 'Customer shipping address', 'woocommerce' ),
+	TaxBasedOn::BILLING  => __( 'Customer billing address', 'woocommerce' ),
+	TaxBasedOn::BASE     => __( 'Shop base address', 'woocommerce' ),
+);
+$tax_based_on_display = $tax_based_on_labels[ $settings['tax_based_on'] ] ?? $settings['tax_based_on'];
+
+$shipping_tax_class_labels  = array( 'inherit' => __( 'Based on cart items', 'woocommerce' ) ) + wc_get_product_tax_class_options();
+$shipping_tax_class_display = $shipping_tax_class_labels[ $settings['shipping_tax_class'] ] ?? $settings['shipping_tax_class'];
+
+$tax_display_labels = array(
+	TaxDisplayMode::INCLUSIVE => __( 'Inclusive', 'woocommerce' ),
+	TaxDisplayMode::EXCLUSIVE => __( 'Exclusive', 'woocommerce' ),
+);
+$tax_display_shop   = $tax_display_labels[ $settings['tax_display_shop'] ] ?? $settings['tax_display_shop'];
+$tax_display_cart   = $tax_display_labels[ $settings['tax_display_cart'] ] ?? $settings['tax_display_cart'];
+
+$tax_total_display_labels = array(
+	'single'   => __( 'Single total', 'woocommerce' ),
+	'itemized' => __( 'Itemized', 'woocommerce' ),
+);
+$tax_total_display        = $tax_total_display_labels[ $settings['tax_total_display'] ] ?? $settings['tax_total_display'];
+
+$default_customer_location_labels = array(
+	DefaultCustomerAddress::NO_DEFAULT       => __( 'No location by default', 'woocommerce' ),
+	DefaultCustomerAddress::BASE             => __( 'Shop country/region', 'woocommerce' ),
+	DefaultCustomerAddress::GEOLOCATION      => __( 'Geolocate', 'woocommerce' ),
+	DefaultCustomerAddress::GEOLOCATION_AJAX => __( 'Geolocate (with page caching support)', 'woocommerce' ),
+);
+$default_customer_location        = $default_customer_location_labels[ $settings['default_customer_location'] ] ?? $settings['default_customer_location'];
 
 // Include necessary WordPress file to use get_plugin_data().
 if ( ! function_exists( 'get_plugin_data' ) ) {
@@ -778,6 +828,80 @@ if ( 0 < $mu_plugins_count ) :
 			<td><?php echo esc_html( implode( ', ', $settings['enabled_features'] ) ); ?></td>
 		</tr>
 
+	</tbody>
+</table>
+<table class="wc_status_table widefat" cellspacing="0">
+	<thead>
+		<tr>
+			<th colspan="3" data-export-label="Tax Settings"><h2><?php esc_html_e( 'Tax settings', 'woocommerce' ); ?></h2></th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-export-label="Enable tax rates and calculations"><?php esc_html_e( 'Enable tax rates and calculations', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Are tax rates and calculations enabled?', 'woocommerce' ) ); ?></td>
+			<td><mark class="<?php echo esc_attr( $settings['taxes_enabled'] ? 'yes' : 'no' ); ?>"><?php echo $settings['taxes_enabled'] ? esc_html__( 'Enabled', 'woocommerce' ) : esc_html__( 'Disabled', 'woocommerce' ); ?></mark></td>
+		</tr>
+		<tr>
+			<td data-export-label="Prices entered with tax"><?php esc_html_e( 'Prices entered with tax', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Are product prices entered inclusive of tax?', 'woocommerce' ) ); ?></td>
+			<td><?php echo $settings['prices_include_tax'] ? esc_html__( 'Inclusive', 'woocommerce' ) : esc_html__( 'Exclusive', 'woocommerce' ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Calculate tax based on"><?php esc_html_e( 'Calculate tax based on', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The address type WooCommerce uses to calculate tax.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $tax_based_on_display ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Shipping tax class"><?php esc_html_e( 'Shipping tax class', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The tax class WooCommerce uses for shipping.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $shipping_tax_class_display ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Rounding"><?php esc_html_e( 'Rounding', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether tax is rounded per line or at subtotal level.', 'woocommerce' ) ); ?></td>
+			<td><?php echo $settings['tax_round_at_subtotal'] ? esc_html__( 'At subtotal level', 'woocommerce' ) : esc_html__( 'Per line', 'woocommerce' ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Additional tax classes"><?php esc_html_e( 'Additional tax classes', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Additional tax classes configured for products. The list is truncated when more than 10 classes are configured.', 'woocommerce' ) ); ?></td>
+			<td><?php echo $additional_tax_classes_display ? esc_html( $additional_tax_classes_display ) : '<mark class="no">&ndash;</mark>'; ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Display prices in the shop"><?php esc_html_e( 'Display prices in the shop', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether shop prices are displayed including or excluding tax.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $tax_display_shop ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Display prices during cart and checkout"><?php esc_html_e( 'Display prices during cart and checkout', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether cart and checkout prices are displayed including or excluding tax.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $tax_display_cart ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Price display suffix"><?php esc_html_e( 'Price display suffix', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Text displayed after product prices.', 'woocommerce' ) ); ?></td>
+			<td><?php echo $settings['price_display_suffix'] ? esc_html( $settings['price_display_suffix'] ) : '<mark class="no">&ndash;</mark>'; ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Display tax totals"><?php esc_html_e( 'Display tax totals', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether tax totals are displayed as a single total or itemized.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $tax_total_display ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Tax rates"><?php esc_html_e( 'Tax rates', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The number of configured tax rates.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( number_format_i18n( $settings['tax_rate_count'] ) ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Store base country"><?php esc_html_e( 'Store base country', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The country configured as the store base location.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $store_base_country_display ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="Default customer location"><?php esc_html_e( 'Default customer location', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The location WooCommerce assumes for a customer before an address is provided.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $default_customer_location ); ?></td>
+		</tr>
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Registe
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
 use Automattic\WooCommerce\Utilities\{ LoggingUtil, OrderUtil, PluginUtil };
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
-use Automattic\WooCommerce\Enums\DefaultCustomerAddress;
+use Automattic\WooCommerce\Enums\{ DefaultCustomerAddress, TaxBasedOn, TaxDisplayMode };
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 
 /**
@@ -625,6 +625,87 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 						'geolocation_enabled'            => array(
 							'description' => __( 'Geolocation enabled?', 'woocommerce' ),
 							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'taxes_enabled'                  => array(
+							'description' => __( 'Are tax rates and calculations enabled?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'prices_include_tax'             => array(
+							'description' => __( 'Are prices entered with tax?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'tax_based_on'                   => array(
+							'description' => __( 'Address type used to calculate tax.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'shipping_tax_class'             => array(
+							'description' => __( 'Tax class used for shipping.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'tax_round_at_subtotal'          => array(
+							'description' => __( 'Is tax rounded at subtotal level?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'additional_tax_classes'         => array(
+							'description' => __( 'Additional tax classes.', 'woocommerce' ),
+							'type'        => 'array',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'tax_display_shop'               => array(
+							'description' => __( 'How prices are displayed in the shop.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'tax_display_cart'               => array(
+							'description' => __( 'How prices are displayed during cart and checkout.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'price_display_suffix'           => array(
+							'description' => __( 'Price display suffix.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'tax_total_display'              => array(
+							'description' => __( 'How tax totals are displayed.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'tax_rate_count'                 => array(
+							'description' => __( 'Number of configured tax rates.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'store_base_country'             => array(
+							'description' => __( 'Store base country.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'default_customer_location'      => array(
+							'description' => __( 'Default customer location.', 'woocommerce' ),
+							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
@@ -1446,6 +1527,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_settings() {
+		global $wpdb;
+
 		// Get a list of terms used for product/order taxonomies.
 		$term_response = array();
 		$terms         = get_terms( 'product_type', array( 'hide_empty' => 0 ) );
@@ -1468,6 +1551,9 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			)
 		);
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$tax_rate_count = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rates" );
+
 		// Return array of useful settings for debugging.
 		return array(
 			'api_enabled'                    => WC()->legacy_rest_api_is_available(),
@@ -1486,6 +1572,19 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				),
 				true
 			),
+			'taxes_enabled'                  => 'yes' === get_option( 'woocommerce_calc_taxes', 'no' ),
+			'prices_include_tax'             => 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ),
+			'tax_based_on'                   => get_option( 'woocommerce_tax_based_on', TaxBasedOn::SHIPPING ),
+			'shipping_tax_class'             => get_option( 'woocommerce_shipping_tax_class', 'inherit' ),
+			'tax_round_at_subtotal'          => 'yes' === get_option( 'woocommerce_tax_round_at_subtotal', 'no' ),
+			'additional_tax_classes'         => WC_Tax::get_tax_classes(),
+			'tax_display_shop'               => get_option( 'woocommerce_tax_display_shop', TaxDisplayMode::EXCLUSIVE ),
+			'tax_display_cart'               => get_option( 'woocommerce_tax_display_cart', TaxDisplayMode::EXCLUSIVE ),
+			'price_display_suffix'           => get_option( 'woocommerce_price_display_suffix', '' ),
+			'tax_total_display'              => get_option( 'woocommerce_tax_total_display', 'itemized' ),
+			'tax_rate_count'                 => absint( $tax_rate_count ),
+			'store_base_country'             => WC()->countries->get_base_country(),
+			'default_customer_location'      => get_option( 'woocommerce_default_customer_address', DefaultCustomerAddress::BASE ),
 			'taxonomies'                     => $term_response,
 			'product_visibility_terms'       => $product_visibility_terms,
 			'woocommerce_com_connected'      => ConnectionHelper::is_connected() ? 'yes' : 'no',

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
@@ -224,7 +224,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test to make sure settings response is correct.
+	 * @testdox The system status settings response contains the expected values.
 	 *
 	 * @since 3.5.0
 	 */
@@ -237,7 +237,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$settings = (array) $this->fetch_or_get_system_status_data_for_user( self::$administrator_user )['settings'];
 
-		$this->assertEquals( 17, count( $settings ) );
+		$this->assertEquals( 30, count( $settings ) );
 		$this->assertEquals( WC()->legacy_rest_api_is_available(), $settings['api_enabled'] );
 		$this->assertEquals( get_woocommerce_currency(), $settings['currency'] );
 		$this->assertEquals( $term_response, $settings['taxonomies'] );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
@@ -1,6 +1,8 @@
 <?php
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Enums\{ DefaultCustomerAddress, TaxBasedOn, TaxDisplayMode };
+
 /**
  * Tests for WC_REST_System_Status_V2_Controller.
  *
@@ -60,5 +62,62 @@ class WC_REST_System_Status_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 			$override_files,
 			'Template overridden via wc_get_template filter should appear in overrides'
 		);
+	}
+
+	/**
+	 * @testdox Should return tax settings used for troubleshooting.
+	 */
+	public function test_get_settings_returns_tax_settings(): void {
+		global $wpdb;
+
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_tax_based_on', TaxBasedOn::BILLING );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+		update_option( 'woocommerce_tax_display_shop', TaxDisplayMode::INCLUSIVE );
+		update_option( 'woocommerce_tax_display_cart', TaxDisplayMode::EXCLUSIVE );
+		update_option( 'woocommerce_price_display_suffix', 'including tax' );
+		update_option( 'woocommerce_tax_total_display', 'single' );
+		update_option( 'woocommerce_default_country', 'IN:MH' );
+		update_option( 'woocommerce_default_customer_address', DefaultCustomerAddress::GEOLOCATION_AJAX );
+
+		$tax_class = WC_Tax::create_tax_class( 'Diagnostic rate' );
+		if ( is_wp_error( $tax_class ) ) {
+			$this->fail( 'The diagnostic tax class should be created.' );
+		}
+		$tax_class_slug = $tax_class['slug'];
+		update_option( 'woocommerce_shipping_tax_class', $tax_class_slug );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$tax_rate_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rates" );
+		WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'IN',
+				'tax_rate_state'    => 'MH',
+				'tax_rate'          => '18.0000',
+				'tax_rate_name'     => 'GST',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 1,
+				'tax_rate_class'    => $tax_class_slug,
+			)
+		);
+
+		$settings = $this->sut->get_settings();
+
+		$this->assertFalse( $settings['taxes_enabled'] );
+		$this->assertTrue( $settings['prices_include_tax'] );
+		$this->assertSame( TaxBasedOn::BILLING, $settings['tax_based_on'] );
+		$this->assertSame( $tax_class_slug, $settings['shipping_tax_class'] );
+		$this->assertTrue( $settings['tax_round_at_subtotal'] );
+		$this->assertContains( 'Diagnostic rate', $settings['additional_tax_classes'] );
+		$this->assertSame( TaxDisplayMode::INCLUSIVE, $settings['tax_display_shop'] );
+		$this->assertSame( TaxDisplayMode::EXCLUSIVE, $settings['tax_display_cart'] );
+		$this->assertSame( 'including tax', $settings['price_display_suffix'] );
+		$this->assertSame( 'single', $settings['tax_total_display'] );
+		$this->assertSame( $tax_rate_count + 1, $settings['tax_rate_count'] );
+		$this->assertSame( 'IN', $settings['store_base_country'] );
+		$this->assertSame( DefaultCustomerAddress::GEOLOCATION_AJAX, $settings['default_customer_location'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Based on https://wp.me/p6q7sZ-lNP

The WooCommerce System Status Report currently exposes general store settings such as currency and decimal configuration, but it does not include the settings that determine how taxes are calculated and displayed. This often requires an additional reply asking the merchant to check or share their tax configuration - to troubleshoot tax issues or anything that might be dependent on tax settings.

This PR extends the existing `settings` object returned by `/wc/v3/system_status` with the following tax-related values:

- Whether tax rates and calculations are enabled.
- Whether entered prices include tax.
- The address type used to calculate tax: customer shipping address, customer billing address, or shop base address.
- The shipping tax class.
- Per-line or subtotal-level rounding.
- Additional tax classes, truncated to the first ten names followed by “and N more” when necessary.
- Shop and cart/checkout tax-display modes.
- The price display suffix.
- Itemized or single-total tax display.
- The total number of configured tax rates.
- The store's base country.
- The default customer location mode.

A **Tax settings** table displays these values in the existing System Status page and copied/downloaded report. Internal option values remain unchanged in the REST response, while the report uses descriptive labels such as **Enabled**, **Exclusive**, **Customer shipping address**, and **Based on cart items**.

The visible additional-tax-class list is limited to ten entries. When more classes exist, the report displays the first ten followed by “and N more.” The complete rate table, percentages, priorities, and location rules are deliberately excluded; only the aggregate rate count is reported.

No new top-level REST section or JavaScript behavior is introduced. The implementation follows the existing `get_settings()` → REST schema → `.wc_status_table` flow, and the existing report exporter automatically includes the new table.

The endpoint performs one small `COUNT(*)` query against the current site's `woocommerce_tax_rates` table. No result is cached, so changes to tax configuration are reflected on the next report request.

### Screenshots or screen recordings:

<img width="1323" height="541" alt="image" src="https://github.com/user-attachments/assets/08b2fde3-b8ea-44e4-833c-e1d90d7d7ef4" />

<img width="730" height="309" alt="image" src="https://github.com/user-attachments/assets/98a403c2-b6e8-4270-b547-0df82282516b" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Open **WooCommerce → Settings → General**. Enable tax rates and calculations, select a store country, and choose a default customer location. Save the settings.
2. Open **WooCommerce → Settings → Tax → Tax options**. Configure prices as inclusive, calculate tax from the customer shipping address, use the cart-item shipping tax class, round at subtotal level, display prices inclusively, and display tax totals as a single total. Add a price suffix and save.
3. Add at least one tax rate. Open **WooCommerce → Status** and confirm the **Tax settings** table displays the configured values using descriptive labels and shows the correct tax-rate count.
4. Click **Get system report** and confirm the copied report contains the same **Tax settings** section.
5. Add more than ten additional tax classes. Reload the status page and confirm only the first ten names are displayed, followed by “and N more.” Confirm there is no separate additional-class count row.
6. Return to the settings and test the opposite/blank-backed states: disable taxes, enter prices exclusively, select the Standard shipping tax class, round per line, and select **No location by default**. Confirm the report displays **Disabled**, **Exclusive**, **Standard**, **Per line**, and **No location by default** without warnings or errors.
7. As an authorized administrator, request `/wp-json/wc/v3/system_status?_fields=settings`. Confirm the new properties use the documented boolean, string, array, and integer types and retain their machine-readable option values.
8. From `plugins/woocommerce`, run the focused REST test class:

   ```bash
   pnpm test:php:env -- --filter WC_REST_System_Status_V2_Controller_Test
   ```

9. Run the changed-line PHP lint command and confirm it reports no violations:

   ```bash
   pnpm lint:php:changes:branch
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add Tax settings section to the System Status Report.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `changelog/add-system-status-tax-settings`.

</details>

### Use of AI Tools

Codex assisted with repository research, source-code analysis, the local proof of concept, runtime verification, edge-case review, investigation notes, and this draft PR description. Kaushik directed the scope and presentation decisions, reviewed the local behavior, and remains responsible for reviewing the final contribution before publication.
