### PR TITLE
[tests] Make the 2 PayPal Standard E2E tests self-cleaning and order-independent

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-paypal-standard
+++ b/plugins/woocommerce/changelog/testops-288-paypal-standard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Isolate the PayPal Standard E2E fixture's settings per test and reload the settings page after onboarding, so both retained browser titles pass from any starting state; no coverage moves between layers.
+

--- a/plugins/woocommerce/tests/e2e/fixtures/paypal-fixtures.ts
+++ b/plugins/woocommerce/tests/e2e/fixtures/paypal-fixtures.ts
@@ -5,17 +5,65 @@ import { test as baseTest } from './fixtures';
 import { ADMIN_STATE_PATH } from '../playwright.config';
 import { wpCLI } from '../utils/cli';
 
+const updatePayPalFixtureSettings = async ( shouldLoad: 'yes' | 'no' ) => {
+	await wpCLI(
+		`wp eval '$settings = get_option( "woocommerce_paypal_settings", array() ); if ( ! is_array( $settings ) ) { throw new RuntimeException( "woocommerce_paypal_settings must be an array." ); } $settings["enabled"] = "no"; $settings["transact_onboarding_complete"] = "no"; $settings["_should_load"] = "${ shouldLoad }"; update_option( "woocommerce_paypal_settings", $settings );'`
+	);
+};
+
+const deletePayPalAccountOptions = async () => {
+	await wpCLI(
+		`wp eval 'delete_option( "woocommerce_paypal_transact_merchant_account_live" ); delete_option( "woocommerce_paypal_transact_merchant_account_test" ); delete_option( "woocommerce_paypal_transact_provider_account_live" ); delete_option( "woocommerce_paypal_transact_provider_account_test" );'`
+	);
+};
+
 export const test = baseTest.extend( {
-	page: async ( { page }, use ) => {
-		await wpCLI(
-			"wp option patch update woocommerce_paypal_settings _should_load 'yes'"
-		);
+	page: async ( { page }, providePage ) => {
+		let setupFailed = false;
+		let setupError: unknown;
+		const cleanupErrors: unknown[] = [];
 
-		await use( page );
+		try {
+			try {
+				await updatePayPalFixtureSettings( 'yes' );
+				await deletePayPalAccountOptions();
+			} catch ( error ) {
+				setupFailed = true;
+				setupError = error;
+			}
 
-		await wpCLI(
-			"wp option patch update woocommerce_paypal_settings _should_load 'no'"
-		);
+			if ( ! setupFailed ) {
+				await providePage( page );
+			}
+		} finally {
+			try {
+				await updatePayPalFixtureSettings( 'no' );
+			} catch ( error ) {
+				cleanupErrors.push( error );
+			}
+
+			try {
+				await deletePayPalAccountOptions();
+			} catch ( error ) {
+				cleanupErrors.push( error );
+			}
+		}
+
+		if ( setupFailed && cleanupErrors.length ) {
+			throw new AggregateError(
+				[ setupError, ...cleanupErrors ],
+				'PayPal fixture setup and cleanup failed.'
+			);
+		}
+		if ( setupFailed ) {
+			throw setupError;
+		}
+		if ( cleanupErrors.length ) {
+			throw new AggregateError(
+				cleanupErrors,
+				'PayPal fixture cleanup failed.'
+			);
+		}
 	},
 	storageState: ADMIN_STATE_PATH,
 } );

--- a/plugins/woocommerce/tests/e2e/tests/paypal/paypal.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/paypal/paypal.spec.ts
@@ -130,15 +130,13 @@ test.describe(
 				name: 'Enable',
 			} );
 
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( await enableLink.isVisible() ) {
-				await enableLink.click();
-				await expect(
-					paypalDiv
-						.getByText( 'Active' )
-						.or( paypalDiv.getByText( 'Test account' ) )
-				).toBeVisible( visibilityOptions );
-			}
+			await expect( enableLink ).toBeVisible( visibilityOptions );
+			await enableLink.click();
+			await expect(
+				paypalDiv
+					.getByText( 'Active' )
+					.or( paypalDiv.getByText( 'Test account' ) )
+			).toBeVisible( visibilityOptions );
 
 			await paypalDiv
 				.getByRole( 'button', {
@@ -174,58 +172,55 @@ test.describe(
 				.locator( '#woocommerce_paypal_title' )
 				.inputValue();
 
-			await test.step( 'Update the title field', async () => {
-				await page
-					.locator( '#woocommerce_paypal_title' )
-					.fill( 'PayPal Custom Title ' + Date.now() );
+			try {
+				await test.step( 'Update the title field', async () => {
+					await page
+						.locator( '#woocommerce_paypal_title' )
+						.fill( 'PayPal Custom Title ' + Date.now() );
 
-				// TODO: Temporarily removing the disabled attribute from the Save changes button.
-				await enableSaveButton( page );
+					// TODO: Temporarily removing the disabled attribute from the Save changes button.
+					await enableSaveButton( page );
 
-				await page
-					.getByRole( 'button', {
-						name: 'Save changes',
-					} )
-					.click();
+					await page
+						.getByRole( 'button', {
+							name: 'Save changes',
+						} )
+						.click();
 
-				await expect(
-					page.locator( 'div.updated.inline' )
-				).toContainText( 'Your settings have been saved.' );
-			} );
+					await expect(
+						page.locator( 'div.updated.inline' )
+					).toContainText( 'Your settings have been saved.' );
 
-			await test.step( 'Check the setting present only when Jetpack onboarding is complete', async () => {
-				const paypalButtonsSetting = page.getByText(
-					'Enable PayPal Buttons',
-					{ exact: true }
-				);
-				await expect( paypalButtonsSetting ).toBeVisible();
-			} );
+					await page.reload();
+				} );
 
-			// Clean up by reverting the title change and disabling PayPal Standard.
-			await test.step( 'Revert title change and disable PayPal Standard', async () => {
-				await page
-					.locator( '#woocommerce_paypal_title' )
-					.fill( originalPayPalTitle );
+				await test.step( 'Check the setting present only when Jetpack onboarding is complete', async () => {
+					const paypalButtonsSetting = page.getByText(
+						'Enable PayPal Buttons',
+						{ exact: true }
+					);
+					await expect( paypalButtonsSetting ).toBeVisible();
+				} );
+			} finally {
+				await test.step( 'Revert title change', async () => {
+					await page
+						.locator( '#woocommerce_paypal_title' )
+						.fill( originalPayPalTitle );
 
-				await page
-					.getByRole( 'checkbox', {
-						name: 'Enable PayPal Standard',
-					} )
-					.uncheck();
+					// TODO: Temporarily removing the disabled attribute from the Save changes button.
+					await enableSaveButton( page );
 
-				// TODO: Temporarily removing the disabled attribute from the Save changes button.
-				await enableSaveButton( page );
+					await page
+						.getByRole( 'button', {
+							name: 'Save changes',
+						} )
+						.click();
 
-				await page
-					.getByRole( 'button', {
-						name: 'Save changes',
-					} )
-					.click();
-
-				await expect(
-					page.locator( 'div.updated.inline' )
-				).toContainText( 'Your settings have been saved.' );
-			} );
+					await expect(
+						page.locator( 'div.updated.inline' )
+					).toContainText( 'Your settings have been saved.' );
+				} );
+			}
 		} );
 	}
 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The two PayPal Standard browser tests share one store, one `woocommerce_paypal_settings` row and one set of Transact account caches, and they leave all of it behind. Run the spec twice in a row against a local environment and it fails both times, in two different places. This PR moves that state into the fixture and puts the spec's own cleanup in a `finally`.

Refs TESTOPS-288

Part of the #68046 split.

**This batch moves no coverage between layers.** Two browser titles before, two after, same two names. It is in the split because the migration branch reworked this spec and its fixture, and that work has to land somewhere.

Measured on trunk at `adefb5f971`, in this order, in one environment:

1. First run: `onboards to Jetpack` fails at `Enable PayPal Buttons` — that setting is not in the page the save returns, even though the save is what unlocks it. A real product gap sits behind this; see below.
2. The failure lands before the test's last step, where the cleanup lived, so the store keeps the enabled gateway, the onboarding flag, both account caches, and a `PayPal Custom Title <timestamp>` title.
3. Second run: `can be enabled` fails instead — the gateway is already enabled, so the `Enable` link is gone. The other title now passes for the wrong reason: onboarding was already complete, so it never exercised the save path it is named for.

| What changed | Before | After |
| --- | --- | --- |
| Who owns the gateway state | the fixture flipped `_should_load`; everything else was undone by the last step of the second test's body | the fixture sets `enabled`, `transact_onboarding_complete` and `_should_load` before each test and again after it, and deletes the four `woocommerce_paypal_transact_*_account_*` options |
| What happens when an assertion fails | cleanup is skipped entirely | setup and teardown both run under `try`/`finally`; the title revert moved into the spec's own `finally` |
| `if ( await enableLink.isVisible() ) { … }` | the whole enable-and-assert block was skipped when the link was absent, silently | `await expect( enableLink ).toBeVisible()`, then click and assert |
| After saving the title | assert `Enable PayPal Buttons` in the save response | reload, then assert |

**Knowingly dropped.** The old cleanup unchecked `Enable PayPal Standard` in the settings form and saved; the fixture now disables the gateway with `update_option`. Nothing asserted that step's result — it was cleanup, not a test — but it did incidentally walk the checkbox-and-save path on a gateway's own settings screen, and no E2E test walks it now.

#### The retained wiring test

Both titles are retained and both are the only Playwright coverage of this gateway anywhere in the suite — `git grep -l -i paypal -- plugins/woocommerce/tests/e2e/tests` returns this one file. `PayPal Standard can be enabled` proves the Payments screen's enable link reaches the gateway; `PayPal Standard onboards to Jetpack upon changing any setting` proves that saving a setting triggers Transact onboarding and that the onboarding-only `Enable PayPal Buttons` field then appears. Neither has a lower-layer equivalent: both are about what the settings screen renders after a real admin POST.

#### What this surfaced: the new setting is missing from the page the save returns

`Enable PayPal Buttons` is dropped from the form by `WC_Gateway_Paypal::maybe_remove_fields()` unless `should_use_orders_v2()` is true, and that runs as a filter on `woocommerce_settings_api_form_fields_paypal` every time the form is rendered. Saving a setting is also what triggers Transact onboarding, so the save is what makes the field available — and the field is still not in the page that save returns.

That is measured, not inferred: remove only the post-save `page.reload()` from this branch and the test fails again at the same assertion. Step 9 below reproduces it in one command. The mocked Jetpack and HTTP filters are cookie-scoped and identical across both requests, so the difference is not an artifact of the mocking.

**A merchant doing the same thing sees the same two pages.** The setting they just unlocked appears on the next load of the settings screen, not on the one the save returns. This PR neither causes that nor fixes it, and the reload is not a wait in disguise — it makes the test observe the state a merchant actually reaches instead of passing on stale state. Which of `should_use_orders_v2()`'s gates is still false while the save response renders is **not** established here, and it is worth its own look.

Clearing the account caches matters for the same reason. `TransactAccountManager` holds merchant and provider account data for 24 hours (`TRANSACT_ACCOUNT_CACHE_EXPIRY`), and `should_use_orders_v2()` reads it. Left in place, a later run finds `Enable PayPal Buttons` already rendered and never exercises its own mocked onboarding response.

#### Both files have to land together

The spec's new unconditional `expect( enableLink ).toBeVisible()` is only safe because the fixture guarantees the gateway starts disabled. Restore trunk's copy of `paypal-fixtures.ts` on top of this branch's spec and the second test fails on the first run, at that very line. They are one change split across two files, not two changes.

Worth knowing for later: the `Core e2e tests - PayPal Standard` CI job triggers on `tests/e2e/tests/paypal/**` and the two PayPal PHP directories, but not on `tests/e2e/fixtures/paypal-fixtures.ts` — so a fixture-only PR would not run it. This PR touches the spec, so it runs here.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
3. Record the starting state so step 6 has something to compare against: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp option get woocommerce_paypal_settings --format=json`. Note the `title`, `enabled` and `transact_onboarding_complete` values. You do not have to clean any of them up by hand — that is what this PR is for.
4. Run the spec with retries disabled and confirm the summary reads `1 skipped` and `4 passed`: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=paypal-standard --retries=0 --workers=1 tests/e2e/tests/paypal/paypal.spec.ts`. The four are the two PayPal titles plus the `global authentication` and `site setup` projects; the skip is `install wc`, which skips itself when `INSTALL_WC` is unset.
5. Run the exact same command a second time, without touching the store in between. Confirm it is green again, with the same `4 passed`. For the contrast, check out `trunk` and run it twice there as well. Which title fails first depends on what the store already had, but the run is not repeatable: when this was measured, the first run failed at `PayPal Standard onboards to Jetpack upon changing any setting` and the second failed at `PayPal Standard can be enabled` instead, because the first run left the gateway enabled. Then come back to this branch.
6. Confirm the store is clean afterwards: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp eval 'print_r( get_option( "woocommerce_paypal_settings" ) );'`. Expect `enabled` and `transact_onboarding_complete` both `no`, and the `title` back to whatever step 3 showed. Then `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp option get woocommerce_paypal_transact_merchant_account_live` — expect it not to exist.
7. Confirm the cleanup survives a failing assertion. In `plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php`, inside `process_admin_options()`, replace `$this->maybe_onboard_with_transact();` with `return $saved;`. Re-run the command from step 4 and expect one failure reading `expect(locator).toBeVisible() failed`, `Locator: getByText('Enable PayPal Buttons', { exact: true })`. Now re-run step 6: the store must still be clean, even though the test failed before its own cleanup step. Restore the line and re-run step 4 to confirm green.
8. Confirm the mocked onboarding response is the thing being exercised. In `plugins/woocommerce/tests/e2e/tests/paypal/paypal.spec.ts`, change `public_id: 'test_public_id',` to `public_id: '',` and re-run step 4. Expect the same failure at the same locator, because an empty public ID cannot complete onboarding. Revert.
9. See the product gap for yourself. In the same file, delete the `await page.reload();` at the end of the `Update the title field` step — the second of the two reloads in the file, not the one that settles the filters — and re-run step 4. Expect the same `Enable PayPal Buttons` failure: the setting the save just unlocked is not on the page the save returned. Restore the line.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch's single commit against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Extraction.** Both files are byte-identical to the migration branch's versions, and neither path has a trunk commit since the diff base, so nothing had to be merged.
- **The problem, reproduced on trunk.** Trunk's own unmodified copy of the spec, run twice in this environment: the first run fails `onboards to Jetpack` at `Enable PayPal Buttons`; the second fails `can be enabled` at the `Enable` link, and the first title passes for the wrong reason. Between the two, the store was left with `enabled=yes`, `transact_onboarding_complete=yes`, both live account options present, and the gateway title overwritten.
- **The retained titles.** Three runs of this branch at `--retries=0 --workers=1`, all `4 passed, 1 skipped`, including one run started from the contaminated store the trunk runs left behind. After six runs — three of them deliberately failed by mutations — the store reads `enabled=no`, `transact_onboarding_complete=no`, and all four account options absent.
- **Mutation re-check, all three behavior families.** Forcing `parent::process_admin_options()` to return false, skipping `maybe_onboard_with_transact()`, and emptying the mocked `public_id` each turn `onboards to Jetpack` red at `paypal.spec.ts:202`, `getByText('Enable PayPal Buttons', { exact: true })` — the assertion the mutation matrix names for each. Each reverted cleanly and went green again.
- **Isolation is load-bearing.** This branch's spec with trunk's fixture restored fails on the first run at `paypal.spec.ts:133`, the assertion that replaced the visibility guard.
- **The reload is load-bearing.** Removing only the post-save `page.reload()` from this branch makes `onboards to Jetpack` fail again at `paypal.spec.ts:200`, the same `Enable PayPal Buttons` assertion. Nothing else was changed for that run.
- **The fixture's guard can actually fire.** The setup throws a PHP `RuntimeException` if `woocommerce_paypal_settings` is not an array. `RuntimeException` resolves in the global namespace `wp eval` runs in, an uncaught throw exits the command non-zero, and `wpCLI` uses promisified `exec`, which rejects on a non-zero exit — so the throw reaches the fixture's `catch` rather than passing silently. Checked directly, not assumed.
- **A failed setup fails the test loudly.** When setup fails, the fixture never calls `use()`. Forcing that path makes the run report `Error: forced fixture setup failure` against the test and exit non-zero — it does not silently pass or hide behind a runner-internal message.
- **Lint.** ESLint reports nothing on either file on this branch, with `--report-unused-disable-directives`. Trunk's copy of the spec reports one `playwright/no-conditional-expect` warning, and a second, `playwright/no-conditional-in-test`, suppressed by an inline disable. This PR removes the conditional, so both go, and the suppression with them. `oxlint` attributes no new finding to the change.
- **Identifier sweep.** No internal campaign identifiers in either touched path, with a control at the same scope where such identifiers are known to exist.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-paypal-standard`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

