### PR TITLE
[tests] Cut product image E2E from 6 titles to 3, moving persistence and rendering to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-product-images
+++ b/plugins/woocommerce/changelog/testops-288-product-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Cut the product images E2E spec from 6 titles to 3; image and gallery persistence and rendering now covered by WC_Meta_Box_Product_Images_Test.
+

--- a/plugins/woocommerce/tests/e2e/tests/product/product-images.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-images.spec.ts
@@ -28,6 +28,10 @@ async function addImageFromLibrary(
 	const dataId = await imageLocator.getAttribute( 'data-id' );
 	await expect( imageLocator ).toBeChecked();
 	await page.getByRole( 'button', { name: actionButtonName } ).click();
+	await expect( page.locator( '.media-modal' ) ).toBeHidden();
+	if ( ! dataId ) {
+		throw new Error( `Media library item ${ imageName } has no data-id.` );
+	}
 	return dataId;
 }
 
@@ -96,23 +100,6 @@ const test = baseTest.extend( {
 
 		await use( productWithImage );
 	},
-	productWithGallery: async ( { restApi, product }, use ) => {
-		const imageIds = await Promise.all(
-			[ 'image-01', 'image-02', 'image-03' ].map(
-				async ( slug ) => ( await getMediaBySlug( slug ) ).id
-			)
-		);
-		let productWithGallery;
-		await restApi
-			.put( `${ WC_API_PATH }/products/${ product.id }`, {
-				images: imageIds.map( ( id ) => ( { id } ) ),
-			} )
-			.then( ( response ) => {
-				productWithGallery = response.data;
-			} );
-
-		await use( productWithGallery );
-	},
 } );
 
 test.describe( 'Products > Product Images', () => {
@@ -147,99 +134,72 @@ test.describe( 'Products > Product Images', () => {
 		).toHaveCount( 1 );
 	} );
 
-	test( 'can set product image', async ( { page, product } ) => {
-		await test.step( 'Navigate to product edit page', async () => {
+	test( 'can manage the product image through the classic editor', async ( {
+		page,
+		product,
+	} ) => {
+		await test.step( 'Set the featured image', async () => {
 			await page.goto(
 				`wp-admin/post.php?post=${ product.id }&action=edit`
 			);
-		} );
-
-		await test.step( 'Set product image', async () => {
-			// TODO: WP 7.0 compat - WP 7.0 changed the featured image metabox link
-			// to a button. Simplify when WP 7.0 is the minimum supported version.
 			await page
 				.getByRole( 'link', { name: 'Set product image' } )
 				.or( page.getByRole( 'button', { name: 'Set product image' } ) )
 				.click();
 			await addImageFromLibrary( page, 'image-01', 'Set product image' );
-
-			// Wait for the product image thumbnail to be updated.
-			// Clicking the "Update" button before this happens will not update the image.
-			// Use src* (contains) instead of src$ (ends with) to match duplicated images, like image-01-1.png
 			await expect(
 				page.locator( '#set-post-thumbnail img[src*="image-01"]' )
 			).toBeVisible();
-
 			await page
 				.locator( '#publishing-action' )
 				.getByRole( 'button', { name: 'Update' } )
 				.click();
-		} );
-
-		await test.step( 'Verify product image was set', async () => {
-			// Verify product was updated
 			await expect( page.getByText( 'Product updated.' ) ).toBeVisible();
 
-			// Verify image in store frontend
 			await page.goto( product.permalink );
 			await expect(
-				page.locator( `img.wp-post-image[src*="image-01"]` )
+				page.locator( 'img.wp-post-image[src*="image-01"]' )
 			).toBeVisible();
 		} );
-	} );
 
-	test( 'can update the product image', async ( {
-		page,
-		productWithImage,
-	} ) => {
-		await test.step( 'Navigate to product edit page', async () => {
+		await test.step( 'Replace the featured image', async () => {
 			await page.goto(
-				`wp-admin/post.php?post=${ productWithImage.id }&action=edit`
+				`wp-admin/post.php?post=${ product.id }&action=edit`
 			);
-		} );
-
-		await test.step( 'Update product image', async () => {
 			await page.locator( '#set-post-thumbnail' ).click();
 			await addImageFromLibrary( page, 'image-02', 'Set product image' );
-
-			// Wait for the product image thumbnail to be updated.
-			// Clicking the "Update" button before this happens will not update the image.
-			// Use src* (contains) instead of src$ (ends with) to match duplicated images, like image-01-1.png
 			await expect(
 				page.locator( '#set-post-thumbnail img[src*="image-02"]' )
 			).toBeVisible();
-
 			await page
 				.locator( '#publishing-action' )
 				.getByRole( 'button', { name: 'Update' } )
 				.click();
-		} );
-
-		await test.step( 'Verify product image was set', async () => {
-			// Verify product was updated
 			await expect( page.getByText( 'Product updated.' ) ).toBeVisible();
 
-			// Verify image in store frontend
-			await page.goto( productWithImage.permalink );
+			await page.goto( product.permalink );
 			await expect(
-				page.locator( `img.wp-post-image[src*="image-02"]` )
+				page.locator( 'img.wp-post-image[src*="image-02"]' )
 			).toBeVisible();
+			await expect(
+				page.locator(
+					'.woocommerce-product-gallery__wrapper img[src*="image-01"]'
+				)
+			).toHaveCount( 0 );
 		} );
-	} );
 
-	test( 'can delete the product image', async ( {
-		page,
-		productWithImage,
-	} ) => {
-		await test.step( 'Navigate to product edit page', async () => {
+		await test.step( 'Clear the featured image', async () => {
 			await page.goto(
-				`wp-admin/post.php?post=${ productWithImage.id }&action=edit`
+				`wp-admin/post.php?post=${ product.id }&action=edit`
 			);
-		} );
-
-		await test.step( 'Remove product image', async () => {
-			// TODO: WP 7.0 compat - WP 7.0 changed the featured image metabox link
-			// to a button. Simplify when WP 7.0 is the minimum supported version.
+			const setProductImage = page
+				.locator( '#postimagediv' )
+				.getByRole( 'link', { name: 'Set product image' } )
+				.or(
+					page
+						.locator( '#postimagediv' )
+						.getByRole( 'button', { name: 'Set product image' } )
+				);
 			await page
 				.getByRole( 'link', { name: 'Remove product image' } )
 				.or(
@@ -248,142 +208,155 @@ test.describe( 'Products > Product Images', () => {
 					} )
 				)
 				.click();
-			await expect(
-				page.getByRole( 'link', { name: 'Set product image' } ).or(
-					page.getByRole( 'button', {
-						name: 'Set product image',
-					} )
-				)
-			).toBeVisible();
-
+			await expect( setProductImage ).toBeVisible();
 			await page
 				.locator( '#publishing-action' )
 				.getByRole( 'button', { name: 'Update' } )
 				.click();
-		} );
-
-		await test.step( 'Verify product image was removed', async () => {
-			// Verify product was updated
 			await expect( page.getByText( 'Product updated.' ) ).toBeVisible();
 
-			// Verify image in store frontend
-			await page.goto( productWithImage.permalink );
+			await page.goto(
+				`wp-admin/post.php?post=${ product.id }&action=edit`
+			);
+			await expect( setProductImage ).toBeVisible();
+
+			await page.goto( product.permalink );
 			await expect(
-				page.getByAltText( 'Awaiting product image' )
-			).toBeVisible();
+				page.locator(
+					'.woocommerce-product-gallery__wrapper img[src*="image-"]'
+				)
+			).toHaveCount( 0 );
 		} );
 	} );
 
-	test( 'can create a product gallery', async ( {
+	test( 'can manage the product gallery through the classic editor', async ( {
 		page,
 		productWithImage,
 	} ) => {
-		const images = [ 'image-02', 'image-03' ];
+		let image02Id = '';
+		let image03Id = '';
 
-		await test.step( 'Navigate to product edit page', async () => {
+		await test.step( 'Create the ordered product gallery', async () => {
 			await page.goto(
 				`wp-admin/post.php?post=${ productWithImage.id }&action=edit`
 			);
-		} );
-
-		await test.step( 'Add product gallery images', async () => {
-			const imageSelector = '#product_images_container img';
-			let initialImagesCount = await page
-				.locator( imageSelector )
-				.count();
-
-			for ( const image of images ) {
-				await page
-					.getByRole( 'link', {
-						name: 'Add product gallery images',
-					} )
-					.click();
-				const dataId = await addImageFromLibrary(
-					page,
-					image,
-					'Add to gallery'
-				);
-
-				await expect(
-					page.locator( `li[data-attachment_id="${ dataId }"]` ),
-					'thumbnail should be visible'
-				).toBeVisible();
-				const currentImagesCount = await page
-					.locator( imageSelector )
-					.count();
-				await expect(
-					currentImagesCount,
-					'number of images should increase'
-				).toEqual( initialImagesCount + 1 );
-				initialImagesCount = currentImagesCount;
-			}
-
-			await page
-				.locator( '#publishing-action' )
-				.getByRole( 'button', { name: 'Update' } )
-				.click();
-		} );
-
-		await test.step( 'Verify product gallery', async () => {
-			// Verify gallery in store frontend
-			await page.goto( productWithImage.permalink );
-			await expect(
-				page
-					.locator( `.woocommerce-product-gallery ol img` )
-					.nth( images.length ),
-				'all gallery images should be visible'
-			).toBeVisible(); // +1 for the featured image
-		} );
-	} );
-
-	test( 'can update a product gallery', async ( {
-		page,
-		productWithGallery,
-	} ) => {
-		let imagesCount;
-
-		await test.step( 'Navigate to product edit page', async () => {
-			await page.goto(
-				`wp-admin/post.php?post=${ productWithGallery.id }&action=edit`
-			);
-		} );
-
-		await test.step( 'Remove images from product gallery', async () => {
-			const imageSelector = '#product_images_container img';
-			imagesCount = await page.locator( imageSelector ).count();
-
 			await page
 				.getByRole( 'link', {
 					name: 'Add product gallery images',
 				} )
-				.scrollIntoViewIfNeeded();
+				.click();
+			image02Id = await addImageFromLibrary(
+				page,
+				'image-02',
+				'Add to gallery'
+			);
+			await page
+				.getByRole( 'link', {
+					name: 'Add product gallery images',
+				} )
+				.click();
+			image03Id = await addImageFromLibrary(
+				page,
+				'image-03',
+				'Add to gallery'
+			);
 
-			await page.locator( imageSelector ).first().hover();
-			await page.getByRole( 'link', { name: ' Delete' } ).click();
-
-			await expect(
-				await page.locator( imageSelector ).count(),
-				'number of images should decrease'
-			).toEqual( imagesCount - 1 );
+			const galleryItems = page.locator(
+				'#product_images_container li[data-attachment_id]'
+			);
+			await expect( galleryItems ).toHaveCount( 2 );
+			await expect( galleryItems.nth( 0 ) ).toHaveAttribute(
+				'data-attachment_id',
+				image02Id
+			);
+			await expect( galleryItems.nth( 1 ) ).toHaveAttribute(
+				'data-attachment_id',
+				image03Id
+			);
 
 			await page
 				.locator( '#publishing-action' )
 				.getByRole( 'button', { name: 'Update' } )
 				.click();
+			await expect( page.getByText( 'Product updated.' ) ).toBeVisible();
+
+			await page.goto( productWithImage.permalink );
+			const frontendImages = page.locator(
+				'.woocommerce-product-gallery__wrapper a[href*="/uploads/"] > img'
+			);
+			await expect( frontendImages ).toHaveCount( 3 );
+			await expect( frontendImages.nth( 0 ) ).toHaveAttribute(
+				'src',
+				/image-01/
+			);
+			await expect( frontendImages.nth( 1 ) ).toHaveAttribute(
+				'src',
+				/image-02/
+			);
+			await expect( frontendImages.nth( 2 ) ).toHaveAttribute(
+				'src',
+				/image-03/
+			);
 		} );
 
-		await test.step( 'Verify product gallery', async () => {
-			// Verify gallery in store frontend
-			await page.goto( productWithGallery.permalink );
-			const selector = `.woocommerce-product-gallery ol img`;
+		await test.step( 'Remove one gallery image and preserve order', async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ productWithImage.id }&action=edit`
+			);
+			const image02Row = page.locator(
+				`#product_images_container li[data-attachment_id="${ image02Id }"]`
+			);
+			await image02Row.hover();
+			await image02Row.getByRole( 'link', { name: /Delete/ } ).click();
+			await expect( image02Row ).toHaveCount( 0 );
 			await expect(
-				page.locator( selector ).nth( imagesCount - 1 ),
-				'gallery images should be visible'
+				page.locator(
+					`#product_images_container li[data-attachment_id="${ image03Id }"]`
+				)
 			).toBeVisible();
-			await expect(
-				page.locator( selector ).nth( imagesCount ),
-				'one gallery image should not be visible'
-			).toBeHidden();
+			await page
+				.locator( '#publishing-action' )
+				.getByRole( 'button', { name: 'Update' } )
+				.click();
+			await expect( page.getByText( 'Product updated.' ) ).toBeVisible();
+
+			await page.goto( productWithImage.permalink );
+			const frontendImages = page.locator(
+				'.woocommerce-product-gallery__wrapper a[href*="/uploads/"] > img'
+			);
+			await expect( frontendImages ).toHaveCount( 2 );
+			await expect( frontendImages.nth( 0 ) ).toHaveAttribute(
+				'src',
+				/image-01/
+			);
+			await expect( frontendImages.nth( 1 ) ).toHaveAttribute(
+				'src',
+				/image-03/
+			);
+		} );
+
+		await test.step( 'Clear the remaining gallery image', async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ productWithImage.id }&action=edit`
+			);
+			const image03Row = page.locator(
+				`#product_images_container li[data-attachment_id="${ image03Id }"]`
+			);
+			await image03Row.hover();
+			await image03Row.getByRole( 'link', { name: /Delete/ } ).click();
+			await expect( image03Row ).toHaveCount( 0 );
+			await page
+				.locator( '#publishing-action' )
+				.getByRole( 'button', { name: 'Update' } )
+				.click();
+			await expect( page.getByText( 'Product updated.' ) ).toBeVisible();
+
+			await page.goto( productWithImage.permalink );
+			const frontendImages = page.locator(
+				'.woocommerce-product-gallery__wrapper a[href*="/uploads/"] > img'
+			);
+			await expect( frontendImages ).toHaveCount( 1 );
+			await expect( frontendImages ).toHaveAttribute( 'src', /image-01/ );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-product-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-product-images-test.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Tests for the product images meta box.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\WooCommerce\Internal\ProductGallery\ProductMediaGallery;
+
+require_once WC_ABSPATH . 'includes/admin/meta-boxes/class-wc-meta-box-product-images.php';
+
+/**
+ * Tests for WC_Meta_Box_Product_Images.
+ */
+class WC_Meta_Box_Product_Images_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Product IDs created by a test.
+	 *
+	 * @var int[]
+	 */
+	private $product_ids = array();
+
+	/**
+	 * Attachment IDs created by a test.
+	 *
+	 * @var int[]
+	 */
+	private $attachment_ids = array();
+
+	/**
+	 * Whether the product media gallery feature option existed before the test.
+	 *
+	 * @var bool
+	 */
+	private $had_product_media_gallery_option;
+
+	/**
+	 * Original product media gallery feature option value.
+	 *
+	 * @var mixed
+	 */
+	private $original_product_media_gallery_option;
+
+	/**
+	 * Whether the product media gallery feature option was autoloaded before the test.
+	 *
+	 * @var bool
+	 */
+	private $product_media_gallery_option_was_autoloaded;
+
+	/**
+	 * Whether the POST global existed before the test.
+	 *
+	 * @var bool
+	 */
+	private $had_post_global;
+
+	/**
+	 * Original POST global value.
+	 *
+	 * @var mixed
+	 */
+	private $original_post_global;
+
+	/**
+	 * Set up test state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$missing_option                                    = new stdClass();
+		$this->original_product_media_gallery_option       = get_option( ProductMediaGallery::ENABLE_OPTION_NAME, $missing_option );
+		$this->had_product_media_gallery_option            = $this->original_product_media_gallery_option !== $missing_option;
+		$this->product_media_gallery_option_was_autoloaded = array_key_exists( ProductMediaGallery::ENABLE_OPTION_NAME, wp_load_alloptions() );
+		$this->had_post_global                             = array_key_exists( '_POST', $GLOBALS );
+		$this->original_post_global                        = $GLOBALS['_POST'] ?? null;
+
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'no' );
+	}
+
+	/**
+	 * Restore test state.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->product_ids as $product_id ) {
+			wp_delete_post( $product_id, true );
+		}
+
+		foreach ( $this->attachment_ids as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+
+		if ( $this->had_product_media_gallery_option ) {
+			update_option( ProductMediaGallery::ENABLE_OPTION_NAME, $this->original_product_media_gallery_option );
+		} else {
+			delete_option( ProductMediaGallery::ENABLE_OPTION_NAME );
+		}
+		$this->assertSame(
+			$this->product_media_gallery_option_was_autoloaded,
+			array_key_exists( ProductMediaGallery::ENABLE_OPTION_NAME, wp_load_alloptions() ),
+			'The product media gallery feature option should retain its original autoload behavior.'
+		);
+
+		if ( $this->had_post_global ) {
+			$GLOBALS['_POST'] = $this->original_post_global;
+		} else {
+			unset( $GLOBALS['_POST'] );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Saves ordered gallery images through the classic product images meta box lifecycle.
+	 */
+	public function test_save_persists_ordered_gallery_lifecycle(): void {
+		$product         = $this->create_simple_product();
+		$first_image_id  = $this->create_image_attachment();
+		$second_image_id = $this->create_image_attachment();
+		$third_image_id  = $this->create_image_attachment();
+
+		$this->save_gallery( $product->get_id(), array( $first_image_id, $second_image_id, $third_image_id ) );
+		$this->assertSame(
+			array( $first_image_id, $second_image_id, $third_image_id ),
+			$this->get_fresh_product( $product->get_id() )->get_gallery_image_ids(),
+			'The classic meta box should persist gallery image IDs in their posted order.'
+		);
+
+		$this->save_gallery( $product->get_id(), array( $second_image_id, $third_image_id ) );
+		$this->assertSame(
+			array( $second_image_id, $third_image_id ),
+			$this->get_fresh_product( $product->get_id() )->get_gallery_image_ids(),
+			'The classic meta box should persist removed gallery images and their remaining order.'
+		);
+
+		$this->save_gallery( $product->get_id(), array() );
+		$this->assertSame(
+			array(),
+			$this->get_fresh_product( $product->get_id() )->get_gallery_image_ids(),
+			'The classic meta box should clear the gallery when its posted field is empty.'
+		);
+	}
+
+	/**
+	 * @testdox Renders saved featured and gallery images in order before rendering the placeholder.
+	 */
+	public function test_saved_gallery_renders_featured_and_gallery_images_then_placeholder(): void {
+		$product         = $this->create_simple_product();
+		$first_image_id  = $this->create_image_attachment();
+		$second_image_id = $this->create_image_attachment();
+		$third_image_id  = $this->create_image_attachment();
+		$product_id      = $product->get_id();
+
+		$product->set_image_id( $first_image_id );
+		$product->save();
+		$this->save_gallery( $product_id, array( $second_image_id, $third_image_id ) );
+
+		$rendered_attachment_ids = array();
+		$record_attachment_id    = static function ( $html, $attachment_id ) use ( &$rendered_attachment_ids ) {
+			$rendered_attachment_ids[] = (int) $attachment_id;
+
+			return $html;
+		};
+		add_filter( 'woocommerce_single_product_image_thumbnail_html', $record_attachment_id, 10, 2 );
+
+		try {
+			$gallery_html = wc_get_product_gallery_html( $this->get_fresh_product( $product_id ) );
+		} finally {
+			remove_filter( 'woocommerce_single_product_image_thumbnail_html', $record_attachment_id );
+		}
+
+		$this->assertSame(
+			array( $first_image_id, $second_image_id, $third_image_id ),
+			$rendered_attachment_ids,
+			'The classic gallery template should render the featured image before saved gallery images.'
+		);
+		$this->assertStringContainsString( 'woocommerce-product-gallery__image', $gallery_html, 'The classic gallery template should render product image markup.' );
+		$this->assertStringContainsString( 'wp-post-image', $gallery_html, 'The classic gallery template should render the featured attachment image.' );
+
+		$product = $this->get_fresh_product( $product_id );
+		$product->set_image_id( $second_image_id );
+		$product->save();
+		$this->save_gallery( $product_id, array( $third_image_id ) );
+
+		$rendered_attachment_ids = array();
+		add_filter( 'woocommerce_single_product_image_thumbnail_html', $record_attachment_id, 10, 2 );
+		try {
+			$gallery_html = wc_get_product_gallery_html( $this->get_fresh_product( $product_id ) );
+		} finally {
+			remove_filter( 'woocommerce_single_product_image_thumbnail_html', $record_attachment_id );
+		}
+
+		$this->assertSame(
+			array( $second_image_id, $third_image_id ),
+			$rendered_attachment_ids,
+			'The classic gallery template should render the updated featured and gallery image order.'
+		);
+		$this->assertStringContainsString( 'wp-post-image', $gallery_html, 'The updated featured attachment should be rendered.' );
+
+		$this->save_gallery( $product_id, array() );
+		$product = $this->get_fresh_product( $product_id );
+		$product->set_image_id( 0 );
+		$product->save();
+
+		$rendered_attachment_ids = array();
+		add_filter( 'woocommerce_single_product_image_thumbnail_html', $record_attachment_id, 10, 2 );
+		try {
+			$gallery_html = wc_get_product_gallery_html( $this->get_fresh_product( $product_id ) );
+		} finally {
+			remove_filter( 'woocommerce_single_product_image_thumbnail_html', $record_attachment_id );
+		}
+
+		$this->assertStringContainsString( 'Awaiting product image', $gallery_html, 'The classic gallery template should render the product image placeholder after both image sources are cleared.' );
+		$this->assertSame(
+			array(),
+			array_values(
+				array_filter(
+					$rendered_attachment_ids,
+					static function ( int $attachment_id ): bool {
+						return $attachment_id > 0;
+					}
+				)
+			),
+			'The placeholder should not render a positive attachment ID.'
+		);
+	}
+
+	/**
+	 * Create and track a simple product.
+	 *
+	 * @return WC_Product
+	 */
+	private function create_simple_product(): WC_Product {
+		$product             = WC_Helper_Product::create_simple_product();
+		$this->product_ids[] = $product->get_id();
+
+		return $product;
+	}
+
+	/**
+	 * Create and track a real image attachment.
+	 *
+	 * @return int
+	 */
+	private function create_image_attachment(): int {
+		$attachment_id          = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$this->attachment_ids[] = $attachment_id;
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Persist gallery image IDs through the real classic meta-box handler.
+	 *
+	 * @param int   $product_id Product ID.
+	 * @param int[] $image_ids  Gallery image IDs.
+	 */
+	private function save_gallery( int $product_id, array $image_ids ): void {
+		$_POST = array(
+			'product-type'          => 'simple',
+			'product_image_gallery' => implode( ',', $image_ids ),
+		);
+
+		$post = get_post( $product_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			throw new RuntimeException( 'Expected the product post to exist before saving its gallery.' );
+		}
+
+		WC_Meta_Box_Product_Images::save( $product_id, $post );
+	}
+
+	/**
+	 * Load a product from persistent storage.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return WC_Product
+	 */
+	private function get_fresh_product( int $product_id ): WC_Product {
+		$product = wc_get_product( $product_id );
+
+		if ( ! $product instanceof WC_Product ) {
+			throw new RuntimeException( 'Expected the saved product to reload from persistent storage.' );
+		}
+
+		return $product;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The product images spec drove the classic editor six times to prove that a featured image and a gallery persist and render. Persistence is a save-and-reload assertion and rendering is a template assertion; neither needs a browser to be trustworthy, and each browser title paid for a full wp-admin page load to make one. Six titles become three, and the behavior underneath moves into a new `WC_Meta_Box_Product_Images_Test`.

Refs TESTOPS-288

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `can set product image` | `can manage the product image through the classic editor`, step `Set the featured image` | Nothing. Same flow, same assertions, one page load instead of three. |
| `can update the product image` | same journey, step `Replace the featured image` | Nothing. |
| `can delete the product image` | same journey, step `Clear the featured image`, plus `WC_Meta_Box_Product_Images_Test::test_saved_gallery_renders_featured_and_gallery_images_then_placeholder` for the placeholder | The **front-end** proof that `Awaiting product image` renders. See below — this one is a layer change, not a like-for-like move. |
| `can create a product gallery` | `can manage the product gallery through the classic editor`, plus `WC_Meta_Box_Product_Images_Test::test_save_persists_ordered_gallery_lifecycle` | Nothing. Ordering is now asserted more strictly than before, by `data-attachment_id` and `src` position rather than by count. |
| `can update a product gallery` | same journey and same PHP method | The `productWithGallery` REST fixture. See below. |

`keeps the product image help tip aligned when the image changes` is unchanged. It is a layout assertion, which is the one thing here that only a browser can make.

#### The placeholder assertion changed layer

The removed `can delete the product image` title visited the product's permalink and asserted the front-end `Awaiting product image` placeholder by its alt text. One of the carried commits, `0edd0ce597`, drops that front-end visit, and the browser now asserts the editor's own control instead. The browser-level proof that the placeholder renders on the storefront is gone.

What replaces it is a PHP assertion on the same string against the same template: `WC_Meta_Box_Product_Images_Test` calls `wc_get_product_gallery_html()`, which renders `templates/single-product/product-image.php`, and asserts `Awaiting product image` appears once both image sources are cleared. That is the template the storefront renders, so the coverage survives — but it now lives a layer down, and that is worth knowing rather than reconstructing from a commit message.

#### The `productWithGallery` fixture is gone

The old spec had a fixture that built a gallery entirely through the REST API and never passed it through `WC_Meta_Box_Product_Images::save()`. It is deleted with no replacement. Nothing now proves the meta box renders a gallery it did not itself write in the same session. The gap is narrow — a gallery written by REST and read back by the editor — but it is a gap.

#### Two of the three carried commits are stabilization, not coverage moves

Neither adds a wait, a retry, a timeout change or a `networkidle`, which is worth stating because their subjects could be read that way:

- `4471e83c98` scopes the `Set product image` locator to `#postimagediv` instead of matching it page-wide, so the assertion cannot be satisfied by a control elsewhere on the page.
- `0edd0ce597` replaces a front-end permalink visit with the admin edit URL, and asserts the editor's control rather than the front-end placeholder's alt text. This is the commit discussed above.

#### One journey now fails as a unit

The five titles became two `test.step()` journeys, so a fault in an early step aborts the rest of that journey and a retry replays the whole chain rather than one flow. That is visible in this PR's own evidence: the recorded fault for the first `Update` boundary stops the journey at the first storefront assertion. It costs blast radius on a flake and buys three fewer wp-admin page loads. Calling it out so the trade is explicit.

#### Why this is only the images half

This started as one batch covering product images *and* up-sells/cross-sells. The two shared no commit, helper or fixture — `405ebe4f13`, `4471e83c98` and `0edd0ce597` touch only the images spec, and the linked-products work sits in a single separate commit — so the batch was split. The linked products half follows as its own PR.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the new class with an anchored filter — `plugins/woocommerce/tests/` also contains `WC_Meta_Box_Product_Data_POS_Visibility_Test` and other `WC_Meta_Box_*` classes, and PHPUnit's `--filter` is an unanchored substring regex: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter '/^WC_Meta_Box_Product_Images_Test::/'`. Expect `OK (2 tests, 12 assertions)`.
4. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/product/product-images.spec.ts`. Expect `5 passed` and `1 skipped` — the 5 are the 3 product-image titles plus the `global authentication` and `site setup` projects; the skip is `install wc`, which skips itself when `INSTALL_WC` is unset.
6. Confirm the PHP test detects a real gallery-ordering regression. In `plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php`, inside the `if ( ! $videos_enabled )` branch, change `$product->set_gallery_image_ids( $attachment_ids );` to `$product->set_gallery_image_ids( array_reverse( $attachment_ids ) );`. Re-run step 3 and expect `test_save_persists_ordered_gallery_lifecycle` to fail on an array-identity assertion. Revert.
7. Confirm the PHP test really guards the placeholder. In `plugins/woocommerce/templates/single-product/product-image.php`, change `esc_html__( 'Awaiting product image', 'woocommerce' )` to `esc_html__( 'Missing product image', 'woocommerce' )`. Re-run step 3 and expect `test_saved_gallery_renders_featured_and_gallery_images_then_placeholder` to fail on the rendered HTML. Revert.
8. Confirm the retained browser titles still detect a front-end regression. In `plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js`, in `updateProductGalleryFields`, change the terminal `.get();` of the `mediaGallery` collection to `.get().slice( 0, -1 );`, then rebuild the classic assets with `pnpm --dir plugins/woocommerce/client/legacy build:project:js`. Re-run step 5 and expect `can manage the product gallery through the classic editor` to fail with `Expected: 3` and `Received: 2`. Revert and rebuild.
9. Confirm the help tip title is real. In the same JS file, in `syncProductImageTooltip`, change `.insertAfter( productImageLink )` to `.insertBefore( productImageLink )`, rebuild as in step 8, re-run step 5 and expect `keeps the product image help tip aligned when the image changes` to fail on the adjacency locator. Revert and rebuild.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Baseline first.** Trunk's copy of the spec ran green before this batch was extracted, so the environment was known good and any later failure is attributable to the change. The uploads the media library serves were also checked: 25 attachments, none missing on disk.
- **Extraction.** Both files are byte-identical to the migration branch, and neither path has a trunk commit since the diff base, so nothing had to be merged.
- **Retained titles.** 3 titles at `--retries=0 --workers=1`, all green.
- **Lower layer.** `WC_Meta_Box_Product_Images_Test` OK (2 tests, 12 assertions) under the anchored filter.
- **Mutation re-check, all 5 behavior families.** One recorded mutation per family, each turning its focused command red at the assertion the mutation matrix names, each reverted and green again: the gallery write in `process_product_object`, the placeholder string in the product image template, the tooltip's `insertAfter`, the gallery serialization's terminal `.get()`, and a controlled `_thumbnail_id` fault immediately before the first Update. The two JavaScript mutations were rebuilt through `grunt js` in both directions, so the browser ran against a bundle that actually carried the fault.
- **Lint.** `lint:changes:branch` exits 0. ESLint reports 2 warnings on this branch's copy of the spec against 7 on trunk's, and no errors either way. `oxlint` attributes no new finding to the change.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; this batch's only PHP file is a test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-product-images`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

