### PR TITLE
[tests] Cut product export E2E from 4 titles to 1, moving the export screen to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-products-admin-export
+++ b/plugins/woocommerce/changelog/testops-288-products-admin-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Cut the product export E2E spec from 4 titles to 1; the export screen's rendering and the exporter's row scoping now covered by WC_Admin_Product_Export_View_Test and WC_Product_CSV_Exporter_Test.
+

--- a/plugins/woocommerce/tests/e2e/tests/product/product-export.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-export.spec.ts
@@ -68,53 +68,7 @@ const test = baseTest.extend( {
 } );
 
 test.describe( 'Product > Export Selected Products', () => {
-	test( 'should allow exporting a single selected simple product', async ( {
-		page,
-		productsFixture,
-	} ) => {
-		const simpleProduct = productsFixture.simple;
-
-		await test.step( 'Navigate to product list and select product', async () => {
-			await page.goto( 'wp-admin/edit.php?post_type=product' );
-			await page.locator( `#cb-select-${ simpleProduct.id }` ).check();
-		} );
-
-		const exportButton = page.locator(
-			'a.page-title-action[href*="page=product_exporter"]'
-		);
-
-		await test.step( 'Verify export button text and link for single selection', async () => {
-			await expect( exportButton ).toHaveText( 'Export 1 selected' );
-			const exportButtonHref = await exportButton.getAttribute( 'href' );
-			expect( exportButtonHref ).toContain(
-				`product_ids=${ simpleProduct.id }`
-			);
-			expect( exportButtonHref ).toContain( '_wpnonce=' );
-		} );
-
-		await test.step( 'Navigate to export page and verify UI elements', async () => {
-			await exportButton.click();
-			await expect( page.locator( '.wrap.woocommerce h1' ) ).toHaveText(
-				'Export Products'
-			);
-			await expect(
-				page.locator( '#selected-product-export-notice p' )
-			).toContainText(
-				'You are about to export 1 product. To export all products, clear your selection.'
-			);
-			await expect(
-				page.locator( 'input[name="product_ids"]' )
-			).toHaveValue( String( simpleProduct.id ) );
-			await expect(
-				page.locator( 'label[for="woocommerce-exporter-types"]' )
-			).toBeHidden();
-			await expect(
-				page.locator( 'label[for="woocommerce-exporter-category"]' )
-			).toBeHidden();
-		} );
-	} );
-
-	test( 'should allow exporting multiple selected products (simple and variable)', async ( {
+	test( 'preserves multiple selection through export and clear', async ( {
 		page,
 		productsFixture,
 	} ) => {
@@ -122,7 +76,7 @@ test.describe( 'Product > Export Selected Products', () => {
 		const variableProduct = productsFixture.variable;
 
 		await test.step( 'Navigate to product list and select multiple products', async () => {
-			await page.goto( 'wp-admin/edit.php?post_type=product' ); // Changed to page.goto
+			await page.goto( 'wp-admin/edit.php?post_type=product' );
 			await page.locator( `#cb-select-${ simpleProduct.id }` ).check();
 			await page.locator( `#cb-select-${ variableProduct.id }` ).check();
 		} );
@@ -134,7 +88,6 @@ test.describe( 'Product > Export Selected Products', () => {
 		await test.step( 'Verify export button text and link for multiple selections', async () => {
 			await expect( exportButton ).toHaveText( 'Export 2 selected' );
 			const exportButtonHref = await exportButton.getAttribute( 'href' );
-			// Use a regex to match product_ids in any order, allowing for both comma and URL-encoded comma.
 			expect( exportButtonHref ).toMatch(
 				new RegExp(
 					`product_ids=(${ simpleProduct.id }(,|%2C)${ variableProduct.id }|${ variableProduct.id }(,|%2C)${ simpleProduct.id })`
@@ -158,11 +111,11 @@ test.describe( 'Product > Export Selected Products', () => {
 				String( simpleProduct.id ),
 				String( variableProduct.id ),
 			]
-				.sort()
+				.toSorted()
 				.join( ',' );
 			const actualIds = ( await productIdsInput.inputValue() )
 				.split( ',' )
-				.sort()
+				.toSorted()
 				.join( ',' );
 			expect( actualIds ).toBe( expectedIds );
 			await expect(
@@ -171,85 +124,38 @@ test.describe( 'Product > Export Selected Products', () => {
 			await expect(
 				page.locator( 'label[for="woocommerce-exporter-category"]' )
 			).toBeHidden();
-		} );
-	} );
-
-	test( 'should allow clearing selection from the export page', async ( {
-		page,
-		productsFixture,
-	} ) => {
-		const simpleProduct = productsFixture.simple;
-
-		await test.step( 'Navigate to product list, select product, and go to export page', async () => {
-			await page.goto( 'wp-admin/edit.php?post_type=product' );
-			await page.locator( `#cb-select-${ simpleProduct.id }` ).check();
-			await page
-				.locator( 'a.page-title-action[href*="page=product_exporter"]' )
-				.click();
-		} );
-
-		await test.step( 'Verify export page notice and URL for selected product', async () => {
 			await expect(
-				page.locator( '#selected-product-export-notice p' )
-			).toContainText( 'You are about to export 1 product.' );
-			await expect( page.url() ).toContain(
-				`product_ids=${ simpleProduct.id }`
+				page.locator( '.woocommerce-exporter header p' )
+			).toHaveText(
+				'This tool allows you to generate and download a CSV file containing the selected products.'
 			);
 		} );
 
-		await test.step( "Click 'clear your selection' link", async () => {
+		await test.step( 'Clear the selected products', async () => {
 			await page
-				.locator( '.notice-info p a:has-text("clear your selection")' )
+				.getByRole( 'link', { name: 'clear your selection' } )
 				.click();
 		} );
 
-		await test.step( 'Verify redirect to general export page and UI elements', async () => {
-			await expect( page.url() ).not.toContain( 'product_ids=' );
-			await expect(
-				page.locator(
-					'.notice-info p:has-text("You are about to export")'
-				)
-			).toBeHidden();
-			await expect(
-				page.locator( 'label[for="woocommerce-exporter-types"]' )
-			).toBeVisible();
-			await expect(
-				page.locator( 'label[for="woocommerce-exporter-category"]' )
-			).toBeVisible();
-		} );
-	} );
-
-	test( 'should show the default export screen when no products are selected', async ( {
-		page,
-		productsFixture,
-	} ) => {
-		expect( productsFixture ).toBeDefined();
-		await test.step( 'Navigate to product list', async () => {
-			await page.goto( 'wp-admin/edit.php?post_type=product' );
-		} );
-
-		const exportButton = page.locator(
-			'a.page-title-action[href*="page=product_exporter"]'
-		);
-
-		await test.step( 'Verify default export button state and navigate to export page', async () => {
-			await expect( exportButton ).toHaveText( 'Export' );
-			await exportButton.click();
-		} );
-
-		await test.step( 'Verify UI elements for default export', async () => {
-			await expect( page.url() ).not.toContain( 'product_ids=' );
-			// Verify the selection-specific notice is NOT present
+		await test.step( 'Verify the default export state', async () => {
+			expect( page.url() ).not.toContain( 'product_ids=' );
 			await expect(
 				page.locator( '#selected-product-export-notice' )
 			).toBeHidden();
-			// Verify the standard filters ARE present
+			await expect(
+				page.locator( 'input[name="product_ids"]' )
+			).toHaveCount( 0 );
 			await expect(
 				page.locator( 'label[for="woocommerce-exporter-types"]' )
 			).toBeVisible();
 			await expect(
 				page.locator( 'label[for="woocommerce-exporter-category"]' )
 			).toBeVisible();
+			await expect(
+				page.locator( '.woocommerce-exporter header p' )
+			).toHaveText(
+				'This tool allows you to generate and download a CSV file containing a list of all products.'
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/tests/php/includes/admin/views/class-wc-admin-product-export-view-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/views/class-wc-admin-product-export-view-test.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests for the Product Export admin view.
+ *
+ * @package WooCommerce\Tests\Admin\Views
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Product Export admin view tests.
+ */
+class WC_Admin_Product_Export_View_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Load the dependencies used directly by the view.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		require_once WC_ABSPATH . 'includes/export/class-wc-product-csv-exporter.php';
+		require_once WC_ABSPATH . 'includes/admin/class-wc-admin-exporters.php';
+	}
+
+	/**
+	 * @testdox Selected products render the exact singular and plural export states.
+	 */
+	public function test_selected_products_render_exact_export_state(): void {
+		$product_ids = array();
+
+		try {
+			$first_product  = WC_Helper_Product::create_simple_product();
+			$product_ids[]  = $first_product->get_id();
+			$second_product = WC_Helper_Product::create_simple_product();
+			$product_ids[]  = $second_product->get_id();
+
+			$singular_output = $this->render_export_view( array( $first_product->get_id() ) );
+
+			$this->assertStringContainsString( 'You are about to export 1 product.', $singular_output );
+			$this->assertSame( (string) $first_product->get_id(), $this->get_hidden_product_ids( $singular_output ) );
+			$this->assertSelectedExportStructure( $singular_output );
+
+			$plural_output = $this->render_export_view( array( $first_product->get_id(), $second_product->get_id() ) );
+
+			$this->assertStringContainsString( 'You are about to export 2 products.', $plural_output );
+			$this->assertSame(
+				$first_product->get_id() . ',' . $second_product->get_id(),
+				$this->get_hidden_product_ids( $plural_output )
+			);
+			$this->assertSelectedExportStructure( $plural_output );
+		} finally {
+			foreach ( array_reverse( $product_ids ) as $product_id ) {
+				WC_Helper_Product::delete_product( $product_id );
+			}
+		}
+	}
+
+	/**
+	 * @testdox No selected products render the default export state.
+	 */
+	public function test_no_selected_products_render_default_export_state(): void {
+		$output = $this->render_export_view( array() );
+
+		$this->assertStringNotContainsString( 'id="selected-product-export-notice"', $output );
+		$this->assertNull( $this->get_hidden_product_ids( $output ) );
+		$this->assertStringContainsString( 'containing a list of all products', $output );
+		$this->assertStringContainsString( 'for="woocommerce-exporter-types"', $output );
+		$this->assertStringContainsString( 'for="woocommerce-exporter-category"', $output );
+	}
+
+	/**
+	 * Assert the selection-specific view structure.
+	 *
+	 * @param string $output Rendered view output.
+	 */
+	private function assertSelectedExportStructure( string $output ): void {
+		$this->assertStringContainsString( 'id="selected-product-export-notice"', $output );
+		$this->assertStringContainsString( 'clear your selection', $output );
+		$this->assertStringContainsString( 'containing the selected products', $output );
+		$this->assertStringNotContainsString( 'for="woocommerce-exporter-types"', $output );
+		$this->assertStringNotContainsString( 'for="woocommerce-exporter-category"', $output );
+
+		$this->assertMatchesRegularExpression(
+			'/<a href="(?![^"]*product_ids=)[^"]*page=product_exporter[^"]*">clear your selection<\/a>/',
+			$output,
+			'The clear link should retain the exporter route without the selected product IDs.'
+		);
+	}
+
+	/**
+	 * Get the hidden selected product IDs from rendered markup.
+	 *
+	 * @param string $output Rendered view output.
+	 * @return string|null
+	 */
+	private function get_hidden_product_ids( string $output ): ?string {
+		$processor = new WP_HTML_Tag_Processor( $output );
+
+		while ( $processor->next_tag( array( 'tag_name' => 'INPUT' ) ) ) {
+			if ( 'product_ids' === $processor->get_attribute( 'name' ) ) {
+				$value = $processor->get_attribute( 'value' );
+				return is_string( $value ) ? $value : null;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Render the Product Export view with an isolated admin request.
+	 *
+	 * @param int[] $product_ids Selected product IDs.
+	 * @return string
+	 */
+	private function render_export_view( array $product_ids ): string {
+		global $wp_scripts;
+
+		$original_get           = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Snapshot test globals before constructing the isolated request.
+		$original_request       = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Snapshot test globals before constructing the isolated request.
+		$original_user_id       = get_current_user_id();
+		$original_buffer_level  = ob_get_level();
+		$had_request_uri        = isset( $_SERVER['REQUEST_URI'] );
+		$original_request_uri   = $had_request_uri ? $_SERVER['REQUEST_URI'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Preserve the exact pre-test server value for restoration.
+		$had_wp_scripts         = isset( $wp_scripts );
+		$original_scripts_queue = $had_wp_scripts ? $wp_scripts->queue : array();
+		$original_scripts_to_do = $had_wp_scripts ? $wp_scripts->to_do : array();
+		$admin_user_id          = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$output                 = '';
+
+		try {
+			wp_set_current_user( $admin_user_id );
+
+			$request_args = array( 'page' => 'product_exporter' );
+			if ( $product_ids ) {
+				$request_args['product_ids'] = implode( ',', $product_ids );
+				$request_args['_wpnonce']    = wp_create_nonce( 'export-selected-products' );
+			}
+			$_GET                   = $request_args;
+			$_REQUEST               = $request_args;
+			$_SERVER['REQUEST_URI'] = add_query_arg( $request_args, '/wp-admin/admin.php' );
+
+			ob_start();
+			include WC_ABSPATH . 'includes/admin/views/html-admin-page-product-export.php';
+			$output = (string) ob_get_clean();
+		} finally {
+			while ( ob_get_level() > $original_buffer_level ) {
+				ob_end_clean();
+			}
+
+			$_GET     = $original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restore the exact globals captured before the test request.
+			$_REQUEST = $original_request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restore the exact globals captured before the test request.
+			if ( $had_request_uri ) {
+				$_SERVER['REQUEST_URI'] = $original_request_uri;
+			} else {
+				unset( $_SERVER['REQUEST_URI'] );
+			}
+
+			if ( $had_wp_scripts ) {
+				$wp_scripts->queue = $original_scripts_queue;
+				$wp_scripts->to_do = $original_scripts_to_do;
+			} else {
+				unset( $wp_scripts );
+			}
+
+			wp_set_current_user( $original_user_id );
+			wp_delete_user( $admin_user_id );
+		}
+
+		return $output;
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
+++ b/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
@@ -163,6 +163,60 @@ class WC_Product_CSV_Exporter_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Selected product IDs restrict the export to those products and their variations.
+	 */
+	public function test_selected_product_ids_restrict_export_rows(): void {
+		$simple_product_ids = array();
+		$variable_product   = new WC_Product_Variable();
+
+		try {
+			$simple_product       = WC_Helper_Product::create_simple_product();
+			$simple_product_ids[] = $simple_product->get_id();
+
+			WC_Helper_Product::create_variation_product( $variable_product );
+			$variation_ids = $variable_product->get_children( 'edit' );
+
+			$unrelated_product    = WC_Helper_Product::create_simple_product();
+			$simple_product_ids[] = $unrelated_product->get_id();
+
+			$exporter = new WC_Product_CSV_Exporter();
+			$exporter->set_product_ids_to_export( array( $simple_product->get_id(), $variable_product->get_id() ) );
+			$exporter->prepare_data_to_export();
+
+			$exported_ids = array_map( 'intval', wp_list_pluck( $this->get_exported_data( $exporter ), 'id' ) );
+			$expected_ids = array_merge(
+				array( $simple_product->get_id(), $variable_product->get_id() ),
+				$variation_ids
+			);
+			sort( $exported_ids );
+			sort( $expected_ids );
+
+			$this->assertSame( $expected_ids, $exported_ids );
+			$this->assertCount( count( $expected_ids ), $exported_ids );
+			$this->assertNotContains( $unrelated_product->get_id(), $exported_ids );
+		} finally {
+			if ( $variable_product->get_id() ) {
+				$variation_ids = (array) wc_get_products(
+					array(
+						'parent' => $variable_product->get_id(),
+						'type'   => ProductType::VARIATION,
+						'return' => 'ids',
+						'limit'  => -1,
+					)
+				);
+				foreach ( $variation_ids as $variation_id ) {
+					WC_Helper_Product::delete_product( $variation_id );
+				}
+				WC_Helper_Product::delete_product( $variable_product->get_id() );
+			}
+
+			foreach ( array_reverse( $simple_product_ids ) as $product_id ) {
+				WC_Helper_Product::delete_product( $product_id );
+			}
+		}
+	}
+
+	/**
 	 * @testdox CSV data is written with an append-only fopen mode so write-only stream wrappers are supported.
 	 */
 	public function test_write_csv_data_uses_append_only_fopen_mode(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Three of the four product export browser titles were checking what the export screen renders when you arrive from the product list with a selection: which products it lists, where the clear link points, and what it shows when nothing is selected. That is a view assertion, and a view is cheaper and more precisely testable from PHP than through wp-admin. Those three move down a layer; the one that genuinely needs a browser stays.

Refs TESTOPS-288

Part of the #68046 split.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `should allow exporting a single selected simple product` | `WC_Admin_Product_Export_View_Test::test_selected_products_render_exact_export_state` renders the real view template and asserts the hidden `product_ids` input and the screen copy | The product list's `Export 1 selected` button text and href. See below. |
| `should allow exporting multiple selected products (simple and variable)` | the same view test, plus `WC_Product_CSV_Exporter_Test::test_selected_product_ids_restrict_export_rows`, which proves the exporter scopes its rows to the selected products **and their variations** | Nothing. The PHP test asserts more than the browser title did: the browser never checked which rows the exporter would produce. |
| `should allow clearing selection from the export page` | folded into the retained title, which still navigates the clear link and asserts the URL drops `product_ids` | Nothing. |
| `should show the default export screen when no products are selected` | `WC_Admin_Product_Export_View_Test`'s second test renders the same template with no selection | Nothing on the export screen itself. |

The retained title, `preserves multiple selection through export and clear`, is the one no lower layer can replace: it starts on the product list, carries a real selection across a navigation, and then clears it.

#### No test here reads an actual CSV file, and none did before

Worth stating plainly, because "product export" suggests otherwise. Neither the removed browser titles nor the new PHP tests ever generate a CSV and read its bytes. The old titles asserted button text, hrefs and screen copy; the new tests assert the rendered view and the exporter's in-memory row set. `product-export.spec.ts` has no download handling at all — the only specs in the suite that wait on a download are `analytics.spec.ts` and `customer-list.spec.ts`.

So this batch moves assertions sideways, from the browser to PHP. **It does not deepen coverage of the export mechanism, and the gap in end-to-end CSV file coverage is pre-existing and untouched.**

#### The one real loss: the product list's export button

The `Export N selected` button on the product list is written by jQuery (`client/legacy/js/admin/woocommerce_admin.js`), not by the view this batch tests, so no PHP test can reach it.

The singular case is less of a loss than it first looks. The button text is a single string with `%d` substituted — `woocommerce_admin.strings.export_selected_products.replace( '%d', count )` — with no separate singular branch, so `Export 1 selected` and `Export 2 selected` travel the same code path, and the retained title still exercises it with two products.

What is genuinely unverified now is the other branch: restoring the button's original text and href when the last checkbox is unchecked. Nothing covers that any more.

#### This file had moved on trunk, and the branch's version was not taken blind

`class-wc-product-csv-exporter-test.php` gained a method on trunk after this work branched: #68567 added `test_export_row_for_product_loaded_before_its_global_attribute_is_deleted`. Checking out the migration branch's copy wholesale would have deleted it.

Instead trunk's file was kept and only this branch's method re-applied on top. The result is checkable rather than asserted: both methods are present, the file's diff against trunk has **zero deleted lines**, and the class goes from 5 tests to 6.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the two PHP classes with anchored filters. Anchoring matters: a sibling class `WC_Tests_Product_CSV_Exporter` exists, and PHPUnit's `--filter` is an unanchored substring regex, so a loose filter runs more than it claims.
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter '/^WC_Product_CSV_Exporter_Test::/'` — expect `OK (6 tests, 32 assertions)`.
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter '/^WC_Admin_Product_Export_View_Test::/'` — expect `OK (2 tests, 21 assertions)`.
4. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/product/product-export.spec.ts`. The retained title should pass; the summary reads `3 passed` and `1 skipped`, the 3 being that title plus the `global authentication` and `site setup` projects.
6. Confirm the new view test detects a real regression in the template. In `plugins/woocommerce/includes/admin/views/html-admin-page-product-export.php`, find the branch that echoes the hidden `product_ids` input and change its `if ( $is_exporting_product_ids ) {` to `if ( false ) {`. Re-run the first command in step 3 and expect `test_selected_products_render_exact_export_state` to fail with `Failed asserting that null is identical to '10'.`. Revert.
7. Confirm the exporter test detects a scoping regression. In `plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php`, in `prepare_data_to_export`, change `$args['include'] = $this->product_ids_to_export;` to `$args['include'] = array();`. Re-run the first command in step 3 and expect `test_selected_product_ids_restrict_export_rows` to fail on an array-identity assertion, admitting an unrelated product and omitting the selected variations. Revert.
8. Confirm the retained browser title still guards the clear link. In the same view file, change `$clear_url = remove_query_arg( 'product_ids' );` to `$clear_url = add_query_arg( 'product_ids', implode( ',', $product_ids_to_export ) );`. Re-run step 5 and expect a failure reading `Expected substring: not "product_ids="`, with the URL still carrying the selected IDs. Revert.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Baseline first.** Trunk's copy of the spec ran green before extraction (4 titles), and trunk's `WC_Product_CSV_Exporter_Test` was `OK (5 tests, 29 assertions)` under the anchored filter. So the environment was known good and the merge result is measured against a real starting point.
- **Extraction.** The spec and the new view test are byte-identical to the migration branch. The exporter test is deliberately not: it is trunk's file plus this branch's one method, verified additive.
- **Retained title.** Green at `--retries=0 --workers=1`.
- **Lower layer.** `WC_Product_CSV_Exporter_Test` OK (6 tests, 32 assertions); `WC_Admin_Product_Export_View_Test` OK (2 tests, 21 assertions).
- **Mutation re-check, all 3 behavior families.** One recorded mutation per family, each turning its focused command red at the assertion the mutation matrix names, each reverted and green again: the view's hidden-input branch, the exporter's `include` scoping, and the view's clear-link URL.
- **Lint.** `lint:changes:branch` exits 0 with one pre-existing warning and no errors. `oxlint` attributes no new finding to the change.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; this batch touches only `tests/`.
- **Identifier sweep.** No internal campaign identifiers in any of the three paths, with a detector proven against a file where such identifiers do exist.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-products-admin-export`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

