### PR TITLE
[tests] Cut product search E2E from 3 titles to 2, moving the search query to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-products-admin-search
+++ b/plugins/woocommerce/changelog/testops-288-products-admin-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Cut the product search E2E spec from 3 titles to 1; partial-match and no-result search queries now covered by WC_Admin_List_Table_Products_Test.
+

--- a/plugins/woocommerce/tests/e2e/tests/product/product-search.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-search.spec.ts
@@ -30,8 +30,9 @@ test.describe( 'Products > Search and View a product', () => {
 		} );
 	} );
 
-	test( 'can do a partial search for a product', async ( { page } ) => {
-		// create a partial search string
+	test( 'can find and open a product from a partial search', async ( {
+		page,
+	} ) => {
 		const searchString = testProduct.name.substring(
 			0,
 			testProduct.name.length / 2
@@ -43,45 +44,33 @@ test.describe( 'Products > Search and View a product', () => {
 		await page.locator( '#post-search-input' ).fill( searchString );
 		await page.locator( '#search-submit' ).click();
 
-		// A partial search can match products that parallel workers create from
-		// this same spec, so scope the assertion to this test's product instead
-		// of asserting on every `.row-title` match.
+		const productLink = page.getByRole( 'link', {
+			name: testProduct.name,
+			exact: true,
+		} );
+		const productRow = page.locator( '#the-list tr' ).filter( {
+			has: productLink,
+		} );
+		await expect( productRow ).toHaveCount( 1 );
 		await expect(
-			page.locator( '.row-title', { hasText: testProduct.name } )
-		).toBeVisible();
-	} );
-
-	test( "can view a product's details after search", async ( { page } ) => {
-		const productIdInURL = new RegExp( `post=${ productId }` );
-
-		await page.goto( 'wp-admin/edit.php?post_type=product' );
-
-		await page.locator( '#post-search-input' ).fill( testProduct.name );
-		await page.locator( '#search-submit' ).click();
-
-		await page
-			.locator( '.row-title', { hasText: testProduct.name } )
+			productRow.getByRole( 'link', {
+				name: testProduct.name,
+				exact: true,
+			} )
+		).toHaveCount( 1 );
+		await productRow
+			.getByRole( 'link', { name: testProduct.name, exact: true } )
 			.click();
 
-		await expect( page ).toHaveURL( productIdInURL );
+		await expect( page ).toHaveURL( /wp-admin\/post\.php/ );
+		expect( new URL( page.url() ).searchParams.get( 'post' ) ).toBe(
+			String( productId )
+		);
 		await expect( page.locator( '#title' ) ).toHaveValue(
 			testProduct.name
 		);
 		await expect( page.locator( '#_regular_price' ) ).toHaveValue(
 			testProduct.regular_price
-		);
-	} );
-
-	test( 'returns no results for non-existent product search', async ( {
-		page,
-	} ) => {
-		await page.goto( 'wp-admin/edit.php?post_type=product' );
-
-		await page.locator( '#post-search-input' ).fill( 'abcd1234' );
-		await page.locator( '#search-submit' ).click();
-
-		await expect( page.locator( '.no-items' ) ).toContainText(
-			'No products found'
 		);
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/product/product-search.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-search.spec.ts
@@ -30,6 +30,26 @@ test.describe( 'Products > Search and View a product', () => {
 		} );
 	} );
 
+	// Canary for the admin product list's empty state. The PHPUnit coverage this
+	// batch adds asserts the search *results*, as IDs, so nothing below the browser
+	// asserts the `No products found` markup, and nothing else in the suite does
+	// either.
+	test( 'shows the empty state when a search matches no products', async ( {
+		page,
+	} ) => {
+		await page.goto( 'wp-admin/edit.php?post_type=product' );
+
+		await expect( page.locator( '#post-search-input' ) ).toBeVisible();
+		await page
+			.locator( '#post-search-input' )
+			.fill( `no-such-product-${ Date.now() }` );
+		await page.locator( '#search-submit' ).click();
+
+		await expect( page.locator( '.no-items' ) ).toContainText(
+			'No products found'
+		);
+	} );
+
 	test( 'can find and open a product from a partial search', async ( {
 		page,
 	} ) => {

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
@@ -87,6 +87,76 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Product searches return a partial title match.
+	 */
+	public function test_product_search_returns_partial_title_match(): void {
+		$target_token = wp_generate_password( 16, false );
+		$search_term  = substr( $target_token, 4, 8 );
+		$target_name  = 'Slice target ' . $target_token;
+		$control_name = 'Unrelated fixture';
+		$target       = null;
+		$control      = null;
+
+		$this->assertFalse(
+			false !== stripos( $control_name, $search_term ),
+			'The control title must not contain the target search substring.'
+		);
+
+		try {
+			$target = WC_Helper_Product::create_simple_product();
+			$target->set_name( $target_name );
+			$target->set_status( 'publish' );
+			$target->set_date_created( '2024-01-02 00:00:00' );
+			$target->save();
+
+			$control = WC_Helper_Product::create_simple_product();
+			$control->set_name( $control_name );
+			$control->set_status( 'publish' );
+			$control->set_date_created( '2024-01-01 00:00:00' );
+			$control->save();
+
+			$this->assertSame(
+				array( $target->get_id() ),
+				$this->get_search_results( $search_term ),
+				'A strict interior title substring should return only its matching product.'
+			);
+		} finally {
+			if ( $control instanceof WC_Product ) {
+				$control->delete( true );
+			}
+
+			if ( $target instanceof WC_Product ) {
+				$target->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Product searches return no results for a missing term.
+	 */
+	public function test_product_search_returns_no_results_for_missing_term(): void {
+		$control = null;
+
+		try {
+			$control = WC_Helper_Product::create_simple_product();
+			$control->set_name( 'Product Search Control ' . wp_generate_password( 8, false ) );
+			$control->set_status( 'publish' );
+			$control->set_date_created( '2024-01-01 00:00:00' );
+			$control->save();
+
+			$this->assertSame(
+				array(),
+				$this->get_search_results( 'Missing Product Search ' . wp_generate_password( 8, false ) ),
+				'A missing product search term should not admit unrelated published products.'
+			);
+		} finally {
+			if ( $control instanceof WC_Product ) {
+				$control->delete( true );
+			}
+		}
+	}
+
+	/**
 	 * @testdox Product searches prioritize titles that match parsed search terms.
 	 * @dataProvider parsed_search_term_provider
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Three browser titles searched the admin product list: one for a partial match, one that opened the matched product, and one that searched for nonsense and checked the empty state. The first two were one journey split in half, and both were really asking whether the search query finds the right products — which is a query question, not a browser one.

Refs TESTOPS-288

Part of the #68046 split.

The spec ends with two titles, not one: the merged journey, and a new canary for the empty state. `WC_Admin_List_Table_Products_Test` goes from 24 methods to 26 and from 42 tests to 44.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `can do a partial search for a product` | `WC_Admin_List_Table_Products_Test::test_product_search_returns_partial_title_match`, which drives the list table's request query down to `WC_Product_Data_Store_CPT::search_products()`, plus the retained browser journey | Nothing. |
| `can view a product's details after search` | merged into the retained `can find and open a product from a partial search`, which searches and opens the result in one pass | Nothing. Same assertions, one page load fewer. |
| `returns no results for non-existent product search` | `WC_Admin_List_Table_Products_Test::test_product_search_returns_no_results_for_missing_term` for the query, **and a new browser canary for the rendering** | See below — this row is not a clean move. |

#### The empty state did not simply move down a layer

Worth being exact about, because the table above could be read as if it had. The PHP test asserts `assertSame( array(), $this->get_search_results( ... ) )` — the search returns no product IDs. It never renders anything.

The removed browser title asserted something different: that the admin list shows `No products found` in its `.no-items` row. Nothing else in the suite asserts that markup — `git grep` for `.no-items` and `No products found` across the whole `tests/e2e` tree finds it only here.

So the second commit adds `shows the empty state when a search matches no products`, which searches for an unmatchable term and asserts that text. Without it this PR would have quietly traded a rendering guarantee for a query guarantee and called it a move.

#### This file had moved on trunk, and the branch's version was not taken blind

`class-wc-admin-list-table-products-test.php` gained two methods on trunk after this work branched: #68094 added `test_stock_status_filter_joins_despite_a_foreign_alias_lookup_join` and `test_stock_status_filter_survives_an_extension_join_under_another_alias`, covering product-list SQL when an extension joins the lookup table under its own alias. Checking out the migration branch's copy wholesale would have deleted both.

Instead trunk's file was kept and only this branch's two methods re-applied on top. The arithmetic is checkable: 22 methods at the diff base, 24 on trunk, 24 on the migration branch, **26** here, with **zero deleted lines** in the diff against trunk.

The production file those trunk tests cover is also newer than the migration branch's copy. This branch matches trunk's, and neither new test's code path reaches the method #68094 changed — both do a plain `s` search, which never enters the sorting-table join.

#### A small documentation loss, recorded rather than fixed

The diff base carried a comment explaining that a partial search can match products other parallel workers created from the same spec, which is why the assertion scopes to this test's own product. The migration's rewrite dropped the comment but kept the behaviour — the retained title still filters rows by the full product name. Restoring the comment would have meant amending the migration commit away from the frozen state it otherwise reproduces exactly, so it is noted here instead.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the class with an anchored filter — a sibling `WC_Admin_List_Table_Orders_Test` exists and PHPUnit's `--filter` is an unanchored substring regex: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter '/^WC_Admin_List_Table_Products_Test::/'`. Expect `OK (44 tests, 61 assertions)`.
4. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/product/product-search.spec.ts`. Both titles should pass; the summary reads `4 passed` and `1 skipped`, the 4 being the two product titles plus the `global authentication` and `site setup` projects.
6. Confirm the PHP test detects a real search regression. In `plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php`, in `search_products()`, change `$like = '%' . $wpdb->esc_like( $search_term ) . '%';` to `$like = $wpdb->esc_like( $search_term );`, dropping the wildcards. Re-run step 3 and expect `test_product_search_returns_partial_title_match` to fail on an array-identity assertion. Revert.
7. Confirm the retained browser journey still detects a search that finds nothing. In `plugins/woocommerce/tests/e2e/tests/product/product-search.spec.ts`, immediately before `await page.locator( '#search-submit' ).click();` in that title, add `const { setFilterValue } = await import( '../../utils/filters' ); await setFilterValue( page, 'posts_search', ' AND 1=0 ' );`. Re-run step 5 and expect a failure at `expect( productRow ).toHaveCount( 1 )` with `Received: 0`. Revert. Do not add a `page.reload()` here — reloading applies the filter to the list page itself, which empties it and makes WordPress hide the search box, so the test fails earlier for the wrong reason.
8. Confirm the new canary guards the rendered empty state. In `plugins/woocommerce/includes/class-wc-post-types.php`, change the product post type's `'not_found' => __( 'No products found', 'woocommerce' ),` label to any other string. Re-run step 5 and expect `shows the empty state when a search matches no products` to fail with `Expected substring: "No products found"`. Revert.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Baseline first.** Trunk's copy of the spec ran green before extraction (3 titles), and trunk's `WC_Admin_List_Table_Products_Test` was `OK (42 tests, 58 assertions)` under the anchored filter, so the merged result is measured against a real starting point.
- **Extraction.** The spec is byte-identical to the migration branch in the first commit; the second adds only the canary. The PHP test is deliberately not identical — it is trunk's file plus this branch's two methods, verified additive.
- **Retained titles.** Both green at `--retries=0 --workers=1`.
- **Lower layer.** `WC_Admin_List_Table_Products_Test` OK (44 tests, 61 assertions).
- **Mutation re-check, both behavior families plus the canary.** Dropping the wildcards from `search_products()` turns the partial-match PHP test red; a controlled `posts_search` filter turns the retained browser journey red at `toHaveCount( 1 )`, `Received: 0`; and changing the product post type's `not_found` label turns the new canary red with `Received string: "Nothing here at all"`. Each reverted cleanly and went green again.
- **One of those was a false kill first, and was redone.** The first attempt at the `posts_search` mutation also reloaded the page, which emptied the product list and made WordPress hide the search box, so the title failed before the search ran. A non-zero exit at the wrong assertion is not a kill. The mutation was rewritten to match what the mutation matrix actually specifies, and the red now lands on the intended assertion.
- **Lint.** `lint:changes:branch` exits 0 with no errors and no warnings. `oxlint` attributes no new finding to the change.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; this batch touches only `tests/`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-products-admin-search`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

