### PR TITLE
[tests] Move review edit and reply to PHPUnit, keep a browser canary for moderation

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-product-reviews
+++ b/plugins/woocommerce/changelog/testops-288-product-reviews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Cut the product reviews E2E spec from 9 titles to 6; review edit and reply now covered by ReviewsAjaxTest, with a retained browser canary for the approve, spam and trash moderation actions.
+

--- a/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
@@ -71,36 +71,6 @@ const test = baseTest.extend( {
 
 test.describe( 'Product Reviews', () => {
 	test.describe( 'Merchant manages reviews', () => {
-		test( 'can view products reviews list', async ( { page, reviews } ) => {
-			await page.goto(
-				`wp-admin/edit.php?post_type=product&page=product-reviews`
-			);
-
-			for ( const review of reviews ) {
-				const reviewRow = page.locator( `#comment-${ review.id }` );
-
-				await expect(
-					reviewRow.locator( '[data-colname="Author"]' )
-				).toContainText( review.reviewer_email );
-				await expect(
-					reviewRow
-						.locator( '[data-colname="Rating"]' )
-						.getByLabel( `${ review.rating } out of 5` )
-				).toBeVisible();
-				await expect(
-					reviewRow.locator( '[data-colname="Review"]' )
-				).toContainText( review.review );
-				await expect(
-					reviewRow
-						.locator( '[data-colname="Product"]' )
-						.getByRole( 'link' )
-						.first()
-				).toContainText( review.product_name );
-			}
-
-			expect( reviews.length ).toBeGreaterThan( 0 );
-		} );
-
 		test( 'can filter the reviews by product', async ( {
 			page,
 			reviews,
@@ -126,12 +96,24 @@ test.describe( 'Product Reviews', () => {
 				1
 			);
 
+			const reviewRow = page.locator( `#comment-${ review.id }` );
 			await expect(
-				page
+				reviewRow.locator( '[data-colname="Author"]' )
+			).toContainText( review.reviewer_email );
+			await expect(
+				reviewRow
+					.locator( '[data-colname="Rating"]' )
+					.getByLabel( `${ review.rating } out of 5` )
+			).toBeVisible();
+			await expect(
+				reviewRow.locator( '[data-colname="Review"]' )
+			).toContainText( review.review );
+			await expect(
+				reviewRow
 					.locator( '[data-colname="Product"]' )
 					.getByRole( 'link' )
-					.filter( { hasText: review.product_name } )
-			).toBeVisible();
+					.first()
+			).toContainText( review.product_name );
 		} );
 
 		test( 'can quick edit a product review', async ( {
@@ -143,7 +125,6 @@ test.describe( 'Product Reviews', () => {
 			await page.goto(
 				`wp-admin/edit.php?post_type=product&page=product-reviews`
 			);
-
 			const reviewRow = page.locator( `#comment-${ review.id }` );
 			await reviewRow.hover();
 			await reviewRow
@@ -163,6 +144,50 @@ test.describe( 'Product Reviews', () => {
 			await expect(
 				reviewRow.getByText( updatedQuickReview )
 			).toBeVisible();
+		} );
+
+		test( 'can reply to a product review', async ( { page, reviews } ) => {
+			const review = reviews[ 0 ];
+
+			await page.goto(
+				'wp-admin/edit.php?post_type=product&page=product-reviews'
+			);
+
+			// Handle notice if present
+			await page.addLocatorHandler(
+				page.getByRole( 'link', { name: 'Dismiss' } ),
+				async () => {
+					await page.getByRole( 'link', { name: 'Dismiss' } ).click();
+				}
+			);
+
+			const reviewRow = page.locator( `#comment-${ review.id }` );
+			await reviewRow.hover();
+			await reviewRow.getByRole( 'button', { name: 'Reply' } ).click();
+			const replyTextArea = page.locator( 'textarea#replycontent' );
+
+			await expect( replyTextArea ).toBeVisible();
+
+			const replyText = `Thank you for your feedback! (replied ${ Date.now() })`;
+			await replyTextArea.fill( replyText );
+
+			await page
+				.getByRole( 'cell', { name: 'Reply to Comment' } )
+				.getByRole( 'button', { name: 'Reply', exact: true } )
+				.click();
+
+			await expect( replyTextArea ).toBeHidden();
+
+			const productLink = await reviewRow
+				.locator( 'a.comments-view-item-link' )
+				.getAttribute( 'href' );
+			await page.goto( productLink );
+			await page.getByRole( 'tab', { name: 'Reviews' } ).click();
+
+			const replyReviews = page.locator(
+				`div.comment_container:has-text("${ replyText }")`
+			);
+			await expect( replyReviews ).toBeVisible();
 		} );
 
 		test( 'can edit a product review', async ( { page, reviews } ) => {
@@ -214,163 +239,6 @@ test.describe( 'Product Reviews', () => {
 			).toContainText( updatedReview );
 			await expect(
 				page.getByLabel( `${ updatedRating } out of 5` )
-			).toBeVisible();
-		} );
-
-		test( 'can approve a product review', async ( { page, reviews } ) => {
-			const review = reviews[ 0 ]; // Select the first review for approval
-
-			await page.goto(
-				`wp-admin/edit.php?post_type=product&page=product-reviews`
-			);
-
-			const reviewRow = page.locator( `#comment-${ review.id }` );
-
-			const approveButton = reviewRow.getByRole( 'button', {
-				name: 'Approve',
-			} );
-
-			await reviewRow.hover();
-			await approveButton.click();
-			const unapproveButton = reviewRow.getByRole( 'button', {
-				name: 'Unapprove',
-			} );
-			await expect( unapproveButton ).toBeVisible();
-		} );
-
-		test( 'can mark a product review as spam', async ( {
-			page,
-			reviews,
-		} ) => {
-			const review = reviews[ 0 ];
-
-			await page.goto(
-				`wp-admin/edit.php?post_type=product&page=product-reviews`
-			);
-
-			const reviewRow = page.locator( `#comment-${ review.id }` );
-			await reviewRow.hover();
-
-			await reviewRow.getByRole( 'button', { name: 'Spam' } ).click();
-
-			await expect(
-				page.locator( `#comment-${ review.id }` )
-			).toBeHidden();
-
-			await page.click( 'a[href*="comment_status=spam"]' );
-
-			await expect(
-				page.locator( `#comment-${ review.id }` )
-			).toBeVisible();
-		} );
-
-		test( 'can reply to a product review', async ( { page, reviews } ) => {
-			const review = reviews[ 0 ];
-
-			await page.goto(
-				'wp-admin/edit.php?post_type=product&page=product-reviews'
-			);
-
-			// Handle notice if present
-			await page.addLocatorHandler(
-				page.getByRole( 'link', { name: 'Dismiss' } ),
-				async () => {
-					await page.getByRole( 'link', { name: 'Dismiss' } ).click();
-				}
-			);
-
-			const reviewRow = page.locator( `#comment-${ review.id }` );
-			await reviewRow.hover();
-			await reviewRow.getByRole( 'button', { name: 'Reply' } ).click();
-			const replyTextArea = page.locator( 'textarea#replycontent' );
-
-			await expect( replyTextArea ).toBeVisible();
-
-			const replyText = `Thank you for your feedback! (replied ${ Date.now() })`;
-			await replyTextArea.fill( replyText );
-
-			await page
-				.getByRole( 'cell', { name: 'Reply to Comment' } )
-				.getByRole( 'button', { name: 'Reply', exact: true } )
-				.click();
-
-			await expect( replyTextArea ).toBeHidden();
-
-			const productLink = await reviewRow
-				.locator( 'a.comments-view-item-link' )
-				.getAttribute( 'href' );
-			await page.goto( productLink );
-			await page.getByRole( 'tab', { name: 'Reviews' } ).click();
-
-			const replyReviews = page.locator(
-				`div.comment_container:has-text("${ replyText }")`
-			);
-			await expect( replyReviews ).toBeVisible();
-		} );
-
-		test( 'can delete a product review', async ( { page, reviews } ) => {
-			const review = reviews[ 0 ];
-
-			await page.goto(
-				`wp-admin/edit.php?post_type=product&page=product-reviews`
-			);
-			const reviewRow = page.locator( `#comment-${ review.id }` );
-			await reviewRow.hover();
-
-			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
-			// WordPress wptexturize may convert straight apostrophes (') to
-			// smart quotes (\u2019) in the reviewer name, so check for both.
-			const trashMessage = `Comment by ${ review.reviewer } moved to the Trash`;
-			const trashMessageSmart = trashMessage.replace( /'/g, '\u2019' );
-			const trashNotice = page.locator( '.trash-undo-inside' ).first();
-			const trashNoticeText = await trashNotice.textContent();
-			expect(
-				trashNoticeText?.includes( trashMessage ) ||
-					trashNoticeText?.includes( trashMessageSmart )
-			).toBeTruthy();
-			await page.getByRole( 'button', { name: 'Undo' } ).click();
-
-			// WordPress 7.1 renders primary list-table cells as row headers.
-			await expect(
-				reviewRow.getByRole( 'cell', { name: review.review } ).or(
-					reviewRow.getByRole( 'rowheader', {
-						name: review.review,
-					} )
-				)
-			).toBeVisible();
-
-			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
-
-			const trashNotice2 = page.locator( '.trash-undo-inside' ).first();
-			const trashNoticeText2 = await trashNotice2.textContent();
-			expect(
-				trashNoticeText2?.includes( trashMessage ) ||
-					trashNoticeText2?.includes( trashMessageSmart )
-			).toBeTruthy();
-
-			// The trash notice renders optimistically, before the trash AJAX
-			// commits. Wait for the row to actually leave the approved list so
-			// navigating to the Trash view does not abort the in-flight request.
-			await expect( reviewRow ).toBeHidden();
-
-			await page.click( 'a[href*="comment_status=trash"]' );
-
-			// WordPress 7.1 renders primary list-table cells as row headers.
-			await expect(
-				reviewRow.getByRole( 'cell', { name: review.review } ).or(
-					reviewRow.getByRole( 'rowheader', {
-						name: review.review,
-					} )
-				)
-			).toBeVisible();
-
-			await page.goto(
-				`wp-admin/comment.php?action=editcomment&c=${ review.id }`
-			);
-			await expect(
-				page.getByText(
-					`This comment is in the Trash. Please move it out of the Trash if you want to edit it.`
-				)
 			).toBeVisible();
 		} );
 	} );

--- a/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
@@ -116,6 +116,76 @@ test.describe( 'Product Reviews', () => {
 			).toContainText( review.product_name );
 		} );
 
+		// Canary for the moderation actions. This batch moved review edit and reply
+		// to ReviewsAjaxTest, but approve, spam and trash have no PHP coverage of
+		// their state transition: ReviewsListTableTest::test_handle_row_actions
+		// asserts only that the row renders those links. Nothing else in the suite
+		// moderates a review.
+		//
+		// Every step checks the review's new status by loading the matching
+		// filtered view rather than by looking at the row's own buttons. The list
+		// renders both Approve and Unapprove in the all view regardless of status,
+		// so asserting on them proves nothing -- an earlier version of this test
+		// did exactly that and survived two mutations of the approve path.
+		//
+		// Spam and trash use different rows on purpose: once a review is spammed
+		// its actions become Not Spam and Delete Permanently, so Trash is only
+		// reachable from the main list.
+		test( 'can approve, spam and trash a product review', async ( {
+			page,
+			reviews,
+		} ) => {
+			const reviewsUrl =
+				'wp-admin/edit.php?post_type=product&page=product-reviews';
+			const moderated = reviews[ 0 ];
+			const trashed = reviews[ 1 ];
+
+			const rowFor = ( id: number ) => page.locator( `#comment-${ id }` );
+
+			await test.step( 'unapprove, then approve again', async () => {
+				await page.goto( reviewsUrl );
+				await rowFor( moderated.id ).hover();
+				await rowFor( moderated.id )
+					.getByRole( 'button', { name: 'Unapprove' } )
+					.click();
+
+				await page.goto( `${ reviewsUrl }&comment_status=moderated` );
+				await expect( rowFor( moderated.id ) ).toBeVisible();
+
+				await rowFor( moderated.id ).hover();
+				await rowFor( moderated.id )
+					.getByRole( 'button', { name: 'Approve' } )
+					.click();
+
+				await page.goto( `${ reviewsUrl }&comment_status=approved` );
+				await expect( rowFor( moderated.id ) ).toBeVisible();
+			} );
+
+			await test.step( 'mark as spam', async () => {
+				await page.goto( reviewsUrl );
+				await rowFor( moderated.id ).hover();
+				await rowFor( moderated.id )
+					.getByRole( 'button', { name: 'Spam' } )
+					.click();
+				await expect( rowFor( moderated.id ) ).toBeHidden();
+
+				await page.goto( `${ reviewsUrl }&comment_status=spam` );
+				await expect( rowFor( moderated.id ) ).toBeVisible();
+			} );
+
+			await test.step( 'trash', async () => {
+				await page.goto( reviewsUrl );
+				await rowFor( trashed.id ).hover();
+				await rowFor( trashed.id )
+					.getByRole( 'button', { name: 'Trash' } )
+					.click();
+				await expect( rowFor( trashed.id ) ).toBeHidden();
+
+				await page.goto( `${ reviewsUrl }&comment_status=trash` );
+				await expect( rowFor( trashed.id ) ).toBeVisible();
+			} );
+		} );
+
 		test( 'can quick edit a product review', async ( {
 			page,
 			reviews,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsAjaxTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsAjaxTest.php
@@ -1,0 +1,399 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\ProductReviews;
+
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews;
+use WC_Helper_Product;
+use WP_Ajax_UnitTestCase;
+use WP_Comment;
+use WPAjaxDieContinueException;
+use WPAjaxDieStopException;
+
+/**
+ * Tests Product Reviews registered AJAX handlers.
+ *
+ * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::handle_edit_review
+ * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::handle_reply_to_review
+ */
+class ReviewsAjaxTest extends WP_Ajax_UnitTestCase {
+	/**
+	 * Registered Product Reviews handler.
+	 *
+	 * @var Reviews
+	 */
+	private $reviews;
+
+	/** @var bool Whether this test added the edit hook. */
+	private $added_edit_hook = false;
+
+	/** @var bool Whether this test added the reply hook. */
+	private $added_reply_hook = false;
+
+	/** @var bool Whether this test added the core edit hook. */
+	private $added_core_edit_hook = false;
+
+	/** @var bool Whether this test added the core reply hook. */
+	private $added_core_reply_hook = false;
+
+	/** @var array<string, mixed> Original POST payload. */
+	private $original_post = array();
+
+	/** @var array<string, mixed> Original request payload. */
+	private $original_request = array();
+
+	/** @var int Original current user ID. */
+	private $original_user_id = 0;
+
+	/**
+	 * Set up the registered Woo handlers.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->original_post         = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Snapshots test-process state; no request data is processed.
+		$this->original_request      = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Snapshots test-process state; no request data is processed.
+		$this->original_user_id      = get_current_user_id();
+		$this->added_edit_hook       = false;
+		$this->added_reply_hook      = false;
+		$this->added_core_edit_hook  = false;
+		$this->added_core_reply_hook = false;
+		$this->reviews               = wc_get_container()->get( Reviews::class );
+
+		if ( false === has_action( 'wp_ajax_edit-comment', array( $this->reviews, 'handle_edit_review' ) ) ) {
+			add_action( 'wp_ajax_edit-comment', array( $this->reviews, 'handle_edit_review' ), -1 );
+			$this->added_edit_hook = true;
+		}
+		if ( false === has_action( 'wp_ajax_replyto-comment', array( $this->reviews, 'handle_reply_to_review' ) ) ) {
+			add_action( 'wp_ajax_replyto-comment', array( $this->reviews, 'handle_reply_to_review' ), -1 );
+			$this->added_reply_hook = true;
+		}
+		if ( false === has_action( 'wp_ajax_edit-comment', 'wp_ajax_edit_comment' ) ) {
+			add_action( 'wp_ajax_edit-comment', 'wp_ajax_edit_comment', 1 );
+			$this->added_core_edit_hook = true;
+		}
+		if ( false === has_action( 'wp_ajax_replyto-comment', 'wp_ajax_replyto_comment' ) ) {
+			add_action( 'wp_ajax_replyto-comment', 'wp_ajax_replyto_comment', 1 );
+			$this->added_core_reply_hook = true;
+		}
+
+		$this->assertSame( -1, has_action( 'wp_ajax_edit-comment', array( $this->reviews, 'handle_edit_review' ) ) );
+		$this->assertSame( -1, has_action( 'wp_ajax_replyto-comment', array( $this->reviews, 'handle_reply_to_review' ) ) );
+	}
+
+	/**
+	 * Reset mutable request and response state.
+	 */
+	public function tear_down(): void {
+		if ( $this->added_edit_hook ) {
+			remove_action( 'wp_ajax_edit-comment', array( $this->reviews, 'handle_edit_review' ), -1 );
+		}
+		if ( $this->added_reply_hook ) {
+			remove_action( 'wp_ajax_replyto-comment', array( $this->reviews, 'handle_reply_to_review' ), -1 );
+		}
+		if ( $this->added_core_edit_hook ) {
+			remove_action( 'wp_ajax_edit-comment', 'wp_ajax_edit_comment', 1 );
+		}
+		if ( $this->added_core_reply_hook ) {
+			remove_action( 'wp_ajax_replyto-comment', 'wp_ajax_replyto_comment', 1 );
+		}
+
+		$_POST                = $this->original_post;
+		$_REQUEST             = $this->original_request;
+		$this->_last_response = '';
+		wp_set_current_user( $this->original_user_id );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Editing a product review uses Woo's registered handler and row renderer.
+	 */
+	public function test_edit_review_via_registered_ajax_persists_and_returns_woo_row(): void {
+		$product = null;
+		$review  = null;
+
+		try {
+			$product = WC_Helper_Product::create_simple_product();
+			$review  = $this->create_review( $product->get_id(), 'Original review' );
+			$this->_setRole( 'administrator' );
+
+			$_POST = array(
+				'_ajax_nonce-replyto-comment' => wp_create_nonce( 'replyto-comment' ),
+				'comment_ID'                  => $review->comment_ID,
+				'content'                     => 'Updated review from AJAX',
+				'position'                    => 7,
+				'status'                      => 'approved',
+			);
+
+			$xml           = $this->dispatch_successful_ajax( 'edit-comment' );
+			$response      = $xml->response[0]->edit_comment;
+			$response_data = (string) $response->response_data;
+			$fresh_review  = get_comment( $review->comment_ID );
+
+			$this->assertInstanceOf( WP_Comment::class, $fresh_review );
+			$this->assertSame( 'Updated review from AJAX', $fresh_review->comment_content );
+			$this->assertSame( 'approved', $fresh_review->comment_approved );
+			$this->assertSame( 'edit-comment_' . $review->comment_ID, (string) $xml->response['action'] );
+			$this->assertSame( (string) $review->comment_ID, (string) $response['id'] );
+			$this->assertSame( '7', (string) $response['position'] );
+			$this->assertStringContainsString( 'id="comment-' . $review->comment_ID . '"', $response_data );
+			$this->assertStringContainsString( 'data-colname="Rating"', $response_data );
+			$this->assertStringContainsString( 'data-colname="Product"', $response_data );
+		} finally {
+			if ( $review ) {
+				wp_delete_comment( (int) $review->comment_ID, true );
+			}
+			if ( $product ) {
+				$product->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * Non-product comments fall through to WordPress core's registered handler.
+	 */
+	public function test_edit_non_product_comment_via_registered_ajax_falls_through_to_core(): void {
+		$post_id = 0;
+		$comment = null;
+
+		try {
+			$post_id = $this->factory()->post->create();
+			$comment = $this->factory()->comment->create_and_get(
+				array(
+					'comment_post_ID' => $post_id,
+					'comment_content' => 'Original core comment',
+				)
+			);
+			$this->_setRole( 'administrator' );
+
+			$_POST = array(
+				'_ajax_nonce-replyto-comment' => wp_create_nonce( 'replyto-comment' ),
+				'comment_ID'                  => $comment->comment_ID,
+				'content'                     => 'Updated by WordPress core',
+				'position'                    => 3,
+			);
+
+			$xml           = $this->dispatch_successful_ajax( 'edit-comment' );
+			$response_data = (string) $xml->response[0]->edit_comment->response_data;
+			$fresh_comment = get_comment( $comment->comment_ID );
+
+			$this->assertInstanceOf( WP_Comment::class, $fresh_comment );
+			$this->assertSame( 'Updated by WordPress core', $fresh_comment->comment_content );
+			$this->assertSame( 'edit-comment_' . $comment->comment_ID, (string) $xml->response['action'] );
+			$this->assertSame( '3', (string) $xml->response[0]->edit_comment['position'] );
+			$this->assertStringNotContainsString( 'data-colname="Rating"', $response_data );
+			$this->assertStringNotContainsString( 'data-colname="Product"', $response_data );
+		} finally {
+			if ( $comment ) {
+				wp_delete_comment( (int) $comment->comment_ID, true );
+			}
+			if ( $post_id ) {
+				wp_delete_post( $post_id, true );
+			}
+		}
+	}
+
+	/**
+	 * Editing a review without permission is rejected without persistence.
+	 */
+	public function test_edit_review_via_registered_ajax_rejects_unauthorized_request(): void {
+		$product = null;
+		$review  = null;
+
+		try {
+			$product = WC_Helper_Product::create_simple_product();
+			$review  = $this->create_review( $product->get_id(), 'Protected review' );
+			$this->_setRole( 'subscriber' );
+
+			$_POST = array(
+				'_ajax_nonce-replyto-comment' => wp_create_nonce( 'replyto-comment' ),
+				'comment_ID'                  => $review->comment_ID,
+				'content'                     => 'Unauthorized edit',
+			);
+
+			$this->assert_ajax_stops_with( 'edit-comment', '-1' );
+
+			$fresh_review = get_comment( $review->comment_ID );
+			$this->assertInstanceOf( WP_Comment::class, $fresh_review );
+			$this->assertSame( 'Protected review', $fresh_review->comment_content );
+		} finally {
+			if ( $review ) {
+				wp_delete_comment( (int) $review->comment_ID, true );
+			}
+			if ( $product ) {
+				$product->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * Replying to a product review persists a child and returns Woo's row.
+	 */
+	public function test_reply_to_review_via_registered_ajax_persists_child_and_returns_woo_row(): void {
+		$product  = null;
+		$review   = null;
+		$reply_id = 0;
+
+		try {
+			$product = WC_Helper_Product::create_simple_product();
+			$review  = $this->create_review( $product->get_id(), 'Parent review' );
+			$this->_setRole( 'administrator' );
+			$current_user = wp_get_current_user();
+
+			$_POST = array(
+				'_ajax_nonce-replyto-comment' => wp_create_nonce( 'replyto-comment' ),
+				'comment_ID'                  => $review->comment_ID,
+				'comment_post_ID'             => $product->get_id(),
+				'comment_type'                => 'comment',
+				'content'                     => 'Store reply from AJAX',
+				'position'                    => 5,
+			);
+
+			$xml           = $this->dispatch_successful_ajax( 'replyto-comment' );
+			$response      = $xml->response[0]->comment;
+			$response_data = (string) $response->response_data;
+			$reply_id      = (int) $response['id'];
+			$fresh_reply   = get_comment( $reply_id );
+
+			$this->assertGreaterThan( 0, $reply_id );
+			$this->assertInstanceOf( WP_Comment::class, $fresh_reply );
+			$this->assertSame( $product->get_id(), (int) $fresh_reply->comment_post_ID );
+			$this->assertSame( (int) $review->comment_ID, (int) $fresh_reply->comment_parent );
+			$this->assertSame( 'comment', $fresh_reply->comment_type );
+			$this->assertSame( 'Store reply from AJAX', $fresh_reply->comment_content );
+			$this->assertSame( $current_user->display_name, $fresh_reply->comment_author );
+			$this->assertSame( $current_user->user_email, $fresh_reply->comment_author_email );
+			$this->assertSame( 'replyto-comment_' . $reply_id, (string) $xml->response['action'] );
+			$this->assertSame( '5', (string) $response['position'] );
+			$this->assertStringContainsString( 'id="comment-' . $reply_id . '"', $response_data );
+			$this->assertStringContainsString( 'data-colname="Product"', $response_data );
+			$this->assertStringContainsString( 'In reply to', $response_data );
+		} finally {
+			if ( $reply_id ) {
+				wp_delete_comment( $reply_id, true );
+			}
+			if ( $review ) {
+				wp_delete_comment( (int) $review->comment_ID, true );
+			}
+			if ( $product ) {
+				$product->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * Replying without permission is rejected without creating a child.
+	 */
+	public function test_reply_to_review_via_registered_ajax_rejects_unauthorized_request(): void {
+		$product = null;
+		$review  = null;
+
+		try {
+			$product = WC_Helper_Product::create_simple_product();
+			$review  = $this->create_review( $product->get_id(), 'Protected parent review' );
+			$this->_setRole( 'subscriber' );
+
+			$_POST = array(
+				'_ajax_nonce-replyto-comment' => wp_create_nonce( 'replyto-comment' ),
+				'comment_ID'                  => $review->comment_ID,
+				'comment_post_ID'             => $product->get_id(),
+				'content'                     => 'Unauthorized reply',
+			);
+
+			$this->assert_ajax_stops_with( 'replyto-comment', '-1' );
+
+			$this->assertSame(
+				array(),
+				get_comments(
+					array(
+						'parent'  => $review->comment_ID,
+						'post_id' => $product->get_id(),
+					)
+				)
+			);
+		} finally {
+			if ( $review ) {
+				wp_delete_comment( (int) $review->comment_ID, true );
+			}
+			if ( $product ) {
+				$product->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * Create a product review fixture.
+	 *
+	 * @param int    $product_id Product ID.
+	 * @param string $content    Review content.
+	 * @return WP_Comment
+	 */
+	private function create_review( int $product_id, string $content ): WP_Comment {
+		$review = $this->factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'      => $product_id,
+				'comment_author'       => 'Review Author',
+				'comment_author_email' => 'reviewer@example.com',
+				'comment_content'      => $content,
+				'comment_approved'     => '1',
+				'comment_type'         => 'review',
+			)
+		);
+		update_comment_meta( $review->comment_ID, 'rating', 4 );
+
+		return $review;
+	}
+
+	/**
+	 * Dispatch an AJAX request that must return a well-formed XML response.
+	 *
+	 * @param string $action AJAX action.
+	 * @return \SimpleXMLElement
+	 */
+	private function dispatch_successful_ajax( string $action ): \SimpleXMLElement {
+		$this->_last_response = '';
+		$buffer_level         = ob_get_level();
+
+		try {
+			$this->_handleAjax( $action );
+		} catch ( WPAjaxDieContinueException $exception ) {
+			unset( $exception );
+		} finally {
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
+			while ( ob_get_level() < $buffer_level ) {
+				ob_start();
+			}
+		}
+
+		$xml = simplexml_load_string( (string) $this->_last_response, 'SimpleXMLElement', LIBXML_NOCDATA );
+		$this->assertInstanceOf( \SimpleXMLElement::class, $xml, (string) $this->_last_response );
+
+		return $xml;
+	}
+
+	/**
+	 * Assert that a registered AJAX request terminates with the expected error.
+	 *
+	 * @param string $action  AJAX action.
+	 * @param string $message Expected exception message.
+	 */
+	private function assert_ajax_stops_with( string $action, string $message ): void {
+		$this->_last_response = '';
+		$did_stop             = false;
+
+		try {
+			$this->_handleAjax( $action );
+		} catch ( WPAjaxDieStopException $exception ) {
+			$did_stop = true;
+			$this->assertSame( $message, $exception->getMessage() );
+		}
+
+		$this->assertTrue( $did_stop, 'The AJAX request should terminate before reaching the core handler.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -1,8 +1,13 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Tests\Internal\Admin\ProductReviews;
 
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable;
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
@@ -53,39 +58,96 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_single_row(): void {
-		$post_id = $this->factory()->post->create();
-		$review  = $this->factory()->comment->create_and_get(
-			array(
-				'comment_post_ID' => $post_id,
-			)
-		);
+		$original_user_id = get_current_user_id();
+		$product          = null;
+		$review           = null;
 
-		$reviews_list_table = $this->get_reviews_list_table();
+		try {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_name( 'Exact Review Row Product' );
+			$product->save();
+			wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 
-		ob_start();
+			$review = $this->factory()->comment->create_and_get(
+				array(
+					'comment_post_ID'      => $product->get_id(),
+					'comment_author'       => 'Exact Review Author',
+					'comment_author_email' => 'row-reviewer@example.com',
+					'comment_content'      => 'Exact review row content',
+					'comment_approved'     => '1',
+					'comment_type'         => 'review',
+				)
+			);
+			update_comment_meta( $review->comment_ID, 'rating', 4 );
 
-		$reviews_list_table->single_row( $review );
+			$reviews_list_table = $this->get_reviews_list_table();
 
-		$row_output = trim( ob_get_clean() );
+			ob_start();
+			$reviews_list_table->single_row( $review );
+			$row_output = trim( ob_get_clean() );
 
-		$this->assertStringStartsWith( '<tr id="comment-' . $review->comment_ID . '"', $row_output );
+			$this->assertStringStartsWith( '<tr id="comment-' . $review->comment_ID . '"', $row_output );
 
-		foreach ( $reviews_list_table->get_columns() as $column_id => $column_name ) {
-			if ( 'cb' !== $column_id ) {
-				$this->assertStringContainsString( 'data-colname="' . $column_name . '"', $row_output );
-			} else {
-				// WordPress 7.1 changed the list table check column cell from <th> to <td>.
-				// Accept either element; the backreference requires the closing tag to
-				// match the captured opening tag.
-				$this->assertMatchesRegularExpression(
-					'~<(?<cell_tag>th|td)[^>]*\bclass="check-column"></\k<cell_tag>>~',
-					$row_output,
-					'The row should contain an empty check-column cell.'
-				);
+			foreach ( $reviews_list_table->get_columns() as $column_id => $column_name ) {
+				if ( 'cb' !== $column_id ) {
+					$this->assertStringContainsString( 'data-colname="' . $column_name . '"', $row_output );
+				} else {
+					$this->assertMatchesRegularExpression(
+						'~<(?<cell_tag>th|td)[^>]*\bclass="check-column"[^>]*>.*?</\k<cell_tag>>~s',
+						$row_output,
+						'The row should contain the standard review checkbox cell.'
+					);
+				}
 			}
-		}
 
-		$this->assertStringEndsWith( '</tr>', $row_output );
+			$document = new DOMDocument();
+			$errors   = libxml_use_internal_errors( true );
+			$document->loadHTML( '<!doctype html><html><body><table>' . $row_output . '</table></body></html>' );
+			libxml_clear_errors();
+			libxml_use_internal_errors( $errors );
+
+			$xpath        = new DOMXPath( $document );
+			$author_cells = $xpath->query(
+				'//td[contains(concat(" ", normalize-space(@class), " "), " author ") and contains(concat(" ", normalize-space(@class), " "), " column-author ")]'
+			);
+			if ( false === $author_cells ) {
+				throw new \RuntimeException( 'Unable to query the author cell.' );
+			}
+
+			$author_cell = $author_cells->item( 0 );
+			$this->assertInstanceOf( DOMElement::class, $author_cell );
+			if ( ! $author_cell instanceof DOMElement ) {
+				throw new \RuntimeException( 'The author cell was not found.' );
+			}
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property name.
+			$this->assertStringContainsString( 'Exact Review Author', $author_cell->textContent );
+
+			$email_links = $xpath->query( './/a[normalize-space(text())="row-reviewer@example.com"]', $author_cell );
+			if ( false === $email_links ) {
+				throw new \RuntimeException( 'Unable to query the author email link.' );
+			}
+
+			$email_link = $email_links->item( 0 );
+			$this->assertInstanceOf( DOMElement::class, $email_link );
+			if ( ! $email_link instanceof DOMElement ) {
+				throw new \RuntimeException( 'The author email link was not found.' );
+			}
+			$this->assertSame( 'mailto:row-reviewer@example.com', $email_link->getAttribute( 'href' ) );
+			$this->assertStringContainsString( 'aria-label="4 out of 5"', $row_output );
+			$this->assertStringContainsString( 'Exact review row content', $row_output );
+			$this->assertStringContainsString( 'Exact Review Row Product', $row_output );
+			$this->assertStringContainsString( 'comments-edit-item-link', $row_output );
+			$this->assertStringContainsString( 'comments-view-item-link', $row_output );
+			$this->assertStringEndsWith( '</tr>', $row_output );
+		} finally {
+			if ( $review ) {
+				wp_delete_comment( $review->comment_ID, true );
+			}
+			if ( $product ) {
+				$product->delete( true );
+			}
+			wp_set_current_user( $original_user_id );
+		}
 	}
 
 	/**
@@ -153,7 +215,72 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 			// Should not contain any tags with _only_ a pipe separator, but no label.
 			$this->assertStringNotContainsString( '> | </span>', $actions );
+			$this->assert_row_action_contracts( $actions, (int) $review->comment_ID, $review_status );
 		}
+	}
+
+	/**
+	 * Assert exact URL, nonce, and `data-wp-lists` contracts for status actions.
+	 *
+	 * @param string $actions       Rendered row actions.
+	 * @param int    $review_id     Review ID.
+	 * @param string $review_status Normalized review status.
+	 */
+	private function assert_row_action_contracts( string $actions, int $review_id, string $review_status ): void {
+		$expected = array(
+			'approved'   => array(
+				'unapprovecomment' => "delete:the-comment-list:comment-{$review_id}:e7e7d3:action=dim-comment&new=unapproved",
+				'spamcomment'      => "delete:the-comment-list:comment-{$review_id}::spam=1",
+				'trashcomment'     => "delete:the-comment-list:comment-{$review_id}::trash=1",
+			),
+			'unapproved' => array(
+				'approvecomment' => "delete:the-comment-list:comment-{$review_id}:e7e7d3:action=dim-comment&new=approved",
+				'spamcomment'    => "delete:the-comment-list:comment-{$review_id}::spam=1",
+				'trashcomment'   => "delete:the-comment-list:comment-{$review_id}::trash=1",
+			),
+			'spam'       => array(
+				'unspamcomment' => "delete:the-comment-list:comment-{$review_id}:66cc66:unspam=1",
+				'deletecomment' => "delete:the-comment-list:comment-{$review_id}::delete=1",
+			),
+			'trash'      => array(
+				'spamcomment'    => "delete:the-comment-list:comment-{$review_id}::spam=1",
+				'untrashcomment' => "delete:the-comment-list:comment-{$review_id}:66cc66:untrash=1",
+				'deletecomment'  => "delete:the-comment-list:comment-{$review_id}::delete=1",
+			),
+		);
+
+		$document = new DOMDocument();
+		$errors   = libxml_use_internal_errors( true );
+		$document->loadHTML( '<!doctype html><html><body>' . $actions . '</body></html>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $errors );
+
+		$actual = array();
+		foreach ( $document->getElementsByTagName( 'a' ) as $link ) {
+			if ( ! $link->hasAttribute( 'data-wp-lists' ) ) {
+				continue;
+			}
+
+			$query = array();
+			parse_str( (string) wp_parse_url( $link->getAttribute( 'href' ), PHP_URL_QUERY ), $query );
+			$action = $query['action'] ?? '';
+
+			$this->assertSame( (string) $review_id, $query['c'] ?? '' );
+			$this->assertArrayHasKey( '_wpnonce', $query );
+			$this->assertSame(
+				1,
+				wp_verify_nonce(
+					$query['_wpnonce'],
+					in_array( $action, array( 'approvecomment', 'unapprovecomment' ), true )
+						? "approve-comment_{$review_id}"
+						: "delete-comment_{$review_id}"
+				)
+			);
+
+			$actual[ $action ] = $link->getAttribute( 'data-wp-lists' );
+		}
+
+		$this->assertSame( $expected[ $review_status ], $actual );
 	}
 
 	/** @see test_handle_row_actions */
@@ -1936,7 +2063,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->invoke( $list_table, $product_id, $pending_review_count );
 		$actual_html = ob_get_clean();
 
-		$this->assertSame( str_replace( 'PRODUCT_ID', $product_id, $expected_html ), $actual_html );
+		$this->assertSame( str_replace( 'PRODUCT_ID', (string) $product_id, $expected_html ), $actual_html );
 	}
 
 	/** @see test_comments_bubble */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The product reviews spec drove wp-admin nine times. Four of those titles were really asking whether an admin-ajax handler persists what it was sent, so they move to a new `ReviewsAjaxTest`. Three more were moderation actions, and those stay in the browser — for a reason worth reading before approving this.

Refs TESTOPS-288

Part of the #68046 split.

Browser titles go from 9 to 6. `ReviewsAjaxTest` is new at 5 tests and 48 assertions; `ReviewsListTableTest` keeps its 135 tests and gains assertions, 243 to 291. `ReviewsTest` gains one assertion.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `can edit a product review` (the ajax half) | `ReviewsAjaxTest::test_edit_review_via_registered_ajax_persists_and_returns_woo_row`, which dispatches the real `wp_ajax_edit-comment` action and asserts both the reloaded comment and the returned row markup | Nothing. The browser title is retained as well, for the editor UI. |
| `can reply to a product review` (the ajax half) | `ReviewsAjaxTest::test_reply_to_review_via_registered_ajax_persists_child_and_returns_woo_row` | Nothing. The browser title is retained. |
| `can view products reviews list` | folded into `can filter the reviews by product` | **Partly.** The retained title asserts one review on a filtered view. The removed title also asserted a second review and the unfiltered list. |
| `can approve a product review` | the new `can approve, spam and trash a product review` browser title | Nothing beyond what is described below. |
| `can mark a product review as spam` | same new title | Nothing beyond the below. |
| `can delete a product review` | same new title covers trash. WooCommerce's two inputs to the trash Undo notice are now guarded in PHPUnit: `ReviewsTest::test_render_reviews_list_table` asserts the page renders core's trash-undo holder, and `ReviewsListTableTest::test_column_author` asserts the `<strong>` that core reads the author name from | **Core's Undo round trip and the blocked-edit message.** The removed title clicked Undo, re-trashed the review, and asserted `This comment is in the Trash.` on its edit page. Both are WordPress core code: core's comment list script builds the Undo row and core's `delete-comment` ajax handler restores the review. |

#### Why approve, spam and trash did not move down a layer

The migration commit is called "Move review actions below E2E", and it does move edit and reply. It does not move the moderation actions, and it removed their browser titles anyway.

`ReviewsAjaxTest` wires only `edit-comment` and `replyto-comment`. The moderation actions are covered in PHP only by `ReviewsListTableTest::test_handle_row_actions`, which asserts that a row renders `Approve`, `Spam` and `Trash` links with the right URLs, nonces and `data-wp-lists` payloads. That is a markup contract. It never dispatches anything and never reads a comment's status back.

So without a browser title, approving a review would have had no test that it approves anything. The second commit adds one title covering all three transitions, replacing the three that were removed. **After this PR, that single title is the only proof anywhere that these three actions do what they say.**

#### The canary asserts status through the filtered views, and it took three attempts

Worth stating because the obvious version of this test is worthless, and it is not obvious that it is worthless.

The list renders **both** `Approve` and `Unapprove` in the all view regardless of a review's status (`ReviewsListTable::handle_row_actions`), and the fixture creates its reviews already approved. So "click Approve, expect Unapprove to appear" passes against a completely broken approve path. That version was written first and survived two separate mutations before the problem was spotted.

The shipped version checks status by loading `comment_status=moderated`, `approved`, `spam` and `trash` and asserting membership. It unapproves, confirms the review is pending, approves, and confirms it is approved again.

It also moderates two different reviews on purpose: once a review is spammed its actions become *Not Spam* and *Delete Permanently*, so Trash is only reachable from the main list. Spam and trash are not stages of one lifecycle.

#### An observation for later, not changed here

`playwright.config.ts` keeps `order/review-order-page.spec.ts` in the serial lane, and the comment justifying that cites the churn it caused for product-reviews' "trash/undo/re-trash flow" — the exact test this PR removes. That justification no longer applies. `playwright.config.ts` is not part of this change, so nothing was touched; someone may want to re-measure whether that spec still needs the serial lane.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the three PHP classes. Their names are unique in the suite, so these filters are unambiguous:
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'ReviewsAjaxTest'` — expect `OK (5 tests, 48 assertions)`.
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'ReviewsListTableTest'` — expect `OK (135 tests, 291 assertions)`.
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'ReviewsTest::'` — expect `OK (34 tests, 51 assertions)`.
4. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/product/product-reviews.spec.ts`. All six titles should pass; the summary reads `8 passed` and `1 skipped`, the 8 being the six product titles plus the `global authentication` and `site setup` projects.
6. Confirm the new ajax test detects a real regression. In `plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php`, in `handle_edit_review`, change `if ( ! $this->is_review_or_reply( $review ) ) {` to `if ( true ) {` so the handler always bails to core. Re-run the first command in step 3 and expect `test_edit_review_via_registered_ajax_persists_and_returns_woo_row` to fail on the returned row markup. Revert.
7. Confirm the moderation canary detects a broken approve. In `plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php`, find the approve action built for a filtered view — the one whose `data-wp-lists` payload contains `action=dim-comment&amp;new=approved` — and change `new=approved` to `new=unapproved`. Re-run step 5 and expect `can approve, spam and trash a product review` to fail at the assertion that the review appears under the Approved view. Revert. Note the all-view approve action a few lines above uses a different payload; mutating that one will **not** fail this test, because the canary approves from the Pending view.
8. Confirm the retained filter title still guards the product filter. In the same file, in `get_filter_product_arguments`, replace `$args['post_id'] = $this->current_product_for_reviews->get_id();` with `$args = array();`. Re-run step 5 and expect `can filter the reviews by product` to fail with more rows than expected. Revert.
9. Confirm the Undo guards. In `plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php`, in `render_reviews_list_table`, delete the `wp_comment_trashnotice();` line. Re-run the third command in step 3 and expect `test_render_reviews_list_table` to fail. Revert. Then in `ReviewsListTable.php`, in `column_author`, change `echo '<strong>' . $author_avatar;` to `echo $author_avatar;` and `echo '</strong><br>';` to `echo '<br>';`. Re-run the second command in step 3 and expect `test_column_author` to fail for both data sets. Revert.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on this branch against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Baseline first.** Trunk's copy of the spec ran green before extraction (9 titles), and trunk's `ReviewsListTableTest` was `OK (135 tests, 243 assertions)`, so the assertion growth is measured against a real starting point.
- **Extraction.** All three files are byte-identical to the migration branch in the first commit; the second adds only the authored canary. No path has a trunk commit since the diff base.
- **Retained titles.** All six green at `--retries=0 --workers=1`.
- **Lower layer.** `ReviewsAjaxTest` OK (5 tests, 48 assertions). `ReviewsListTableTest` OK (135 tests, 291 assertions) — the same 135 tests as trunk, with stronger assertions, not new cases. `ReviewsTest` OK (34 tests, 51 assertions).
- **Mutation re-check, all 11 behavior families plus the authored canary.** Twelve mutations, each turning its focused command red at the assertion the mutation matrix names, each reverted and green again. They cover the two ajax handlers, the five list-table column renderers, the row actions, the single-row template, the product filter, the review rating meta box, and a controlled `pre_comment_content` boundary in the retained edit title.
- **The Undo guards were proven against the gap they close.** Before the two new assertions, deleting `wp_comment_trashnotice()` or the author `<strong>` left all three review classes green (174 tests). With them, the first mutation fails `test_render_reviews_list_table` and the second fails `test_column_author` on both data sets.
- **The canary's own proof took three attempts, and two of the failures were mine rather than the test's.** The first version modelled the product wrongly and could not reach Trash from the spam view. The second asserted something that is true whatever the code does. Two mutations then survived the third version because I aimed them at the all-view branch of the approve action, which the canary never executes; retargeted at the filtered-view branch it fails exactly where it should.
- **Lint.** `lint:changes:branch` exits 0 with five warnings in the spec and no errors. Its PHP half lints only `includes/` and `src/`, so changed-lines PHPCS ran on the two edited test classes separately and exits 0. `oxlint` attributes no new finding to the change.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; this batch touches only `tests/`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-product-reviews`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
