### PR TITLE
[tests] Make the post comments E2E spec own the post it tests

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-post-comments-fixture
+++ b/plugins/woocommerce/changelog/testops-288-post-comments-fixture
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: The WordPress post comments E2E spec now creates and deletes its own post instead of relying on the default Hello world post, which no longer exists in the shared E2E environment.
+

--- a/plugins/woocommerce/tests/e2e/tests/wp-core/post-comments.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/wp-core/post-comments.spec.ts
@@ -13,7 +13,18 @@ const test = baseTest.extend( {
 	storageState: CUSTOMER_STATE_PATH,
 } );
 
+const postSlug = `comment-test-${ Date.now() }`;
+let postId: number;
+
 test.beforeAll( async ( { restApi } ) => {
+	const createPostResponse = await restApi.post( `${ WP_API_PATH }/posts`, {
+		title: 'Comment test post',
+		slug: postSlug,
+		status: 'publish',
+		comment_status: 'open',
+	} );
+	postId = createPostResponse.data.id;
+
 	// Jetpack Comments replaces the default WordPress comment form when activated, and will cause this test to fail.
 	// Make sure it's disabled prior to running this test.
 	await test.step( 'disable Jetpack comments if Jetpack is installed and active', async () => {
@@ -43,15 +54,26 @@ test.beforeAll( async ( { restApi } ) => {
 	} );
 } );
 
+test.afterAll( async ( { restApi } ) => {
+	if ( postId ) {
+		await restApi.delete( `${ WP_API_PATH }/posts/${ postId }`, {
+			force: true,
+		} );
+	}
+} );
+
 test(
 	'logged-in customer can comment on a post',
 	{
 		tag: [ tags.WP_CORE ],
 	},
 	async ( { page } ) => {
-		await page.goto( 'hello-world/' );
+		await page.goto( `${ postSlug }/` );
 		await expect(
-			page.getByRole( 'heading', { name: 'Hello world!', exact: true } )
+			page.getByRole( 'heading', {
+				name: 'Comment test post',
+				exact: true,
+			} )
 		).toBeVisible();
 
 		await expect( page.getByText( `Logged in as` ) ).toBeVisible();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The WordPress post comments spec navigated to `hello-world/` and asserted the heading `Hello world!`. It never created that post. It relied on WordPress's default first post still existing, still being published, still having comments open, and still being called what a fresh install calls it.

Refs TESTOPS-288

Part of the #68046 split.

**This batch moves no coverage between layers.** One browser title before, one after, asserting the same things about the same comment form. It is in the split because the migration branch changed this spec's fixture, and that change has to land somewhere.

#### It is not a hypothetical dependency — trunk's copy fails today

Listing posts in this repository's shared E2E environment returns exactly one, and it is not the default:

```
ID  post_title                post_name                 post_status  comment_status
55  Product Collection block  product-collection-block  publish      open
```

So trunk's copy of this spec fails at the heading assertion, before it reaches the comment form at all. This branch's copy passes in the same environment, one command apart.

**I did not establish which part of the suite removes the default post**, only that it is absent. No seeding script deletes it explicitly, and the post that remains is created by a Blocks spec. That is as far as the evidence goes, and the fix does not depend on knowing the answer.

| What changed | Before | After |
| --- | --- | --- |
| The post under test | WordPress's default `hello-world`, never created by the spec | created in `beforeAll` through the REST API with a `comment-test-<timestamp>` slug |
| What the heading assertion targets | `Hello world!` | the spec's own `Comment test post` |
| Comments being open | assumed | set explicitly on creation |
| Cleanup | none — the spec left nothing behind because it made nothing | the post is deleted in `afterAll` |

#### What it still does not own

Worth naming rather than implying the spec is now hermetic. It still depends on the customer account from the shared storage state, on the active theme rendering a comment form, and on the site's discussion settings — if comment moderation were switched on, the submitted comment would be held rather than displayed and the final assertion would fail. Those are unchanged by this PR and are not new risks; they are simply not what this change addresses.

The Jetpack guard in `beforeAll` is also unchanged. It tries to disable Jetpack comments and swallows the failure when Jetpack is not installed, which is what happens in this environment.

#### There is already a fixture for half of this

`fixtures.ts` exposes a `testPost` fixture that generates a title and slug using the shared `random()` helper and cleans up by slug afterwards. `create-post.spec.ts`, in this same `wp-core/` folder, uses it.

It is not a drop-in replacement here: it yields a name rather than creating a post, and its only consumer builds the post through the editor UI, whereas this spec wants a published post with comments open created cheaply over REST. But the slug generation and the teardown that this change hand-rolls are duplicating what that fixture already does, and someone may prefer to fold them together. Left alone here because this PR ships the migration branch's version of the file rather than an improved one.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
3. Confirm the premise on your own environment: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env:e2e run cli -- wp post list --post_type=post --fields=ID,post_title,post_name --format=table`. If `Hello world!` is listed, your environment still has the default post and trunk's copy of this spec will pass for you; the change is then a removal of a dependency rather than a fix for a break you can see. If it is absent, as it is here, trunk's copy fails.
4. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/wp-core/post-comments.spec.ts`. Expect `3 passed` and `1 skipped` — the 3 are the one title plus the `global authentication` and `site setup` projects.
5. Confirm the spec cleans up after itself. Re-run step 3 and check that no `comment-test-<timestamp>` post remains.
6. Confirm the title still detects a broken comment submission. In `plugins/woocommerce/tests/e2e/tests/wp-core/post-comments.spec.ts`, immediately before the `Post Comment` click, add `const { setFilterValue } = await import( '../../utils/filters' ); await setFilterValue( page, 'pre_comment_content', 'filtered comment' );`. Re-run step 4 and expect a failure at the final assertion, where the generated comment text is no longer found on the page. Revert.
7. For the contrast, check out `trunk` and run step 4 there. On an environment without the default post it fails at `getByRole('heading', { name: 'Hello world!' })`.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **The problem, reproduced on trunk.** Trunk's unmodified copy of this spec fails in this environment at the `Hello world!` heading assertion, exit non-zero. The WP-CLI listing above is the reason, captured at the same time.
- **The fix, in the same environment.** This branch's copy passes at `--retries=0 --workers=1`.
- **Extraction.** The spec is byte-identical to the migration branch's version, and the path has no trunk commit since the diff base, so nothing had to be merged.
- **Mutation re-check, one behavior family.** Injecting a controlled `pre_comment_content` filter immediately before the comment is posted turns the title red at the final `getByText( comment )` assertion — the assertion the mutation matrix names — and reverting turns it green. The applied change is recorded alongside the logs rather than described.
- **Lint.** `lint:changes:branch` exits 0 with no errors and no warnings. `oxlint` attributes no new finding to the change.
- **No PHP in this batch**, so PHPUnit and PHPStan have nothing to run.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-post-comments-fixture`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

