### PR TITLE
[tests] Move grouped product cart removal to PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-product-grouped
+++ b/plugins/woocommerce/changelog/testops-288-product-grouped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move the grouped product cart removal E2E title to PHPUnit; WC_Cart_Test now covers removing grouped children through the real update-cart form handler.
+

--- a/plugins/woocommerce/tests/e2e/tests/product/product-grouped.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-grouped.spec.ts
@@ -120,36 +120,5 @@ test.describe(
 				0
 			);
 		} );
-
-		test( 'should be able to remove grouped products from the cart', async ( {
-			page,
-		} ) => {
-			await page.goto( `product/${ groupedProductSlug }` );
-			await page.locator( 'div.quantity input.qty >> nth=0' ).fill( '1' );
-			await page.locator( 'div.quantity input.qty >> nth=1' ).fill( '1' );
-			await page
-				.getByRole( 'button', { name: 'Add to cart', exact: true } )
-				.click();
-
-			await expect(
-				page.getByText(
-					new RegExp(
-						`${ simpleProduct1.name }.*and.*${ simpleProduct2.name }.*have been added to your cart`
-					)
-				)
-			).toBeVisible();
-
-			await page.goto( 'cart/' );
-			await page
-				.getByRole( 'button', { name: 'Remove' } )
-				.first()
-				.click();
-			await page
-				.getByRole( 'button', { name: 'Remove' } )
-				.first()
-				.click();
-
-			await checkCartContent( false, page, [], 0 );
-		} );
 	}
 );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -2267,4 +2267,127 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		return array( (string) $cart_item_key, WC()->cart->get_cart_item( (string) $cart_item_key ) );
 	}
+
+	/**
+	 * @testdox Should remove grouped child cart items through consecutive form requests.
+	 */
+	public function test_update_cart_action_removes_grouped_child_items(): void {
+		$original_get                     = $GLOBALS['_GET'];
+		$original_post                    = $GLOBALS['_POST'];
+		$original_request                 = $GLOBALS['_REQUEST'];
+		$original_server                  = $GLOBALS['_SERVER'];
+		$original_cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add', null );
+		$original_notices                 = WC()->session->get( 'wc_notices', null );
+		$original_cart                    = WC()->cart->get_cart();
+		$original_session_cart            = WC()->session->get( 'cart', null );
+		$first_child                      = null;
+		$second_child                     = null;
+		$grouped_product                  = null;
+
+		try {
+			unset( $GLOBALS['_SERVER']['HTTP_REFERER'] );
+			update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+			WC()->cart->empty_cart();
+			WC()->session->set( 'wc_notices', null );
+
+			$first_child = WC_Helper_Product::create_simple_product();
+			$first_child->set_regular_price( '10' );
+			$first_child->save();
+
+			$second_child = WC_Helper_Product::create_simple_product();
+			$second_child->set_regular_price( '20' );
+			$second_child->save();
+
+			$grouped_product = new WC_Product_Grouped();
+			$grouped_product->set_name( 'Grouped removal request product' );
+			$grouped_product->set_children(
+				array(
+					$first_child->get_id(),
+					$second_child->get_id(),
+				)
+			);
+			$grouped_product->save();
+
+			$grouped_quantities  = array(
+				$first_child->get_id()  => 1,
+				$second_child->get_id() => 1,
+			);
+			$GLOBALS['_REQUEST'] = array(
+				'add-to-cart' => $grouped_product->get_id(),
+				'quantity'    => $grouped_quantities,
+			);
+			$GLOBALS['_POST']    = array(
+				'quantity' => $grouped_quantities,
+			);
+
+			WC_Form_Handler::add_to_cart_action( false );
+
+			$cart_items                = WC()->cart->get_cart();
+			$cart_item_keys_by_product = array();
+			foreach ( $cart_items as $cart_item_key => $cart_item ) {
+				$cart_item_keys_by_product[ $cart_item['product_id'] ] = $cart_item_key;
+			}
+			$expected_child_ids = array( $first_child->get_id(), $second_child->get_id() );
+			$actual_child_ids   = array_map( 'intval', array_keys( $cart_item_keys_by_product ) );
+			sort( $expected_child_ids );
+			sort( $actual_child_ids );
+
+			$this->assertCount( 2, $cart_items, 'Both grouped children should be cart lines.' );
+			$this->assertSame(
+				$expected_child_ids,
+				$actual_child_ids,
+				'Only the grouped children should be cart lines.'
+			);
+			$this->assertArrayNotHasKey( $grouped_product->get_id(), $cart_item_keys_by_product, 'The grouped parent should not become a cart line.' );
+
+			$cart_item_keys = array_values( $cart_item_keys_by_product );
+			foreach ( $cart_item_keys as $index => $cart_item_key ) {
+				$GLOBALS['_GET']     = array(
+					'remove_item' => $cart_item_key,
+				);
+				$GLOBALS['_POST']    = array();
+				$GLOBALS['_REQUEST'] = array(
+					'_wpnonce'    => wp_create_nonce( 'woocommerce-cart' ),
+					'remove_item' => $cart_item_key,
+				);
+
+				WC_Form_Handler::update_cart_action();
+
+				$remaining_cart_items = WC()->cart->get_cart();
+				if ( 0 === $index ) {
+					$this->assertArrayNotHasKey( $cart_item_key, $remaining_cart_items, 'The first requested cart item should be removed.' );
+					$this->assertSame( array( $cart_item_keys[1] ), array_keys( $remaining_cart_items ), 'Only the other original cart item should remain.' );
+				} else {
+					$this->assertEmpty( $remaining_cart_items, 'The second removal request should empty the cart.' );
+				}
+			}
+		} finally {
+			WC()->cart->empty_cart();
+
+			if ( $grouped_product instanceof WC_Product_Grouped ) {
+				$grouped_product->delete( true );
+			}
+			if ( $second_child instanceof WC_Product ) {
+				$second_child->delete( true );
+			}
+			if ( $first_child instanceof WC_Product ) {
+				$first_child->delete( true );
+			}
+
+			if ( null === $original_cart_redirect_after_add ) {
+				delete_option( 'woocommerce_cart_redirect_after_add' );
+			} else {
+				update_option( 'woocommerce_cart_redirect_after_add', $original_cart_redirect_after_add );
+			}
+
+			$GLOBALS['_GET']     = $original_get;
+			$GLOBALS['_POST']    = $original_post;
+			$GLOBALS['_REQUEST'] = $original_request;
+			$GLOBALS['_SERVER']  = $original_server;
+
+			WC()->cart->set_cart_contents( $original_cart );
+			WC()->session->set( 'cart', $original_session_cart );
+			WC()->session->set( 'wc_notices', $original_notices );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The grouped products spec had two titles: one that adds grouped children to the cart, one that removes them again. The removal title went to `cart/`, which is the Cart block in the E2E environment, and clicked Remove on each grouped child line. Once added, grouped children are plain cart lines with no parent data, so that title exercised generic line removal that `cart.spec.ts` already covers on both cart pages. `WC_Cart_Test` adds a direct check that the classic update-cart form handler removes grouped child lines.

Refs TESTOPS-288

Part of the #68046 split.

The spec goes from 2 titles to 1. `WC_Cart_Test` goes from 50 methods to 51, and from 53 tests to 54.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `should be able to remove grouped products from the cart` | `cart.spec.ts` `can add and remove products, increase quantity and proceed to checkout - blocks cart` and `- classic cart`, which remove lines through the rendered controls on both cart pages; the Store API route tests `test_remove_cart_item` and `test_remove_item_fires_remove_action` in `tests/php/src/Blocks/StoreApi/Routes/Cart.php`; and the new `WC_Cart_Test::test_update_cart_action_removes_grouped_child_items`, which posts a real update-cart request through `WC_Form_Handler` and asserts the resulting cart contents | **A browser removal of grouped child lines specifically.** See below — this is not a like-for-like move. |

#### What the PHP test does not do

The removed title clicked the Cart block's `Remove` button twice, which sends a Store API `cart/remove-item` request each time, and then asserted the cart page showed an empty cart. It also asserted the add-to-cart notice naming both products.

The PHP test proves the *data* on a different path: after a classic update-cart request, the cart no longer contains those items. It never renders the cart page and never calls the Store API, so it cannot prove that the `Remove` button exists, that clicking it reaches the server, or that the empty cart renders its message. That is a layer change, not an equivalence, and the table above should be read with that in mind. Rendered removal stays covered on both cart pages by `cart.spec.ts`, and grouped children need nothing special there because they enter the cart as plain lines.

What keeps the browser honest for grouped products is the retained title, `should be able to add grouped products to the cart`, which still drives the grouped product form and asserts the cart contents afterwards.

#### Grouped products are covered elsewhere too

Worth stating so this PR does not read as the last line of defence. Besides the retained title, the tree also has `tests/e2e/tests/product/product-grouped-stock-status.spec.ts`, and the Blocks suite covers grouped products against a different surface in `tests/e2e/tests/blocks/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts`, including `allows adding grouped products to cart` and `allows adding grouped products to cart when inside the Product block`. Those exercise the Add to Cart with Options block rather than the classic form, so they do not replace the retained title, but grouped products are not down to one test.

#### The shared test file needed care, and that is most of the risk in this PR

`class-wc-cart-test.php` is touched by two different migration commits that belong to two different pull requests, and it had also moved on trunk.

- Trunk's #67527 added eleven methods to the class after this work branched. All eleven are kept.
- This batch carries exactly one migration method, `test_update_cart_action_removes_grouped_child_items`, from `8e1bd64631`.
- The other migration method, `test_add_to_cart_action_handles_grouped_product_quantities` from `760478af4c`, belongs to the Add to Cart options work and ships separately. **It is deliberately absent here.**

A three-way apply was not usable: `760478af4c` landed first on the migration branch, so the patch's reconstructed pre-image already contained that batch's method and the merge tried to re-add it. Taking that resolution would have shipped another pull request's test inside this one. The method was instead taken from the migration branch's own blob and inserted into trunk's copy.

The result is checkable rather than asserted: 51 methods, the other batch's method absent, **zero deleted lines** against trunk, and the inserted method byte-identical to the migration branch's version including its docblock.

#### Why this is only part of the original batch

This started as one batch that also carried `product-variable.spec.ts` and `update-variations.spec.ts`. Neither removes a title — both are stabilization — and one of them adds an explicit 45-second timeout, which is a question worth answering on its own rather than inside a coverage migration. They follow separately.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the cart test class: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'WC_Cart_Test'`. Expect `OK (54 tests, 256 assertions)`. On `trunk` the same command gives `OK (53 tests, 250 assertions)`.
4. Confirm the other pull request's method is not here: `grep -c test_add_to_cart_action_handles_grouped_product_quantities plugins/woocommerce/tests/php/includes/class-wc-cart-test.php` should print `0`.
5. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
6. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/product/product-grouped.spec.ts`. Expect `3 passed` and `1 skipped` — the 3 are the one retained title plus the `global authentication` and `site setup` projects.
7. Confirm the new PHP test detects a real regression. In `plugins/woocommerce/includes/class-wc-form-handler.php`, in `update_cart_action`, change `$removed = WC()->cart->remove_cart_item( $cart_item_key );` to `$removed = false;`. Re-run step 3 and expect `test_update_cart_action_removes_grouped_child_items` to fail at `The first requested cart item should be removed.`. Revert.
8. Confirm the retained browser title still guards the grouped add flow. In the same file, in `add_to_cart_action`, change `self::add_to_cart_handler_grouped( $product_id )` to `self::add_to_cart_handler_simple( $product_id )`. Re-run step 6 and expect the retained title to fail on the cart contents. Revert.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Baseline first.** Trunk's `WC_Cart_Test` was `OK (53 tests, 250 assertions)` and trunk's copies of the original batch's specs were green before extraction, so the counts here are measured against a real starting point.
- **Extraction.** `product-grouped.spec.ts` is byte-identical to the migration branch. `class-wc-cart-test.php` is a rebuild of trunk's file plus one method, verified additive.
- **Retained title.** Green at `--retries=0 --workers=1`.
- **Lower layer.** `WC_Cart_Test` OK (54 tests, 256 assertions).
- **Mutation re-check, one behavior family.** Forcing `remove_cart_item` to return false turns the new PHP test red at the assertion the mutation matrix names, and reverting turns it green. The mutation matrix also records a second row for this file, but it targets the method that belongs to the other pull request and is therefore not run here.
- **Lint.** `lint:changes:branch` exits 0 with no errors and no warnings. `oxlint` attributes no new finding to the change.
- **No forbidden patterns.** The diff adds no retry, wait, timeout, worker or skip change. In particular the 45-second timeout from the other half of the original batch is not in this diff.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; this batch's only PHP file is a test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-product-grouped`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


