### PR TITLE
[tests] Stabilise variable product and variation bulk edit specs

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-variable-and-variations-sync
+++ b/plugins/woocommerce/changelog/testops-288-variable-and-variations-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Assert the rendered cart estimated total in the variable product E2E spec, and wait for the product data overlay to clear before bulk editing variations.
+

--- a/plugins/woocommerce/tests/e2e/tests/product/product-variable.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-variable.spec.ts
@@ -255,14 +255,18 @@ test.describe(
 				).toHaveValue( '1' );
 			}
 
-			const expectedTotal = variations1.reduce( ( sum, variation ) => {
-				const price = parseFloat( variation.regular_price );
-				return sum + price;
-			}, 0 );
+			const estimatedTotal = page
+				.getByRole( 'main' )
+				.locator( '.wc-block-components-totals-item' )
+				.filter( { hasText: 'Estimated total' } );
+			const estimatedTotalValue = estimatedTotal.locator(
+				'.wc-block-components-totals-item__value'
+			);
 
-			await expect(
-				page.locator( '.wc-block-components-totals-item__value' ).last()
-			).toContainText( expectedTotal.toString() );
+			await expect( estimatedTotalValue ).toBeVisible();
+			await expect( estimatedTotalValue ).toContainText(
+				/^\$\d+\.\d{2}$/
+			);
 		} );
 
 		test( 'should be able to remove variation products from the cart', async ( {

--- a/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
@@ -378,6 +378,11 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 			await page
 				.locator( '#field_to_edit' )
 				.selectOption( 'toggle_downloadable' );
+			await expect(
+				page.locator(
+					'#woocommerce-product-data .blockUI.blockOverlay'
+				)
+			).toBeHidden( { timeout: 45_000 } );
 		} );
 
 		await test.step( 'Expand all variations.', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Two E2E specs, no titles removed from either, no coverage moved between layers. Both changes are stabilization carried from the migration branch, and **two of them are judgement calls that need your decision** — which is why this is a separate pull request from the grouped products migration it started with.

Refs TESTOPS-288

Part of the #68046 split.

**Question for you, 1: the cart total is no longer checked against a computed sum.**

`product-variable.spec.ts` used to compute the expected total from the selected variations' prices and assert the rendered value contained it. It now asserts only that the Estimated total row shows a value shaped like `$NN.NN`.

The reasoning behind the change is sound as far as it goes, and it is in the migration commits. The old assertion took the *last* totals value as the product sum, so it picked up shipping whenever a parallel test configured shipping; and it assumed a pre-tax sum that the configured Cart does not render. Both produced failures with every variation correctly present.

The replacement, though, stops checking the number. A wrong price, a double-counted variation or a `$0.00` total would pass. Is a tax- and shipping-aware expected value reachable here, rather than dropping value checking altogether?

**Question for you, 2: an explicit 45 second timeout.**

`update-variations.spec.ts` waits for the product data panel's overlay to clear after selecting a bulk action:

```js
await expect(
	page.locator( '#woocommerce-product-data .blockUI.blockOverlay' )
).toBeHidden( { timeout: 45_000 } );
```

The wait is the right shape — a condition, not a sleep. The ceiling is the question:

| | |
| --- | --- |
| Overlay actually clears in | 798 ms, 805 ms, 802 ms across three runs on this checkout |
| Project default for `expect()` | 10 s locally, 20 s in CI (`playwright.config.ts`) |
| This override | 45 s, roughly 56× the observed duration |
| Same file, same overlay, lines 680 and 752 | no override — both use the default |
| Removing the override entirely | still passes here |

An independent review of this branch read it plainly as timeout inflation that should come off, with no incident cited for the figure. I have not edited it, because the number may be answering something in CI that a local checkout does not reproduce, and that is your call rather than mine. If it is not, dropping the override is a one-line change and the assertion stands on the default like its two siblings.

#### What actually changed

| File | Change | Titles |
| --- | --- | --- |
| `product-variable.spec.ts` | the cart total assertion, across two commits — first retargeted off the shipping-polluted last value, then moved onto the rendered Estimated total | 6 before, 6 after |
| `update-variations.spec.ts` | waits for the bulk-action overlay to clear before expanding variations | 9 before, 9 after |

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
3. Run both specs with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/product/product-variable.spec.ts tests/e2e/tests/product/update-variations.spec.ts`. Expect `17 passed` and `1 skipped` — the 17 are 15 titles plus the `global authentication` and `site setup` projects.
4. Check the timeout question yourself. In `plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts`, change `).toBeHidden( { timeout: 45_000 } );` to `).toBeHidden();` and re-run step 3 with `--grep 'can bulk edit variations'`. It passes here. If it does not pass for you, that is the evidence the override is answering something real, and this question is settled in its favour.
5. Measure the overlay for yourself if you want the number. Add `const t = Date.now();` before that assertion and `console.log( 'ms', Date.now() - t );` after, then run step 4. On this checkout it prints around 800.
6. Confirm the retained cart title still detects a broken cart total rendering. In `plugins/woocommerce/client/blocks/packages/public-api/blocks-components/totals/item/index.tsx`, in the `isValidElement( value )` branch of `TotalsItemValue`, rename the wrapper class from `wc-block-components-totals-item__value` to anything else, rebuild with `pnpm --dir plugins/woocommerce/client/blocks build:project:bundle`, and re-run step 3 with `--grep 'should be able to add variation products to the cart'`. Expect a failure at the Estimated total visibility assertion. Revert and rebuild.
7. Note while doing step 6: the first run straight after a bundle rebuild can fail earlier, on the cart rows count, because the Cart block has not hydrated. Re-run before concluding anything; the second run fails at the intended assertion.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Baseline first.** Trunk's copies of these specs were green before extraction.
- **Extraction.** `product-variable.spec.ts` is byte-identical to the migration branch. `update-variations.spec.ts` had trunk drift — trunk gained two tests on that path after this work branched — and was resolved by re-applying the migration's change onto trunk's file; the diff against trunk has no deleted lines and both sides' changes are present.
- **Retained titles.** All 15 green at `--retries=0 --workers=1`.
- **Mutation re-check, one behavior family.** Renaming the totals value wrapper class and rebuilding the Blocks bundle turns the cart title red at the Estimated total assertion the mutation matrix names, and reverting turns it green.
- **A false kill on the way there, recorded rather than hidden.** The first attempt at that mutation failed at the cart rows count instead, with an empty Cart block, because it was the first page load after the bundle rebuild. A non-zero exit at the wrong assertion is not a kill. The re-run failed at the intended assertion. Only the corrected log is retained, since the harness names logs by mutation id.
- **The timeout measurements.** Three runs of the owning title with the overlay instrumented: 798, 805, 802 ms. The title passes both with the override and with it removed.
- **Lint.** `lint:changes:branch` exits 0 with no errors. `oxlint` attributes no new finding to the change.
- **No PHP in this batch**, so PHPUnit and PHPStan have nothing to run.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-variable-and-variations-sync`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

