### PR TITLE
[tests] Add Jest and PHPUnit coverage for the Add to Cart with Options stores

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/testops-234-add-to-cart-with-options
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the four Add to Cart with Options Interactivity API stores, plus PHPUnit coverage for the legacy form markup and the grouped-product quantity handler. No E2E tests are removed.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/test/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/test/frontend.ts
@@ -1,0 +1,206 @@
+/**
+ * Internal dependencies
+ */
+import type { Context } from '../../frontend';
+import type { GroupedProductAddToCartWithOptionsStore } from '../frontend';
+
+const mockClearErrors = jest.fn();
+const mockAddError = jest.fn();
+const mockBatchAddCartItems = jest.fn();
+const mockGetConfig = jest.fn();
+
+let mockContext: Context;
+let mockRegisteredStore: GroupedProductAddToCartWithOptionsStore | null;
+let mockAddToCartStore: GroupedProductAddToCartWithOptionsStore;
+
+const mockProductsState = {
+	findProduct: jest.fn(),
+};
+
+const mockStore = jest.fn( ( namespace, definition ) => {
+	if ( namespace === 'woocommerce/products' ) {
+		return { state: mockProductsState };
+	}
+
+	if ( namespace === 'woocommerce/add-to-cart-with-options' ) {
+		if ( definition?.actions ) {
+			Object.assign( mockAddToCartStore.actions, definition.actions );
+		}
+		if ( definition?.callbacks ) {
+			Object.assign( mockAddToCartStore.callbacks, definition.callbacks );
+		}
+		mockRegisteredStore = mockAddToCartStore;
+		return mockAddToCartStore;
+	}
+
+	if ( namespace === 'woocommerce' ) {
+		return {
+			actions: {
+				batchAddCartItems: mockBatchAddCartItems,
+			},
+		};
+	}
+
+	return {};
+} );
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: mockStore,
+		getContext: jest.fn( () => mockContext ),
+		getConfig: mockGetConfig,
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@woocommerce/stores/woocommerce/cart', () => ( {} ) );
+jest.mock( '@woocommerce/stores/woocommerce/products', () => ( {} ) );
+
+const getRegisteredStore = (): GroupedProductAddToCartWithOptionsStore => {
+	if ( ! mockRegisteredStore ) {
+		throw new Error( 'Grouped product selector store was not registered.' );
+	}
+	return mockRegisteredStore;
+};
+
+const runGenerator = async ( iterator: Generator ) => {
+	let result = iterator.next();
+	while ( ! result.done ) {
+		await result.value;
+		result = iterator.next();
+	}
+};
+
+describe( 'Add to Cart + Options grouped product selector store', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		jest.clearAllMocks();
+
+		mockContext = {
+			selectedAttributes: [],
+			quantity: {},
+			validationErrors: [],
+			tempQuantity: 0,
+			groupedProductIds: [],
+		};
+		mockRegisteredStore = null;
+		mockAddToCartStore = {
+			state: {} as GroupedProductAddToCartWithOptionsStore[ 'state' ],
+			actions: {
+				clearErrors: mockClearErrors,
+				addError: mockAddError,
+			} as unknown as GroupedProductAddToCartWithOptionsStore[ 'actions' ],
+			callbacks:
+				{} as GroupedProductAddToCartWithOptionsStore[ 'callbacks' ],
+		};
+		mockGetConfig.mockReturnValue( {
+			errorMessages: {
+				groupedProductAddToCartMissingItems: 'Choose products.',
+				invalidQuantities: 'Choose valid quantities.',
+			},
+		} );
+		mockProductsState.findProduct.mockReturnValue( null );
+
+		jest.isolateModules( () => {
+			jest.requireActual( '../frontend' );
+		} );
+	} );
+
+	it( 'reports an empty grouped selection', () => {
+		mockContext.quantity = { 11: 0, 12: 0 };
+
+		getRegisteredStore().callbacks.validateQuantities();
+
+		expect( mockClearErrors ).toHaveBeenCalledWith( 'invalid-quantities' );
+		expect( mockAddError ).toHaveBeenCalledWith( {
+			code: 'groupedProductAddToCartMissingItems',
+			message: 'Choose products.',
+			group: 'invalid-quantities',
+		} );
+	} );
+
+	it( 'reports nonzero child quantities outside the product bounds', () => {
+		mockContext.quantity = { 11: 4, 12: 1 };
+		mockProductsState.findProduct.mockImplementation( ( { id } ) => ( {
+			id,
+			add_to_cart: { minimum: 1, maximum: id === 11 ? 3 : 1 },
+		} ) );
+
+		getRegisteredStore().actions.validateGroupedProductQuantity();
+
+		expect( mockAddError ).toHaveBeenCalledWith( {
+			code: 'invalidQuantities',
+			message: 'Choose valid quantities.',
+			group: 'invalid-quantities',
+		} );
+	} );
+
+	it( 'reports a positive child quantity below the product minimum', () => {
+		mockContext.quantity = { 11: 2, 12: 0 };
+		mockProductsState.findProduct.mockImplementation( ( { id } ) => ( {
+			id,
+			add_to_cart: { minimum: id === 11 ? 3 : 1, maximum: 5 },
+		} ) );
+
+		getRegisteredStore().actions.validateGroupedProductQuantity();
+
+		expect( mockAddError ).toHaveBeenCalledWith( {
+			code: 'invalidQuantities',
+			message: 'Choose valid quantities.',
+			group: 'invalid-quantities',
+		} );
+	} );
+
+	it( 'accepts zero optional children and valid selected quantities', () => {
+		mockContext.quantity = { 11: 0, 12: 1 };
+		mockProductsState.findProduct.mockImplementation( ( { id } ) => ( {
+			id,
+			add_to_cart: { minimum: 1, maximum: 2 },
+		} ) );
+
+		getRegisteredStore().actions.validateGroupedProductQuantity();
+
+		expect( mockAddError ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends exact nonzero child vectors including sold-individually choices', async () => {
+		mockContext.groupedProductIds = [ 11, 12, 13, 14 ];
+		mockContext.quantity = { 11: 2, 12: 0, 13: 1, 14: 3 };
+		mockContext.selectedAttributes = [
+			{ attribute: 'attribute_pa_color', value: 'blue' },
+		];
+		mockProductsState.findProduct.mockImplementation( ( { id } ) => {
+			if ( id === 14 ) {
+				return null;
+			}
+			return {
+				id,
+				type: 'simple',
+				sold_individually: id === 13,
+			};
+		} );
+
+		await runGenerator(
+			getRegisteredStore().actions.batchAddToCart() as Generator
+		);
+
+		expect( mockBatchAddCartItems ).toHaveBeenCalledWith(
+			[
+				{
+					id: 11,
+					quantityToAdd: 2,
+					variation: mockContext.selectedAttributes,
+					type: 'simple',
+				},
+				{
+					id: 13,
+					quantityToAdd: 1,
+					variation: mockContext.selectedAttributes,
+					type: 'simple',
+				},
+			],
+			{ showCartUpdatesNotices: false }
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/test/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/test/frontend.ts
@@ -1,0 +1,205 @@
+/**
+ * Internal dependencies
+ */
+import type { QuantitySelectorStore } from '../frontend';
+
+const mockSetQuantity = jest.fn();
+const mockGetElement = jest.fn();
+
+let mockContext: {
+	allowZero?: boolean;
+	inputElement?: HTMLInputElement | null;
+};
+let mockRegisteredStore: QuantitySelectorStore | null;
+
+const mockProductsState = {
+	productInContext: null as Record< string, unknown > | null,
+};
+
+const mockAddToCartStore = {
+	state: {
+		quantity: {} as Record< number, number >,
+	},
+	actions: {
+		setQuantity: mockSetQuantity,
+	},
+};
+
+const mockStore = jest.fn( ( namespace, definition ) => {
+	if ( namespace === 'woocommerce/products' ) {
+		return { state: mockProductsState };
+	}
+	if ( namespace === 'woocommerce/add-to-cart-with-options' ) {
+		return mockAddToCartStore;
+	}
+	if (
+		namespace === 'woocommerce/add-to-cart-with-options-quantity-selector'
+	) {
+		mockRegisteredStore = definition;
+		return definition;
+	}
+	return {};
+} );
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: mockStore,
+		getContext: jest.fn( () => mockContext ),
+		getElement: mockGetElement,
+	} ),
+	{ virtual: true }
+);
+
+const getRegisteredStore = (): QuantitySelectorStore => {
+	if ( ! mockRegisteredStore ) {
+		throw new Error( 'Quantity selector store was not registered.' );
+	}
+	return mockRegisteredStore;
+};
+
+const createInput = ( value: string ) => {
+	const input = document.createElement( 'input' );
+	input.type = 'number';
+	input.value = value;
+	return input;
+};
+
+describe( 'Add to Cart + Options quantity selector store', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		jest.clearAllMocks();
+
+		mockContext = {};
+		mockRegisteredStore = null;
+		mockProductsState.productInContext = {
+			id: 42,
+			is_in_stock: true,
+			sold_individually: false,
+			add_to_cart: {
+				minimum: 4,
+				maximum: 8,
+				multiple_of: 2,
+			},
+		};
+		mockAddToCartStore.state.quantity = { 42: 4 };
+
+		jest.isolateModules( () => {
+			jest.requireActual( '../frontend' );
+		} );
+	} );
+
+	it( 'derives quantity controls from stock, sold-individually, and bounds', () => {
+		const state = getRegisteredStore().state;
+
+		expect( state.allowsQuantityChange ).toBe( true );
+		expect( state.allowsDecrease ).toBe( false );
+		expect( state.allowsIncrease ).toBe( true );
+
+		mockProductsState.productInContext = {
+			...mockProductsState.productInContext,
+			is_in_stock: false,
+		};
+		expect( state.allowsQuantityChange ).toBe( false );
+
+		mockProductsState.productInContext = {
+			...mockProductsState.productInContext,
+			is_in_stock: true,
+		};
+
+		mockAddToCartStore.state.quantity[ 42 ] = 8;
+		expect( state.allowsIncrease ).toBe( false );
+
+		mockAddToCartStore.state.quantity[ 42 ] = 4;
+		mockContext.allowZero = true;
+		expect( state.allowsDecrease ).toBe( true );
+
+		mockProductsState.productInContext = {
+			...mockProductsState.productInContext,
+			sold_individually: true,
+		};
+		expect( state.allowsQuantityChange ).toBe( false );
+	} );
+
+	it( 'clamps increase and decrease button actions to product bounds', () => {
+		mockContext.inputElement = createInput( '7' );
+
+		getRegisteredStore().actions.increaseQuantity();
+
+		expect( mockSetQuantity ).toHaveBeenLastCalledWith( 42, 8 );
+
+		mockSetQuantity.mockClear();
+		mockContext.inputElement.value = '5';
+		getRegisteredStore().actions.decreaseQuantity();
+		expect( mockSetQuantity ).toHaveBeenLastCalledWith( 42, 4 );
+
+		mockSetQuantity.mockClear();
+		mockContext.allowZero = true;
+		mockContext.inputElement.value = '4';
+		getRegisteredStore().actions.decreaseQuantity();
+		expect( mockSetQuantity ).toHaveBeenLastCalledWith( 42, 0 );
+	} );
+
+	it.each( [
+		{ label: 'zero', value: '0' },
+		{ label: 'empty', value: '' },
+	] )(
+		'resets $label simple-product input to the minimum on blur',
+		( { value } ) => {
+			mockContext.inputElement = createInput( value );
+
+			getRegisteredStore().actions.handleQuantityBlur();
+
+			expect( mockSetQuantity ).toHaveBeenCalledWith( 42, 4 );
+		}
+	);
+
+	it.each( [
+		{ label: 'zero', value: '0' },
+		{ label: 'empty', value: '' },
+	] )(
+		'keeps $label grouped-product input at zero when zero is allowed',
+		( { value } ) => {
+			mockContext.allowZero = true;
+			mockContext.inputElement = createInput( value );
+
+			getRegisteredStore().actions.handleQuantityBlur();
+
+			expect( mockSetQuantity ).toHaveBeenCalledWith( 42, 0 );
+		}
+	);
+
+	it( 'preserves a positive manual value for validation by the parent store', () => {
+		mockContext.inputElement = createInput( '3' );
+
+		getRegisteredStore().actions.handleQuantityBlur();
+
+		expect( mockSetQuantity ).toHaveBeenCalledWith( 42, 3 );
+	} );
+
+	it( 'maps a sold-individually checkbox to zero or one', () => {
+		const checkbox = document.createElement( 'input' );
+		checkbox.type = 'checkbox';
+		mockGetElement.mockReturnValue( { ref: checkbox } );
+
+		checkbox.checked = true;
+		getRegisteredStore().actions.handleQuantityCheckboxChange();
+		expect( mockSetQuantity ).toHaveBeenLastCalledWith( 42, 1 );
+
+		checkbox.checked = false;
+		getRegisteredStore().actions.handleQuantityCheckboxChange();
+		expect( mockSetQuantity ).toHaveBeenLastCalledWith( 42, 0 );
+	} );
+
+	it( 'stores the native quantity input from the rendered wrapper', () => {
+		const wrapper = document.createElement( 'div' );
+		const input = createInput( '4' );
+		input.className = 'qty';
+		wrapper.appendChild( input );
+		mockGetElement.mockReturnValue( { ref: wrapper } );
+
+		getRegisteredStore().callbacks.storeInputElementRef();
+
+		expect( mockContext.inputElement ).toBe( input );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/frontend.ts
@@ -1,0 +1,262 @@
+/**
+ * Internal dependencies
+ */
+import type { AddToCartWithOptionsStore, Context } from '../frontend';
+
+type RegisteredStore = {
+	state: AddToCartWithOptionsStore[ 'state' ];
+	actions: AddToCartWithOptionsStore[ 'actions' ];
+};
+
+const mockAddCartItem = jest.fn();
+const mockBatchAddCartItems = jest.fn();
+const mockAddNotice = jest.fn();
+const mockRemoveNotice = jest.fn();
+const mockGetConfig = jest.fn();
+
+let mockContext: Context;
+let mockQuantitySelectorContext: { inputElement?: HTMLInputElement };
+let mockRegisteredStore: RegisteredStore | null;
+let mockAddToCartStore: RegisteredStore;
+
+const mockProductsState = {
+	productId: 0,
+	productInContext: null as Record< string, unknown > | null,
+	mainProductInContext: null as Record< string, unknown > | null,
+	findProduct: jest.fn(),
+};
+
+const mockStore = jest.fn( ( namespace, definition ) => {
+	if ( namespace === 'woocommerce/products' ) {
+		return { state: mockProductsState };
+	}
+
+	if ( namespace === 'woocommerce/add-to-cart-with-options' ) {
+		if ( definition?.state ) {
+			Object.defineProperties(
+				mockAddToCartStore.state,
+				Object.getOwnPropertyDescriptors( definition.state )
+			);
+		}
+		if ( definition?.actions ) {
+			Object.assign( mockAddToCartStore.actions, definition.actions );
+		}
+		mockRegisteredStore = mockAddToCartStore;
+		return mockAddToCartStore;
+	}
+
+	if ( namespace === 'woocommerce/store-notices' ) {
+		return {
+			actions: {
+				addNotice: mockAddNotice,
+				removeNotice: mockRemoveNotice,
+			},
+		};
+	}
+
+	if ( namespace === 'woocommerce' ) {
+		return {
+			actions: {
+				addCartItem: mockAddCartItem,
+				batchAddCartItems: mockBatchAddCartItems,
+			},
+		};
+	}
+
+	return {};
+} );
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: mockStore,
+		getContext: jest.fn( ( namespace?: string ) =>
+			namespace ===
+			'woocommerce/add-to-cart-with-options-quantity-selector'
+				? mockQuantitySelectorContext
+				: mockContext
+		),
+		getConfig: mockGetConfig,
+		withSyncEvent: ( action: unknown ) => action,
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@woocommerce/stores/woocommerce/cart', () => ( {} ) );
+jest.mock( '@woocommerce/stores/woocommerce/products', () => ( {} ) );
+jest.mock( '@woocommerce/stores/store-notices', () => ( {} ) );
+
+const getRegisteredStore = (): RegisteredStore => {
+	if ( ! mockRegisteredStore ) {
+		throw new Error( 'Add to Cart + Options store was not registered.' );
+	}
+	return mockRegisteredStore;
+};
+
+const runGenerator = async ( iterator: Generator ) => {
+	let result = iterator.next();
+	while ( ! result.done ) {
+		await result.value;
+		result = iterator.next();
+	}
+};
+
+describe( 'Add to Cart + Options interactivity store', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		jest.clearAllMocks();
+
+		mockContext = {
+			selectedAttributes: [],
+			quantity: { 42: 2 },
+			validationErrors: [],
+			tempQuantity: 0,
+			groupedProductIds: [],
+		};
+		mockQuantitySelectorContext = {};
+		mockRegisteredStore = null;
+		mockAddToCartStore = {
+			state: {} as AddToCartWithOptionsStore[ 'state' ],
+			actions: {} as AddToCartWithOptionsStore[ 'actions' ],
+		};
+		mockProductsState.productId = 42;
+		mockProductsState.productInContext = {
+			id: 42,
+			type: 'simple',
+			is_purchasable: true,
+			is_in_stock: true,
+			add_to_cart: {
+				minimum: 1,
+				maximum: 5,
+			},
+		};
+		mockProductsState.mainProductInContext =
+			mockProductsState.productInContext;
+		mockGetConfig.mockReturnValue( {
+			errorMessages: {
+				invalidQuantities: 'Choose a valid quantity.',
+			},
+		} );
+
+		jest.isolateModules( () => {
+			jest.requireActual( '../frontend' );
+		} );
+	} );
+
+	it( 'validates zero and out-of-range quantities with the configured message', () => {
+		const registeredStore = getRegisteredStore();
+		mockProductsState.productInContext = {
+			...mockProductsState.productInContext,
+			add_to_cart: {
+				minimum: 0,
+				maximum: 5,
+			},
+		};
+
+		registeredStore.actions.validateQuantity( 42, 0 );
+
+		expect( registeredStore.state.validationErrors ).toEqual( [
+			{
+				code: 'invalidQuantities',
+				message: 'Choose a valid quantity.',
+				group: 'invalid-quantities',
+			},
+		] );
+		expect( registeredStore.state.isFormValid ).toBe( false );
+
+		registeredStore.actions.validateQuantity( 42, 6 );
+		expect( registeredStore.state.validationErrors ).toHaveLength( 1 );
+
+		registeredStore.actions.validateQuantity( 42, 3 );
+		expect( registeredStore.state.validationErrors ).toEqual( [] );
+		expect( registeredStore.state.isFormValid ).toBe( true );
+	} );
+
+	it( 'rejects a positive quantity below the product minimum', () => {
+		mockProductsState.productInContext = {
+			...mockProductsState.productInContext,
+			add_to_cart: {
+				minimum: 4,
+				maximum: 5,
+			},
+		};
+
+		getRegisteredStore().actions.validateQuantity( 42, 2 );
+
+		expect( getRegisteredStore().state.validationErrors ).toEqual( [
+			{
+				code: 'invalidQuantities',
+				message: 'Choose a valid quantity.',
+				group: 'invalid-quantities',
+			},
+		] );
+	} );
+
+	it.each( [
+		{
+			title: 'simple product',
+			type: 'simple',
+			selectedAttributes: [],
+		},
+		{
+			title: 'selected variation',
+			type: 'variation',
+			selectedAttributes: [
+				{ attribute: 'attribute_pa_color', value: 'blue' },
+				{ attribute: 'Logo', value: 'No' },
+			],
+		},
+	] )(
+		'forwards the exact $title cart payload',
+		async ( { type, selectedAttributes } ) => {
+			mockContext.selectedAttributes = selectedAttributes;
+			mockProductsState.productInContext = {
+				...mockProductsState.productInContext,
+				id: 42,
+				type,
+			};
+			const preventDefault = jest.fn();
+
+			await runGenerator(
+				getRegisteredStore().actions.addToCart( {
+					preventDefault,
+				} as unknown as SubmitEvent )
+			);
+
+			expect( preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( mockAddCartItem ).toHaveBeenCalledWith(
+				{
+					id: 42,
+					quantityToAdd: 2,
+					variation: selectedAttributes,
+					type,
+				},
+				{ showCartUpdatesNotices: false }
+			);
+		}
+	);
+
+	it( 'surfaces validation errors without sending a cart request', async () => {
+		const registeredStore = getRegisteredStore();
+		registeredStore.actions.addError( {
+			code: 'missingVariation',
+			group: 'variable-product',
+			message: 'Choose product options.',
+		} );
+		mockAddNotice.mockReturnValue( 'notice-1' );
+
+		await runGenerator(
+			registeredStore.actions.addToCart( {
+				preventDefault: jest.fn(),
+			} as unknown as SubmitEvent )
+		);
+
+		expect( mockAddNotice ).toHaveBeenCalledWith( {
+			notice: 'Choose product options.',
+			type: 'error',
+			dismissible: true,
+		} );
+		expect( registeredStore.state.noticeIds ).toEqual( [ 'notice-1' ] );
+		expect( mockAddCartItem ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/test/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/test/frontend.ts
@@ -1,0 +1,385 @@
+/**
+ * External dependencies
+ */
+import type { SelectedAttributes } from '@woocommerce/stores/woocommerce/cart';
+
+/**
+ * Internal dependencies
+ */
+import type { VariableProductAddToCartWithOptionsStore } from '../frontend';
+
+type RegisteredStore = VariableProductAddToCartWithOptionsStore;
+
+type VariationContext = {
+	name: string;
+	selectedValue: string | null;
+	selectedAttributes: SelectedAttributes[];
+	variationAttributeOptions: Array< {
+		id: string;
+		label: string;
+		value: string;
+	} >;
+	autoselect: boolean;
+	disabledAttributesAction?: 'disable' | 'hide';
+	quantity: Record< number, number >;
+};
+
+const mockClearErrors = jest.fn();
+const mockAddError = jest.fn();
+const mockSetQuantity = jest.fn();
+const mockGetConfig = jest.fn();
+const mockGetElement = jest.fn();
+
+let mockContext: VariationContext;
+let mockProductContext: { variationId?: number | null } | null;
+let mockRegisteredStore: RegisteredStore | null;
+let mockAddToCartStore: RegisteredStore;
+
+const mockProductsState = {
+	productId: 100,
+	variationId: null as number | null,
+	mainProductInContext: null as Record< string, unknown > | null,
+	productVariationInContext: null as Record< string, unknown > | null,
+	productVariations: {} as Record< number, Record< string, unknown > >,
+	findProduct: jest.fn(),
+};
+
+const mockStore = jest.fn( ( namespace, definition ) => {
+	if ( namespace === 'woocommerce/products' ) {
+		return { state: mockProductsState };
+	}
+
+	if ( namespace === 'woocommerce/add-to-cart-with-options' ) {
+		if ( definition?.state ) {
+			Object.defineProperties(
+				mockAddToCartStore.state,
+				Object.getOwnPropertyDescriptors( definition.state )
+			);
+		}
+		if ( definition?.actions ) {
+			Object.assign( mockAddToCartStore.actions, definition.actions );
+		}
+		if ( definition?.callbacks ) {
+			Object.assign( mockAddToCartStore.callbacks, definition.callbacks );
+		}
+		mockRegisteredStore = mockAddToCartStore;
+		return mockAddToCartStore;
+	}
+
+	return {};
+} );
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: mockStore,
+		getContext: jest.fn( ( namespace?: string ) =>
+			namespace === 'woocommerce/products'
+				? mockProductContext
+				: mockContext
+		),
+		getConfig: mockGetConfig,
+		getElement: mockGetElement,
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@woocommerce/stores/woocommerce/products', () => ( {} ) );
+
+const getRegisteredStore = (): RegisteredStore => {
+	if ( ! mockRegisteredStore ) {
+		throw new Error( 'Variation selector store was not registered.' );
+	}
+	return mockRegisteredStore;
+};
+
+const variation = (
+	id: number,
+	attributes: Array< { name: string; value: string | null } >
+) => ( { id, attributes } );
+
+describe( 'Add to Cart + Options variation selector store', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		jest.clearAllMocks();
+
+		mockContext = {
+			name: 'Color',
+			selectedValue: '',
+			selectedAttributes: [],
+			variationAttributeOptions: [],
+			autoselect: false,
+			disabledAttributesAction: 'disable',
+			quantity: {},
+		};
+		mockProductContext = { variationId: null };
+		mockRegisteredStore = null;
+		mockAddToCartStore = {
+			state: {} as RegisteredStore[ 'state' ],
+			actions: {
+				clearErrors: mockClearErrors,
+				addError: mockAddError,
+				setQuantity: mockSetQuantity,
+			} as unknown as RegisteredStore[ 'actions' ],
+			callbacks: {} as RegisteredStore[ 'callbacks' ],
+		};
+		mockProductsState.mainProductInContext = null;
+		mockProductsState.productVariationInContext = null;
+		mockProductsState.productVariations = {};
+		mockProductsState.findProduct.mockReturnValue( null );
+		mockGetConfig.mockReturnValue( {
+			errorMessages: {
+				variableProductMissingAttributes: 'Choose options.',
+				variableProductOutOfStock: 'Variation unavailable.',
+			},
+		} );
+
+		jest.isolateModules( () => {
+			jest.requireActual( '../frontend' );
+		} );
+	} );
+
+	it.each( [
+		{ action: 'disable', hidden: false },
+		{ action: 'hide', hidden: true },
+	] as const )(
+		'marks invalid choices for the $action action',
+		( { action, hidden } ) => {
+			mockProductsState.mainProductInContext = {
+				id: 100,
+				type: 'variable',
+				variations: [
+					variation( 101, [
+						{ name: 'Color', value: 'blue' },
+						{ name: 'Size', value: 'xl' },
+					] ),
+					variation( 102, [
+						{ name: 'Color', value: 'red' },
+						{ name: 'Size', value: 'l' },
+					] ),
+				],
+			};
+			mockContext = {
+				...mockContext,
+				name: 'Size',
+				disabledAttributesAction: action,
+				selectedAttributes: [
+					{ attribute: 'attribute_pa_color', value: 'blue' },
+				],
+				variationAttributeOptions: [
+					{ id: 'size-l', label: 'L', value: 'l' },
+					{ id: 'size-xl', label: 'XL', value: 'xl' },
+				],
+			};
+
+			const selectableByValue = Object.fromEntries(
+				getRegisteredStore().state.selectableItems.map( ( item ) => [
+					item.value,
+					item,
+				] )
+			);
+
+			expect( selectableByValue.l ).toMatchObject( {
+				id: 'size-l',
+				selected: false,
+				disabled: true,
+				hidden,
+			} );
+			expect( selectableByValue.xl ).toMatchObject( {
+				id: 'size-xl',
+				selected: false,
+				disabled: false,
+				hidden: false,
+			} );
+		}
+	);
+
+	it( 'preserves a custom attribute slug while matching its Store API label', () => {
+		mockProductsState.mainProductInContext = {
+			id: 100,
+			type: 'variable',
+			variations: [
+				variation( 101, [ { name: 'Numeric Size', value: '42' } ] ),
+			],
+		};
+		mockContext = {
+			...mockContext,
+			name: 'attribute_pa_numeric-size',
+			variationAttributeOptions: [
+				{ id: 'numeric-42', label: '42', value: '42' },
+			],
+		};
+
+		const item = getRegisteredStore().state.selectableItems[ 0 ];
+		expect( item.disabled ).toBe( false );
+
+		getRegisteredStore().actions.toggle( item );
+
+		expect( mockContext.selectedAttributes ).toEqual( [
+			{ attribute: 'attribute_pa_numeric-size', value: '42' },
+		] );
+	} );
+
+	it( 'autoselects only unique valid options outside the changed attribute', () => {
+		mockProductsState.mainProductInContext = {
+			id: 100,
+			type: 'variable',
+			variations: [
+				variation( 101, [
+					{ name: 'Type', value: 't-shirt' },
+					{ name: 'Color', value: 'blue' },
+					{ name: 'Size', value: 'xl' },
+					{ name: 'Material', value: 'cotton' },
+				] ),
+				variation( 102, [
+					{ name: 'Type', value: 't-shirt' },
+					{ name: 'Color', value: 'blue' },
+					{ name: 'Size', value: 'xl' },
+					{ name: 'Material', value: 'linen' },
+				] ),
+				variation( 103, [
+					{ name: 'Type', value: 't-shirt' },
+					{ name: 'Color', value: 'green' },
+					{ name: 'Size', value: 's' },
+				] ),
+			],
+		};
+		mockContext.autoselect = true;
+		mockContext.selectedAttributes = [
+			{ attribute: 'Color', value: 'blue' },
+		];
+
+		getRegisteredStore().actions.autoselectAttributes( {
+			excludedAttributes: [ 'attribute_pa_color' ],
+		} );
+
+		expect( mockContext.selectedAttributes ).not.toContainEqual( {
+			attribute: 'Material',
+			value: 'cotton',
+		} );
+		expect( mockContext.selectedAttributes ).toEqual( [
+			{ attribute: 'Color', value: 'blue' },
+			{ attribute: 'Type', value: 't-shirt' },
+			{ attribute: 'Size', value: 'xl' },
+		] );
+	} );
+
+	it( 'does not rewrite a changed custom attribute slug when its Store API label is excluded', () => {
+		mockProductsState.mainProductInContext = {
+			id: 100,
+			type: 'variable',
+			variations: [
+				variation( 101, [ { name: 'Color', value: 'blue' } ] ),
+			],
+		};
+		mockContext = {
+			...mockContext,
+			autoselect: true,
+			selectedAttributes: [
+				{ attribute: 'attribute_pa_color', value: 'blue' },
+			],
+		};
+
+		getRegisteredStore().actions.autoselectAttributes( {
+			excludedAttributes: [ 'attribute_pa_color' ],
+		} );
+
+		expect( mockContext.selectedAttributes ).toEqual( [
+			{ attribute: 'attribute_pa_color', value: 'blue' },
+		] );
+	} );
+
+	it( 'accepts any-value variations when another selected attribute matches', () => {
+		mockProductsState.mainProductInContext = {
+			id: 100,
+			type: 'variable',
+			variations: [
+				variation( 101, [
+					{ name: 'Color', value: null },
+					{ name: 'Size', value: 'large' },
+				] ),
+			],
+		};
+		mockContext = {
+			...mockContext,
+			name: 'Color',
+			selectedAttributes: [ { attribute: 'Size', value: 'large' } ],
+			variationAttributeOptions: [
+				{ id: 'color-blue', label: 'Blue', value: 'blue' },
+			],
+		};
+
+		expect( getRegisteredStore().state.selectableItems[ 0 ].disabled ).toBe(
+			false
+		);
+	} );
+
+	it( 'updates the selected variation ID and reports missing or unavailable matches', () => {
+		const selectedAttributes = [ { attribute: 'Color', value: 'blue' } ];
+		mockProductsState.mainProductInContext = {
+			id: 100,
+			variations: [ variation( 101, [] ) ],
+		};
+		mockContext.selectedAttributes = selectedAttributes;
+		mockProductsState.findProduct.mockImplementation(
+			( { id, selectedAttributes: receivedAttributes } ) => {
+				const selectedColor = receivedAttributes?.find(
+					( attribute ) => attribute.attribute === 'Color'
+				);
+
+				return id === 100 &&
+					receivedAttributes?.length === 1 &&
+					selectedColor?.value === 'blue'
+					? { id: 101 }
+					: mockProductsState.mainProductInContext;
+			}
+		);
+		mockProductsState.productVariations[ 101 ] = {
+			id: 101,
+			is_in_stock: false,
+		};
+
+		getRegisteredStore().callbacks.setSelectedVariationId();
+		getRegisteredStore().callbacks.validateVariation();
+
+		expect( mockProductContext?.variationId ).toBe( 101 );
+		expect( mockAddError ).toHaveBeenCalledWith( {
+			code: 'variableProductOutOfStock',
+			message: 'Variation unavailable.',
+			group: 'variable-product',
+		} );
+
+		mockAddError.mockClear();
+		mockProductsState.findProduct.mockReturnValue(
+			mockProductsState.mainProductInContext
+		);
+		getRegisteredStore().callbacks.validateVariation();
+		expect( mockAddError ).toHaveBeenCalledWith( {
+			code: 'variableProductMissingAttributes',
+			message: 'Choose options.',
+			group: 'variable-product',
+		} );
+	} );
+
+	it.each( [
+		{ current: 2, expected: 4 },
+		{ current: 10, expected: 8 },
+	] )(
+		'clamps variation quantity $current to $expected when the input is idle',
+		( { current, expected } ) => {
+			const input = document.createElement( 'input' );
+			input.type = 'number';
+			input.value = String( current );
+			mockGetElement.mockReturnValue( { ref: input } );
+			mockProductsState.productVariationInContext = {
+				id: 101,
+				add_to_cart: { minimum: 4, maximum: 8 },
+			};
+			mockContext.quantity = { 101: current };
+
+			getRegisteredStore().callbacks.watchQuantityConstraints();
+
+			expect( mockSetQuantity ).toHaveBeenCalledWith( 101, expected );
+		}
+	);
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-add-to-cart-with-options
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-add-to-cart-with-options
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the four Add to Cart with Options Interactivity API stores, plus PHPUnit coverage for the legacy form markup and the grouped-product quantity handler. No E2E tests are removed.

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -2267,4 +2267,76 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		return array( (string) $cart_item_key, WC()->cart->get_cart_item( (string) $cart_item_key ) );
 	}
+
+	/**
+	 * @testdox Should add only selected grouped children with their submitted quantities.
+	 */
+	public function test_add_to_cart_action_handles_grouped_product_quantities(): void {
+		$first_child = WC_Helper_Product::create_simple_product();
+		$first_child->set_name( 'First grouped child' );
+		$first_child->save();
+
+		$skipped_child = WC_Helper_Product::create_simple_product();
+		$skipped_child->set_name( 'Skipped grouped child' );
+		$skipped_child->save();
+
+		$single_child = WC_Helper_Product::create_simple_product();
+		$single_child->set_name( 'Sold individually grouped child' );
+		$single_child->set_sold_individually( true );
+		$single_child->save();
+
+		$grouped_product = new WC_Product_Grouped();
+		$grouped_product->set_name( 'Grouped request product' );
+		$grouped_product->set_children(
+			array(
+				$first_child->get_id(),
+				$skipped_child->get_id(),
+				$single_child->get_id(),
+			)
+		);
+		$grouped_product->save();
+
+		$original_redirect = get_option( 'woocommerce_cart_redirect_after_add' );
+
+		try {
+			update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+			WC()->cart->empty_cart();
+
+			$grouped_quantities = array(
+				$first_child->get_id()   => 2,
+				$skipped_child->get_id() => 0,
+				$single_child->get_id()  => 1,
+			);
+
+			$_REQUEST['add-to-cart'] = $grouped_product->get_id();
+			$_REQUEST['quantity']    = $grouped_quantities;
+			$_POST['quantity']       = $grouped_quantities;
+
+			WC_Form_Handler::add_to_cart_action( false );
+
+			$cart_quantities = array();
+			foreach ( WC()->cart->get_cart() as $cart_item ) {
+				$cart_quantities[ $cart_item['product_id'] ] = (int) $cart_item['quantity'];
+			}
+
+			$this->assertSame(
+				array(
+					$first_child->get_id()  => 2,
+					$single_child->get_id() => 1,
+				),
+				$cart_quantities,
+				'Only positive grouped child quantities should be added to the cart.'
+			);
+			$this->assertArrayNotHasKey( $skipped_child->get_id(), $cart_quantities, 'A zero-quantity grouped child should be skipped.' );
+			$this->assertArrayNotHasKey( $grouped_product->get_id(), $cart_quantities, 'The grouped parent should not become a cart line.' );
+		} finally {
+			unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
+			update_option( 'woocommerce_cart_redirect_after_add', $original_redirect );
+			WC()->cart->empty_cart();
+			$grouped_product->delete( true );
+			$single_child->delete( true );
+			$skipped_child->delete( true );
+			$first_child->delete( true );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -299,6 +299,125 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Legacy add-to-cart forms expose the request fields required by each product type.
+	 *
+	 * @dataProvider provider_legacy_form_fields
+	 *
+	 * @param string $product_type Product type under test.
+	 */
+	public function test_legacy_form_fields_for_product_types( string $product_type ): void {
+		global $product;
+
+		$previous_product  = $product;
+		$products          = array();
+		$original_redirect = get_option( 'woocommerce_cart_redirect_after_add' );
+
+		try {
+			if ( 'simple' === $product_type ) {
+				$product = new \WC_Product_Simple();
+				$product->set_name( 'Legacy Simple' );
+				$product->set_regular_price( '10' );
+				$product->save();
+				$products[]      = $product;
+				$expected_fields = array( 'name="add-to-cart"', 'name="quantity"' );
+			} elseif ( 'variable' === $product_type ) {
+				$product = new \WC_Product_Variable();
+				$product->set_name( 'Legacy Variable' );
+				$product->set_attributes(
+					array( \WC_Helper_Product::create_product_attribute_object( 'color', array( 'blue' ) ) )
+				);
+				$product->save();
+
+				$variation = new \WC_Product_Variation();
+				$variation->set_parent_id( $product->get_id() );
+				$variation->set_attributes( array( 'pa_color' => 'blue' ) );
+				$variation->set_regular_price( '10' );
+				$variation->save();
+				\WC_Product_Variable::sync( $product->get_id() );
+
+				$products[]      = $variation;
+				$products[]      = $product;
+				$expected_fields = array( 'name="add-to-cart"', 'name="product_id"', 'name="variation_id"', 'name="attribute_pa_color"', 'name="quantity"' );
+			} else {
+				$child = new \WC_Product_Simple();
+				$child->set_name( 'Legacy Grouped Child' );
+				$child->set_regular_price( '10' );
+				$child->save();
+
+				$product = new \WC_Product_Grouped();
+				$product->set_name( 'Legacy Grouped' );
+				$product->set_children( array( $child->get_id() ) );
+				$product->save();
+
+				$products[]      = $product;
+				$products[]      = $child;
+				$expected_fields = array( 'name="add-to-cart"', 'name="quantity[' . $child->get_id() . ']"' );
+			}
+
+			update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+			$this->assertStringContainsString( '<form ', $markup, 'A legacy HTML form should be rendered.' );
+			$this->assertStringContainsString( 'method="post"', $markup, 'The legacy form should submit with POST.' );
+			$this->assertStringContainsString( 'enctype="multipart/form-data"', $markup, 'The legacy form should retain multipart compatibility.' );
+			$this->assertStringNotContainsString( 'data-wp-on--submit="actions.addToCart"', $markup, 'The Interactivity API submit binding should be absent in legacy mode.' );
+			$this->assertStringContainsString( 'name="add-to-cart" value="' . $product->get_id() . '"', $markup, 'The parent product ID should be submitted.' );
+
+			foreach ( $expected_fields as $expected_field ) {
+				$this->assertStringContainsString( $expected_field, $markup, "The {$product_type} form should contain {$expected_field}." );
+			}
+		} finally {
+			update_option( 'woocommerce_cart_redirect_after_add', $original_redirect );
+			$product = $previous_product;
+			foreach ( $products as $created_product ) {
+				$created_product->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for legacy form field coverage.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public static function provider_legacy_form_fields(): array {
+		return array(
+			'simple product'   => array( 'simple' ),
+			'variable product' => array( 'variable' ),
+			'grouped product'  => array( 'grouped' ),
+		);
+	}
+
+	/**
+	 * @testdox Disabling archive AJAX add-to-cart leaves the block's Interactivity API submit binding enabled.
+	 */
+	public function test_ajax_archive_setting_does_not_disable_interactive_form(): void {
+		global $product;
+
+		$previous_product  = $product;
+		$original_ajax     = get_option( 'woocommerce_enable_ajax_add_to_cart' );
+		$original_redirect = get_option( 'woocommerce_cart_redirect_after_add' );
+		$product           = new \WC_Product_Simple();
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		try {
+			update_option( 'woocommerce_enable_ajax_add_to_cart', 'no' );
+			update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+
+			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+			$this->assertStringContainsString( 'data-wp-on--submit="actions.addToCart"', $markup, 'The block should keep its Interactivity API submit binding.' );
+			$this->assertStringNotContainsString( 'method="post"', $markup, 'The archive AJAX option should not force the block into legacy mode.' );
+		} finally {
+			update_option( 'woocommerce_enable_ajax_add_to_cart', $original_ajax );
+			update_option( 'woocommerce_cart_redirect_after_add', $original_redirect );
+			$product->delete( true );
+			$product = $previous_product;
+		}
+	}
+
+	/**
 	 * Tests that the default attributes are selected when defined in product
 	 * data or in the URL parameters.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**This pull request removes no test.** It adds 28 Jest cases and 4 PHPUnit tests underneath the Add to Cart with Options block, and leaves every browser title the block has today running exactly as it does now. 1255 insertions, zero deletions.

Refs TESTOPS-234

Part of the #68046 split.

That is unusual for this split, and it is deliberate — see the last section for why the other half is not here.

**What the new tests own**

| New coverage | What it proves |
| --- | --- |
| `add-to-cart-with-options/test/frontend.ts`, 5 cases | the parent store's add-to-cart payload for simple and variable products, and that a failed quantity validation sends no cart request at all |
| `grouped-product-selector/test/frontend.ts`, 5 cases | the exact child vector a grouped selection sends, zero-quantity children excluded, and the bounds messages for empty, under-minimum and over-maximum selections |
| `quantity-selector/test/frontend.ts`, 9 cases | blur behaviour for simple and grouped products, the increase and decrease clamps, the sold-individually checkbox mapping, and the derived `allowsIncrease` / `allowsDecrease` / `allowsQuantityChange` state |
| `variation-selector/test/frontend.ts`, 9 cases | variation resolution from selected attributes, custom attribute slugs against Store API labels, the "any" attribute rule, autoselection's uniqueness guard, and quantity constraints |
| `AddToCartWithOptions.php`, 2 new methods running as 4 tests | the legacy form markup chosen per product type (one method with a three-case data provider), and that the AJAX archive setting does not disable the interactive form |
| `class-wc-cart-test.php`, 1 test | the classic form handler's grouped-product quantity map — the non-block path the same shopper action takes |

Each Jest suite registers the block's Interactivity API store through a virtual `@wordpress/interactivity` mock and then drives the **real** module through `jest.requireActual`. The mock replaces the framework's `store()` registration call and nothing else, so the functions under test are the production ones.

#### The shared cart test file needed care

`class-wc-cart-test.php` is touched by two migration commits belonging to two different pull requests, and it also moved on trunk.

- Trunk's #67527 added eleven methods after this work branched. All eleven are kept.
- This branch carries exactly one migration method, `test_add_to_cart_action_handles_grouped_product_quantities`.
- The other, `test_update_cart_action_removes_grouped_child_items`, belongs to the grouped-cart-removal pull request and is **deliberately absent**.

A three-way apply was not usable: the commit this branch carries landed first on the migration branch, so the patch's reconstructed pre-image already contained the other batch's method and the merge tried to re-add it. Taking that resolution would have shipped another pull request's test inside this one. The method was instead lifted from the migration branch's own blob and inserted into trunk's copy.

The result is checkable rather than asserted: **50 test methods to 51**, the other batch's method absent, **zero deleted lines** against trunk, and the inserted method byte-identical to the migration branch's version including its docblock. Both pull requests independently take trunk to 51, so whichever merges second will need a rebase.

#### Why the spec change is not in this pull request

The migration also consolidates `add-to-cart-with-options.block_theme.spec.ts` from 24 titles to 16. I held it back, because it does not pass.

`allows adding grouped products to cart` fails at its `products sold individually can be added to cart` step: it expects `Number of items in the cart: 5` and the page shows **3**. Three full-file runs, three identical failures. It passes when run alone, and it passes when run with the six titles that precede it — only the whole file fails.

**Trunk's copy of the same spec passes all 28 titles in the same environment**, which is what rules out the environment and points at the change.

I did not adjust the counts, add a wait, or relax the assertion. Any of those would have hidden a real problem inside a pull request labelled a test move.

**The cause is now known, and it is not the arithmetic.** #68672 carries the consolidation and diagnoses it: the fold moved the persistence step of the reconcile title to the end and left two unprotected reloads between the re-add and it, so the re-add lost the race and the cart read 3. The totals are unchanged there, a barrier on the cart store's idle signal is all that was added, and the full Blocks e2e matrix is green. Deleting that one line reproduces the failure at 5-showing-3 on demand.

An earlier revision of this section argued the expectation of 5 was itself wrong — that zeroing the children also removed them from the cart. That was a hypothesis drawn from the failure snapshot and it did not survive: if the arithmetic were wrong, no barrier would make 5 pass. Struck rather than deleted, so the two descriptions do not read as disagreeing.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the four Jest suites. No environment is needed.
   - `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js assets/js/blocks/add-to-cart-with-options/test/frontend.ts --runInBand` — expect `5 passed`.
   - The same command for `grouped-product-selector/test/frontend.ts` — expect `5 passed`.
   - The same command for `quantity-selector/test/frontend.ts` — expect `9 passed`.
   - The same command for `variation-selector/test/frontend.ts` — expect `9 passed`.
3. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
4. Run the two PHP classes:
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'WC_Cart_Test'` — expect `OK (54 tests, 253 assertions)`. On `trunk` the same command gives `OK (53 tests, 250 assertions)`.
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'AddToCartWithOptions'` — expect `OK (18 tests, 81 assertions)`.
5. Confirm the other pull request's method is not here: `grep -c test_update_cart_action_removes_grouped_child_items plugins/woocommerce/tests/php/includes/class-wc-cart-test.php` should print `0`.
6. Confirm the Jest suites detect a real regression. In `plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts`, in `actions.validateGroupedProductQuantity`, invert the empty-selection guard. Re-run the grouped-product-selector suite and expect `reports an empty grouped selection` to fail. Revert. No rebuild is needed — Jest transpiles the source directly.
7. Confirm the new PHP test detects a real regression. In `plugins/woocommerce/includes/class-wc-form-handler.php`, in `add_to_cart_action`, change `self::add_to_cart_handler_grouped( $product_id )` to `self::add_to_cart_handler_simple( $product_id )`. Re-run the first command in step 4 and expect `test_add_to_cart_action_handles_grouped_product_quantities` to fail at `Only positive grouped child quantities should be added to the cart.`. Revert.
8. Confirm nothing was taken away. `git diff trunk...HEAD --numstat` should show no deleted lines in any file, and the block's E2E spec should not appear in the diff at all.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress. Trunk was at `adefb5f971`.

- **Extraction.** The four Jest suites and `AddToCartWithOptions.php` are byte-identical to the migration branch. `class-wc-cart-test.php` is trunk's file plus one method, verified additive and verified not to contain the other pull request's method.
- **Focused lower-layer runs.** All 32 focused commands from the mutation matrix exit 0, covering 46 matrix rows. The four PHPUnit runs were checked to have executed real tests rather than matching nothing — a filter that matches no test also exits 0.
- **Suite totals, all measured on this branch.** 5, 5, 9 and 9 Jest cases. `WC_Cart_Test` is `OK (54 tests, 253 assertions)` here against `OK (53 tests, 250 assertions)` on trunk, both run in the same environment. `AddToCartWithOptions` is `OK (18 tests, 81 assertions)`.
- **Mutation re-check, all 21 behavior families.** One mutation per distinct system under test, each turning its focused command red at the assertion the matrix names, each reverted clean and green again. Nineteen were applied from the matrix's own FORWARD text; two were read by hand.
- **One of those needed disambiguating.** The `setAttribute` mutation's anchor appears twice in the variation selector — once in the assignment branch and once in the `push` branch the matrix names. Mutating the wrong one would have left the test green and read as a survivor.
- **A twenty-second mutation, added because the first choice proved the wrong thing.** For the block's render family my chosen mutation happened to be killed by `test_form_fallback`, which already exists on `trunk` — so it showed a pre-existing test still works, not that this pull request's new coverage does. Forcing legacy mode instead turns the new `test_ajax_archive_setting_does_not_disable_interactive_form` red at its Interactivity API submit-binding assertion, and reverting turns it green.
- **One test title claims slightly more than it proves.** `sends exact nonzero child vectors including sold-individually choices` reads as though `batchAddToCart` has a sold-individually branch; it does not, so what the case really shows is that such a child is not wrongly excluded. The wording comes from the migration branch and is left as written rather than edited here.
- **Unchanged spec, run anyway.** The block's E2E spec on this branch is byte-identical to `trunk`, and a full run of it at `--retries=0 --workers=1` in this environment reports `28 passed`.
- **Lint.** `oxlint` exits 0 on the four new Jest files. `lint:changes:branch` exits 0 with no errors and no warnings.
- **A lint result I did not trust.** `lint:php:changes` exited 0 having linted nothing: it diffs unstaged files, and the work was already committed. `lint:changes:branch`, which compares the whole branch against trunk, is the one reported above.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; both touched PHP files are under `tests/`.
- **Dangling-reference sweep: nothing to sweep.** The batch deletes no file and removes no test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-add-to-cart-with-options` and `plugins/woocommerce/client/blocks/changelog/testops-234-add-to-cart-with-options`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


