### PR TITLE
[tests] Move 3 Checkout Link error tests to PHPUnit and add a logged-in browser test

### DIFF
--- a/plugins/woocommerce/changelog/testops-288-checkout-link
+++ b/plugins/woocommerce/changelog/testops-288-checkout-link
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Reduce Checkout Link E2E tests from 5 to 3 and rewrite CheckoutLinkTest from 2 methods to 9; PHPUnit owns the invalid coupon, invalid product and malformed list cases, and a new browser test covers the logged-in redirect.

--- a/plugins/woocommerce/tests/e2e/tests/checkout/checkout-link.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/checkout/checkout-link.spec.ts
@@ -7,13 +7,10 @@ import { faker } from '@faker-js/faker';
 /**
  * Internal dependencies
  */
-import {
-	expect,
-	tags,
-	test as baseTest,
-	guestFile,
-} from '../../fixtures/fixtures';
+import { expect, tags, test as baseTest } from '../../fixtures/fixtures';
+import { CUSTOMER_STATE_PATH } from '../../playwright.config';
 import { getFakeProduct } from '../../utils/data';
+import { guestFile } from '../../utils/blocks/constants';
 
 const test = baseTest.extend( {
 	products: async ( { restApi }, use ) => {
@@ -74,95 +71,24 @@ test.describe( 'Checkout Link Endpoint', () => {
 			'Guest user redirected to checkout with correct cart',
 			{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 			async ( { page, baseURL, products, coupon } ) => {
-				// Visit checkout-link
 				const checkoutLink = `${ baseURL }/checkout-link?products=${ products[ 0 ].id },${ products[ 1 ].id }&coupon=${ coupon.code }`;
 				await page.goto( checkoutLink );
 
-				// Should redirect to checkout
 				await expect( page ).toHaveURL( /\/checkout/ );
+				const session = new URL( page.url() ).searchParams.get(
+					'session'
+				);
+				expect( session ).not.toBeNull();
+				expect( session ).not.toBe( '' );
 
-				// Assert both products are in the cart
 				const cartItems = page.locator(
 					'.wc-block-components-order-summary'
 				);
 				await expect( cartItems ).toContainText( products[ 0 ].name );
 				await expect( cartItems ).toContainText( products[ 1 ].name );
 
-				// Assert coupon is applied
 				await expect(
 					page.getByText( `Coupon: ${ coupon.code }` )
-				).toBeVisible();
-			}
-		);
-
-		test(
-			'Guest user sees error when invalid coupon is applied',
-			{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
-			async ( { page, baseURL, products } ) => {
-				// Visit checkout-link with invalid coupon
-				const checkoutLink = `${ baseURL }/checkout-link?products=${ products[ 0 ].id },${ products[ 1 ].id }&coupon=INVALID_COUPON`;
-				await page.goto( checkoutLink );
-
-				// Should redirect to checkout
-				await expect( page ).toHaveURL( /\/checkout/ );
-
-				// Assert both products are in the cart
-				const cartItems = page.locator(
-					'.wc-block-components-order-summary'
-				);
-				await expect( cartItems ).toContainText( products[ 0 ].name );
-				await expect( cartItems ).toContainText( products[ 1 ].name );
-
-				// Assert error notice is shown for invalid coupon
-				await expect(
-					page.getByText(
-						'Coupon "INVALID_COUPON" cannot be applied because it does not exist.'
-					)
-				).toBeVisible();
-			}
-		);
-
-		test(
-			'Guest user sees error when invalid products are provided',
-			{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
-			async ( { page, baseURL, products } ) => {
-				// Visit checkout-link with invalid product ID in list.
-				const checkoutLink = `${ baseURL }/checkout-link?products=${ products[ 0 ].id },999999`;
-				await page.goto( checkoutLink );
-
-				// Should redirect to checkout
-				await expect( page ).toHaveURL( /\/checkout/ );
-
-				// Assert error notice is shown for invalid product
-				await expect(
-					page.getByText(
-						'Product with ID "999999" was not found and cannot be added to the cart.'
-					)
-				).toBeVisible();
-			}
-		);
-
-		test(
-			'Guest user sees error when invalid product is provided',
-			{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
-			async ( { page, baseURL } ) => {
-				// Visit checkout-link with invalid product ID only.
-				const checkoutLink = `${ baseURL }/checkout-link?products=999999`;
-				await page.goto( checkoutLink );
-
-				// Should redirect to cart if cart is empty.
-				await expect( page ).toHaveURL( /\/cart/ );
-
-				// Assert error notice is shown for invalid product
-				await expect(
-					page.getByText(
-						'Product with ID "999999" was not found and cannot be added to the cart.'
-					)
-				).toBeVisible();
-
-				// Cart should be empty
-				await expect(
-					page.getByText( 'Your cart is currently empty!' )
 				).toBeVisible();
 			}
 		);
@@ -171,23 +97,47 @@ test.describe( 'Checkout Link Endpoint', () => {
 			'Guest user sees error when invalid link is provided',
 			{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 			async ( { page, baseURL } ) => {
-				// Visit checkout-link with invalid product ID only.
 				const checkoutLink = `${ baseURL }/checkout-link?products=abc`;
 				await page.goto( checkoutLink );
 
-				// Should redirect to cart if cart is empty.
 				await expect( page ).toHaveURL( /\/cart/ );
 
-				// Assert error notice is shown for invalid product
 				await expect(
 					page.getByText(
 						'The provided checkout link was out of date or invalid. No products were added to the cart.'
 					)
 				).toBeVisible();
 
-				// Cart should be empty
 				await expect(
 					page.getByText( 'Your cart is currently empty!' )
+				).toBeVisible();
+			}
+		);
+	} );
+
+	test.describe( 'Logged-in user', () => {
+		test.use( { storageState: CUSTOMER_STATE_PATH } );
+
+		test(
+			'Logged-in user redirected to checkout with correct cart',
+			{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
+			async ( { page, baseURL, products, coupon } ) => {
+				const checkoutLink = `${ baseURL }/checkout-link?products=${ products[ 0 ].id },${ products[ 1 ].id }&coupon=${ coupon.code }`;
+				await page.goto( checkoutLink );
+
+				await expect( page ).toHaveURL( /\/checkout/ );
+				expect(
+					new URL( page.url() ).searchParams.get( 'session' )
+				).toBeNull();
+
+				const cartItems = page.locator(
+					'.wc-block-components-order-summary'
+				);
+				await expect( cartItems ).toContainText( products[ 0 ].name );
+				await expect( cartItems ).toContainText( products[ 1 ].name );
+
+				await expect(
+					page.getByText( `Coupon: ${ coupon.code }` )
 				).toBeVisible();
 			}
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
@@ -5,11 +5,167 @@ namespace Automattic\WooCommerce\Tests\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutLink;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
+use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
 
 /**
  * Unit tests for CheckoutLink.
  */
 class CheckoutLinkTest extends \WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CheckoutLink
+	 */
+	private $sut;
+
+	/**
+	 * Product IDs created by a test.
+	 *
+	 * @var int[]
+	 */
+	private $product_ids = array();
+
+	/**
+	 * Coupon IDs created by a test.
+	 *
+	 * @var int[]
+	 */
+	private $coupon_ids = array();
+
+	/**
+	 * Original request globals.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_get;
+
+	/**
+	 * Original cookies.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_cookie;
+
+	/**
+	 * Original query string.
+	 *
+	 * @var string|null
+	 */
+	private $original_query_string;
+
+	/**
+	 * Whether the original query string existed.
+	 *
+	 * @var bool
+	 */
+	private $had_query_string;
+
+	/**
+	 * Original current user ID.
+	 *
+	 * @var int
+	 */
+	private $original_user_id;
+
+	/**
+	 * Original WooCommerce session.
+	 *
+	 * @var \WC_Session
+	 */
+	private $original_session;
+
+	/**
+	 * Original WooCommerce cart.
+	 *
+	 * @var \WC_Cart
+	 */
+	private $original_cart;
+
+	/**
+	 * Filter callback that provides a deterministic Cart URL.
+	 *
+	 * @var \Closure
+	 */
+	private $cart_url_filter;
+
+	/**
+	 * Filter callback that provides a deterministic Checkout URL.
+	 *
+	 * @var \Closure
+	 */
+	private $checkout_url_filter;
+
+	/**
+	 * Set up an isolated checkout-link runtime.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_get          = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->original_cookie       = $_COOKIE;
+		$this->had_query_string      = array_key_exists( 'QUERY_STRING', $_SERVER );
+		$this->original_query_string = $this->had_query_string ? (string) $_SERVER['QUERY_STRING'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$this->original_user_id      = get_current_user_id();
+		$this->original_session      = WC()->session;
+		$this->original_cart         = WC()->cart;
+		$this->sut                   = new CheckoutLink();
+		$this->cart_url_filter       = static function () {
+			return 'https://example.org/test-cart/';
+		};
+		$this->checkout_url_filter   = static function () {
+			return 'https://example.org/test-checkout/';
+		};
+
+		add_filter( 'woocommerce_get_cart_url', $this->cart_url_filter );
+		add_filter( 'woocommerce_get_checkout_url', $this->checkout_url_filter );
+
+		$this->reset_runtime();
+	}
+
+	/**
+	 * Restore global state and delete test fixtures.
+	 */
+	public function tearDown(): void {
+		try {
+			if ( WC()->cart ) {
+				WC()->cart->empty_cart();
+			}
+			wc_clear_notices();
+
+			foreach ( array_reverse( $this->coupon_ids ) as $coupon_id ) {
+				$coupon = new \WC_Coupon( $coupon_id );
+				if ( $coupon->get_id() ) {
+					$coupon->delete( true );
+				}
+			}
+
+			foreach ( array_reverse( $this->product_ids ) as $product_id ) {
+				$product = wc_get_product( $product_id );
+				if ( $product ) {
+					$product->delete( true );
+				}
+			}
+		} finally {
+			remove_filter( 'woocommerce_get_cart_url', $this->cart_url_filter );
+			remove_filter( 'woocommerce_get_checkout_url', $this->checkout_url_filter );
+
+			$_GET    = $this->original_get;
+			$_COOKIE = $this->original_cookie;
+
+			if ( $this->had_query_string ) {
+				$_SERVER['QUERY_STRING'] = $this->original_query_string;
+			} else {
+				unset( $_SERVER['QUERY_STRING'] );
+			}
+
+			wp_set_current_user( $this->original_user_id );
+			WC()->session = $this->original_session;
+			WC()->cart    = $this->original_cart;
+
+			parent::tearDown();
+		}
+	}
+
 	/**
 	 * @testdox Installing-mode requests queue the endpoint rewrite without replacing persisted rules.
 	 */
@@ -50,63 +206,341 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that products and coupon are added and token in url.
+	 * @testdox Adds products and a coupon and includes a guest session token in the Checkout URL.
 	 */
-	public function test_products_and_coupon_are_added_and_token_in_url() {
-		$test_products = [
-			\WC_Helper_Product::create_simple_product(),
-			\WC_Helper_Product::create_simple_product(),
-			\WC_Helper_Product::create_simple_product(),
-		];
-
-		$product_ids = array_map(
-			function ( $product ) {
-				return $product->get_id();
-			},
-			$test_products
+	public function test_products_and_coupon_are_added_and_guest_token_in_url(): void {
+		$product_ids = $this->create_products( 3 );
+		$this->create_coupon( 'test-coupon' );
+		$this->set_request(
+			array(
+				'products'      => implode( ',', $product_ids ),
+				'coupon'        => 'test-coupon',
+				'checkout-link' => '1',
+				'utm_source'    => 'checkout-link-test',
+			)
 		);
 
-		$coupon = CouponHelper::create_coupon( 'test-coupon' );
+		$url   = $this->get_checkout_link();
+		$query = $this->get_url_query( $url );
 
-		$_GET['products'] = implode( ',', $product_ids );
-		$_GET['coupon']   = 'test-coupon';
+		$this->assertSame(
+			array_combine( $product_ids, array( 1, 1, 1 ) ),
+			$this->get_cart_product_quantities(),
+			'The guest cart should contain each requested product with its exact quantity.'
+		);
+		$this->assertSame( array( 'test-coupon' ), WC()->cart->get_applied_coupons(), 'The requested coupon should be applied.' );
+		$this->assertSame( wc_get_checkout_url(), remove_query_arg( array( 'utm_source', 'session' ), $url ), 'The redirect should use the Checkout URL.' );
+		$this->assertSame( 'checkout-link-test', $query['utm_source'] ?? null, 'Unrelated query arguments should be preserved.' );
+		$this->assertArrayNotHasKey( 'products', $query, 'The products argument should be stripped from the redirect.' );
+		$this->assertArrayNotHasKey( 'coupon', $query, 'The coupon argument should be stripped from the redirect.' );
+		$this->assertArrayNotHasKey( 'checkout-link', $query, 'The endpoint argument should be stripped from the redirect.' );
+		$this->assertNotSame( '', $query['session'] ?? '', 'Guest redirects should contain a non-empty session token.' );
+		$this->assertTrue( CartTokenUtils::validate_cart_token( (string) $query['session'] ), 'The guest session token should be valid.' );
+	}
 
-		$service = new class() extends CheckoutLink {
-			/**
-			 * Get the checkout link for testing.
-			 *
-			 * @return string The checkout link.
-			 */
-			public function get_checkout_link_test() {
-				return parent::get_checkout_link();
+	/**
+	 * @testdox Parses quantities, lets the last duplicate win, and discards malformed or zero entries.
+	 */
+	public function test_parses_quantities_and_discards_invalid_entries(): void {
+		$product_ids = $this->create_products( 2 );
+		$this->set_request(
+			array(
+				'products' => sprintf( '%1$d:2,abc,0:4,%2$d:0,%1$d:5,%2$d:3', $product_ids[0], $product_ids[1] ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				$product_ids[0] => 5,
+				$product_ids[1] => 3,
+			),
+			$this->get_products_from_checkout_link(),
+			'Only valid products and quantities should remain, with the final duplicate quantity taking precedence.'
+		);
+	}
+
+	/**
+	 * @testdox Rejects a product list containing only malformed or zero entries.
+	 */
+	public function test_rejects_malformed_product_list(): void {
+		$this->set_request( array( 'products' => 'abc,0,2:0' ) );
+
+		$this->assertFalse( $this->validate_checkout_link(), 'A checkout link without any valid product entries should be rejected.' );
+	}
+
+	/**
+	 * @testdox Keeps valid products and adds the exact notice when a coupon is invalid.
+	 */
+	public function test_invalid_coupon_keeps_valid_products_and_adds_exact_notice(): void {
+		$product_id = $this->create_products( 1 )[0];
+		$this->set_request(
+			array(
+				'products' => (string) $product_id,
+				'coupon'   => 'INVALID_COUPON',
+			)
+		);
+
+		$url = $this->get_checkout_link();
+
+		$this->assertSame( array( $product_id => 1 ), $this->get_cart_product_quantities(), 'The valid product should remain in the cart.' );
+		$this->assertSame( array(), WC()->cart->get_applied_coupons(), 'An invalid coupon should not be applied.' );
+		$this->assertSame( wc_get_checkout_url(), remove_query_arg( 'session', $url ), 'A valid cart should redirect to Checkout.' );
+		$this->assertSame(
+			array( 'Coupon &quot;invalid_coupon&quot; cannot be applied because it does not exist.' ),
+			$this->get_error_notice_messages(),
+			'The invalid coupon notice should be exact.'
+		);
+	}
+
+	/**
+	 * @testdox Keeps valid products and adds the exact notice when another product is missing.
+	 */
+	public function test_missing_product_keeps_valid_product_and_adds_exact_notice(): void {
+		$product_id = $this->create_products( 1 )[0];
+		$this->set_request( array( 'products' => $product_id . ',999999' ) );
+
+		$url = $this->get_checkout_link();
+
+		$this->assertSame( array( $product_id => 1 ), $this->get_cart_product_quantities(), 'The valid product should remain in the cart.' );
+		$this->assertSame( wc_get_checkout_url(), remove_query_arg( 'session', $url ), 'A valid cart should redirect to Checkout.' );
+		$this->assertSame(
+			array( 'Product with ID &quot;999999&quot; was not found and cannot be added to the cart.' ),
+			$this->get_error_notice_messages(),
+			'The missing-product notice should be exact.'
+		);
+	}
+
+	/**
+	 * @testdox Uses the query string for a missing-product error when no session exists.
+	 */
+	public function test_only_missing_product_without_session_uses_query_error(): void {
+		$this->set_request( array( 'products' => '999999' ) );
+
+		$url   = $this->get_checkout_link();
+		$query = $this->get_url_query( $url );
+
+		$this->assertSame( wc_get_cart_url(), remove_query_arg( 'wc_error', $url ), 'An empty cart should redirect to the Cart URL.' );
+		$this->assertSame(
+			'Product with ID &quot;999999&quot; was not found and cannot be added to the cart.',
+			$query['wc_error'] ?? null,
+			'The missing-product error should be transported in the URL without a session.'
+		);
+		$this->assertSame( array(), WC()->cart->get_cart(), 'The cart should remain empty.' );
+		$this->assertSame( array(), $this->get_error_notice_messages(), 'No notice should be queued without a session.' );
+	}
+
+	/**
+	 * @testdox Queues missing-product and generic errors when an established session exists.
+	 */
+	public function test_only_missing_product_with_session_queues_notices(): void {
+		$session = $this->get_session_handler();
+		$session->set_customer_session_cookie( true );
+		$this->set_request( array( 'products' => '999999' ) );
+
+		$url = $this->get_checkout_link();
+
+		$this->assertSame( wc_get_cart_url(), $url, 'An empty cart with a session should redirect to the Cart URL without query transport.' );
+		$this->assertArrayNotHasKey( 'wc_error', $this->get_url_query( $url ), 'The error should not be duplicated in the URL.' );
+		$this->assertSame( array(), WC()->cart->get_cart(), 'The cart should remain empty.' );
+		$this->assertSame(
+			array(
+				'Product with ID &quot;999999&quot; was not found and cannot be added to the cart.',
+				'The provided checkout link was out of date or invalid. No products were added to the cart.',
+			),
+			$this->get_error_notice_messages(),
+			'Both empty-cart errors should be queued in order.'
+		);
+	}
+
+	/**
+	 * @testdox Omits the session token for a logged-in customer while preserving products and coupon.
+	 */
+	public function test_logged_in_checkout_omits_session_token(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+		$this->reset_runtime( $user_id );
+
+		$product_ids = $this->create_products( 2 );
+		$this->create_coupon( 'logged-in-coupon' );
+		$this->set_request(
+			array(
+				'products' => implode( ',', $product_ids ),
+				'coupon'   => 'logged-in-coupon',
+			)
+		);
+
+		$url = $this->get_checkout_link();
+
+		$this->assertSame(
+			array_combine( $product_ids, array( 1, 1 ) ),
+			$this->get_cart_product_quantities(),
+			'The logged-in cart should contain each requested product.'
+		);
+		$this->assertSame( array( 'logged-in-coupon' ), WC()->cart->get_applied_coupons(), 'The requested coupon should be applied.' );
+		$this->assertSame( wc_get_checkout_url(), $url, 'A logged-in customer should receive the Checkout URL without a session token.' );
+		$this->assertArrayNotHasKey( 'session', $this->get_url_query( $url ), 'Logged-in redirects should not contain a session token.' );
+	}
+
+	/**
+	 * Reset WooCommerce cart and session state.
+	 *
+	 * @param int $user_id Current user ID.
+	 * @return void
+	 */
+	private function reset_runtime( int $user_id = 0 ): void {
+		wp_set_current_user( $user_id );
+		$_GET = array();
+
+		foreach ( array_keys( $_COOKIE ) as $cookie_name ) {
+			if ( str_starts_with( $cookie_name, 'wp_woocommerce_session_' ) ) {
+				unset( $_COOKIE[ $cookie_name ] );
 			}
-		};
-
-		$url = $service->get_checkout_link_test();
-
-		$cart_contents    = WC()->cart->get_cart();
-		$cart_product_ids = array_map(
-			function ( $item ) {
-				return $item['product_id'];
-			},
-			$cart_contents
-		);
-
-		$applied_coupons      = WC()->cart->get_coupons();
-		$applied_coupon_codes = array_map(
-			function ( $coupon ) {
-				return $coupon->get_code();
-			},
-			$applied_coupons
-		);
-
-		$this->assertEquals( array_values( $product_ids ), array_values( $cart_product_ids ) );
-		$this->assertEquals( array_values( [ 'test-coupon' ] ), array_values( $applied_coupon_codes ) );
-		$this->assertStringContainsString( 'session=', $url );
-
-		// Clean up.
-		foreach ( $test_products as $product ) {
-			wp_delete_post( $product->get_id(), true );
 		}
+
+		WC()->session = new \WC_Session_Handler();
+		WC()->session->init_session_cookie();
+		WC()->cart = new \WC_Cart();
+		wc_clear_notices();
+	}
+
+	/**
+	 * Create simple products and track them for cleanup.
+	 *
+	 * @param int $count Number of products.
+	 * @return int[]
+	 */
+	private function create_products( int $count ): array {
+		$product_ids = array();
+
+		for ( $index = 0; $index < $count; $index++ ) {
+			$product_id          = \WC_Helper_Product::create_simple_product()->get_id();
+			$product_ids[]       = $product_id;
+			$this->product_ids[] = $product_id;
+		}
+
+		return $product_ids;
+	}
+
+	/**
+	 * Create a coupon and track it for cleanup.
+	 *
+	 * @param string $code Coupon code.
+	 * @return \WC_Coupon
+	 */
+	private function create_coupon( string $code ): \WC_Coupon {
+		$coupon             = CouponHelper::create_coupon( $code );
+		$this->coupon_ids[] = $coupon->get_id();
+
+		return $coupon;
+	}
+
+	/**
+	 * Set request globals from query arguments.
+	 *
+	 * @param array<string, string> $query Request arguments.
+	 * @return void
+	 */
+	private function set_request( array $query ): void {
+		$_GET                    = $query;
+		$_SERVER['QUERY_STRING'] = http_build_query( $query );
+	}
+
+	/**
+	 * Get product quantities from the cart.
+	 *
+	 * @return array<int, int>
+	 */
+	private function get_cart_product_quantities(): array {
+		$quantities = array();
+
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			$quantities[ (int) $cart_item['product_id'] ] = (int) $cart_item['quantity'];
+		}
+
+		return $quantities;
+	}
+
+	/**
+	 * Get decoded query arguments from a URL.
+	 *
+	 * @param string $url URL to parse.
+	 * @return array<string, string>
+	 */
+	private function get_url_query( string $url ): array {
+		$query        = array();
+		$scalar_query = array();
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+
+		foreach ( $query as $key => $value ) {
+			if ( is_string( $key ) && is_string( $value ) ) {
+				$scalar_query[ $key ] = $value;
+			}
+		}
+
+		return $scalar_query;
+	}
+
+	/**
+	 * Get queued error notice messages.
+	 *
+	 * @return string[]
+	 */
+	private function get_error_notice_messages(): array {
+		return array_values( wp_list_pluck( wc_get_notices( 'error' ), 'notice' ) );
+	}
+
+	/**
+	 * Get the real isolated session handler.
+	 *
+	 * @return \WC_Session_Handler
+	 */
+	private function get_session_handler(): \WC_Session_Handler {
+		$session = WC()->session;
+
+		if ( ! $session instanceof \WC_Session_Handler ) {
+			throw new \RuntimeException( 'The isolated Checkout Link runtime requires WC_Session_Handler.' );
+		}
+
+		return $session;
+	}
+
+	/**
+	 * Invoke a protected CheckoutLink method through a reusable test seam.
+	 *
+	 * @param string $method Method name.
+	 * @return mixed
+	 */
+	private function invoke_checkout_link_method( string $method ) {
+		$reflection = new \ReflectionMethod( $this->sut, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( $this->sut );
+	}
+
+	/**
+	 * Get parsed checkout-link products.
+	 *
+	 * @return array<int, int>
+	 */
+	private function get_products_from_checkout_link(): array {
+		return (array) $this->invoke_checkout_link_method( 'get_products_from_checkout_link' );
+	}
+
+	/**
+	 * Validate the checkout-link request.
+	 *
+	 * @return bool
+	 */
+	private function validate_checkout_link(): bool {
+		return (bool) $this->invoke_checkout_link_method( 'validate_checkout_link' );
+	}
+
+	/**
+	 * Build the checkout-link redirect.
+	 *
+	 * @return string
+	 */
+	private function get_checkout_link(): string {
+		return (string) $this->invoke_checkout_link_method( 'get_checkout_link' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Checkout Link endpoint had five browser tests, and three of them drove a real page load to find out what the endpoint does with a bad request: an invalid coupon, a list containing a missing product, and a malformed product list. Those are decisions the endpoint makes before anything renders, so they move to `CheckoutLinkTest`.

Refs TESTOPS-288

Part of the #68046 split.

The spec goes from 5 titles to 3. `CheckoutLinkTest` goes from 2 methods to 9.

This is not a pure migration, and the table below should be read with that in mind: it removes three browser titles, strengthens one that stays, and **adds** a browser title for a case that had no working coverage at all.

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `Guest user sees error when invalid coupon is applied` | `CheckoutLinkTest::test_invalid_coupon_keeps_valid_products_and_adds_exact_notice` | The rendered notice. The PHP test asserts which notice is queued and that the valid products survive alongside it; it never renders the cart page. |
| `Guest user sees error when invalid products are provided` | `test_missing_product_keeps_valid_product_and_adds_exact_notice`, plus `test_only_missing_product_without_session_uses_query_error` and `test_only_missing_product_with_session_queues_notices` | Same: the notice is proven as data, not as markup. |
| `Guest user sees error when invalid product is provided` | `test_rejects_malformed_product_list` and `test_parses_quantities_and_discards_invalid_entries` | Same. |

#### What is added, not moved

`Logged-in user redirected to checkout with correct cart` is new. A describe block claiming to cover the logged-in case existed before and was removed in #68207, because it ran with no storage state and therefore exercised the guest path a second time. This one uses the real customer state and asserts the redirect carries **no** session token, which is the difference that matters between the two paths.

`test_products_and_coupon_are_added_and_token_in_url` is renamed to `..._and_guest_token_in_url` and rewritten. It is strictly stronger: three assertions become nine, `assertEquals` becomes `assertSame`, the stripped query arguments are checked one by one, and the session token is validated through `CartTokenUtils` rather than matched as the substring `session=`. That rewrite is the source of the 44 deleted lines in the diff; no test is lost.

#### One contract still belongs to the browser

Worth naming rather than leaving for a reviewer to discover. After this PR, the invalid-link redirect query key is observed **only** by the retained `Guest user sees error when invalid link is provided`. Renaming that `wc_error` key turns the browser title red and leaves the whole of `CheckoutLinkTest` green, so the PHP layer does not cover it. That is correct — it is a redirect-and-render contract — but it means the title is load-bearing and should not be removed later without replacing it.

#### A note on the collision in the batch plan

This batch was recorded as colliding with #68207 and needing its remainder re-derived against trunk. It does not. #68207's merge commit is an ancestor of this work's own diff base, so it is already accounted for, and trunk has no commit touching either file since. The diff against trunk and the diff against the migration base are byte-identical.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
3. Run the PHP class: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'CheckoutLinkTest'`. Expect `OK (9 tests, 33 assertions)`. On `trunk` the same command gives `OK (2 tests, 6 assertions)`.
4. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
5. Run the spec with retries disabled: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=core-parallel --retries=0 --workers=1 tests/e2e/tests/checkout/checkout-link.spec.ts`. Expect `5 passed` — the 3 titles plus the `global authentication` and `site setup` projects. Do not add `--no-deps`: every title in this spec needs `site setup`, and the logged-in one needs the authentication project to refresh the customer storage state.
6. Confirm the PHP tests detect a real regression. In `plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php`, in `get_products_from_checkout_link`, change `$products[ $product_id ] = $qty;` to `$products[ $product_id ] = 1;`. Re-run step 3 and expect `test_parses_quantities_and_discards_invalid_entries` to fail. Revert.
7. Confirm the new logged-in title detects a real regression. In the same file, change `if ( ! is_user_logged_in() ) {` to `if ( true ) {` so a logged-in redirect also carries a guest token. Re-run step 5 and expect `Logged-in user redirected to checkout with correct cart` to fail on the session assertion. Revert.
8. Confirm the retained invalid-link title still guards the redirect query key. In the same file, in `handle_checkout_link_endpoint`, change the `add_query_arg( 'wc_error', … )` key to anything else — the one carrying "The provided checkout link was out of date or invalid", not the one in `get_checkout_link`. Re-run step 5 and expect that title to fail because the notice never renders. Revert. Note that a re-run started immediately after a failing run can fail again on stale bytecode; give it a few seconds before concluding the revert did not take.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress, with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Extraction.** Both files are byte-identical to the migration branch, and neither path has a trunk commit since the migration base, so nothing had to be merged.
- **Retained titles.** `5 passed` at `--retries=0 --workers=1`, on two full runs of the spec.
- **Lower layer, measured on both sides.** `CheckoutLinkTest` is `OK (9 tests, 33 assertions)` here against `OK (2 tests, 6 assertions)` on trunk, both run in the same environment. Each new method was also exercised individually through its own focused filter, and each was checked to have executed a real test rather than matching nothing — a filter that matches no test also exits 0.
- **Mutation re-check, all 10 behavior families.** Eight were killed directly at their own layer, each turning its focused command red at the assertion the mutation matrix names and going green again on revert.
- **Two of those took a second attempt, and the first attempt was wrong.** The guest-session-token and product-loop mutations initially appeared to survive the browser, and I wrote that up as coverage having moved to the PHP layer. It had not: those runs had executed stale bytecode. Both turn the guest title red once the container is confirmed to hold the mutated file, and both go green on revert. The tests were right and the measurement was wrong.
- **Four contracts are now covered at both layers.** Applying the session-token, product-loop, coupon and logged-in-guard mutations also turns `CheckoutLinkTest` red, so those four are caught in PHP as well as in the browser.
- **The Blocks empty-cart mutation needed a bundle rebuild**, and the built bundle was searched for the mutated string before either the red or the green was trusted.
- **Stability.** The two retained guest titles were each run repeatedly on their own before their mutation results were accepted: the invalid-link title three times, the cart title four times, all passing. The invalid-link title is the sole observer for one behavior family, which is why it was measured rather than assumed.
- **Lint.** `oxlint` exits 0 on the changed spec. `lint:changes:branch` exits 0 with no errors and two warnings, both `react-hooks/rules-of-hooks` false positives on Playwright's `use()` inside the fixture block — which is byte-identical to trunk's and untouched here; they surface only because the file changed.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; the only PHP file here is a test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-288-checkout-link`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

