### PR TITLE
[tests] Add Jest and browser coverage for the Customer Account block

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-customer-account-block
+++ b/plugins/woocommerce/changelog/testops-234-customer-account-block
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the Customer Account block's sidebar settings, and a browser test for the accessible name its link exposes to a logged-in customer, which nothing covered before.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/test/sidebar-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/test/sidebar-settings.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { BlockSettings } from '../sidebar-settings';
+import { DisplayStyle, IconStyle } from '../types';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	InspectorControls: jest.fn( ( { children } ) => <div>{ children }</div> ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	...jest.requireActual( '@wordpress/components' ),
+	__experimentalToggleGroupControl: jest.fn( ( { children } ) => (
+		<div>{ children }</div>
+	) ),
+	__experimentalToggleGroupControlOption: jest.fn( () => null ),
+} ) );
+
+describe( 'Customer Account sidebar settings', () => {
+	it.each( [
+		{
+			option: 'Icon and text',
+			initialDisplayStyle: DisplayStyle.TEXT_ONLY,
+			expectedDisplayStyle: DisplayStyle.ICON_AND_TEXT,
+		},
+		{
+			option: 'Text-only',
+			initialDisplayStyle: DisplayStyle.ICON_ONLY,
+			expectedDisplayStyle: DisplayStyle.TEXT_ONLY,
+		},
+		{
+			option: 'Icon-only',
+			initialDisplayStyle: DisplayStyle.ICON_AND_TEXT,
+			expectedDisplayStyle: DisplayStyle.ICON_ONLY,
+		},
+	] )(
+		'maps "$option" to its serialized display style',
+		async ( { option, initialDisplayStyle, expectedDisplayStyle } ) => {
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<BlockSettings
+					attributes={ {
+						displayStyle: initialDisplayStyle,
+						iconStyle: IconStyle.DEFAULT,
+						iconClass: 'wc-block-customer-account__account-icon',
+					} }
+					setAttributes={ setAttributes }
+				/>
+			);
+
+			const displayStyleSelect = screen.getByRole( 'combobox', {
+				name: 'Icon options',
+			} );
+			const targetOption = screen.getByRole( 'option', {
+				name: option,
+			} );
+
+			await user.selectOptions( displayStyleSelect, targetOption );
+
+			expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				displayStyle: expectedDisplayStyle,
+			} );
+		}
+	);
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-customer-account-block
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-customer-account-block
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the Customer Account block's sidebar settings, and a browser test for the accessible name its link exposes to a logged-in customer, which nothing covered before.

--- a/plugins/woocommerce/tests/e2e/tests/blocks/customer-account/customer-account.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/customer-account/customer-account.block_theme.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@woocommerce/e2e-utils';
+
+const blockData = {
+	name: 'woocommerce/customer-account',
+	selectors: {
+		frontend: {
+			icon: 'svg',
+			label: '.label',
+		},
+	},
+};
+
+test.describe( `${ blockData.name } Block`, () => {
+	test( 'Icon Options can be set to Icon-only', async ( {
+		admin,
+		editor,
+		page,
+		frontendUtils,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.name } );
+		await editor.insertBlock( { name: blockData.name } );
+
+		const editorBlocks = await editor.getBlockByName( blockData.name );
+		await expect( editorBlocks ).toHaveCount( 2 );
+		await editorBlocks.nth( 1 ).click();
+
+		const iconOptions = page.getByRole( 'combobox', {
+			name: 'Icon options',
+		} );
+		await expect( iconOptions ).toHaveValue( 'icon_and_text' );
+		await iconOptions.selectOption( { label: 'Icon-only' } );
+		await expect( iconOptions ).toHaveValue( 'icon_only' );
+
+		await editor.publishAndVisitPost();
+
+		// We have specified the parent block name as 'main' to ensure that the
+		// block is found within the main content area of the page and not the hooked block in the header.
+		const blocks = await frontendUtils.getBlockByName(
+			blockData.name,
+			'main'
+		);
+		await expect( blocks ).toHaveCount( 2 );
+
+		const defaultBlock = blocks.nth( 0 );
+		await expect(
+			defaultBlock.locator( blockData.selectors.frontend.label )
+		).toBeVisible();
+		await expect(
+			defaultBlock.locator( blockData.selectors.frontend.icon )
+		).toBeVisible();
+
+		const iconOnlyBlock = blocks.nth( 1 );
+		await expect(
+			iconOnlyBlock.locator( blockData.selectors.frontend.label )
+		).toHaveCount( 0 );
+		await expect(
+			iconOnlyBlock.locator( blockData.selectors.frontend.icon )
+		).toBeVisible();
+		await expect(
+			iconOnlyBlock.getByRole( 'link', {
+				name: 'My Account',
+				exact: true,
+			} )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Customer Account block's **editor settings** have no test anywhere, and the accessible name its link renders for a logged-in customer has none either. This adds a Jest suite for the first and one browser title for the second.

Refs TESTOPS-234

Part of the #68046 split.

Four files — two tests and two changelog entries — with 151 insertions and **zero deletions**. No test is removed and no production code changes.

`CustomerAccountTest` already covers the block's rendering on `trunk` and is untouched here — this PR is not claiming the block was untested.

#### What the suite covers

`BlockSettings` is rendered with `InspectorControls` and the experimental toggle-group control stubbed, each option is chosen through a real `user-event` interaction, and the exact value handed to `setAttributes` is asserted. Three cases, one per display style: icon and text, text-only, icon-only.

That is a more precise claim than the browser spec made. The spec checked what the block rendered after the setting changed; these check the attribute that gets serialized, which is the thing the editor actually persists.

#### One browser title, in a file `trunk` deleted — and it is new coverage, not restored coverage

This needs stating precisely, because the short version would be misleading.

`customer-account.block_theme.spec.ts` held three titles and was removed from `trunk` in #68122 as redundant. Separately, the migration branch rewrote that same file down to one title and, in doing so, **added an assertion the three originals never had**: that the block's link exposes the accessible name "My Account" to a logged-in customer. `git show` at the migration base confirms no such assertion existed there.

So this PR is not reversing the deletion or resurrecting something that was judged redundant. The three titles that were deleted did not contain this check. What lands here is coverage that has never existed on `trunk`, which happens to live at a path `trunk` deleted.

It is worth having, and that is measured rather than argued. `CustomerAccount::render_label` returns "My Account" for a logged-in customer and "Login" otherwise. Change that string to "Account" and `CustomerAccountTest` stays green — `OK (6 tests, 15 assertions)` — because `test_display_style` only asserts that `class="label"` and `aria-label=` are **present**, never what they contain. The title added here fails on exactly that change, at `getByRole( 'link', { name: 'My Account', exact: true } )`.

If you would rather that contract stayed uncovered, or would rather it were covered in PHP than in a browser, dropping this file leaves the Jest suite standing on its own.

#### Where this differs from the TESTOPS-234 audit

This is one of the audit's disputed files, and the dispute is internal to the audit itself: `customer-account` appears in **both** the "pure E2E" list and the "start here" list, which are contradictory recommendations for the same file. Trunk then resolved it a third way by deleting the spec outright rather than keeping it or migrating it.

This PR takes no position on which was right. It observes that one rendered contract has no test anywhere and adds the title that covers it, alongside the unit coverage the editor side never had.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the suite. No environment is needed — it is jsdom only.
   `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js assets/js/blocks/customer-account/test/sidebar-settings.tsx --runInBand`
   Expect `Tests: 3 passed, 3 total`.
3. Start and seed the E2E environment for Blocks: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`. Then run the added title: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/customer-account/customer-account.block_theme.spec.ts`. Expect `2 passed`.
4. Confirm the added title earns its place. In `plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php`, in `render_label`, change `__( 'My Account', 'woocommerce' )` to `__( 'Account', 'woocommerce' )`. Re-run step 3 and expect a failure at `getByRole( 'link', { name: 'My Account', exact: true } )`. With the same edit in place run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'CustomerAccountTest'` and see it still pass — that is the gap this title covers. Revert.
5. Confirm the Jest suite detects a real regression. In `plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/sidebar-settings.tsx`, change `setAttributes( { displayStyle: value } );` to `setAttributes( {} );`. Re-run step 2 and expect all three cases to fail on the argument passed to `setAttributes`. Revert. No rebuild is needed; Jest transpiles the source directly.
6. Confirm nothing was taken away: `git diff trunk...HEAD --numstat` should show no deleted lines in any file.

<!-- End testing instructions -->

### Testing that has already taken place:

- **Extraction.** Both files are byte-identical to the migration branch's copies. The two modules the Jest suite imports, `sidebar-settings.tsx` and `types.ts`, are byte-identical between `trunk` and the migration branch, so it is additive against unchanged production code.
- **Focused lower-layer runs.** All three focused commands from the mutation matrix exit 0, and the suite as a whole reports `3 passed`.
- **Mutation re-check, the one behavior family.** Dropping the `displayStyle` attribute from the `setAttributes` call turns all three cases red on the argument assertion, and reverting turns them green.
- **Mutation re-check, the second behavior family.** Changing `render_label`'s logged-in string turns the restored browser title red at the accessible-name assertion, and reverting turns it green. The container was confirmed to hold the mutated file before the red was trusted. The same mutation leaves `CustomerAccountTest` green, which is what establishes the title is covering something nothing else does.
- **The added title.** `--list` shows exactly the one title; the spec runs `2 passed` at `--retries=0 --workers=1`, the second being the `blocks setup` project.
- **Lint.** `oxlint` exits 0 on both changed files. `lint:changes:branch` exits 0 with no findings.
- **PHPStan: nothing to run.** This batch changes no PHP file. `CustomerAccountTest` was run only as the control described above.
- **Dangling-reference sweep: nothing to sweep.** The batch deletes no file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-customer-account-block` and `plugins/woocommerce/client/blocks/changelog/testops-234-customer-account-block`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

