### PR TITLE
[tests] Add Jest coverage for Catalog Sorting block registration

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-catalog-sorting
+++ b/plugins/woocommerce/changelog/testops-234-catalog-sorting
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the Catalog Sorting block's registration, dynamic save callback and editor placeholder. No E2E test is removed.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/test/index.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { registerBlockType } from '@wordpress/blocks';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../block.json';
+import Edit from '../edit';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children }: { children: ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	useBlockProps: ( props: Record< string, unknown > ) => props,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Disabled: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	ToggleControl: () => null,
+	__experimentalToolsPanel: ( { children }: { children: ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	__experimentalToolsPanelItem: ( { children }: { children: ReactNode } ) => (
+		<div>{ children }</div>
+	),
+} ) );
+
+type RegisteredBlock = {
+	attributes: typeof metadata.attributes;
+	edit: unknown;
+	save: () => null;
+};
+
+const loadRegisteredBlock = () => {
+	let isolatedEdit: unknown;
+
+	jest.isolateModules( () => {
+		isolatedEdit = (
+			jest.requireActual( '../edit' ) as {
+				default: unknown;
+			}
+		 ).default;
+		jest.requireActual( '../index' );
+	} );
+
+	expect( registerBlockType ).toHaveBeenCalledTimes( 1 );
+	const [ registeredMetadata, settings ] = ( registerBlockType as jest.Mock )
+		.mock.calls[ 0 ];
+
+	expect( registeredMetadata ).toEqual( metadata );
+	expect( registeredMetadata.name ).toBe( 'woocommerce/catalog-sorting' );
+	expect( settings.attributes ).toEqual( metadata.attributes );
+
+	return {
+		registeredMetadata,
+		settings: settings as RegisteredBlock,
+		isolatedEdit,
+	};
+};
+
+describe( 'Catalog Sorting block registration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'registers the real editor component', () => {
+		const { registeredMetadata, settings, isolatedEdit } =
+			loadRegisteredBlock();
+
+		expect( registeredMetadata ).toEqual( metadata );
+		expect( registeredMetadata.name ).toBe( 'woocommerce/catalog-sorting' );
+		expect( settings.attributes ).toEqual( metadata.attributes );
+		expect( settings.edit ).toBe( isolatedEdit );
+	} );
+
+	it( 'registers a dynamic save callback that returns null', () => {
+		const { settings } = loadRegisteredBlock();
+
+		expect( settings.save() ).toBeNull();
+	} );
+} );
+
+describe( 'Catalog Sorting editor placeholder', () => {
+	it( 'renders the default sorting option without a visual label', () => {
+		render(
+			<Edit
+				attributes={ { useLabel: false } }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'option', { name: 'Default sorting' } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-catalog-sorting
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-catalog-sorting
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the Catalog Sorting block's registration, dynamic save callback and editor placeholder. No E2E test is removed.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**This pull request removes no test.** It adds one Jest suite for the Catalog Sorting block's editor behaviour, which had no unit coverage, and leaves the block's single browser test exactly as it is.

Refs TESTOPS-234

Part of the #68046 split.

Three files — one test and two changelog entries — with 110 insertions and **zero deletions**. No production code changes.

#### What the suite covers

Three cases: that the block registers its real `edit` component rather than a stub, that its `save` callback is dynamic and returns `null`, and that the editor placeholder renders the default sorting option without a visual label.

#### Why the browser test is kept, when the migration branch deletes it

The migration branch removes `catalog-sorting.block_theme.spec.ts` on the grounds that the Jest suite replaces it. It does not, and the reason is worth recording because it is not obvious from reading either test.

That browser test asserts on the **editor canvas** — it inserts the block into a template and checks the canvas shows "Default sorting". That looks like something worth improving, and the obvious improvement is to assert on a rendered page instead. I tried that, and withdrew it. The reason is worth stating, because it is about shared test state rather than about this block.

The block does render on the shop archive, when the archive uses the blockified Product Catalog template — which is the default. Measured on this checkout:

| `wc_blocks_use_blockified_product_grid_block_as_template` | `.wc-block-catalog-sorting` on `/shop` |
| --- | --- |
| unset (default) | 2 |
| `false` | 0, and the classic `woocommerce-ordering` markup appears instead |

With the option `false` the archive falls back to the classic template and `woocommerce_catalog_ordering()` takes the legacy path, so the block renders nothing.

**Five specs under `tests/e2e` set that option to `false` and none restores it.** A front-end assertion for this block therefore passes or fails according to what ran before it in the same environment — which is exactly what happened to my attempt: it passed while the option was default, then failed once another run had flipped it.

A front-end test here is achievable, but it has to pin that option itself. That is a deliberate change, not something to slip in while moving unit coverage, so this PR leaves the editor-canvas test alone and keeps it as the block's canary.

> **Correction (2026-09-15):** the shared-state explanation above is wrong. The Blocks E2E `page` fixture resets the database from the `blocks_e2e.sql` snapshot after every test, and that snapshot has no row for this option, so a spec that sets it to `false` cannot change what a later test sees. The measurement in the table still holds. A front-end test would not need to pin the option, but the later failure of the withdrawn attempt is still unexplained, so find its cause before relying on one.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suite. No environment is needed — it is jsdom only.
   `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js assets/js/blocks/catalog-sorting/test/index.tsx --runInBand`
   Expect `Tests: 3 passed, 3 total`.
3. Confirm it detects a broken registration. In `plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/index.tsx`, replace the `edit,` registration property with `edit: () => null,`. Re-run step 2 and expect "registers the real editor component" to fail. Revert. No rebuild is needed; Jest transpiles the source directly.
4. Confirm the save callback case is real. In the same file, change the `return null;` inside `save()` to `return <div />;`. Re-run step 2 and expect "registers a dynamic save callback that returns null" to fail. Revert.
5. Confirm the placeholder case is real. In `.../catalog-sorting/edit.tsx`, change `Default sorting` to `Catalog sorting`. Re-run step 2 and expect "renders the default sorting option without a visual label" to fail. Revert.
6. Confirm the existing browser test still passes, unchanged: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`, then `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/catalog-sorting/catalog-sorting.block_theme.spec.ts`. Expect `2 passed`.
7. Confirm nothing was taken away: `git diff trunk...HEAD --numstat` should show no deleted lines in any file.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Extraction.** The Jest suite is byte-identical to the migration branch's copy. The three modules it imports — `block.json`, `edit.tsx`, `index.tsx` — are byte-identical between `trunk` and the migration branch, so it is additive against unchanged production code.
- **Focused lower-layer runs.** All three focused commands from the mutation matrix exit 0, and the suite reports `3 passed`.
- **Mutation re-check, all three behavior families.** Renaming the placeholder string, stubbing the `edit` registration property, and returning markup from a `save()` that must return `null` each turn their focused command red at the assertion the matrix names, and each goes green on revert.
- **The existing browser test was run on this branch** and passes, `2 passed`, so the block keeps a working browser canary.
- **A front-end canary was attempted and withdrawn, and the reason was measured rather than guessed.** An earlier version of this PR asserted on the rendered shop page. It passed, then failed on a later run with an unchanged tree. Toggling `wc_blocks_use_blockified_product_grid_block_as_template` reproduces both outcomes on demand: unset gives two matches on `/shop`, `false` gives none. Five specs set that option to `false` without restoring it, so the attempt was measuring test-suite state rather than the block. It was withdrawn rather than patched. _Correction, 2026-09-15: the shared-state explanation is wrong; see the correction under "Why the browser test is kept"._
- **Lint.** `oxlint` exits 0 on the new file. `lint:changes:branch` exits 0 with no findings.
- **PHPStan and PHPUnit: nothing to run.** This batch changes no PHP.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-catalog-sorting` and `plugins/woocommerce/client/blocks/changelog/testops-234-catalog-sorting`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


