### PR TITLE
[tests] Add Jest and PHPUnit coverage for the Product Results Count block

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-product-results-count
+++ b/plugins/woocommerce/changelog/testops-234-product-results-count
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the Product Results Count block's registration and PHPUnit coverage for its rendered result count. No E2E test is removed.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-results-count/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-results-count/test/index.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { registerBlockType } from '@wordpress/blocks';
+import type { ComponentType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../block.json';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: ( props: Record< string, unknown > ) => props,
+} ) );
+
+type RegisteredBlock = {
+	edit: ComponentType< Record< string, unknown > >;
+	save: () => null;
+};
+
+const loadRegisteredBlock = (): RegisteredBlock => {
+	jest.isolateModules( () => {
+		jest.requireActual( '../index' );
+	} );
+
+	expect( registerBlockType ).toHaveBeenCalledTimes( 1 );
+	const [ registeredMetadata, settings ] = ( registerBlockType as jest.Mock )
+		.mock.calls[ 0 ];
+
+	expect( registeredMetadata ).toEqual( metadata );
+	expect( registeredMetadata.name ).toBe(
+		'woocommerce/product-results-count'
+	);
+	expect( settings ).not.toHaveProperty( 'attributes' );
+
+	return settings as RegisteredBlock;
+};
+
+describe( 'Product Results Count block registration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'registers its real editor placeholder and dynamic save callback', () => {
+		const { edit: Edit, save } = loadRegisteredBlock();
+
+		render( <Edit /> );
+
+		expect(
+			screen.getByText( 'Showing 1-X of X results' )
+		).toBeInTheDocument();
+		expect( save() ).toBeNull();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-product-results-count
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-product-results-count
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for the Product Results Count block's registration and PHPUnit coverage for its rendered result count. No E2E test is removed.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductResultsCountTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductResultsCountTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WP_HTML_Tag_Processor;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the Product Results Count block type.
+ */
+class ProductResultsCountTest extends WP_UnitTestCase {
+
+	/**
+	 * Whether the WooCommerce loop existed before the test.
+	 *
+	 * @var bool
+	 */
+	private bool $had_woocommerce_loop;
+
+	/**
+	 * WooCommerce loop value before the test.
+	 *
+	 * @var mixed
+	 */
+	private $original_woocommerce_loop;
+
+	/**
+	 * Set up the paginated product loop.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->had_woocommerce_loop      = array_key_exists( 'woocommerce_loop', $GLOBALS );
+		$this->original_woocommerce_loop = $this->had_woocommerce_loop ? $GLOBALS['woocommerce_loop'] : null;
+
+		wc_setup_loop(
+			array(
+				'is_paginated' => true,
+				'total'        => 12,
+				'per_page'     => 4,
+				'current_page' => 2,
+			)
+		);
+	}
+
+	/**
+	 * Restore the WooCommerce loop.
+	 */
+	public function tearDown(): void {
+		wc_reset_loop();
+
+		if ( $this->had_woocommerce_loop ) {
+			$GLOBALS['woocommerce_loop'] = $this->original_woocommerce_loop;
+		} else {
+			unset( $GLOBALS['woocommerce_loop'] );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Renders exact paginated output and query-specific Interactivity attributes.
+	 */
+	public function test_renders_paginated_result_count_with_query_context(): void {
+		$markup = do_blocks(
+			'<!-- wp:query {"queryId":17} --><div class="wp-block-query"><!-- wp:woocommerce/product-results-count /--></div><!-- /wp:query -->'
+		);
+		$p      = new WP_HTML_Tag_Processor( $markup );
+
+		$this->assertTrue( $p->next_tag( array( 'class_name' => 'wc-block-product-results-count' ) ), 'The rendered result count wrapper should exist.' );
+		$this->assertSame( 'woocommerce/product-results-count', $p->get_attribute( 'data-wp-interactive' ), 'The wrapper should declare the Product Results Count Interactivity store.' );
+		$this->assertSame( 'wc-product-results-count-17', $p->get_attribute( 'data-wp-router-region' ), 'The router region should include the inherited query ID.' );
+		$class_tokens = preg_split( '/\s+/', trim( (string) $p->get_attribute( 'class' ) ) );
+		$class_tokens = is_array( $class_tokens ) ? array_values( array_filter( $class_tokens ) ) : array();
+		$this->assertContains( 'woocommerce', $class_tokens, 'The wrapper should include the WooCommerce class.' );
+		$this->assertContains( 'wp-block-woocommerce-product-results-count', $class_tokens, 'The wrapper should include the WordPress block class.' );
+
+		$text = html_entity_decode( wp_strip_all_tags( $markup ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$text = preg_replace( '/\s+/', ' ', trim( $text ) );
+		$this->assertIsString( $text );
+		$this->assertStringContainsString( 'Showing 5–8 of 12 results', $text, 'The block should expose the exact second-page result range.' );
+	}
+
+	/**
+	 * @testdox Uses the default router region when no query context is present.
+	 */
+	public function test_uses_default_router_region_without_query_context(): void {
+		$markup = do_blocks( '<!-- wp:woocommerce/product-results-count /-->' );
+		$p      = new WP_HTML_Tag_Processor( $markup );
+
+		$this->assertTrue( $p->next_tag( array( 'class_name' => 'wc-block-product-results-count' ) ), 'The standalone result count wrapper should exist.' );
+		$this->assertSame( 'wc-product-results-count-0', $p->get_attribute( 'data-wp-router-region' ), 'The standalone router region should use the default query ID.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**This pull request removes no test.** The Product Results Count block had one browser test and nothing underneath it. This adds both missing layers and leaves the browser test alone.

Refs TESTOPS-234

Part of the #68046 split.

Four files — two tests and two changelog entries — with 161 insertions and **zero deletions**. No production code changes.

| New coverage | What it proves |
| --- | --- |
| `product-results-count/test/index.tsx`, 1 case | the block registers its real editor placeholder and a dynamic `save` callback, rather than stubs |
| `ProductResultsCountTest.php`, 2 tests | the paginated result count rendered with a query context, and the default router region used when no query context is supplied |

The PHPUnit class is the more valuable half. This block's logic is its `render()`, and until now nothing exercised it at all.

#### Why the browser test is kept, when the migration branch deletes it

Same reasoning as the Catalog Sorting pull request in this split, and it is worth repeating rather than cross-referencing.

That test asserts on the **editor canvas**. Moving it to the rendered archive looks like the obvious improvement, and it is a trap: whether this block appears on `/shop` depends on `wc_blocks_use_blockified_product_grid_block_as_template`. With the option at its default the blockified Product Catalog template renders the block; with the option `false` the archive falls back to the classic template and the block is absent. **Five specs under `tests/e2e` set that option to `false` and none of them restores it**, so a front-end assertion here reports what ran before it rather than anything about the block.

> **Correction (2026-09-15):** the claim that those five specs leak the option is wrong. The Blocks E2E `page` fixture resets the database from the `blocks_e2e.sql` snapshot after every test, and that snapshot has no row for this option, so each test starts with it unset. The block's dependency on the option is real, but a front-end test would not inherit a `false` from an earlier spec. The second trap below still stands.

There is a second trap specific to this block, for anyone who does write that test later. `render()` opens its wrapper `<div>` **unconditionally** and only then buffers `woocommerce_result_count()`:

```php
ob_start();
echo '<div>';
woocommerce_result_count();
echo '</div>';
```

So the wrapper element, and the block's class, are present even when the count itself is empty. A front-end check that asserts on `.wc-block-product-results-count` being visible would pass against a completely broken count. It has to assert the rendered text.

The PHPUnit tests added here assert the text, which is why they are the right home for this contract today.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suite. No environment is needed — it is jsdom only.
   `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js assets/js/blocks/product-results-count/test/index.tsx --runInBand`
   Expect `Tests: 1 passed, 1 total`.
3. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
4. Run the PHP class: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'ProductResultsCountTest'`. Expect `OK (2 tests, 9 assertions)`.
5. Confirm the PHP tests detect a real regression. In `plugins/woocommerce/src/Blocks/BlockTypes/ProductResultsCount.php`, in `render()`, change `$p->set_attribute( 'data-wp-interactive', $this->get_full_block_name() );` to any other string. Re-run step 4 and expect a failure. Revert.
6. Confirm the Jest case detects a broken registration. In `plugins/woocommerce/client/blocks/assets/js/blocks/product-results-count/index.tsx`, replace the `edit,` registration property with `edit: () => <div />,`. Re-run step 2 and expect it to fail. Revert. No rebuild is needed; Jest transpiles the source directly.
7. Confirm the existing browser test still passes, unchanged: `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`, then `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/product-results-count/product-results-count.block_theme.spec.ts`. Expect `2 passed`.
8. Confirm nothing was taken away: `git diff trunk...HEAD --numstat` should show no deleted lines in any file.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran against a local WordPress with retries disabled and one worker. Trunk was at `adefb5f971`.

- **Extraction.** Both test files are byte-identical to the migration branch's copies. The three modules the Jest suite imports — `block.json`, `edit.tsx`, `index.tsx` — are byte-identical between `trunk` and the migration branch, so it is additive against unchanged production code.
- **Focused lower-layer runs.** All three focused commands from the mutation matrix exit 0, and each PHPUnit filter was checked to have executed a real test rather than matching nothing — a filter that matches no test also exits 0.
- **Suite totals.** Jest `1 passed`; `ProductResultsCountTest` `OK (2 tests, 9 assertions)`.
- **Mutation re-check, all six behavior families, plus one extra.** Five registration mutations on `index.tsx` — a duplicated `registerBlockType` call, a renamed metadata block name, an emptied settings argument, a stubbed `edit`, and a `save()` returning markup instead of `null` — and two on `render()`: changing the interactivity namespace, and changing the router-region fallback from `0` to `1`. Each turns its focused command red at the assertion the matrix names and goes green on revert.
- **The second mutation exists because one per family was not enough here.** Both PHPUnit methods belong to the single `render` behavior family, so the campaign's rule of one kill per family would have left `test_uses_default_router_region_without_query_context` unverified. The router-region mutation covers it: it fails that method specifically.
- **One recorded red was thrown away rather than counted.** An earlier run of the interactivity-namespace mutation exited non-zero, which looks like a kill, but the log shows PHPUnit dying in its bootstrap with an unrelated `ParseError` before reaching any assertion. A non-zero exit at the wrong place is not a kill. Re-run from a verified-clean tree it fails at the intended assertion in `test_renders_paginated_result_count_with_query_context`, and the recorded patch now matches the mutation matrix's text exactly.
- **The existing browser test was run on this branch** and passes, `2 passed`, so the block keeps a working browser canary.
- **Lint.** `oxlint` exits 0 on the new Jest file. `lint:changes:branch` exits 0 with no findings.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; the only changed PHP file is a test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-product-results-count` and `plugins/woocommerce/client/blocks/changelog/testops-234-product-results-count`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


