### PR TITLE
[tests] Cover two more blocks in the unregister-block-types test

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-unregister-block-types
+++ b/plugins/woocommerce/changelog/testops-234-unregister-block-types
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Extend the unregister-block-types unrestricted-context test to cover Catalog Sorting and Product Results Count.

--- a/plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/test/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/test/index.ts
@@ -122,7 +122,9 @@ describe( 'unregister block types', () => {
 		( adminPage ) => {
 			loadFilter( adminPage, [
 				'woocommerce/breadcrumbs',
+				'woocommerce/catalog-sorting',
 				'woocommerce/checkout',
+				'woocommerce/product-results-count',
 				'myplugin/client-only',
 			] );
 

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-unregister-block-types
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-unregister-block-types
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Extend the unregister-block-types unrestricted-context test to cover Catalog Sorting and Product Results Count.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Two block names are added to the input of one existing test case, so that case also proves Catalog Sorting and Product Results Count survive editor contexts that are neither the post editor nor the widgets screen.

Refs TESTOPS-234

Part of the #68046 split.

Three files — one test and two changelog entries — with 8 insertions and **zero deletions**. No production code changes and no test removed.

This is a deliberately small pull request, and the reason it is small is the interesting part.

#### The migration branch makes three changes here; this carries one

`unregister-block-types/test/index.ts` is one of the files in the #68046 migration. Its changes to this file are these:

1. **Adding Catalog Sorting and Product Results Count** to the unrestricted-editor-context case. Carried. Both are in `WIDGET_EDITOR_ALLOWED_BLOCK_TYPES`, so they are the kind of block a regression in context detection would take out. In fairness this is a modest gain: the case asserts `unregisterBlockType` is never called at all, and the fixtures already there would catch such a regression, so the two extra names widen the sample rather than covering anything new.
2. **Reordering two assertions** so `product-reviews` precedes `product-results-count`. Not carried. It is neither alphabetical nor otherwise clearer, so it is noise in a diff.
3. **A `woocommerce/cart` assertion the migration branch does not have.** Not carried, and it is worth explaining because the reason turned out to be simpler than it first looked.

#### The `woocommerce/cart` difference is a stale branch, not a decision

Taking the migration's copy of this file wholesale would drop `woocommerce/cart` from the widgets case, lower the expected unregister count from four to three, and delete the assertion naming the block. That reads like a deliberate removal.

It is not. **#68122 added that coverage to `trunk` after this work branched.** In the widgets case it adds the input entry and the assertion and raises that case's expected count from three to four, as a backfill for an E2E test it deleted. (The same commit also takes the post-editor case from two to four, which is a separate hunk and unrelated to `woocommerce/cart`.) That commit is on `trunk` and is **not** an ancestor of the migration branch, so the migration's copy simply predates it.

The assertion is also correct on its own terms: `block-types.ts` is byte-identical between `trunk` and the migration branch, `woocommerce/cart` is in `WIDGET_EDITOR_ALLOWED_BLOCK_TYPES` in neither, and the widgets branch of `getBlockTypesToUnregister` unregisters every `woocommerce/*` block not in that allow-list.

So checking out the migration's file would have quietly reverted another pull request's backfill. This branch keeps `trunk`'s version and adds only what the migration genuinely contributes.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the suite. No environment is needed — it is jsdom only.
   `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js assets/js/filters/unregister-block-types/test/index.ts --runInBand`
   Expect `Tests: 6 passed, 6 total`.
3. Confirm the suite detects a broken context check. In `plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/index.ts`, in `getBlockEditorContext`, change the fallback `return 'other';` to `return 'post';`. Re-run step 2 and expect the unrestricted-context case to fail, because blocks would then be unregistered where they should not be. Revert.
4. Confirm it detects a broken allow-list check. In the same file, in the `widgets` branch, drop the `!` from `! WIDGET_EDITOR_ALLOWED_BLOCK_TYPES.includes( blockType )` so the filter inverts. Re-run step 2 and expect the widgets case to fail. Revert.
5. Confirm the post-editor branch is covered too. In the same file, in the `post` branch, replace `POST_EDITOR_BLOCK_TYPES_TO_UNREGISTER.filter(` with `[].filter(`. Re-run step 2 and expect "unregisters only post-editor block types in the deny list in post-php" to fail. Revert.
6. Check the `woocommerce/cart` question for yourself. `grep -n "woocommerce/cart'," plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/block-types.ts` returns nothing, so the block is not allow-listed and must be unregistered on the widgets screen. `git log --oneline origin/trunk -1 -- .../unregister-block-types/test/index.ts` shows the commit that added that coverage to trunk after this work branched.

<!-- End testing instructions -->

### Testing that has already taken place:

- **Focused lower-layer runs.** All six focused commands from the mutation matrix exit 0, and the suite reports `6 passed, 6 total`.
- **Mutation re-check, both behavior families and all three context branches.** The matrix groups these rows into two systems under test, but that grouping hides a branch: `getBlockTypesToUnregister` has a post-editor path, a widgets path and a fallback. All three are now covered — emptying the post-editor deny list, inverting the widget allow-list filter, and changing `getBlockEditorContext`'s fallback from `other` to `post`. Each turns its focused command red at the named test and goes green on revert, and each red was checked not to be a module-resolution or suite-load failure, which is a distinct failure mode that also exits non-zero.
- **The declined change was verified rather than assumed.** Blob hashes for `block-types.ts` at `trunk` and at the migration branch, and the absence of `woocommerce/cart` from the allow-list at both, are recorded alongside the evidence.
- **Lint.** `oxlint` exits 0 on the changed file. `lint:changes:branch` exits 0, with one pre-existing `no-require-imports` warning at line 32 of this file that the diff neither introduces nor touches.
- **PHPStan and PHPUnit: nothing to run.** This batch changes no PHP.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-unregister-block-types` and `plugins/woocommerce/client/blocks/changelog/testops-234-unregister-block-types`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

