### PR TITLE
[tests] Add Jest coverage for registering product collections

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-product-collection-registration
+++ b/plugins/woocommerce/changelog/testops-234-product-collection-registration
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for __experimentalRegisterProductCollection, covering falsy-value preservation, invalid-input rejection, prop-injection scoping and reference-context routing. No E2E test is removed.

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-product-collection-registration
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-product-collection-registration
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add Jest coverage for __experimentalRegisterProductCollection, covering falsy-value preservation, invalid-input rejection, prop-injection scoping and reference-context routing. No E2E test is removed.

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/product-collection/test/register-product-collection.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/product-collection/test/register-product-collection.tsx
@@ -1,0 +1,543 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import {
+	getBlockVariations,
+	registerBlockVariation,
+	store as blocksStore,
+	unregisterBlockVariation,
+} from '@wordpress/blocks';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { createRegistry, RegistryProvider, select } from '@wordpress/data';
+import { applyFilters, removeFilter } from '@wordpress/hooks';
+import {
+	__experimentalRegisterProductCollection,
+	type ProductCollectionConfig,
+} from '@woocommerce/blocks-registry';
+import {
+	ProductCollectionUIStatesInEditor,
+	type ProductCollectionAttributes,
+	type ProductCollectionEditComponentProps,
+} from '@woocommerce/blocks/product-collection/types';
+import { useProductCollectionUIState } from '@woocommerce/blocks/product-collection/utils';
+import {
+	LocationType,
+	type WooCommerceBlockLocation,
+} from '@woocommerce/blocks/product-template/utils';
+
+const BLOCK_NAME = 'woocommerce/product-collection';
+const TEST_NAMESPACE = 'test-plugin/product-collection';
+
+type ProbeProps = ProductCollectionEditComponentProps & {
+	location: WooCommerceBlockLocation;
+};
+
+const attemptedCollectionNames = new Set< string >();
+
+const trackAttemptedCollectionName = ( config: unknown ) => {
+	if (
+		config &&
+		typeof config === 'object' &&
+		'name' in config &&
+		typeof config.name === 'string'
+	) {
+		attemptedCollectionNames.add( config.name );
+	}
+};
+
+const registerCollection = ( config: ProductCollectionConfig ) => {
+	trackAttemptedCollectionName( config );
+	__experimentalRegisterProductCollection( config );
+};
+
+const getRegisteredVariation = ( name: string ) => {
+	const variation = getBlockVariations( BLOCK_NAME )?.find(
+		( candidate ) => candidate.name === name
+	);
+
+	if ( ! variation ) {
+		throw new Error( `Expected Product Collection variation "${ name }".` );
+	}
+
+	return variation;
+};
+
+const makeAttributes = ( collection: string, productReference?: number ) =>
+	( {
+		collection,
+		query: productReference === undefined ? {} : { productReference },
+	} ) as ProductCollectionAttributes;
+
+const getRegisteredAttributes = ( name: string, productReference?: number ) => {
+	const attributes = getRegisteredVariation( name )
+		.attributes as ProductCollectionAttributes;
+	const query = { ...attributes.query };
+	if ( productReference !== undefined ) {
+		query.productReference = productReference;
+	}
+
+	return {
+		...attributes,
+		query,
+	};
+};
+
+const makeBlockEditProps = (
+	attributes: ProductCollectionAttributes
+): ProductCollectionEditComponentProps =>
+	( {
+		attributes,
+		clientId: 'test-product-collection',
+		context: {},
+		isSelected: true,
+		name: BLOCK_NAME,
+		setAttributes: jest.fn(),
+	} ) as ProductCollectionEditComponentProps;
+
+const StateProbe = ( { attributes, location, usesReference }: ProbeProps ) => {
+	const { productCollectionUIStateInEditor, isLoading } =
+		useProductCollectionUIState( {
+			attributes,
+			hasInnerBlocks: true,
+			location,
+			usesReference,
+		} );
+
+	return (
+		<output data-testid="collection-state">
+			{ isLoading ? 'loading' : productCollectionUIStateInEditor }
+		</output>
+	);
+};
+
+const renderFilteredState = ( {
+	attributes,
+	location,
+	registry,
+}: {
+	attributes: ProductCollectionAttributes;
+	location: WooCommerceBlockLocation;
+	registry: ReturnType< typeof createRegistry >;
+} ) => {
+	const FilteredStateProbe = applyFilters(
+		'editor.BlockEdit',
+		StateProbe
+	) as typeof StateProbe;
+
+	return render(
+		<RegistryProvider value={ registry }>
+			<FilteredStateProbe
+				{ ...makeBlockEditProps( attributes ) }
+				location={ location }
+			/>
+		</RegistryProvider>
+	);
+};
+
+describe( '__experimentalRegisterProductCollection', () => {
+	const originalWpDescriptor = Object.getOwnPropertyDescriptor(
+		window,
+		'wp'
+	);
+
+	beforeEach( () => {
+		Object.defineProperty( window, 'wp', {
+			configurable: true,
+			writable: true,
+			value: {
+				...window.wp,
+				blocks: {
+					...window.wp?.blocks,
+					registerBlockVariation,
+				},
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		const registeredVariationNames = new Set(
+			getBlockVariations( BLOCK_NAME )?.map(
+				( variation ) => variation.name
+			)
+		);
+		for ( const name of attemptedCollectionNames ) {
+			if ( registeredVariationNames.has( name ) ) {
+				unregisterBlockVariation( BLOCK_NAME, name );
+			}
+			if ( name ) {
+				removeFilter( 'editor.BlockEdit', name );
+			}
+		}
+		attemptedCollectionNames.clear();
+
+		if ( originalWpDescriptor ) {
+			Object.defineProperty( window, 'wp', originalWpDescriptor );
+		} else {
+			Reflect.deleteProperty( window, 'wp' );
+		}
+	} );
+
+	it.each( [
+		{ caseName: 'a null configuration', config: null },
+		{ caseName: 'an empty configuration', config: {} },
+		{
+			caseName: 'an empty name',
+			config: { name: '', title: 'Missing name' },
+		},
+		{
+			caseName: 'an empty title',
+			config: {
+				name: `${ TEST_NAMESPACE }/missing-title`,
+				title: '',
+			},
+		},
+		{
+			caseName: 'a non-array usesReference value',
+			config: {
+				name: `${ TEST_NAMESPACE }/invalid-references`,
+				title: 'Invalid references',
+				usesReference: 'product',
+			},
+		},
+	] )( 'does not register $caseName', ( { config } ) => {
+		const variationsBefore = getBlockVariations( BLOCK_NAME ) || [];
+		const variationNamesBefore = variationsBefore.map(
+			( variation ) => variation.name
+		);
+		trackAttemptedCollectionName( config );
+
+		__experimentalRegisterProductCollection(
+			config as unknown as ProductCollectionConfig
+		);
+
+		const variationsAfter = getBlockVariations( BLOCK_NAME ) || [];
+		expect( variationsAfter ).toHaveLength( variationsBefore.length );
+		expect(
+			variationsAfter.map( ( variation ) => variation.name )
+		).toEqual( variationNamesBefore );
+		expect( variationsAfter ).toEqual( variationsBefore );
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'registers a complete variation while preserving supported falsy values and caller attributes', () => {
+		const name = `${ TEST_NAMESPACE }/complete`;
+		const innerBlocks: ProductCollectionConfig[ 'innerBlocks' ] = [
+			[ 'core/paragraph', { placeholder: 'Collection content' } ],
+		];
+
+		registerCollection( {
+			name,
+			title: 'Complete collection',
+			description: 'A complete public collection.',
+			category: 'woocommerce',
+			keywords: [ 'complete', 'collection' ],
+			scope: [ 'block' ],
+			innerBlocks,
+			attributes: {
+				align: 'wide',
+				displayLayout: {
+					columns: 4,
+					shrinkColumns: false,
+				},
+				hideControls: [ 'inherit', 'keyword', 'inherit' ],
+				inherit: true,
+				query: {
+					featured: false,
+					inherit: true,
+					offset: 0,
+					pages: 0,
+					perPage: 0,
+					woocommerceOnSale: false,
+				},
+			},
+		} );
+
+		const variation = getRegisteredVariation( name );
+		expect( variation ).toMatchObject( {
+			name,
+			title: 'Complete collection',
+			description: 'A complete public collection.',
+			category: 'woocommerce',
+			keywords: [ 'complete', 'collection' ],
+			scope: [ 'block' ],
+			innerBlocks,
+			isDefault: false,
+			attributes: {
+				align: 'wide',
+				collection: name,
+				dimensions: { widthType: 'fill' },
+				displayLayout: {
+					columns: 4,
+					shrinkColumns: false,
+					type: 'flex',
+				},
+				forcePageReload: false,
+				hideControls: [ 'inherit', 'keyword' ],
+				inherit: false,
+				query: {
+					exclude: [],
+					featured: false,
+					filterable: false,
+					inherit: false,
+					isProductCollectionBlock: true,
+					offset: 0,
+					order: 'asc',
+					orderBy: 'title',
+					pages: 0,
+					perPage: 0,
+					postType: 'product',
+					priceRange: undefined,
+					relatedBy: { categories: true, tags: true },
+					search: '',
+					taxQuery: {},
+					timeFrame: undefined,
+					woocommerceAttributes: [],
+					woocommerceHandPickedProducts: [],
+					woocommerceOnSale: false,
+					woocommerceStockStatus: [],
+				},
+				queryContextIncludes: [ 'collection' ],
+				tagName: 'div',
+			},
+		} );
+
+		expect( typeof variation.isActive ).toBe( 'function' );
+		const isActive = variation.isActive as (
+			blockAttributes: Record< string, unknown >,
+			variationAttributes: Record< string, unknown >
+		) => boolean;
+		expect( isActive( { collection: name }, { collection: name } ) ).toBe(
+			true
+		);
+		expect(
+			isActive(
+				{ collection: `${ TEST_NAMESPACE }/other` },
+				{ collection: name }
+			)
+		).toBe( false );
+	} );
+
+	it( 'injects preview and reference props only into the matching collection edit', () => {
+		const name = `${ TEST_NAMESPACE }/wrapped`;
+		const setPreviewState = jest.fn();
+		registerCollection( {
+			name,
+			title: 'Wrapped collection',
+			preview: {
+				initialPreviewState: {
+					isPreview: true,
+					previewMessage: 'Preview message',
+				},
+				setPreviewState,
+			},
+			usesReference: [ 'product' ],
+		} );
+
+		const PropsProbe = ( {
+			preview,
+			usesReference,
+		}: ProductCollectionEditComponentProps ) => (
+			<output
+				data-testid="additional-props"
+				data-preview={ preview?.initialPreviewState?.previewMessage }
+				data-references={ usesReference?.join( ',' ) }
+				data-setter={
+					preview?.setPreviewState === setPreviewState
+						? 'matching-setter'
+						: undefined
+				}
+			/>
+		);
+		const FilteredProbe = applyFilters(
+			'editor.BlockEdit',
+			PropsProbe
+		) as typeof PropsProbe;
+
+		const { getByTestId, rerender } = render(
+			<FilteredProbe
+				{ ...makeBlockEditProps( makeAttributes( name ) ) }
+			/>
+		);
+		expect( getByTestId( 'additional-props' ) ).toHaveAttribute(
+			'data-preview',
+			'Preview message'
+		);
+		expect( getByTestId( 'additional-props' ) ).toHaveAttribute(
+			'data-references',
+			'product'
+		);
+		expect( getByTestId( 'additional-props' ) ).toHaveAttribute(
+			'data-setter',
+			'matching-setter'
+		);
+
+		rerender(
+			<FilteredProbe
+				{ ...makeBlockEditProps(
+					makeAttributes( `${ TEST_NAMESPACE }/other` )
+				) }
+			/>
+		);
+		expect( getByTestId( 'additional-props' ) ).not.toHaveAttribute(
+			'data-preview'
+		);
+		expect( getByTestId( 'additional-props' ) ).not.toHaveAttribute(
+			'data-references'
+		);
+		expect( getByTestId( 'additional-props' ) ).not.toHaveAttribute(
+			'data-setter'
+		);
+	} );
+
+	it.each( [
+		{
+			id: 'product',
+			matchingLocations: [ { type: LocationType.Product } ],
+			usesReference: [ LocationType.Product ],
+			expectedNonmatchingState:
+				ProductCollectionUIStatesInEditor.PRODUCT_REFERENCE_PICKER,
+		},
+		{
+			id: 'cart',
+			matchingLocations: [ { type: LocationType.Cart } ],
+			usesReference: [ LocationType.Cart ],
+			expectedNonmatchingState: ProductCollectionUIStatesInEditor.VALID,
+		},
+		{
+			id: 'order',
+			matchingLocations: [ { type: LocationType.Order } ],
+			usesReference: [ LocationType.Order ],
+			expectedNonmatchingState: ProductCollectionUIStatesInEditor.VALID,
+		},
+		{
+			id: 'archive',
+			matchingLocations: [ { type: LocationType.Archive } ],
+			usesReference: [ LocationType.Archive ],
+			expectedNonmatchingState: ProductCollectionUIStatesInEditor.VALID,
+		},
+		{
+			id: 'multiple',
+			matchingLocations: [
+				{ type: LocationType.Product },
+				{ type: LocationType.Order },
+			],
+			usesReference: [ LocationType.Product, LocationType.Order ],
+			expectedNonmatchingState:
+				ProductCollectionUIStatesInEditor.PRODUCT_REFERENCE_PICKER,
+		},
+	] )(
+		'routes $id reference contexts through the registered edit wrapper and real UI-state hook',
+		( {
+			id,
+			matchingLocations,
+			usesReference,
+			expectedNonmatchingState,
+		} ) => {
+			const name = `${ TEST_NAMESPACE }/context-${ id }`;
+			registerCollection( {
+				name,
+				title: `${ id } context collection`,
+				usesReference,
+			} );
+
+			for ( const location of matchingLocations ) {
+				const registry = createRegistry();
+				registry.register( coreDataStore );
+				const { getByTestId: getMatchingByTestId, unmount } =
+					renderFilteredState( {
+						attributes: getRegisteredAttributes( name ),
+						location: location as WooCommerceBlockLocation,
+						registry,
+					} );
+				expect(
+					getMatchingByTestId( 'collection-state' )
+				).toHaveTextContent(
+					ProductCollectionUIStatesInEditor.VALID_WITH_PREVIEW
+				);
+				unmount();
+			}
+
+			const nonmatchingRegistry = createRegistry();
+			nonmatchingRegistry.register( coreDataStore );
+			const {
+				getByTestId: getNonmatchingByTestId,
+				unmount: unmountNonmatching,
+			} = renderFilteredState( {
+				attributes: getRegisteredAttributes( name ),
+				location: { type: LocationType.Site },
+				registry: nonmatchingRegistry,
+			} );
+			expect(
+				getNonmatchingByTestId( 'collection-state' )
+			).toHaveTextContent( expectedNonmatchingState );
+
+			unmountNonmatching();
+			const selectedProductRegistry = createRegistry();
+			selectedProductRegistry.register( coreDataStore );
+			selectedProductRegistry.dispatch( coreDataStore ).addEntities( [
+				{
+					baseURL: '/wc/v3/products',
+					kind: 'postType',
+					name: 'product',
+				},
+			] );
+			selectedProductRegistry
+				.dispatch( coreDataStore )
+				.receiveEntityRecords( 'postType', 'product', [
+					{ id: 73, status: 'publish' },
+				] );
+			selectedProductRegistry
+				.dispatch( coreDataStore )
+				.finishResolution( 'getEntityRecord', [
+					'postType',
+					'product',
+					73,
+				] );
+			const { getByTestId: getSelectedByTestId } = renderFilteredState( {
+				attributes: getRegisteredAttributes( name, 73 ),
+				location: { type: LocationType.Site },
+				registry: selectedProductRegistry,
+			} );
+			expect(
+				getSelectedByTestId( 'collection-state' )
+			).toHaveTextContent( ProductCollectionUIStatesInEditor.VALID );
+		}
+	);
+
+	it( 'stores and queries block and inserter scopes in the real Blocks registry', () => {
+		const blockName = `${ TEST_NAMESPACE }/block-scope`;
+		const inserterName = `${ TEST_NAMESPACE }/inserter-scope`;
+		registerCollection( {
+			name: blockName,
+			title: 'Block scope',
+			scope: [ 'block' ],
+		} );
+		registerCollection( {
+			name: inserterName,
+			title: 'Inserter scope',
+			scope: [ 'inserter' ],
+		} );
+
+		expect(
+			getBlockVariations( BLOCK_NAME, 'block' )?.map(
+				( variation ) => variation.name
+			)
+		).toContain( blockName );
+		expect(
+			getBlockVariations( BLOCK_NAME, 'block' )?.map(
+				( variation ) => variation.name
+			)
+		).not.toContain( inserterName );
+		expect(
+			select( blocksStore )
+				.getBlockVariations( BLOCK_NAME, 'inserter' )
+				?.map( ( variation ) => variation.name )
+		).toContain( inserterName );
+		expect(
+			select( blocksStore )
+				.getBlockVariations( BLOCK_NAME, 'inserter' )
+				?.map( ( variation ) => variation.name )
+		).not.toContain( blockName );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**This pull request removes no test.** `__experimentalRegisterProductCollection` is public API whose registration logic was proven only through the browser. This adds a Jest suite for it.

Refs TESTOPS-234

Part of the #68046 split.

Three files — one test and two changelog entries — with 549 insertions and **zero deletions**. No production code changes.

#### What the suite covers

Thirteen cases from five call sites, covering five contracts:

| Contract | Why it matters |
| --- | --- |
| Falsy attribute values survive registration | `featured: false` must stay `false` rather than be treated as absent — the difference between "not featured" and "unset" |
| Invalid configuration is rejected | an invalid config must register nothing at all, not a partial variation |
| Injected props stay scoped | props injected by one collection must not leak into another |
| Reference context routes correctly | `usesReference` must reach the collection that declared it |
| The scope registry answers queries | `scope` must be preserved so the collection appears where it should |

#### The block's browser spec is not touched, and that took some working out

The migration branch changes `register-product-collection.block_theme.spec.ts`, and on inspection there is nothing in those changes worth carrying.

**Its title set is identical to trunk's.** Both sides independently removed the same three duplicated preview-label titles after this work branched: twenty titles at the branch point, seventeen on `trunk` and seventeen on the migration branch, with the same names on both. So trunk is already where the migration wanted this file to be, and there is no coverage to move or drop.

Two differences remain. One is structural and does not matter: trunk flattened a `test.describe( 'with "usesReference" argument', … )` wrapper around about fifteen of those tests, which the migration branch still has. The leaf titles and bodies are the same either way, so nothing is covered differently.

**The other is one the migration should not win.** Trunk wraps the test plugin's activation in a three-attempt retry with exponential backoff and a REST verification step:

```js
// There's been multiple instances of flaky tests due to "socket hang up" errors.
// ...
// This is a retry mechanism to ensure the plugin is activated and ready.
```

That was added deliberately to absorb `socket hang up` failures that made these tests flaky. The migration branch replaces the whole block with a bare `activatePlugin()` call, as part of a transport change that is out of scope for this split. Carrying it would reintroduce a known flake, so the spec stays exactly as `trunk` has it.

This is worth flagging rather than burying: if the retry loop is no longer needed, removing it is a reasonable change — but it should be its own pull request with its own evidence, not a side effect of adding unit tests.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the suite. No environment is needed — it is jsdom only.
   `pnpm --filter=@woocommerce/block-library exec jest --config tests/js/jest.config.js packages/public-api/blocks-registry/product-collection/test/register-product-collection.tsx --runInBand`
   Expect `Tests: 13 passed, 13 total`.
3. Confirm the falsy-value case is real. In `plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/product-collection/register-product-collection.tsx`, change `featured: query.featured,` to `featured: true,`. Re-run step 2 and expect a failure. Revert. No rebuild is needed; Jest transpiles the source directly.
4. Confirm the prop-scoping case is real. In the same file, change `props.attributes.collection !==` to `props.attributes.collection ===`. Re-run step 2 and expect a failure. Revert.
5. Confirm the scope registry case is real. In the same file, change `scope: config.scope,` to `scope: [],`. Re-run step 2 and expect a failure. Revert.
6. Confirm nothing was taken away: `git diff trunk...HEAD --numstat` should show no deleted lines, and the block's E2E spec should not appear in the diff at all.

<!-- End testing instructions -->

### Testing that has already taken place:

- **Extraction.** The suite is byte-identical to the migration branch's copy. Every module it imports — the registration module itself, the Product Collection types and utils, the Product Template utils, and the blocks registry index — is byte-identical between `trunk` and the migration branch, so it is additive against unchanged production code.
- **Focused lower-layer runs.** All thirteen focused commands from the mutation matrix exit 0, and the suite reports `13 passed, 13 total`.
- **Mutation re-check, all five contracts.** The matrix groups these rows under a single system under test, so one kill per behavior family would have covered one contract out of five. All five were run instead: forcing `featured` true, making an invalid configuration register a variation anyway, inverting the collection-scoping comparison, emptying the reference context, and emptying the scope. Each turns its focused command red at the assertion the matrix names and goes green on revert, and each red was checked to be a genuine assertion failure rather than a module-resolution, reference or suite-load error — all of which also exit non-zero.
- **One of those reds was thrown away and redone.** The invalid-configuration mutation was first written with a bare `registerBlockVariation(...)`, which is not imported in that module, so the run died with a `ReferenceError` before reaching the assertion. It exited non-zero and would have passed a gate that only checks the exit code. Rewritten in the form the file actually uses, `wp.blocks.registerBlockVariation(...)`, it fails at `expect( variationsAfter ).toHaveLength( variationsBefore.length )` with `Expected length: 0, Received length: 1` — which is the point: an invalid config must register nothing, not merely skip the happy path.
- **The untouched spec.** The block's E2E spec is byte-identical to `trunk` on this branch, so it carries no risk from this change.
- **Lint.** `oxlint` exits 0 on the new file. `lint:changes:branch` exits 0 with no findings.
- **PHPStan and PHPUnit: nothing to run.** This batch changes no PHP.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-product-collection-registration` and `plugins/woocommerce/client/blocks/changelog/testops-234-product-collection-registration`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

