### PR TITLE
[tests] Fix the hour-boundary flake in the Orders Stats report tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-stats-report-test-hour-boundary
+++ b/plugins/woocommerce/changelog/fix-orders-stats-report-test-hour-boundary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Pin date_paid on the Orders Stats report test fixtures so a run that crosses the top of the hour no longer drops orders out of the queried window.

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreBasicsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreBasicsTest.php
@@ -38,6 +38,9 @@ class DataStoreBasicsTest extends OrdersStatsTestCase {
 		$coupon->save();
 
 		$order = WC_Helper_Order::create_order( 1, $product );
+		// Pin date_paid to date_created, which the window below is derived from; otherwise
+		// the two can land in different hours when the save crosses the top of the hour.
+		$order->set_date_paid( $order->get_date_created() );
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->set_shipping_total( 10 );
 		$order->apply_coupon( $coupon );
@@ -319,14 +322,18 @@ class DataStoreBasicsTest extends OrdersStatsTestCase {
 		$order_datetime->setTime( (int) $order_datetime->format( 'H' ), 10, 0 );
 		$order_time = (int) $order_datetime->format( 'U' );
 
+		// Both orders pin date_paid alongside date_created, because the report queries
+		// date_paid and the window below comes from date_created.
 		$customer_1_order = WC_Helper_Order::create_order( $customer_1->get_id() );
 		$customer_1_order->set_date_created( $order_time );
+		$customer_1_order->set_date_paid( $order_time );
 		$customer_1_order->set_status( OrderStatus::COMPLETED );
 		$customer_1_order->save();
 
 		// Offset by 1 second to keep both orders in the same hour but distinct.
 		$customer_2_order = WC_Helper_Order::create_order( $customer_2->get_id() );
 		$customer_2_order->set_date_created( $order_time + 1 );
+		$customer_2_order->set_date_paid( $order_time + 1 );
 		$customer_2_order->set_status( OrderStatus::COMPLETED );
 		$customer_2_order->save();
 

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreFilterQueriesTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreFilterQueriesTest.php
@@ -133,12 +133,19 @@ class DataStoreFilterQueriesTest extends OrdersStatsTestCase {
 		$order_time = (int) $order_datetime->format( 'U' );
 
 		$iterations = 1;
+		// The Orders Stats report queries date_paid by default, so each order pins it
+		// alongside date_created. Left unset, reaching a paid status stamps date_paid with
+		// the wall clock, and a run that crosses the hour puts orders outside the window
+		// the assertions query.
 		foreach ( $primary_products as $product ) {
 			foreach ( array( null, $small_coupon, $large_coupon ) as $coupon ) {
 				foreach ( array( OrderStatus::COMPLETED, OrderStatus::PROCESSING ) as $order_status ) {
-					$single_product_order = WC_Helper_Order::create_order( $customer->get_id(), $product );
 					// Offset each order by 1 second.
-					$single_product_order->set_date_created( $order_time + $iterations++ );
+					$single_order_time = $order_time + $iterations++;
+
+					$single_product_order = WC_Helper_Order::create_order( $customer->get_id(), $product );
+					$single_product_order->set_date_created( $single_order_time );
+					$single_product_order->set_date_paid( $single_order_time );
 					$single_product_order->set_status( $order_status );
 
 					if ( $coupon ) {
@@ -161,7 +168,9 @@ class DataStoreFilterQueriesTest extends OrdersStatsTestCase {
 					$item->save();
 					$two_product_order->add_item( $item );
 					// Offset each order by 1 second.
-					$two_product_order->set_date_created( $order_time + $iterations++ );
+					$two_order_time = $order_time + $iterations++;
+					$two_product_order->set_date_created( $two_order_time );
+					$two_product_order->set_date_paid( $two_order_time );
 					$two_product_order->set_status( $order_status );
 
 					if ( $coupon ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Every order fixture in the Orders Stats report tests now pins `date_paid` alongside `date_created`, which removes a flake that fails a whole test class when a run crosses the top of the hour.

**Why it failed.** The report queries `date_paid`, not `date_created`. The fixtures pinned only `date_created`, so reaching a paid status left `WC_Order` to stamp `date_paid` with the wall clock. The assertions query the hour the fixtures were built in, so orders paid after the hour turned over fell outside it. `DataStoreFilterQueriesTest` matched 18 of its 36 orders and failed 27 of 28 scenarios, with a window of `13:00:00`–`13:59:59` and the failure logged at `14:06`.

**What changed.** Each fixture sets `date_paid` to the timestamp it already sets for `date_created`. The sibling `DataStoreZeroFillTest` does this today, so the three classes now agree. They still exercise the default `date_paid` path.

**What else is in here.** Two fixtures in `DataStoreBasicsTest` share the cause through a narrower window, needing only the save to cross the hour. Neither has been seen failing. I fixed them rather than leave a known flake to surface later.

Found while triaging CI failures on unrelated pull requests, so there is no linked issue. Over to you.

### How to test the changes in this Pull Request:

Test-only change. Both scenarios start from a fresh checkout with Docker running.

**Scenario 1 — the three classes pass**

1. From the repository root, run `pnpm install`.
2. Change into the plugin directory: `cd plugins/woocommerce`.
3. Start the PHPUnit environment: `pnpm env:test`. Wait for it to report the WordPress site is ready on port `8186`.
4. Run `pnpm test:php:env -- --filter 'DataStoreFilterQueriesTest'`.
5. Confirm the run ends with `OK` and reports 29 tests, no failures and no errors.
6. Run `pnpm test:php:env -- --filter 'DataStoreBasicsTest'`.
7. Confirm the run ends with `OK`, no failures and no errors.
8. Run `pnpm test:php:env -- --filter 'DataStoreZeroFillTest'`.
9. Confirm the run ends with `OK`, no failures and no errors. This class is unchanged and is here as the control.

**Scenario 2 — the failure is reproducible on `trunk` and gone here**

The failure needs the fixtures and the wall clock to fall in different hours. Instead of waiting for the top of the hour, move the fixtures back one hour. The orders are then created in the previous hour, the assertions query the previous hour, and `date_paid` still lands in the current one, which is what a boundary-crossing run produces.

10. Check out `trunk`.
11. Open `plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreFilterQueriesTest.php` and find `wpSetUpBeforeClass()`.
12. Directly above the line `$order_datetime->setTime( (int) $order_datetime->format( 'H' ), 10, 0 );`, add one line: `$order_datetime->modify( '-1 hour' );`
13. Run `pnpm test:php:env -- --filter 'DataStoreFilterQueriesTest'`.
14. Confirm the run **fails**, and that the first failure shows `orders_count` as `0` where the scenario expected a non-zero count. The orders are paid in the current hour while the query window is the previous one, so the report matches nothing.
15. Discard the edit from step 12.
16. Check out this branch and make the same one-line edit again.
17. Run `pnpm test:php:env -- --filter 'DataStoreFilterQueriesTest'`.
18. Confirm the run **passes** with `OK`. `date_paid` now follows `date_created` into the queried hour, so moving the fixtures in time no longer changes the result.
19. Discard the edit.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

The entry is already in the branch, written by hand: `plugins/woocommerce/changelog/fix-orders-stats-report-test-hour-boundary`, significance patch, type dev.

### Use of AI Tools

This change was written by Claude Code, starting from a triage of CI failures across unrelated pull requests. The cause was established by reading the code paths named above. The author reviewed the diff and takes responsibility for it. No agent review is offered in place of the human review this PR still needs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
