### PR TITLE
[tests] Let the wp-env start retry recover from root-owned mount points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,8 @@ jobs:
             if grep -qF 'curl error 28' "$log"; then reason=packagist
             elif grep -qE 'registry-1\.docker\.io|context deadline exceeded|failed to receive status: rpc error|connection reset by peer' "$log"; then reason=dockerhub
             elif grep -qE 'ETIMEDOUT|socket hang up|ECONNRESET' "$log"; then reason=wordpress
+            elif grep -qF 'the sample-data image import did not complete' "$log"; then reason=blocks-seed
+            elif grep -qE 'EACCES: permission denied, rmdir' "$log"; then reason=stale-mount
             else reason=unknown
             fi
             if [ "$attempt" -ge "$max_attempts" ]; then
@@ -385,6 +387,14 @@ jobs:
             # a repeat failure then records every connect attempt with its address and errno.
             # Healthy first attempts stay untraced, so this costs nothing on a green job.
             export NODE_DEBUG=net
+            # An attempt that got as far as running containers leaves wp-env's mapped
+            # directories owned by root, because the container writes into them as root.
+            # `wp-env start` removes a mapping's directory before re-creating it, so those
+            # leftovers make every later attempt fail with "EACCES: permission denied,
+            # rmdir" no matter what the original failure was -- the retry can never
+            # recover. Hand the tree back to the runner user first. Only retries pay this
+            # cost; a green first attempt never reaches it.
+            sudo chown -R "$(id -u):$(id -g)" "${WP_ENV_HOME:-$HOME/wp-env}" 2>/dev/null || true
             sleep "$((attempt * 15))"
             attempt=$((attempt + 1))
           done


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `wp-env start` retry now hands its mount points back to the runner user before each attempt, so a Blocks e2e job that fails once can recover instead of spending all three attempts on the same error.

**Why the retry could not recover.** `.wp-env.e2e.json` maps `test-data/images/` into the container, and the container writes there as root. `wp-env start` removes a mapping's directory before re-creating it. So once any attempt has run containers, every later attempt dies with `EACCES: permission denied, rmdir` on that directory, whatever failed the first time.

**How Blocks e2e reaches it.** Attempt 1 fails the `products.sh` guard `the sample-data image import did not complete`. #67707 made that seed step re-runnable, which is what the retry is for, but attempts 2 and 3 never get to it. The job then reports the permission error rather than the import.

**What changed.** Reclaim ownership of the wp-env home before each retry, and classify the two signatures so the existing `reason=` marker says `blocks-seed` or `stale-mount` instead of `unknown`. The loop still retries regardless of cause.

**What this does not fix.** Why the image import fails. That trigger is still unknown. This only lets the retry absorb it, and names both signatures in the log so the real rate becomes measurable.

**Verified on runners, as a matched pair.** The same deliberate first-attempt failure recovers with this fix and dies on `EACCES` without it, on 30 Blocks shards each. The logs are under "Testing that has already taken place". Two points still worth your eye: `sudo` is unguarded, and `WP_ENV_HOME` is unset in this repository, so the `$HOME/wp-env` fallback is what runs.

Found while triaging CI failures on unrelated pull requests, so there is no linked issue. Over to you.

### How to test the changes in this Pull Request:

The change is CI shell logic, so this PR's own jobs carry the real evidence. Scenarios 2 and 3 run anywhere.

**Scenario 1 — this PR's own Blocks e2e jobs**

1. Open the Checks tab on this pull request.
2. Find the jobs named `Blocks e2e tests N/10`.
3. Confirm each one either passes, or fails on a test rather than on `wp-env start failed after 3 attempts`.
4. Search each job's log for `wp-env-start-retry`.
5. If a marker is present, confirm its `reason=` reads `packagist`, `dockerhub`, `wordpress`, `blocks-seed` or `stale-mount`. A `reason=unknown` on a seed or permission failure means the classifiers missed.
6. If no marker is present, no attempt failed, and this change did nothing on that job. That is the expected result on a healthy run.

**Scenario 2 — the workflow parses and the step is valid shell**

7. From the repository root, run `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('parses')"`.
8. Confirm it prints `parses`.
9. Open `.github/workflows/ci.yml` at the `Start Test Environment: start` step.
10. Confirm the `sudo chown` line sits inside the `until ... done` body and below the `if [ "$attempt" -ge "$max_attempts" ]` exit, so only an attempt that will be followed by another reaches it.

**Scenario 3 — the classifiers match the real log lines**

11. Save the script below as `classify.sh`. It is the classifier chain from the workflow, unchanged, with one sample log per branch.
12. Run `bash classify.sh`.
13. Confirm the output is the five lines given below. The two new branches match the real strings, and adding them shadowed none of the three that were already there.
14. Delete `classify.sh` and the five `.log` files.

<details>

<summary>Step 11: the script, and the exact output step 13 expects</summary>

```bash
classify() {
  log="$1"
  if grep -qF 'curl error 28' "$log"; then reason=packagist
  elif grep -qE 'registry-1\.docker\.io|context deadline exceeded|failed to receive status: rpc error|connection reset by peer' "$log"; then reason=dockerhub
  elif grep -qE 'ETIMEDOUT|socket hang up|ECONNRESET' "$log"; then reason=wordpress
  elif grep -qF 'the sample-data image import did not complete' "$log"; then reason=blocks-seed
  elif grep -qE 'EACCES: permission denied, rmdir' "$log"; then reason=stale-mount
  else reason=unknown
  fi
  echo "$reason"
}
printf '%s\n' 'Missing gallery attachment; the sample-data image import did not complete.' > a.log
printf '%s\n' "Error: EACCES: permission denied, rmdir '/home/runner/wp-env/8a1b/WordPress/wordpress-latest/test-data/images'" > b.log
printf '%s\n' 'curl error 28 while downloading' > c.log
printf '%s\n' 'AggregateError: ETIMEDOUT' > d.log
printf '%s\n' 'some unrelated failure' > e.log
for f in a b c d e; do echo "$f.log -> $(classify $f.log)"; done
```

Expected output:

```
a.log -> blocks-seed
b.log -> stale-mount
c.log -> packagist
d.log -> wordpress
e.log -> unknown
```

</details>

### Testing that has already taken place:

Scenarios 2 and 3 were both run and gave the results shown: `ci.yml` parses as YAML, the step's embedded script passes `bash -n`, and the classifier produced those five lines exactly.

**The retry path has now been exercised on real runners, as a matched pair.** Because the failure cannot be reproduced on a developer machine, the first `wp-env start` of a Blocks e2e job was made to fail on purpose, once, after the containers were already running, using the real seed guard's message. The same sabotage commit was then run twice: once with this fix, once on plain `trunk`. The two runs differ only in whether this fix is present.

**With the fix applied, the retry recovers. 29 of 30 Blocks shards passed, none failed.**

```
Missing gallery attachment; the sample-data image import did not complete.
##[warning]wp-env-start-retry reason=blocks-seed attempt=1/3 -- retrying in 15s
> pnpm env:e2e:start && bash ./tests/e2e/bin/blocks/test-env-setup.sh ...
ℹ Starting 'rm -f blocks_e2e.sql' on the cli container.
```

Attempt 2 ran `wp-env start` again with no `EACCES` and reached the seed, and the shard then passed its tests.

**On `trunk`, the same sabotage cannot recover. Every Blocks shard that reached the step failed.**

```
Missing gallery attachment; the sample-data image import did not complete.
##[warning]wp-env-start-retry reason=unknown attempt=1/3 -- retrying in 15s
✖ EACCES: permission denied, rmdir '/home/runner/wp-env/wp-env-woocommerce-e2e-a5923692/wordpress-latest/test-data/images'
##[warning]wp-env-start-retry reason=unknown attempt=2/3 -- retrying in 30s
✖ EACCES: permission denied, rmdir '/home/runner/wp-env/wp-env-woocommerce-e2e-a5923692/wordpress-latest/test-data/images'
##[error]wp-env start failed after 3 attempts (last reason=unknown)
```

`Run tests (e2e)` was skipped, so the shard never ran a test. This is the same failure #68655 and #68663 hit for real, reproduced on demand.

Two things follow. The recovery comes from this change rather than from the retry already being able to cope, and the classifier earns its place: the same first failure reads `blocks-seed` here and `unknown` on `trunk`.

One limit worth stating. The `chown` prints nothing, so no log line attests to it directly. The claim rests on the paired outcome above, not on an observation of that command.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>No package is modified, so no project changelog applies</summary>

#### Comment

This PR changes only `.github/workflows/ci.yml`. The `needs-changelog-validation` filter in that same file scopes changelog checks to `{packages,plugins}/*`.

</details>

### Use of AI Tools

This change was written by Claude Code, starting from a triage of CI failures across unrelated pull requests. The mechanism was established by reading the retry loop, the `.wp-env.e2e.json` mapping and the `products.sh` guard against the failing job logs. The author reviewed the diff and takes responsibility for it. No agent review is offered in place of the human review this PR still needs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


