### PR TITLE
[tests] Demote 4 Products block E2E titles to Jest and PHPUnit

### DIFF
--- a/plugins/woocommerce/changelog/testops-234-products-block
+++ b/plugins/woocommerce/changelog/testops-234-products-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move the Products block inspector policy to Jest and its per-item Interactivity context to PHPUnit, cutting the block's browser spec from seven titles to three while keeping the editor, hydrated cart, and Product Catalog journeys.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/test/inspector-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/test/inspector-controls.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+import { isSiteEditorPage } from '@woocommerce/utils';
+
+/**
+ * Internal dependencies
+ */
+import { useAllowedControls } from '../utils';
+
+const mockAllowedControls = [ 'wooInherit', 'onSale' ];
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn( ( select ) =>
+		select( () => ( {
+			getActiveBlockVariation: () => ( {
+				allowedControls: mockAllowedControls,
+			} ),
+		} ) )
+	),
+} ) );
+
+jest.mock( '@woocommerce/utils', () => ( {
+	...jest.requireActual( '@woocommerce/utils' ),
+	isSiteEditorPage: jest.fn(),
+} ) );
+
+const mockIsSiteEditorPage = isSiteEditorPage as jest.Mock;
+
+describe( 'Product Query inspector controls', () => {
+	it( 'shows only query inheritance for inherited Site Editor queries', () => {
+		mockIsSiteEditorPage.mockReturnValue( true );
+
+		const { result } = renderHook( () =>
+			useAllowedControls( {
+				query: { inherit: true },
+			} as never )
+		);
+
+		expect( result.current ).toEqual( [ 'wooInherit' ] );
+	} );
+
+	it( 'restores advanced controls when Site Editor query inheritance is disabled', () => {
+		mockIsSiteEditorPage.mockReturnValue( true );
+
+		const { result, rerender } = renderHook(
+			( { inherit } ) =>
+				useAllowedControls( {
+					query: { inherit },
+				} as never ),
+			{ initialProps: { inherit: true } }
+		);
+
+		rerender( { inherit: false } );
+
+		expect( result.current ).toEqual( mockAllowedControls );
+	} );
+
+	it( 'removes only query inheritance from Post Editor controls', () => {
+		mockIsSiteEditorPage.mockReturnValue( false );
+
+		const { result } = renderHook( () =>
+			useAllowedControls( {
+				query: { inherit: true },
+			} as never )
+		);
+
+		expect( result.current ).toEqual( [ 'onSale' ] );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/changelog/testops-234-products-block
+++ b/plugins/woocommerce/client/blocks/changelog/testops-234-products-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Move the Products block inspector policy to Jest and its per-item Interactivity context to PHPUnit, cutting the block's browser spec from seven titles to three while keeping the editor, hydrated cart, and Product Catalog journeys.
+

--- a/plugins/woocommerce/tests/e2e/tests/blocks/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/products/products.block_theme.spec.ts
@@ -13,7 +13,8 @@ import {
  */
 import {
 	getProductsNameFromClassicTemplate,
-	getProductsNameFromProductQuery,
+	getProductCollectionQuery,
+	getProductsNameFromProductCollection,
 	insertProductsQuery,
 } from './utils';
 
@@ -28,41 +29,11 @@ const blockData: BlockData = {
 };
 
 const templates = {
-	// This test is disabled because archives are disabled for attributes by default. This can be uncommented when this is toggled on.
-	//'taxonomy-product_attribute': {
-	//	templateTitle: 'Product Attribute',
-	//	slug: 'taxonomy-product_attribute',
-	//	frontendPage: '/product-attribute/color/',
-	//	legacyBlockName: 'woocommerce/legacy-template',
-	//	needsCreation: false,
-	//},
-	'taxonomy-product_cat': {
-		templateTitle: 'Product Category',
-		slug: 'taxonomy-product_cat',
-		frontendPage: '/product-category/music/',
-		legacyBlockName: 'woocommerce/legacy-template',
-		needsCreation: true,
-	},
-	'taxonomy-product_tag': {
-		templateTitle: 'Product Tag',
-		slug: 'taxonomy-product_tag',
-		frontendPage: '/product-tag/recommended/',
-		legacyBlockName: 'woocommerce/legacy-template',
-		needsCreation: true,
-	},
 	'archive-product': {
 		templateTitle: 'Product Catalog',
 		slug: 'archive-product',
 		frontendPage: '/shop/',
 		legacyBlockName: 'woocommerce/legacy-template',
-		needsCreation: false,
-	},
-	'product-search-results': {
-		templateTitle: 'Product Search Results',
-		slug: 'product-search-results',
-		frontendPage: '/?s=shirt&post_type=product',
-		legacyBlockName: 'woocommerce/legacy-template',
-		needsCreation: false,
 	},
 };
 
@@ -124,27 +95,6 @@ test.describe( `${ blockData.name } Block `, () => {
 		const cartLink = page.getByRole( 'link', { name: 'View cart' } );
 		await expect( cartLink ).toBeVisible();
 	} );
-
-	test( 'product button should add product to the cart when not inheriting query from template', async ( {
-		admin,
-		editor,
-		page,
-	} ) => {
-		await admin.createNewPost();
-		await expect(
-			editor.canvas.getByLabel( /Add default block|Empty block/ )
-		).toBeVisible();
-		await insertProductsQuery( editor, { inherit: false } );
-		await editor.publishAndVisitPost();
-
-		const addToCartButton = page.getByRole( 'button', {
-			name: 'Add to cart: “Single”',
-		} );
-		await addToCartButton.click();
-		await expect( addToCartButton ).toHaveText( '1 in cart' );
-		const cartLink = page.getByRole( 'link', { name: 'View cart' } );
-		await expect( cartLink ).toBeVisible();
-	} );
 } );
 
 for ( const {
@@ -152,45 +102,53 @@ for ( const {
 	slug,
 	frontendPage,
 	legacyBlockName,
-	needsCreation,
 } of Object.values( templates ) ) {
 	test.describe( `${ templateTitle } template`, () => {
-		test( 'Products block matches with classic template block', async ( {
+		test( 'Product Collection matches with classic template block', async ( {
 			admin,
 			editor,
 			page,
 		} ) => {
-			if ( needsCreation ) {
-				await admin.visitSiteEditor( {
-					postType: 'wp_template',
-				} );
-				await editor.createTemplate( {
-					templateName: 'Products by Category',
-				} );
-			} else {
-				await admin.visitSiteEditor( {
-					postId: `${ BLOCK_THEME_SLUG }//${ slug }`,
-					postType: 'wp_template',
-					canvas: 'edit',
-				} );
-			}
+			await admin.visitSiteEditor( {
+				postId: `${ BLOCK_THEME_SLUG }//${ slug }`,
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
 			await editor.setContent( '' );
 			await insertProductsQuery( editor );
+			await page
+				.getByRole( 'button', {
+					name: 'Upgrade to Product Collection',
+				} )
+				.click();
+			const expectProductCollectionQuery = async () => {
+				const query = await getProductCollectionQuery( page );
+				expect( query.isProductCollectionBlock ).toBe( true );
+				expect( query.inherit ).toBe( true );
+				expect( query.perPage ).toBeGreaterThan( 1 );
+			};
+			await expectProductCollectionQuery();
+
 			await editor.insertBlock( { name: legacyBlockName } );
 			await editor.canvas.locator( 'body' ).click();
 
 			await editor.saveSiteEditorEntities( {
 				isOnlyCurrentEntityDirty: true,
 			} );
+			await page.reload();
+			await editor.canvas.locator( 'body' ).waitFor();
+			await expectProductCollectionQuery();
 
 			await page.goto( frontendPage );
 
 			const classicProducts =
 				await getProductsNameFromClassicTemplate( page );
-			const productQueryProducts =
-				await getProductsNameFromProductQuery( page );
+			const productCollectionProducts =
+				await getProductsNameFromProductCollection( page );
 
-			expect( classicProducts ).toEqual( productQueryProducts );
+			expect( classicProducts.length ).toBeGreaterThan( 1 );
+			expect( productCollectionProducts.length ).toBeGreaterThan( 1 );
+			expect( classicProducts ).toEqual( productCollectionProducts );
 		} );
 	} );
 }

--- a/plugins/woocommerce/tests/e2e/tests/blocks/products/utils.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/products/utils.ts
@@ -9,10 +9,25 @@ export const getProductsNameFromClassicTemplate = async ( page: Page ) => {
 	return products.allTextContents();
 };
 
-export const getProductsNameFromProductQuery = async ( page: Page ) => {
-	const products = page.locator( '.wp-block-query .wp-block-post-title' );
+export const getProductsNameFromProductCollection = async ( page: Page ) => {
+	const products = page.locator(
+		'.wp-block-woocommerce-product-collection .wp-block-post-title'
+	);
 	return products.allTextContents();
 };
+
+export const getProductCollectionQuery = async ( page: Page ) =>
+	page.evaluate( () => {
+		const block = window.wp.data
+			.select( 'core/block-editor' )
+			.getBlocks()
+			.find(
+				( candidate: { name: string } ) =>
+					candidate.name === 'woocommerce/product-collection'
+			);
+
+		return block?.attributes.query ?? {};
+	} );
 
 export const productQueryInnerBlocksTemplate = [
 	{

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductQuery.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Tests\Blocks\Mocks\ProductQueryMock;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use WC_Helper_Product;
 
 /**
  * Tests for the ProductQuery block type
@@ -14,6 +15,91 @@ class ProductQuery extends \WP_UnitTestCase {
 	 * @var ProductQueryMock
 	 */
 	private $block_instance;
+
+	/**
+	 * @testdox Should add Interactivity API context only to valid product loop items.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_iapi_context_updates_only_valid_product_loop_items(): void {
+		$product_ids = array();
+		$post_id     = 0;
+
+		try {
+			$product_ids[] = WC_Helper_Product::create_simple_product()->get_id();
+			$product_ids[] = WC_Helper_Product::create_simple_product()->get_id();
+			$post_id       = self::factory()->post->create();
+
+			$markup = sprintf(
+				'<ul><li id="first-product" class="wp-block-post post-%1$d"></li><li id="second-product" class="extra wp-block-post post-%2$d"></li><li id="missing-id" class="wp-block-post"></li><li id="malformed-id" class="wp-block-post post-not-a-number"></li><li id="non-product" class="wp-block-post post-%3$d"></li></ul>',
+				$product_ids[0],
+				$product_ids[1],
+				$post_id
+			);
+
+			$this->assertSame(
+				$markup,
+				$this->block_instance->add_iapi_context(
+					$markup,
+					array( 'attrs' => array( '__woocommerceNamespace' => 'another-block' ) )
+				),
+				'A different block namespace should leave the markup byte-identical.'
+			);
+
+			$processed_markup = $this->block_instance->add_iapi_context(
+				$markup,
+				array( 'attrs' => array( '__woocommerceNamespace' => 'woocommerce/product-query/product-template' ) )
+			);
+			$processor        = new \WP_HTML_Tag_Processor( $processed_markup );
+			$items            = array();
+
+			while ( $processor->next_tag( array( 'tag_name' => 'LI' ) ) ) {
+				$items[ $processor->get_attribute( 'id' ) ] = array(
+					'interactive' => $processor->get_attribute( 'data-wp-interactive' ),
+					'context'     => $processor->get_attribute( 'data-wp-context' ),
+					'key'         => $processor->get_attribute( 'data-wp-key' ),
+				);
+			}
+
+			foreach (
+				array(
+					'first-product'  => $product_ids[0],
+					'second-product' => $product_ids[1],
+				) as $item_id => $product_id
+			) {
+				$this->assertSame( 'woocommerce/products', $items[ $item_id ]['interactive'] );
+				$this->assertSame( 'product-item-' . $product_id, $items[ $item_id ]['key'] );
+				$context = $items[ $item_id ]['context'];
+				$this->assertIsString( $context );
+				if ( ! is_string( $context ) ) {
+					throw new \UnexpectedValueException( 'Product context should be a serialized string.' );
+				}
+				list( $namespace, $json_context ) = explode( '::', $context, 2 );
+				$this->assertSame( 'woocommerce/products', $namespace );
+				$this->assertSame(
+					array(
+						'productId'   => $product_id,
+						'variationId' => null,
+					),
+					json_decode( $json_context, true )
+				);
+			}
+
+			foreach ( array( 'missing-id', 'malformed-id', 'non-product' ) as $item_id ) {
+				$this->assertNull( $items[ $item_id ]['interactive'], "$item_id should not become interactive." );
+				$this->assertNull( $items[ $item_id ]['context'], "$item_id should not receive product context." );
+				$this->assertNull( $items[ $item_id ]['key'], "$item_id should not receive an Interactivity API key." );
+			}
+		} finally {
+			foreach ( $product_ids as $product_id ) {
+				WC_Helper_Product::delete_product( $product_id );
+			}
+			if ( $post_id ) {
+				wp_delete_post( $post_id, true );
+			}
+		}
+	}
 
 	/**
 	 * Return starting point for parsed block test data.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   I have assessed the impact of this change and followed the applicable [review requirements](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/contributing/deciding-pr-high-impact.md#review-requirements).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Products block — the deprecated `core/query` variation registered under the `woocommerce/product-query` namespace — spent seven Playwright identities on contracts that do not need a browser. This moves those contracts down a layer and keeps three browser journeys.

Refs TESTOPS-234

Part of the #68046 split.

Six files, 212 insertions and 73 deletions. No production code changes.

| Layer | Before | After |
| --- | --- | --- |
| `products.block_theme.spec.ts` runtime titles | 7 | 3 |
| `ProductQuery.php` PHPUnit methods | 16 | 17 |
| `product-query/test/inspector-controls.tsx` Jest cases | 0 (file is new) | 3 |

**Please merge #68618 before this one.** The reason is in the next section, and it is about which pull request carries a test rather than about risk to coverage.

#### Read this before the table: where the three parity routes are owned

Three of the four removed titles are archive-route parity checks. The table names their owner on `trunk` today, so nothing below depends on another pull request landing first.

That owner is `product-collection.block_theme.spec.ts`, which already runs a parity loop over Product Category (`/product-category/music/`), Product Tag (`/product-tag/recommended/`), Product Catalog (`/shop/`) and Product Search Results (`/?s=shirt&post_type=product`), asserting `toHaveCount( expectedProductsCount )` and then name equality against the classic loop. That is a cardinality floor the removed Products titles never had — they compared two scraped arrays with `toEqual`, which passes on two empty arrays.

`RouteContextParityTest::test_product_collection_and_product_query_match_classic_route` adds a PHP owner for the same three routes, and its Products arm was written by this batch's slice commit. It lands inside a file **#68618 carries whole**, so it is not on `trunk` and not in this diff — `git cat-file -e origin/trunk:plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/RouteContextParityTest.php` fails today. Treat it as a later addition, not as the replacement this pull request rests on.

What only #68618 adds is an owner that renders the **Products** block specifically, rather than Product Collection.

#### Removed and rewritten titles

| Removed E2E test | Existing coverage | Knowingly dropped |
| --- | --- | --- |
| `core/query Block  › product button should add product to the cart when not inheriting query from template` | `tests/php/src/Blocks/BlockTypes/ProductQuery.php::test_add_iapi_context_updates_only_valid_product_loop_items` (in this PR) owns the per-item Interactivity wiring the button depends on: the exact `woocommerce/products` namespace, the `product-item-{id}` key and the decoded `{ productId, variationId: null }` context, proven on real products and proven absent on three kinds of invalid loop item | Browser proof that a Products block with `inherit: false` on a published post hydrates and completes a real add-to-cart click. The PHP owner asserts the context attributes that drive the button, not the click, the `1 in cart` label or the `View cart` link. The retained inheriting-query title keeps that journey character-for-character, but on the archive route only, so the second query mode has no end-to-end owner |
| `Product Category template › Products block matches with classic template block` | `product-collection.block_theme.spec.ts` › `Product Category template` › `Product Collection block matches with classic template block`, on `trunk` today. It runs the same route and compares the block output against the classic loop | Browser proof that the category template itself resolves and renders through a Site Editor save. The owner above covers the route; what it does not cover is the un-migrated Products block rendering it |
| `Product Tag template › Products block matches with classic template block` | Same spec, its `Product Tag template` iteration, on `trunk` today | As above. See the note below: this title was not testing what its name said |
| `Product Search Results template › Products block matches with classic template block` | Same spec, its `Product Search Results template` iteration, on `trunk` today | As above |
| `Product Catalog template › Products block matches with classic template block` | Not removed — renamed and strengthened into `Product Collection matches with classic template block`, which stays in the browser | Browser proof that the **un-migrated Products block** renders the catalog. After the upgrade click the title compares Product Collection instead. The block still renders on `/shop/` in the retained add-to-cart title, so its catalog render keeps a browser owner, but its ordered parity with the classic loop on that route now has no owner at any layer: `RouteContextParityTest`'s provider has category, tag and search rows and no `archive-product` row |

**The removed Product Tag title never tested a Product Tag template.** The base loop hard-codes `templateName: 'Products by Category'` inside the shared body, so both `needsCreation` rows created a *category* template; the Tag iteration then visited `/product-tag/recommended/` and compared two arrays that were empty. Worth knowing before treating its removal as a loss.

#### Relocated to Jest

`useAllowedControls` decides which inspector controls the block offers. Three cases: the inherited Site Editor branch returns only `wooInherit`; re-rendering with `inherit: false` restores the full list, which proves the hook reacts to the attribute rather than caching its first branch; the Post Editor branch removes `wooInherit` and keeps everything else.

#### The retained wiring test

Three titles survive, all in this batch's own spec, and `--list` shows exactly these three:

1. `core/query Block  › when Inherits Query From Template other options are hidden, show up otherwise` — inserts the block in the Site Editor and reads the real inspector.
2. `core/query Block  › product button should add product to the cart when inheriting query from template` — the only surviving title anywhere that renders this block on a front end and buys from it. It carries the block's entire frontend contract.
3. `Product Catalog template › Product Collection matches with classic template block` — the upgrade path, asserting the migrated query's `isProductCollectionBlock`, `inherit` and `perPage` before the save and again after a reload, with cardinality floors on both sides.

One more lives outside this PR: `product-collection.block_theme.spec.ts` › `Can be migrated to from Products (Deprecated) block` is, after this change, the block's **only** Post Editor coverage.

#### Things a reviewer should not have to find

Everything in this list is left exactly as the migration branch wrote it, because this pull request moves tests rather than improving them. They are listed so nobody has to rediscover them.

- **The rewritten title's mutation observer is a Product Collection symbol**, `ProductCollection/Utils.php::prepare_and_execute_query`, not a Products one. That follows from the title now clicking through the upgrade: once migrated, the frontend query belongs to Product Collection.
- **`insertProductsQuery`'s `inherit` option is now dead.** Its only `{ inherit: false }` caller was the removed title. The parameter is kept as the migration branch has it.
- **There is a race window at `products.block_theme.spec.ts:138-140`.** The post-reload read waits on the canvas body, which can resolve before the editor store has parsed, and the `?? {}` fallback in `utils.ts:29` turns that into a hard failure rather than a retry. It passed three times here at `--retries=0 --workers=1`, and a fourth run cleared the same window before failing where its mutation aimed. The alternative is adding a wait, which this campaign does not do.
- **The Jest suite's `@wordpress/data` mock ignores the store it is asked for.** The fake `select` returns the same variation whatever key it receives, so `select( WP_BLOCKS_STORE ).getActiveBlockVariation( QUERY_LOOP_ID, attributes )` would behave identically with the wrong store, without `QUERY_LOOP_ID`, or without forwarding `attributes` — mutations to any of those three would survive this suite. What the three cases do assert is `useAllowedControls`' branching, and all three are mutation-killed on exactly that.
- **`test_add_iapi_context_updates_only_valid_product_loop_items` is `@runInSeparateProcess` with `@preserveGlobalState disabled`,** which is unusual in `tests/php`. It is correct here: `ProductsStore` holds a static product cache and the method writes `wp_interactivity_state()`, and the test-case transaction rollback resets neither.
- **That method also carries an unreachable `throw` after an `assertIsString`.** PHPUnit has already failed the test by the time the `throw` could run, so it is dead defensive code rather than a guard.

### Screenshots or screen recordings:

Not applicable. Test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --frozen-lockfile` from the repository root.
2. Run the Jest suite. No environment is needed — it is jsdom only.
   `pnpm --filter=@woocommerce/block-library test:js --runInBand assets/js/blocks/product-query/test/inspector-controls.tsx`
   Expect `Tests: 3 passed, 3 total`.
3. Start the PHPUnit environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test`.
4. Run the new PHP method: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite=wc-phpunit-main --filter 'test_add_iapi_context_updates_only_valid_product_loop_items'`. Expect `OK (1 test, 20 assertions)`.
5. Confirm the PHP test detects a real regression. In `plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php`, in `add_iapi_context()`, change `'variationId' => null,` to `'variationId' => 0,`. Re-run step 4 and expect a failure on the decoded context array. Revert.
6. Confirm it rejects non-products. In the same method, change `if ( ! $product_id || 'product' !== get_post_type( $product_id ) ) {` to `if ( ! $product_id ) {`. Re-run step 4 and expect `Failed asserting that 'woocommerce/products' is null` — the non-product list item now gets annotated. Revert.
7. Confirm the Jest cases are real. In `plugins/woocommerce/client/blocks/assets/js/blocks/product-query/utils.tsx`, replace the Site Editor ternary's true branch `controls.filter( ( control ) => control === 'wooInherit' )` with `controls`. Re-run step 2 and expect the inherited-query case to fail with `expected [wooInherit], received [wooInherit, onSale]`. Revert. No rebuild is needed; Jest transpiles the source directly.
8. Start the Blocks E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`, then `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`. The second command is required, not optional — it seeds the store (products, options and editor preferences) that the specs assume. The admin storage state, the database snapshot and the block theme activation all come from the Playwright `blocks setup` project, which step 9 runs because it passes no `--no-deps`.
9. Run the three retained titles: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:with-env default --project=blocks-chromium --retries=0 --workers=1 tests/e2e/tests/blocks/products/products.block_theme.spec.ts`. Expect `4 passed`, which is the three titles plus the setup project.
10. Confirm the rewritten parity title has teeth. In `plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Utils.php`, immediately after `$query = clone $wp_query;`, add `$query->posts = array_slice( $query->posts, 0, 1 );` and `$query->post_count = 1;`. Re-run step 9 and expect a failure at `expect( productCollectionProducts.length ).toBeGreaterThan( 1 )` — and note that the classic-side floor on the line above passes first, which is what proves only the collection's cloned query was truncated. Revert.

<!-- End testing instructions -->

### Testing that has already taken place:

Everything below ran on a local WordPress with retries disabled and one worker. `trunk` was at `7cda01098f`.

- **Extraction.** All four test files are byte-identical to the migration branch's copies at `8fe7a01548`, verified by blob hash. Trunk drift on all four paths is empty since the diff base, so the change applies to trunk unmodified and nothing had to be re-derived.
- **Focused lower-layer runs.** All five distinct focused commands from the mutation matrix exit 0. PHPUnit reports `OK (1 test, 20 assertions)` and each Jest command reports `2 skipped, 1 passed, 3 total` — both the exact green identities the matrix recorded. The PHPUnit filter was checked to have executed a real test rather than matching nothing, which also exits 0.
- **Retained Playwright titles.** `--list` shows exactly the three titles above; the run passes `4 passed` at `--retries=0 --workers=1`.
- **Mutation re-check: all ten matrix rows, not the three the campaign's floor requires.** The six PHPUnit rows all target the single new method but each disables a different load-bearing value — the namespace guard, the interactive namespace, the `data-wp-key` prefix, `productId`, `variationId`, and the post-type guard — so one kill would have spoken for one contract out of six. Each red fails at the assertion the matrix names and goes green on revert. The assertion counts corroborate the line numbers rather than just accompanying them: the clean run makes 20 assertions and the reds stop at 2, 2, 3, 6, 6 and 18, precisely where each mutated value is first read.
- **Every red was checked to be a genuine assertion failure**, not a parse error, bootstrap failure, module-resolution error, login failure or missing-fixture error — all of which also exit non-zero. This mattered: an earlier round of the PHPUnit mutations produced three reds carrying `ParseError` and two greens that failed after revert, none of them real. The cause was the container's view of the bind-mounted source lagging the host's, so a run could execute a half-written or still-mutated file. Those runs were discarded and re-run behind a check that confirms the container hashes the same bytes as the host before either the red or the green is trusted.
- **Lint.** `oxlint` exits 0 on the three changed JS/TS files. `lint:changes:branch` exits 0. `phpcs` run directly on the changed PHP test file reports two errors, and running phpcs on **trunk's copy at the same path** reports the identical pair — a missing `strict_types` declaration and a spacing error on a pre-existing closure that this change's insertion shifts from line 258 to line 344. Neither is introduced here.
- **PHPStan: not applicable, and checked rather than assumed.** `phpstan.neon` scopes to `woocommerce.php`, `src/` and `includes/`; no file in this diff is in scope.
- **Three independent agent reviews.** The first two returned no blocking findings; a third, run over the corrections and this description, found two and both are fixed. Every finding was applied or declined in writing with a reason. Four corrections they produced are visible above: trunk's Product Collection parity loop is named as the interim route owner, the mis-wired Product Tag title is disclosed, the coverage table's expected fixture names were corrected to the ones #68618 actually ships (they had been quoted from the migration branch, which renamed them), and step 8 no longer credits `env:start:blocks` with creating the storage state and snapshot that the `blocks setup` project creates. A stale mutation summary that contradicted its own logs was also regenerated from them.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/testops-234-products-block` and `plugins/woocommerce/client/blocks/changelog/testops-234-products-block`.

</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

The migration was produced by an agent-run campaign with per-test mutation verification (see #68046). This PR was assembled, verified in isolation, and reviewed by an agent; the author reviewed the diff and takes responsibility for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


