### PR TITLE
[DO NOT MERGE] Force the first wp-env start to fail, to verify the retry fix on a runner

### DIFF
--- a/plugins/woocommerce/tests/e2e/bin/blocks/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/test-env-setup.sh
@@ -7,6 +7,25 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+###################################################################################################
+# TEMPORARY SABOTAGE -- DO NOT MERGE. Delete this block before this branch goes anywhere.
+###################################################################################################
+# Forces the job's first `wp-env start` to fail here, after the containers are
+# already running, which is the one condition the retry in ci.yml could not
+# recover from. The marker lives in the runner's temp directory and survives
+# between attempts within the job, so attempt 2 gets past this block and the job
+# then shows whether the retry recovers. The message is the real seed guard's,
+# so the workflow's reason= classifier is exercised as well.
+forced_failure_marker="${RUNNER_TEMP:-/tmp}/wp-env-forced-first-failure"
+if [ ! -f "$forced_failure_marker" ]; then
+	: > "$forced_failure_marker"
+	echo "Missing gallery attachment; the sample-data image import did not complete." >&2
+	exit 1
+fi
+###################################################################################################
+# END TEMPORARY SABOTAGE
+###################################################################################################
+
 # Command prefix for running wp-cli against the single-container E2E environment
 # (started via `wp-env --config .wp-env.e2e.json`, whose container is `cli`).
 wp_cli="wp-env --config .wp-env.e2e.json run cli"


### PR DESCRIPTION
## ⚠️ Do not merge. Do not review. This branch will be deleted.

Throwaway experiment that exists to run one check on a real runner for #68666, then be thrown away. It targets that PR's branch rather than `trunk`, so the diff here is only the sabotage commit.

**Why it cannot be tested locally.** macOS maps container file ownership back to the host user. I probed it: a container running as root wrote into a bind mount and the files came back owned by uid `501`, so `rmdir` succeeded. The root-owned mount point that #68666 is entirely about never appears on a developer machine, in any checkout. Only a Linux runner reproduces it.

**What the sabotage does.** The job's first `wp-env start` now fails inside `tests/e2e/bin/blocks/test-env-setup.sh`, after the containers are up, with the real seed guard's message. A marker in `RUNNER_TEMP` survives between attempts, so attempt 2 gets past it.

**What to read off the Blocks e2e jobs.** Two things #68666 asserts but could not demonstrate:

- The retry recovers. Attempt 1 fails, attempt 2 gets through the seed, and the job does not die with `wp-env start failed after 3 attempts`. On `trunk` this is impossible: attempts 2 and 3 hit `EACCES: permission denied, rmdir` on the mapped `test-data/images` directory.
- The classifier is right. The retry warning reads `reason=blocks-seed`, not `reason=unknown`.

A failure here is the useful outcome too: it would mean reclaiming ownership is not sufficient, and #68666 should not land as it stands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
