### PR TITLE
[DO NOT MERGE] Control for #68666: same forced failure on trunk, no fix

### DIFF
--- a/plugins/woocommerce/tests/e2e/bin/blocks/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/test-env-setup.sh
@@ -7,6 +7,25 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+###################################################################################################
+# TEMPORARY SABOTAGE -- DO NOT MERGE. Delete this block before this branch goes anywhere.
+###################################################################################################
+# Forces the job's first `wp-env start` to fail here, after the containers are
+# already running, which is the one condition the retry in ci.yml could not
+# recover from. The marker lives in the runner's temp directory and survives
+# between attempts within the job, so attempt 2 gets past this block and the job
+# then shows whether the retry recovers. The message is the real seed guard's,
+# so the workflow's reason= classifier is exercised as well.
+forced_failure_marker="${RUNNER_TEMP:-/tmp}/wp-env-forced-first-failure"
+if [ ! -f "$forced_failure_marker" ]; then
+	: > "$forced_failure_marker"
+	echo "Missing gallery attachment; the sample-data image import did not complete." >&2
+	exit 1
+fi
+###################################################################################################
+# END TEMPORARY SABOTAGE
+###################################################################################################
+
 # Command prefix for running wp-cli against the single-container E2E environment
 # (started via `wp-env --config .wp-env.e2e.json`, whose container is `cli`).
 wp_cli="wp-env --config .wp-env.e2e.json run cli"


### PR DESCRIPTION
## ⚠️ Do not merge. Do not review. This branch will be deleted.

The control half of #68668, which is itself a throwaway experiment for #68666. Plain `trunk` plus the same one forced failure, and **no fix**. Both branches get deleted once they have reported.

**Why it exists.** #68668 showed that with #68666 applied, a Blocks e2e job whose first `wp-env start` fails goes on to recover. On its own that does not show the fix was what did it, because the `chown` leaves no trace in the log. This run supplies the missing half.

**A red job here is the result being looked for.** The expected sequence:

- Attempt 1 fails in the blocks seed with `the sample-data image import did not complete`.
- Attempts 2 and 3 both die with `EACCES: permission denied, rmdir` on the mapped `test-data/images` directory, because nothing reclaims ownership of the wp-env home.
- The job ends with `::error::wp-env start failed after 3 attempts`, and the reason reads `unknown`, since `trunk` has neither the `blocks-seed` nor the `stale-mount` classifier.

That is the same failure #68655 and #68663 hit for real. Reproducing it on demand, against the identical sabotage that #68668 recovered from, is what makes the pair a controlled comparison rather than two separate observations.

**If these jobs pass instead,** the premise behind #68666 is wrong: the retry could already cope, and the `EACCES` in those real jobs came from something else. That would be worth knowing before the fix lands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
